### PR TITLE
feat(analytics,ui): wire pillar-analytics end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9057,6 +9057,7 @@ name = "mockforge-ui"
 version = "0.3.116"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum 0.8.8",
  "base64 0.22.1",
  "bcrypt",

--- a/crates/mockforge-analytics/src/pillar_usage.rs
+++ b/crates/mockforge-analytics/src/pillar_usage.rs
@@ -472,7 +472,7 @@ impl AnalyticsDatabase {
         let chaos_enabled_count = if let Some(ws_id) = workspace_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.scenario_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.scenario_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'reality'
                 AND metric_name = 'chaos_injection'
@@ -490,7 +490,7 @@ impl AnalyticsDatabase {
         } else if let Some(org) = org_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.scenario_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.scenario_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'reality'
                 AND metric_name = 'chaos_injection'
@@ -665,7 +665,7 @@ impl AnalyticsDatabase {
         let drift_budget_configured_count = if let Some(ws_id) = workspace_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.endpoint'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.endpoint'))
                 FROM pillar_usage_events
                 WHERE pillar = 'contracts'
                 AND metric_name = 'drift_budget_configured'
@@ -682,7 +682,7 @@ impl AnalyticsDatabase {
         } else if let Some(org) = org_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.endpoint'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.endpoint'))
                 FROM pillar_usage_events
                 WHERE pillar = 'contracts'
                 AND metric_name = 'drift_budget_configured'
@@ -745,7 +745,7 @@ impl AnalyticsDatabase {
         let contract_sync_cycles = if let Some(ws_id) = workspace_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.sync_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.sync_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'contracts'
                 AND metric_name = 'contract_sync'
@@ -762,7 +762,7 @@ impl AnalyticsDatabase {
         } else if let Some(org) = org_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.sync_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.sync_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'contracts'
                 AND metric_name = 'contract_sync'
@@ -803,7 +803,7 @@ impl AnalyticsDatabase {
         let sdk_installations = if let Some(ws_id) = workspace_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.sdk_type'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.sdk_type'))
                 FROM pillar_usage_events
                 WHERE pillar = 'devx'
                 AND metric_name = 'sdk_installation'
@@ -820,7 +820,7 @@ impl AnalyticsDatabase {
         } else if let Some(org) = org_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.sdk_type'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.sdk_type'))
                 FROM pillar_usage_events
                 WHERE pillar = 'devx'
                 AND metric_name = 'sdk_installation'
@@ -881,7 +881,7 @@ impl AnalyticsDatabase {
         let playground_sessions = if let Some(ws_id) = workspace_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.session_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.session_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'devx'
                 AND metric_name = 'playground_session'
@@ -898,7 +898,7 @@ impl AnalyticsDatabase {
         } else if let Some(org) = org_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.session_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.session_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'devx'
                 AND metric_name = 'playground_session'
@@ -976,7 +976,7 @@ impl AnalyticsDatabase {
         let shared_scenarios_count = if let Some(ws_id) = workspace_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.scenario_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.scenario_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'cloud'
                 AND metric_name = 'scenario_shared'
@@ -993,7 +993,7 @@ impl AnalyticsDatabase {
         } else if let Some(org) = org_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.scenario_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.scenario_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'cloud'
                 AND metric_name = 'scenario_shared'
@@ -1054,7 +1054,7 @@ impl AnalyticsDatabase {
         let org_templates_used = if let Some(ws_id) = workspace_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.template_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.template_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'cloud'
                 AND metric_name = 'template_use'
@@ -1071,7 +1071,7 @@ impl AnalyticsDatabase {
         } else if let Some(org) = org_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.template_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.template_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'cloud'
                 AND metric_name = 'template_use'
@@ -1093,7 +1093,7 @@ impl AnalyticsDatabase {
         let collaborative_workspaces = if let Some(ws_id) = workspace_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.workspace_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.workspace_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'cloud'
                 AND metric_name = 'workspace_creation'
@@ -1111,7 +1111,7 @@ impl AnalyticsDatabase {
         } else if let Some(org) = org_id {
             sqlx::query_scalar::<_, i64>(
                 r"
-                SELECT COUNT(DISTINCT json_extract(metadata, '$.workspace_id'))
+                SELECT COUNT(DISTINCT json_extract(metric_value, '$.workspace_id'))
                 FROM pillar_usage_events
                 WHERE pillar = 'cloud'
                 AND metric_name = 'workspace_creation'

--- a/crates/mockforge-cli/src/contract_sync_commands.rs
+++ b/crates/mockforge-cli/src/contract_sync_commands.rs
@@ -7,11 +7,13 @@
 use mockforge_core::{
     contract_validation::{ContractValidator, ValidationResult},
     openapi::OpenApiSpec,
+    pillar_tracking::record_contracts_usage,
     Error, Result,
 };
 use mockforge_workspace::git_watch::{GitWatchConfig, GitWatchService};
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
+use uuid::Uuid;
 
 /// Handle the contract-sync command
 #[allow(clippy::too_many_arguments)]
@@ -107,6 +109,22 @@ pub async fn handle_contract_sync(
             }
         }
     }
+
+    // Record a contract-sync event so the Contracts pillar dashboard reflects usage.
+    let sync_id = Uuid::new_v4().to_string();
+    record_contracts_usage(
+        None,
+        None,
+        "contract_sync",
+        serde_json::json!({
+            "sync_id": sync_id,
+            "spec_count": spec_files.len(),
+            "errors": overall_result.errors.len(),
+            "breaking_changes": overall_result.breaking_changes.len(),
+            "passed": overall_result.passed,
+        }),
+    )
+    .await;
 
     // Exit with appropriate code
     if overall_result.passed {

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2105,6 +2105,36 @@ enum Commands {
     },
 }
 
+/// Return a short name for the top-level CLI subcommand used for pillar analytics.
+fn cli_command_name(cmd: &Commands) -> &'static str {
+    match cmd {
+        Commands::Serve(_) => "serve",
+        #[cfg(feature = "smtp")]
+        Commands::Smtp { .. } => "smtp",
+        #[cfg(feature = "mqtt")]
+        Commands::Mqtt { .. } => "mqtt",
+        #[cfg(feature = "ftp")]
+        Commands::Ftp { .. } => "ftp",
+        #[cfg(feature = "kafka")]
+        Commands::Kafka { .. } => "kafka",
+        #[cfg(feature = "amqp")]
+        Commands::Amqp { .. } => "amqp",
+        Commands::Data { .. } => "data",
+        Commands::Admin { .. } => "admin",
+        Commands::Sync { .. } => "sync",
+        Commands::Quick { .. } => "quick",
+        Commands::Completions { .. } => "completions",
+        Commands::Init { .. } => "init",
+        Commands::Wizard => "wizard",
+        Commands::ValidateFixtures { .. } => "validate-fixtures",
+        Commands::Generate { .. } => "generate",
+        Commands::Schema { .. } => "schema",
+        Commands::DevSetup { .. } => "dev-setup",
+        Commands::Config { .. } => "config",
+        _ => "other",
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cli = Cli::parse();
@@ -2124,6 +2154,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         eprintln!("Failed to initialize logging: {}", e);
         std::process::exit(1);
     }
+
+    // Record the invoked CLI subcommand for the DevX pillar dashboard.
+    let command_name = cli_command_name(&cli.command);
+    mockforge_core::pillar_tracking::record_devx_usage(
+        None,
+        None,
+        "cli_command",
+        serde_json::json!({ "command": command_name }),
+    )
+    .await;
 
     match cli.command {
         Commands::Serve(args) => {

--- a/crates/mockforge-cli/src/registry_commands.rs
+++ b/crates/mockforge-cli/src/registry_commands.rs
@@ -416,6 +416,18 @@ async fn install_from_registry(plugin_spec: &str, force: bool) -> Result<()> {
 
     println!("{} Downloading version {}...", "↓".green(), target_version);
 
+    // Cloud pillar: marketplace_download event.
+    mockforge_core::pillar_tracking::record_cloud_usage(
+        None,
+        None,
+        "marketplace_download",
+        serde_json::json!({
+            "source": "plugin_registry",
+            "version": target_version,
+        }),
+    )
+    .await;
+
     // Download plugin
     let data = client.download(&version_entry.download_url).await?;
 

--- a/crates/mockforge-core/src/ai_contract_diff/mod.rs
+++ b/crates/mockforge-core/src/ai_contract_diff/mod.rs
@@ -165,6 +165,20 @@ impl ContractDiffAnalyzer {
         // Recalculate overall confidence with recommendations and corrections
         result.confidence = ConfidenceScorer::calculate_overall_confidence(&result.mismatches);
 
+        // Record AI pillar usage (ai_generation type=contract_diff) so the dashboard reflects contract-diff activity.
+        crate::pillar_tracking::record_ai_usage(
+            None,
+            None,
+            "ai_generation",
+            serde_json::json!({
+                "type": "contract_diff",
+                "mismatches": result.mismatches.len(),
+                "recommendations": result.recommendations.len(),
+                "corrections": result.corrections.len(),
+            }),
+        )
+        .await;
+
         Ok(result)
     }
 

--- a/crates/mockforge-core/src/ai_studio/nl_mock_generator.rs
+++ b/crates/mockforge-core/src/ai_studio/nl_mock_generator.rs
@@ -150,6 +150,19 @@ impl MockGenerator {
             None
         };
 
+        // Record AI pillar usage (ai_generation type=mock)
+        crate::pillar_tracking::record_ai_usage(
+            _workspace_id.map(String::from),
+            None,
+            "ai_generation",
+            serde_json::json!({
+                "type": "mock",
+                "endpoints": parsed.endpoints.len(),
+                "models": parsed.models.len(),
+            }),
+        )
+        .await;
+
         Ok(MockGenerationResult {
             spec: Some(spec_json),
             message: format!(
@@ -190,6 +203,24 @@ impl MockGenerator {
 
         // Convert spec to JSON for response
         let spec_json = serde_json::to_value(&spec.spec)?;
+
+        // Record AI pillar usage. Merge counts as ai_refinement; new generation as ai_generation.
+        let metric_name = if existing_spec.is_some() {
+            "ai_refinement"
+        } else {
+            "ai_generation"
+        };
+        crate::pillar_tracking::record_ai_usage(
+            None,
+            None,
+            metric_name,
+            serde_json::json!({
+                "type": "mock",
+                "endpoints": parsed.endpoints.len(),
+                "models": parsed.models.len(),
+            }),
+        )
+        .await;
 
         Ok(MockGenerationResult {
             spec: Some(spec_json),

--- a/crates/mockforge-core/src/contract_validation.rs
+++ b/crates/mockforge-core/src/contract_validation.rs
@@ -193,6 +193,16 @@ impl ContractValidator {
     ) -> ValidationResult {
         let mut result = ValidationResult::new();
 
+        // Record the active validation mode for the Contracts pillar dashboard.
+        let mode = if self.strict_mode { "enforce" } else { "warn" };
+        crate::pillar_tracking::record_contracts_usage(
+            None,
+            None,
+            "validation_mode",
+            serde_json::json!({ "mode": mode }),
+        )
+        .await;
+
         for (path, path_item_ref) in &spec.spec.paths.paths {
             if let openapiv3::ReferenceOr::Item(path_item) = path_item_ref {
                 let operations = vec![

--- a/crates/mockforge-core/src/voice/command_parser.rs
+++ b/crates/mockforge-core/src/voice/command_parser.rs
@@ -131,6 +131,19 @@ don't include it in the response."#;
             ))
         })?;
 
+        // Record the voice-command event so the AI pillar dashboard reflects usage.
+        crate::pillar_tracking::record_ai_usage(
+            None,
+            None,
+            "voice_command",
+            serde_json::json!({
+                "kind": "parse_command",
+                "api_type": parsed.api_type,
+                "endpoints": parsed.endpoints.len(),
+            }),
+        )
+        .await;
+
         Ok(parsed)
     }
 

--- a/crates/mockforge-http/src/middleware/drift_tracking.rs
+++ b/crates/mockforge-http/src/middleware/drift_tracking.rs
@@ -143,6 +143,25 @@ pub async fn drift_tracking_middleware_with_extensions(
                 )
                 .await;
 
+                // If this endpoint has a drift budget configured, record that so
+                // the Contracts pillar dashboard can count distinct budgeted endpoints.
+                let endpoint_key = format!("{} {}", method, path);
+                let budget_config = state.drift_engine.config();
+                if budget_config.enabled
+                    && (budget_config.per_endpoint_budgets.contains_key(&endpoint_key)
+                        || budget_config.default_budget.is_some())
+                {
+                    mockforge_core::pillar_tracking::record_contracts_usage(
+                        None,
+                        None,
+                        "drift_budget_configured",
+                        serde_json::json!({
+                            "endpoint": endpoint_key,
+                        }),
+                    )
+                    .await;
+                }
+
                 // Create incident if budget is exceeded or breaking changes detected
                 if drift_result.should_create_incident {
                     let incident_type = if drift_result.breaking_changes > 0 {

--- a/crates/mockforge-scenarios/src/installer.rs
+++ b/crates/mockforge-scenarios/src/installer.rs
@@ -609,6 +609,19 @@ impl ScenarioInstaller {
 
         info!("Downloading version {} ({} bytes)", target_version, version_entry.size);
 
+        // Cloud pillar: marketplace_download event for scenario installs.
+        mockforge_core::pillar_tracking::record_cloud_usage(
+            None,
+            None,
+            "marketplace_download",
+            serde_json::json!({
+                "source": "scenario_registry",
+                "scenario": name,
+                "version": target_version,
+            }),
+        )
+        .await;
+
         // Download package
         let package_data = registry
             .download(&version_entry.download_url, Some(&version_entry.checksum))

--- a/crates/mockforge-scenarios/src/registry.rs
+++ b/crates/mockforge-scenarios/src/registry.rs
@@ -419,6 +419,18 @@ impl ScenarioRegistry {
             ScenarioError::Network(format!("Failed to parse publish response: {}", e))
         })?;
 
+        // Cloud pillar: scenario_shared event.
+        mockforge_core::pillar_tracking::record_cloud_usage(
+            None,
+            None,
+            "scenario_shared",
+            serde_json::json!({
+                "scenario_id": result.name.clone(),
+                "version": result.version.clone(),
+            }),
+        )
+        .await;
+
         Ok(result)
     }
 

--- a/crates/mockforge-ui/Cargo.toml
+++ b/crates/mockforge-ui/Cargo.toml
@@ -32,6 +32,7 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["time"] }
 futures-util = "0.3"
+async-trait = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/mockforge-ui/src/handlers/pillar_analytics.rs
+++ b/crates/mockforge-ui/src/handlers/pillar_analytics.rs
@@ -4,26 +4,37 @@
 //! at both workspace and organization levels.
 
 use axum::{
-    extract::{Path, Query, State},
+    extract::{Path, Query},
     http::StatusCode,
     Json,
 };
 use mockforge_analytics::{AnalyticsDatabase, PillarUsageMetrics};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tokio::sync::OnceCell;
 use tracing::{debug, error};
 
 use crate::models::ApiResponse;
 
-/// Pillar analytics state
+/// Pillar analytics state backed by a lazy-initialized `AnalyticsDatabase`.
+///
+/// Shares the same `OnceCell<AnalyticsDatabase>` with coverage metrics so the
+/// admin UI only needs to initialize the database once.
 #[derive(Clone)]
 pub struct PillarAnalyticsState {
-    pub db: Arc<AnalyticsDatabase>,
+    pub db: Arc<OnceCell<AnalyticsDatabase>>,
 }
 
 impl PillarAnalyticsState {
-    pub fn new(db: AnalyticsDatabase) -> Self {
-        Self { db: Arc::new(db) }
+    pub fn new(db: Arc<OnceCell<AnalyticsDatabase>>) -> Self {
+        Self { db }
+    }
+
+    async fn get_db(&self) -> Result<&AnalyticsDatabase, StatusCode> {
+        self.db.get().ok_or_else(|| {
+            error!("Analytics database not initialized");
+            StatusCode::SERVICE_UNAVAILABLE
+        })
     }
 }
 
@@ -43,28 +54,26 @@ fn default_duration() -> i64 {
     3600 // 1 hour
 }
 
-/// Get pillar usage metrics for a workspace
-///
-/// Returns comprehensive pillar usage metrics including:
-/// - Reality pillar: blended reality usage, personas, chaos
-/// - Contracts pillar: validation modes, drift budgets
-/// - DevX pillar: SDK usage, client generations
-/// - Cloud pillar: shared scenarios, templates
-/// - AI pillar: AI-generated mocks, contract diffs
+fn resolve_duration(query: &PillarAnalyticsQuery) -> i64 {
+    if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
+        end - start
+    } else {
+        query.duration
+    }
+}
+
+/// GET /api/v2/analytics/pillars/workspace/{workspace_id}
 pub async fn get_workspace_pillar_metrics(
-    State(state): State<PillarAnalyticsState>,
+    axum::extract::Extension(state): axum::extract::Extension<PillarAnalyticsState>,
     Path(workspace_id): Path<String>,
     Query(query): Query<PillarAnalyticsQuery>,
 ) -> Result<Json<ApiResponse<PillarUsageMetrics>>, StatusCode> {
     debug!("Fetching pillar metrics for workspace: {}", workspace_id);
 
-    let duration = if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
-        end - start
-    } else {
-        query.duration
-    };
+    let db = state.get_db().await?;
+    let duration = resolve_duration(&query);
 
-    match state.db.get_workspace_pillar_metrics(&workspace_id, duration).await {
+    match db.get_workspace_pillar_metrics(&workspace_id, duration).await {
         Ok(metrics) => Ok(Json(ApiResponse::success(metrics))),
         Err(e) => {
             error!("Failed to get workspace pillar metrics: {}", e);
@@ -73,23 +82,18 @@ pub async fn get_workspace_pillar_metrics(
     }
 }
 
-/// Get pillar usage metrics for an organization
-///
-/// Returns aggregated pillar metrics across all workspaces in the organization.
+/// GET /api/v2/analytics/pillars/org/{org_id}
 pub async fn get_org_pillar_metrics(
-    State(state): State<PillarAnalyticsState>,
+    axum::extract::Extension(state): axum::extract::Extension<PillarAnalyticsState>,
     Path(org_id): Path<String>,
     Query(query): Query<PillarAnalyticsQuery>,
 ) -> Result<Json<ApiResponse<PillarUsageMetrics>>, StatusCode> {
     debug!("Fetching pillar metrics for org: {}", org_id);
 
-    let duration = if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
-        end - start
-    } else {
-        query.duration
-    };
+    let db = state.get_db().await?;
+    let duration = resolve_duration(&query);
 
-    match state.db.get_org_pillar_metrics(&org_id, duration).await {
+    match db.get_org_pillar_metrics(&org_id, duration).await {
         Ok(metrics) => Ok(Json(ApiResponse::success(metrics))),
         Err(e) => {
             error!("Failed to get org pillar metrics: {}", e);
@@ -105,27 +109,22 @@ pub struct RealityPillarDetails {
     pub time_range: String,
 }
 
+/// GET /api/v2/analytics/pillars/workspace/{workspace_id}/reality
 pub async fn get_reality_pillar_details(
-    State(state): State<PillarAnalyticsState>,
+    axum::extract::Extension(state): axum::extract::Extension<PillarAnalyticsState>,
     Path(workspace_id): Path<String>,
     Query(query): Query<PillarAnalyticsQuery>,
 ) -> Result<Json<ApiResponse<RealityPillarDetails>>, StatusCode> {
     debug!("Fetching Reality pillar details for workspace: {}", workspace_id);
 
-    let duration = if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
-        end - start
-    } else {
-        query.duration
-    };
+    let db = state.get_db().await?;
+    let duration = resolve_duration(&query);
 
-    match state.db.get_workspace_pillar_metrics(&workspace_id, duration).await {
-        Ok(metrics) => {
-            let details = RealityPillarDetails {
-                metrics: metrics.reality,
-                time_range: metrics.time_range,
-            };
-            Ok(Json(ApiResponse::success(details)))
-        }
+    match db.get_workspace_pillar_metrics(&workspace_id, duration).await {
+        Ok(metrics) => Ok(Json(ApiResponse::success(RealityPillarDetails {
+            metrics: metrics.reality,
+            time_range: metrics.time_range,
+        }))),
         Err(e) => {
             error!("Failed to get Reality pillar details: {}", e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
@@ -140,27 +139,22 @@ pub struct ContractsPillarDetails {
     pub time_range: String,
 }
 
+/// GET /api/v2/analytics/pillars/workspace/{workspace_id}/contracts
 pub async fn get_contracts_pillar_details(
-    State(state): State<PillarAnalyticsState>,
+    axum::extract::Extension(state): axum::extract::Extension<PillarAnalyticsState>,
     Path(workspace_id): Path<String>,
     Query(query): Query<PillarAnalyticsQuery>,
 ) -> Result<Json<ApiResponse<ContractsPillarDetails>>, StatusCode> {
     debug!("Fetching Contracts pillar details for workspace: {}", workspace_id);
 
-    let duration = if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
-        end - start
-    } else {
-        query.duration
-    };
+    let db = state.get_db().await?;
+    let duration = resolve_duration(&query);
 
-    match state.db.get_workspace_pillar_metrics(&workspace_id, duration).await {
-        Ok(metrics) => {
-            let details = ContractsPillarDetails {
-                metrics: metrics.contracts,
-                time_range: metrics.time_range,
-            };
-            Ok(Json(ApiResponse::success(details)))
-        }
+    match db.get_workspace_pillar_metrics(&workspace_id, duration).await {
+        Ok(metrics) => Ok(Json(ApiResponse::success(ContractsPillarDetails {
+            metrics: metrics.contracts,
+            time_range: metrics.time_range,
+        }))),
         Err(e) => {
             error!("Failed to get Contracts pillar details: {}", e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
@@ -175,27 +169,22 @@ pub struct AiPillarDetails {
     pub time_range: String,
 }
 
+/// GET /api/v2/analytics/pillars/workspace/{workspace_id}/ai
 pub async fn get_ai_pillar_details(
-    State(state): State<PillarAnalyticsState>,
+    axum::extract::Extension(state): axum::extract::Extension<PillarAnalyticsState>,
     Path(workspace_id): Path<String>,
     Query(query): Query<PillarAnalyticsQuery>,
 ) -> Result<Json<ApiResponse<AiPillarDetails>>, StatusCode> {
     debug!("Fetching AI pillar details for workspace: {}", workspace_id);
 
-    let duration = if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
-        end - start
-    } else {
-        query.duration
-    };
+    let db = state.get_db().await?;
+    let duration = resolve_duration(&query);
 
-    match state.db.get_workspace_pillar_metrics(&workspace_id, duration).await {
-        Ok(metrics) => {
-            let details = AiPillarDetails {
-                metrics: metrics.ai,
-                time_range: metrics.time_range,
-            };
-            Ok(Json(ApiResponse::success(details)))
-        }
+    match db.get_workspace_pillar_metrics(&workspace_id, duration).await {
+        Ok(metrics) => Ok(Json(ApiResponse::success(AiPillarDetails {
+            metrics: metrics.ai,
+            time_range: metrics.time_range,
+        }))),
         Err(e) => {
             error!("Failed to get AI pillar details: {}", e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
@@ -229,130 +218,133 @@ pub struct PillarRanking {
     pub is_least_used: bool,
 }
 
-/// Get pillar usage summary showing most/least used pillars
-///
-/// This endpoint provides a high-level view of pillar usage, ranking pillars
-/// by their usage metrics to help identify where investment and usage are concentrated.
-pub async fn get_pillar_usage_summary(
-    State(state): State<PillarAnalyticsState>,
+fn build_summary(metrics: PillarUsageMetrics) -> PillarUsageSummary {
+    let mut rankings = Vec::new();
+    let mut total_usage = 0u64;
+
+    if let Some(ref reality) = metrics.reality {
+        let usage = (reality.blended_reality_percent + reality.smart_personas_percent) as u64
+            + reality.chaos_enabled_count;
+        rankings.push(PillarRanking {
+            pillar: "Reality".to_string(),
+            usage,
+            percentage: 0.0,
+            is_most_used: false,
+            is_least_used: false,
+        });
+        total_usage += usage;
+    }
+
+    if let Some(ref contracts) = metrics.contracts {
+        let usage = contracts.validation_enforce_percent as u64
+            + contracts.drift_budget_configured_count
+            + contracts.drift_incidents_count;
+        rankings.push(PillarRanking {
+            pillar: "Contracts".to_string(),
+            usage,
+            percentage: 0.0,
+            is_most_used: false,
+            is_least_used: false,
+        });
+        total_usage += usage;
+    }
+
+    if let Some(ref devx) = metrics.devx {
+        let usage = devx.sdk_installations + devx.client_generations + devx.playground_sessions;
+        rankings.push(PillarRanking {
+            pillar: "DevX".to_string(),
+            usage,
+            percentage: 0.0,
+            is_most_used: false,
+            is_least_used: false,
+        });
+        total_usage += usage;
+    }
+
+    if let Some(ref cloud) = metrics.cloud {
+        let usage = cloud.shared_scenarios_count
+            + cloud.marketplace_downloads
+            + cloud.collaborative_workspaces;
+        rankings.push(PillarRanking {
+            pillar: "Cloud".to_string(),
+            usage,
+            percentage: 0.0,
+            is_most_used: false,
+            is_least_used: false,
+        });
+        total_usage += usage;
+    }
+
+    if let Some(ref ai) = metrics.ai {
+        let usage = ai.ai_generated_mocks + ai.ai_contract_diffs + ai.llm_assisted_operations;
+        rankings.push(PillarRanking {
+            pillar: "AI".to_string(),
+            usage,
+            percentage: 0.0,
+            is_most_used: false,
+            is_least_used: false,
+        });
+        total_usage += usage;
+    }
+
+    for ranking in &mut rankings {
+        if total_usage > 0 {
+            ranking.percentage = (ranking.usage as f64 / total_usage as f64) * 100.0;
+        }
+    }
+
+    rankings.sort_by(|a, b| b.usage.cmp(&a.usage));
+
+    let rankings_len = rankings.len();
+    if let Some(first) = rankings.first_mut() {
+        first.is_most_used = true;
+    }
+    if rankings_len > 1 {
+        if let Some(last) = rankings.last_mut() {
+            last.is_least_used = true;
+        }
+    }
+
+    PillarUsageSummary {
+        time_range: metrics.time_range,
+        rankings,
+        total_usage,
+    }
+}
+
+/// GET /api/v2/analytics/pillars/workspace/{workspace_id}/summary
+pub async fn get_workspace_pillar_usage_summary(
+    axum::extract::Extension(state): axum::extract::Extension<PillarAnalyticsState>,
     Path(workspace_id): Path<String>,
     Query(query): Query<PillarAnalyticsQuery>,
 ) -> Result<Json<ApiResponse<PillarUsageSummary>>, StatusCode> {
     debug!("Fetching pillar usage summary for workspace: {}", workspace_id);
 
-    let duration = if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
-        end - start
-    } else {
-        query.duration
-    };
+    let db = state.get_db().await?;
+    let duration = resolve_duration(&query);
 
-    match state.db.get_workspace_pillar_metrics(&workspace_id, duration).await {
-        Ok(metrics) => {
-            let mut rankings = Vec::new();
-            let mut total_usage = 0u64;
-
-            // Calculate usage scores for each pillar
-            // Reality: blended_reality_percent + smart_personas_percent + chaos_enabled_count
-            if let Some(ref reality) = metrics.reality {
-                let usage = (reality.blended_reality_percent + reality.smart_personas_percent)
-                    as u64
-                    + reality.chaos_enabled_count;
-                rankings.push(PillarRanking {
-                    pillar: "Reality".to_string(),
-                    usage,
-                    percentage: 0.0, // Will calculate after total
-                    is_most_used: false,
-                    is_least_used: false,
-                });
-                total_usage += usage;
-            }
-
-            // Contracts: validation_enforce_percent + drift_budget_configured_count + drift_incidents_count
-            if let Some(ref contracts) = metrics.contracts {
-                let usage = contracts.validation_enforce_percent as u64
-                    + contracts.drift_budget_configured_count
-                    + contracts.drift_incidents_count;
-                rankings.push(PillarRanking {
-                    pillar: "Contracts".to_string(),
-                    usage,
-                    percentage: 0.0,
-                    is_most_used: false,
-                    is_least_used: false,
-                });
-                total_usage += usage;
-            }
-
-            // DevX: sdk_installations + client_generations + playground_sessions
-            if let Some(ref devx) = metrics.devx {
-                let usage =
-                    devx.sdk_installations + devx.client_generations + devx.playground_sessions;
-                rankings.push(PillarRanking {
-                    pillar: "DevX".to_string(),
-                    usage,
-                    percentage: 0.0,
-                    is_most_used: false,
-                    is_least_used: false,
-                });
-                total_usage += usage;
-            }
-
-            // Cloud: shared_scenarios_count + marketplace_downloads + collaborative_workspaces
-            if let Some(ref cloud) = metrics.cloud {
-                let usage = cloud.shared_scenarios_count
-                    + cloud.marketplace_downloads
-                    + cloud.collaborative_workspaces;
-                rankings.push(PillarRanking {
-                    pillar: "Cloud".to_string(),
-                    usage,
-                    percentage: 0.0,
-                    is_most_used: false,
-                    is_least_used: false,
-                });
-                total_usage += usage;
-            }
-
-            // AI: ai_generated_mocks + ai_contract_diffs + llm_assisted_operations
-            if let Some(ref ai) = metrics.ai {
-                let usage =
-                    ai.ai_generated_mocks + ai.ai_contract_diffs + ai.llm_assisted_operations;
-                rankings.push(PillarRanking {
-                    pillar: "AI".to_string(),
-                    usage,
-                    percentage: 0.0,
-                    is_most_used: false,
-                    is_least_used: false,
-                });
-                total_usage += usage;
-            }
-
-            // Calculate percentages and sort by usage (highest first)
-            for ranking in &mut rankings {
-                if total_usage > 0 {
-                    ranking.percentage = (ranking.usage as f64 / total_usage as f64) * 100.0;
-                }
-            }
-
-            rankings.sort_by(|a, b| b.usage.cmp(&a.usage));
-
-            // Mark most/least used
-            let rankings_len = rankings.len();
-            if let Some(first) = rankings.first_mut() {
-                first.is_most_used = true;
-            }
-            if rankings_len > 1 {
-                if let Some(last) = rankings.last_mut() {
-                    last.is_least_used = true;
-                }
-            }
-
-            let summary = PillarUsageSummary {
-                time_range: metrics.time_range,
-                rankings,
-                total_usage,
-            };
-
-            Ok(Json(ApiResponse::success(summary)))
+    match db.get_workspace_pillar_metrics(&workspace_id, duration).await {
+        Ok(metrics) => Ok(Json(ApiResponse::success(build_summary(metrics)))),
+        Err(e) => {
+            error!("Failed to get pillar usage summary: {}", e);
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
+    }
+}
+
+/// GET /api/v2/analytics/pillars/org/{org_id}/summary
+pub async fn get_org_pillar_usage_summary(
+    axum::extract::Extension(state): axum::extract::Extension<PillarAnalyticsState>,
+    Path(org_id): Path<String>,
+    Query(query): Query<PillarAnalyticsQuery>,
+) -> Result<Json<ApiResponse<PillarUsageSummary>>, StatusCode> {
+    debug!("Fetching pillar usage summary for org: {}", org_id);
+
+    let db = state.get_db().await?;
+    let duration = resolve_duration(&query);
+
+    match db.get_org_pillar_metrics(&org_id, duration).await {
+        Ok(metrics) => Ok(Json(ApiResponse::success(build_summary(metrics)))),
         Err(e) => {
             error!("Failed to get pillar usage summary: {}", e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)

--- a/crates/mockforge-ui/src/handlers/workspaces.rs
+++ b/crates/mockforge-ui/src/handlers/workspaces.rs
@@ -184,6 +184,19 @@ pub async fn create_workspace(
                     };
 
                     tracing::info!("Created workspace: {}", request.id);
+
+                    // Cloud pillar: workspace_creation event.
+                    mockforge_core::pillar_tracking::record_cloud_usage(
+                        Some(request.id.clone()),
+                        None,
+                        "workspace_creation",
+                        serde_json::json!({
+                            "workspace_id": request.id,
+                            "collaborative": 1,
+                        }),
+                    )
+                    .await;
+
                     Ok(Json(ApiResponse::success(item)))
                 }
                 Err(e) => {

--- a/crates/mockforge-ui/src/lib.rs
+++ b/crates/mockforge-ui/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod audit;
 pub mod auth;
 pub mod handlers;
+pub mod pillar_tracking_init;
 pub mod rbac;
 #[cfg(feature = "registry-admin")]
 pub mod registry_admin;

--- a/crates/mockforge-ui/src/pillar_tracking_init.rs
+++ b/crates/mockforge-ui/src/pillar_tracking_init.rs
@@ -1,0 +1,60 @@
+//! Initialize pillar tracking with the analytics-database adapter.
+//!
+//! Bridges `mockforge_core::pillar_tracking` to `AnalyticsDatabase` so that
+//! pillar-usage events emitted anywhere in the workspace are persisted to the
+//! admin UI's analytics store. Mirrors the adapter in `mockforge-registry-server`
+//! but is invoked whenever the admin UI's lazy `AnalyticsDatabase` OnceCell is
+//! initialized.
+
+use mockforge_analytics::{
+    AnalyticsDatabase, Pillar as AnalyticsPillar, PillarUsageEvent as AnalyticsPillarUsageEvent,
+};
+use mockforge_core::pillar_tracking::{PillarUsageEvent, PillarUsageRecorder};
+use std::sync::Arc;
+
+pub struct AnalyticsPillarRecorder {
+    db: Arc<AnalyticsDatabase>,
+}
+
+impl AnalyticsPillarRecorder {
+    pub fn new(db: Arc<AnalyticsDatabase>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait::async_trait]
+impl PillarUsageRecorder for AnalyticsPillarRecorder {
+    async fn record(
+        &self,
+        event: PillarUsageEvent,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let pillar = match event.pillar {
+            mockforge_core::pillars::Pillar::Reality => AnalyticsPillar::Reality,
+            mockforge_core::pillars::Pillar::Contracts => AnalyticsPillar::Contracts,
+            mockforge_core::pillars::Pillar::DevX => AnalyticsPillar::DevX,
+            mockforge_core::pillars::Pillar::Cloud => AnalyticsPillar::Cloud,
+            mockforge_core::pillars::Pillar::Ai => AnalyticsPillar::Ai,
+        };
+
+        let analytics_event = AnalyticsPillarUsageEvent {
+            workspace_id: event.workspace_id,
+            org_id: event.org_id,
+            pillar,
+            metric_name: event.metric_name,
+            metric_value: event.metric_value,
+            timestamp: event.timestamp,
+        };
+
+        self.db
+            .record_pillar_usage(&analytics_event)
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+    }
+}
+
+/// Install the analytics-backed pillar-usage recorder as the global sink.
+pub async fn init_pillar_tracking(db: Arc<AnalyticsDatabase>) {
+    let recorder = Arc::new(AnalyticsPillarRecorder::new(db));
+    mockforge_core::pillar_tracking::init(recorder).await;
+    tracing::info!("Pillar tracking initialized with analytics database");
+}

--- a/crates/mockforge-ui/src/routes.rs
+++ b/crates/mockforge-ui/src/routes.rs
@@ -448,6 +448,11 @@ pub fn create_admin_router(
                     if let Err(e) = analytics_db.run_migrations().await {
                         tracing::warn!("Failed to run analytics database migrations: {}. Coverage metrics routes may not work correctly.", e);
                     } else {
+                        // Wire the pillar-tracking recorder into the same database so emitters
+                        // across the workspace persist events that the pillar dashboard reads back.
+                        let db_for_pillars = Arc::new(analytics_db.clone());
+                        crate::pillar_tracking_init::init_pillar_tracking(db_for_pillars).await;
+
                         let _ = coverage_db_clone.set(analytics_db);
                         tracing::info!("Analytics database initialized for coverage metrics");
                     }
@@ -463,6 +468,7 @@ pub fn create_admin_router(
 
         // Add routes directly to main router to avoid state type conflicts
         use crate::handlers::coverage_metrics;
+        use crate::handlers::pillar_analytics::{self, PillarAnalyticsState};
         router = router
             .route("/api/v2/analytics/scenarios/usage", get(coverage_metrics::get_scenario_usage))
             .route("/api/v2/analytics/personas/ci-hits", get(coverage_metrics::get_persona_ci_hits))
@@ -478,21 +484,42 @@ pub fn create_admin_router(
                 "/api/v2/analytics/drift/percentage",
                 get(coverage_metrics::get_drift_percentage),
             )
-            .layer(axum::extract::Extension(coverage_state));
+            // Pillar usage analytics (shares the same AnalyticsDatabase OnceCell)
+            .route(
+                "/api/v2/analytics/pillars/workspace/{workspace_id}",
+                get(pillar_analytics::get_workspace_pillar_metrics),
+            )
+            .route(
+                "/api/v2/analytics/pillars/workspace/{workspace_id}/reality",
+                get(pillar_analytics::get_reality_pillar_details),
+            )
+            .route(
+                "/api/v2/analytics/pillars/workspace/{workspace_id}/contracts",
+                get(pillar_analytics::get_contracts_pillar_details),
+            )
+            .route(
+                "/api/v2/analytics/pillars/workspace/{workspace_id}/ai",
+                get(pillar_analytics::get_ai_pillar_details),
+            )
+            .route(
+                "/api/v2/analytics/pillars/workspace/{workspace_id}/summary",
+                get(pillar_analytics::get_workspace_pillar_usage_summary),
+            )
+            .route(
+                "/api/v2/analytics/pillars/org/{org_id}",
+                get(pillar_analytics::get_org_pillar_metrics),
+            )
+            .route(
+                "/api/v2/analytics/pillars/org/{org_id}/summary",
+                get(pillar_analytics::get_org_pillar_usage_summary),
+            )
+            .layer(axum::extract::Extension(coverage_state.clone()))
+            .layer(axum::extract::Extension(PillarAnalyticsState::new(coverage_state.db.clone())));
 
         tracing::info!(
-            "Coverage metrics routes mounted at /api/v2/analytics (database initializing)"
+            "Coverage + pillar analytics routes mounted at /api/v2/analytics (database initializing)"
         );
     }
-
-    // Pillar analytics routes
-    // Note: These routes require an analytics database to be configured.
-    // The handlers will return appropriate errors if the database is not available.
-    // To enable analytics database:
-    // 1. Initialize analytics database connection from config
-    // 2. Add database connection to handler state (e.g., AnalyticsState)
-    // 3. Pass state to analytics route handlers
-    // For now, routes are defined but handlers will return errors if database is not configured
 
     // Add workspace router with WorkspaceState
     {

--- a/crates/mockforge-ui/ui/e2e/pillar-analytics-rankings-deployed.spec.ts
+++ b/crates/mockforge-ui/ui/e2e/pillar-analytics-rankings-deployed.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Pillar Analytics — Rankings Card & Extended Metric Fields
+ *
+ * Covers the elements added alongside wiring the /api/v2/analytics/pillars/*
+ * admin-UI routes: the "Pillar Usage Rankings" card and the surfacing of
+ * ai_contract_diffs / cli_commands / collaborative_workspaces inside the
+ * per-pillar detail cards.
+ *
+ * Run against the deployed site with:
+ *   E2E_EMAIL=you@example.com E2E_PASSWORD=secret \
+ *   npx playwright test --config=playwright-deployed.config.ts pillar-analytics-rankings
+ *
+ * Run against a local dev build (after logging in):
+ *   PLAYWRIGHT_BASE_URL=http://localhost:49080 \
+ *   npx playwright test pillar-analytics-rankings
+ */
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'https://app.mockforge.dev';
+
+function mainContent(page: import('@playwright/test').Page) {
+  return page.getByRole('main');
+}
+
+test.describe('Pillar Analytics — Rankings & Extended Fields', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${BASE_URL}/pillar-analytics`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 30000,
+    });
+
+    await expect(
+      mainContent(page).getByRole('heading', { name: 'Pillar Usage Analytics', level: 1 })
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('renders the Pillar Usage Rankings card', async ({ page }) => {
+    await expect(
+      mainContent(page).getByRole('heading', { name: 'Pillar Usage Rankings', level: 2 })
+    ).toBeVisible();
+  });
+
+  test('rankings card shows empty state or ranked list', async ({ page }) => {
+    const main = mainContent(page);
+    const emptyState = main.getByText('No pillar usage data recorded yet.');
+    // At least one of the five pillar rows becomes a "#1 / #2 …" heading in the ranked list.
+    const rankedRow = main.getByText(/^#\d+$/).first();
+
+    const hasEmpty = await emptyState.isVisible({ timeout: 3000 }).catch(() => false);
+    const hasRanked = await rankedRow.isVisible({ timeout: 3000 }).catch(() => false);
+
+    expect(hasEmpty || hasRanked).toBeTruthy();
+  });
+
+  test('rankings card renders with total or empty-state sibling when ranked', async ({ page }) => {
+    const main = mainContent(page);
+    const rankedRow = main.getByText(/^#\d+$/).first();
+    const hasRanked = await rankedRow.isVisible({ timeout: 3000 }).catch(() => false);
+
+    if (hasRanked) {
+      // When a ranked list is shown, the most-used / least-used pills must appear.
+      await expect(main.getByText(/Most used/i).first()).toBeVisible();
+      await expect(main.getByText(/Least used/i).first()).toBeVisible();
+      // And the total-usage pill next to the heading.
+      await expect(main.getByText(/^Total:\s/)).toBeVisible();
+    } else {
+      // Empty state must show the expected copy (asserted in the prior test) — nothing to add.
+      test.skip();
+    }
+  });
+
+  test.describe('detailed pillar cards surface newly wired fields', () => {
+    // These assertions only run when a workspace has been selected and the
+    // per-pillar detail cards render. When no workspace is selected the page
+    // shows only the overview cards, so we skip rather than fail.
+    test('DevX card shows CLI commands', async ({ page }) => {
+      const main = mainContent(page);
+      const devxSection = main.getByRole('heading', { name: 'DevX Pillar', level: 3 });
+      const hasDevx = await devxSection.isVisible({ timeout: 3000 }).catch(() => false);
+      if (!hasDevx) {
+        test.skip();
+      }
+      await expect(main.getByText(/CLI commands:/)).toBeVisible();
+    });
+
+    test('Cloud card shows Collaborative workspaces', async ({ page }) => {
+      const main = mainContent(page);
+      const cloudSection = main.getByRole('heading', { name: 'Cloud Pillar', level: 3 });
+      const hasCloud = await cloudSection.isVisible({ timeout: 3000 }).catch(() => false);
+      if (!hasCloud) {
+        test.skip();
+      }
+      await expect(main.getByText(/Collaborative workspaces:/)).toBeVisible();
+    });
+
+    test('AI card shows AI contract diffs', async ({ page }) => {
+      const main = mainContent(page);
+      const aiSection = main.getByRole('heading', { name: 'AI Pillar', level: 3 });
+      const hasAi = await aiSection.isVisible({ timeout: 3000 }).catch(() => false);
+      if (!hasAi) {
+        test.skip();
+      }
+      await expect(main.getByText(/AI contract diffs:/)).toBeVisible();
+    });
+  });
+});

--- a/crates/mockforge-ui/ui/src/components/analytics/PillarAnalyticsDashboard.tsx
+++ b/crates/mockforge-ui/ui/src/components/analytics/PillarAnalyticsDashboard.tsx
@@ -11,9 +11,10 @@
 
 import React, { useState } from 'react';
 import { Card } from '../ui/Card';
-import { usePillarMetrics } from '@/hooks/usePillarAnalytics';
+import { usePillarMetrics, usePillarUsageSummary } from '@/hooks/usePillarAnalytics';
 import { PillarOverviewCards } from './PillarOverviewCards';
 import { PillarUsageChart } from './PillarUsageChart';
+import { PillarRankingsCard } from './PillarRankingsCard';
 import { RealityPillarDetails } from './RealityPillarDetails';
 import { ContractsPillarDetails } from './ContractsPillarDetails';
 import { TimeRangeSelector } from './TimeRangeSelector';
@@ -36,6 +37,12 @@ export const PillarAnalyticsDashboard: React.FC<PillarAnalyticsDashboardProps> =
   };
 
   const { data: metrics, isLoading, error } = usePillarMetrics(
+    workspaceId,
+    orgId,
+    query
+  );
+
+  const { data: rankings, isLoading: rankingsLoading } = usePillarUsageSummary(
     workspaceId,
     orgId,
     query
@@ -75,13 +82,17 @@ export const PillarAnalyticsDashboard: React.FC<PillarAnalyticsDashboardProps> =
       {/* Overview Cards */}
       <PillarOverviewCards data={metrics} isLoading={isLoading} />
 
-      {/* Pillar Usage Chart */}
-      <Card className="p-6">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
-          Pillar Usage Distribution
-        </h2>
-        <PillarUsageChart data={metrics} isLoading={isLoading} />
-      </Card>
+      {/* Rankings and Distribution */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <PillarRankingsCard data={rankings} isLoading={rankingsLoading} />
+
+        <Card className="p-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+            Pillar Usage Distribution
+          </h2>
+          <PillarUsageChart data={metrics} isLoading={isLoading} />
+        </Card>
+      </div>
 
       {/* Detailed Pillar Views */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -117,6 +128,9 @@ export const PillarAnalyticsDashboard: React.FC<PillarAnalyticsDashboardProps> =
             <p className="text-sm text-gray-600 dark:text-gray-400">
               Playground sessions: {metrics.devx.playground_sessions}
             </p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              CLI commands: {metrics.devx.cli_commands}
+            </p>
           </Card>
         )}
 
@@ -134,6 +148,9 @@ export const PillarAnalyticsDashboard: React.FC<PillarAnalyticsDashboardProps> =
             <p className="text-sm text-gray-600 dark:text-gray-400">
               Org templates used: {metrics.cloud.org_templates_used}
             </p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Collaborative workspaces: {metrics.cloud.collaborative_workspaces}
+            </p>
           </Card>
         )}
 
@@ -144,6 +161,9 @@ export const PillarAnalyticsDashboard: React.FC<PillarAnalyticsDashboardProps> =
             </h3>
             <p className="text-sm text-gray-600 dark:text-gray-400">
               AI-generated mocks: {metrics.ai.ai_generated_mocks}
+            </p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              AI contract diffs: {metrics.ai.ai_contract_diffs}
             </p>
             <p className="text-sm text-gray-600 dark:text-gray-400">
               Voice commands: {metrics.ai.voice_commands}

--- a/crates/mockforge-ui/ui/src/components/analytics/PillarRankingsCard.tsx
+++ b/crates/mockforge-ui/ui/src/components/analytics/PillarRankingsCard.tsx
@@ -1,0 +1,93 @@
+/**
+ * Pillar usage rankings card — shows pillars ordered by usage with most/least markers
+ */
+
+import React from 'react';
+import { Card } from '../ui/Card';
+import { TrendingUp, TrendingDown } from 'lucide-react';
+import type { PillarUsageSummary } from '@/hooks/usePillarAnalytics';
+
+interface PillarRankingsCardProps {
+  data: PillarUsageSummary | null | undefined;
+  isLoading?: boolean;
+}
+
+export const PillarRankingsCard: React.FC<PillarRankingsCardProps> = ({ data, isLoading }) => {
+  if (isLoading) {
+    return (
+      <Card className="p-6 animate-pulse">
+        <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-48 mb-4" />
+        <div className="space-y-3">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-8 bg-gray-200 dark:bg-gray-700 rounded" />
+          ))}
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data || data.rankings.length === 0) {
+    return (
+      <Card className="p-6">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+          Pillar Usage Rankings
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No pillar usage data recorded yet.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          Pillar Usage Rankings
+        </h2>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          Total: {data.total_usage.toLocaleString()}
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        {data.rankings.map((ranking, idx) => (
+          <div key={ranking.pillar}>
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-mono text-gray-400 dark:text-gray-500 w-6">
+                  #{idx + 1}
+                </span>
+                <span className="text-sm font-medium text-gray-900 dark:text-white">
+                  {ranking.pillar}
+                </span>
+                {ranking.is_most_used && (
+                  <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300">
+                    <TrendingUp className="h-3 w-3" />
+                    Most used
+                  </span>
+                )}
+                {ranking.is_least_used && (
+                  <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
+                    <TrendingDown className="h-3 w-3" />
+                    Least used
+                  </span>
+                )}
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">
+                {ranking.usage.toLocaleString()}{' '}
+                <span className="text-xs">({ranking.percentage.toFixed(1)}%)</span>
+              </div>
+            </div>
+            <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+              <div
+                className="bg-gradient-to-r from-blue-500 to-purple-500 h-2 rounded-full transition-all"
+                style={{ width: `${Math.min(100, ranking.percentage)}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+};

--- a/crates/mockforge-ui/ui/src/hooks/usePillarAnalytics.ts
+++ b/crates/mockforge-ui/ui/src/hooks/usePillarAnalytics.ts
@@ -126,3 +126,58 @@ export const usePillarMetrics = (
     staleTime: 30000, // 30 seconds
   });
 };
+
+export interface PillarRanking {
+  pillar: string;
+  usage: number;
+  percentage: number;
+  is_most_used: boolean;
+  is_least_used: boolean;
+}
+
+export interface PillarUsageSummary {
+  time_range: string;
+  rankings: PillarRanking[];
+  total_usage: number;
+}
+
+/**
+ * Fetch the ranked pillar usage summary (most/least used pillars)
+ */
+export const usePillarUsageSummary = (
+  workspaceId: string | undefined,
+  orgId: string | undefined,
+  query: PillarMetricsQuery
+) => {
+  return useQuery<PillarUsageSummary>({
+    queryKey: ['pillar-usage-summary', workspaceId, orgId, query.time_range],
+    queryFn: async () => {
+      let url: string;
+      if (workspaceId) {
+        url = `${API_BASE_URL}/workspace/${workspaceId}/summary`;
+      } else if (orgId) {
+        url = `${API_BASE_URL}/org/${orgId}/summary`;
+      } else {
+        throw new Error('Either workspaceId or orgId must be provided');
+      }
+
+      const params = new URLSearchParams();
+      const duration = query.time_range
+        ? timeRangeToDuration(query.time_range)
+        : 3600;
+      params.append('duration', duration.toString());
+
+      const response = await axios.get<{ success: boolean; data: PillarUsageSummary }>(
+        `${url}?${params.toString()}`
+      );
+
+      if (response.data.success && response.data.data) {
+        return response.data.data;
+      }
+
+      throw new Error('Failed to fetch pillar usage summary');
+    },
+    enabled: !!(workspaceId || orgId),
+    staleTime: 30000,
+  });
+};

--- a/crates/mockforge-ui/ui/src/pages/PillarAnalyticsPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PillarAnalyticsPage.tsx
@@ -10,10 +10,8 @@ import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
 import { Card } from '@/components/ui/Card';
 
 export const PillarAnalyticsPage: React.FC = () => {
-  const { currentWorkspace } = useWorkspaceStore();
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | undefined>(
-    currentWorkspace?.id
-  );
+  const { activeWorkspace } = useWorkspaceStore();
+  const [selectedWorkspaceId] = useState<string | undefined>(activeWorkspace?.id);
 
   return (
     <div className="space-y-6 p-6">

--- a/docs/CLOUD_ENVIRONMENTS.md
+++ b/docs/CLOUD_ENVIRONMENTS.md
@@ -357,6 +357,10 @@ GET /api/v2/analytics/pillars/workspace/{workspace_id}/contracts
 
 # Get detailed AI pillar metrics
 GET /api/v2/analytics/pillars/workspace/{workspace_id}/ai
+
+# Get ranked pillar usage summary (most/least used pillars)
+GET /api/v2/analytics/pillars/workspace/{workspace_id}/summary
+GET /api/v2/analytics/pillars/org/{org_id}/summary
 ```
 
 ## Governance Guide for Larger Organizations
@@ -510,6 +514,8 @@ CREATE TABLE environment_permission_policies (
 - `GET /api/v2/analytics/pillars/workspace/{workspace_id}/reality` - Reality pillar details
 - `GET /api/v2/analytics/pillars/workspace/{workspace_id}/contracts` - Contracts pillar details
 - `GET /api/v2/analytics/pillars/workspace/{workspace_id}/ai` - AI pillar details
+- `GET /api/v2/analytics/pillars/workspace/{workspace_id}/summary` - Ranked pillar usage (most/least used)
+- `GET /api/v2/analytics/pillars/org/{org_id}/summary` - Org-level ranked pillar usage
 
 ## Best Practices
 

--- a/docs/CLOUD_ENVIRONMENTS_IMPLEMENTATION.md
+++ b/docs/CLOUD_ENVIRONMENTS_IMPLEMENTATION.md
@@ -120,6 +120,8 @@ let policy = EnvironmentPermissionPolicy::new(
 - `GET /api/v2/analytics/pillars/workspace/{workspace_id}/reality` - Reality details
 - `GET /api/v2/analytics/pillars/workspace/{workspace_id}/contracts` - Contracts details
 - `GET /api/v2/analytics/pillars/workspace/{workspace_id}/ai` - AI details
+- `GET /api/v2/analytics/pillars/workspace/{workspace_id}/summary` - Ranked pillar usage summary
+- `GET /api/v2/analytics/pillars/org/{org_id}/summary` - Org-level ranked pillar usage
 
 **UI Components:**
 - PillarAnalyticsDashboard - Main dashboard


### PR DESCRIPTION
## Summary

- Mounts `/api/v2/analytics/pillars/*` admin-UI routes (rankings, reality/contracts/AI details, workspace & org metrics) that the React hook was already hitting — before this PR every request 404'd.
- Fills in the zeros: adds emitters for `validation_mode`, `contract_sync`, `drift_budget_configured`, `ai_generation` (mock + contract_diff), `ai_refinement`, `voice_command`, `cli_command`, `marketplace_download`, `scenario_shared`, `workspace_creation`.
- Fixes 16 pre-existing query bugs in `mockforge-analytics` that referenced a non-existent `metadata` column; all DISTINCT-based pillar metrics silently returned 0 before.
- Adds `PillarRankingsCard` + `usePillarUsageSummary` on the dashboard; surfaces `ai_contract_diffs`, `cli_commands`, and `collaborative_workspaces` (fields the types carried but no card rendered).
- Fixes the page using `currentWorkspace` (doesn't exist in the store — the field is `activeWorkspace`), which is why the live dashboard has been stuck on the \"Select Workspace\" prompt.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p <crate> --all-targets -- -D warnings` clean on mockforge-analytics, mockforge-cli, mockforge-core, mockforge-http, mockforge-scenarios, mockforge-ui
- [x] Rust tests pass: analytics 91, core 22, http 574, scenarios 118, ui 443, cli 496
- [x] `tsc --noEmit` clean; `pnpm lint` 0 errors (pre-existing warnings only)
- [x] Smoke-checked against a local `mockforge serve` with analytics DB: `/api/v2/analytics/pillars/workspace/{id}` returns the expected shape, `workspace_creation` emitter persists to SQLite, rankings card renders on `/pillar-analytics`
- [x] Added `pillar-analytics-rankings-deployed.spec.ts` that runs under the existing deployed-auth setup and covers the rankings card + the three newly-surfaced fields — point it at the Cloudflare Pages preview URL for this PR

## Verification I could not do locally

- E2E spec against `http://localhost` — our admin UI has server-side RBAC on `/pillar-analytics`, so the deployed auth-state pattern doesn't translate directly. The spec is intentionally named `*-deployed.spec.ts` so it can be run against the preview URL (`PLAYWRIGHT_BASE_URL=<preview>` + `E2E_EMAIL` + `E2E_PASSWORD`).
- Real-data rendering of the ranked list — local DB only has one event (the smoke `workspace_creation`), not enough to exercise the multi-pillar ordering beyond empty state.

## Out of scope / follow-ups

- Per-workspace attribution of CLI-invoked events (`cli_command`, `contract_sync`, `marketplace_download`): the CLI does not currently open the shared analytics DB, so those emitters silently no-op outside the `serve` process. In-process emitters (validation, AI, workspace, drift) are unaffected.
- The \"Select Workspace\" prompt and dashboard render simultaneously when no workspace is selected — pre-existing UX wart I didn't touch.