### PR TITLE
feat(hosted-mocks,ui): wire spec upload, region/project selectors, redeploy, stop/start, custom domain

### DIFF
--- a/crates/mockforge-registry-server/src/deployment/flyio.rs
+++ b/crates/mockforge-registry-server/src/deployment/flyio.rs
@@ -247,6 +247,52 @@ impl FlyioClient {
         Ok(machine)
     }
 
+    /// Stop a running machine (graceful shutdown, keeps the machine around
+    /// so it can be restarted later without recreating its config).
+    pub async fn stop_machine(&self, app_name: &str, machine_id: &str) -> Result<()> {
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/apps/{}/machines/{}/stop", self.base_url, app_name, machine_id);
+
+        let response = client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_token))
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .context("Failed to stop Fly.io machine")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+            anyhow::bail!("Failed to stop Fly.io machine: {} - {}", status, error_text);
+        }
+
+        Ok(())
+    }
+
+    /// Start a stopped machine.
+    pub async fn start_machine(&self, app_name: &str, machine_id: &str) -> Result<()> {
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/apps/{}/machines/{}/start", self.base_url, app_name, machine_id);
+
+        let response = client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_token))
+            .header("Content-Type", "application/json")
+            .send()
+            .await
+            .context("Failed to start Fly.io machine")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+            anyhow::bail!("Failed to start Fly.io machine: {} - {}", status, error_text);
+        }
+
+        Ok(())
+    }
+
     /// Delete a machine
     pub async fn delete_machine(&self, app_name: &str, machine_id: &str) -> Result<()> {
         let client = reqwest::Client::new();

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -799,6 +799,160 @@ pub async fn redeploy_deployment(
     })))
 }
 
+fn deployment_app_name(deployment: &HostedMock) -> String {
+    format!(
+        "mockforge-{}-{}",
+        deployment
+            .org_id
+            .to_string()
+            .replace('-', "")
+            .chars()
+            .take(8)
+            .collect::<String>(),
+        deployment.slug
+    )
+}
+
+/// Stop a running hosted mock deployment.
+///
+/// Gracefully stops the Fly.io machine (without deleting it) and marks
+/// the deployment as `stopped`. Only active deployments can be stopped.
+pub async fn stop_deployment(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(deployment_id): Path<Uuid>,
+) -> ApiResult<Json<DeploymentResponse>> {
+    let pool = state.db.pool();
+
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    let checker = PermissionChecker::new(&state);
+    checker
+        .require_permission(user_id, org_ctx.org_id, Permission::HostedMockUpdate)
+        .await?;
+
+    let deployment = state
+        .store
+        .find_hosted_mock_by_id(deployment_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Deployment not found".to_string()))?;
+
+    if deployment.org_id != org_ctx.org_id {
+        return Err(ApiError::InvalidRequest("Deployment not found".to_string()));
+    }
+
+    let status = deployment.status();
+    if !matches!(status, DeploymentStatus::Active) {
+        return Err(ApiError::InvalidRequest(format!(
+            "Cannot stop a deployment with status '{}'. Must be 'active'.",
+            status
+        )));
+    }
+
+    if let Ok(flyio_token) = std::env::var("FLYIO_API_TOKEN") {
+        let flyio_client = FlyioClient::new(flyio_token);
+        let app_name = deployment_app_name(&deployment);
+        let machine_id = deployment.metadata_json.get("flyio_machine_id").and_then(|v| v.as_str());
+
+        if let Some(machine_id) = machine_id {
+            flyio_client.stop_machine(&app_name, machine_id).await.map_err(|e| {
+                ApiError::Internal(anyhow::anyhow!("Failed to stop machine: {}", e))
+            })?;
+        } else {
+            warn!(
+                "No Fly.io machine ID found for deployment {}; marking as stopped anyway",
+                deployment_id
+            );
+        }
+    }
+
+    state
+        .store
+        .update_hosted_mock_status(deployment_id, DeploymentStatus::Stopped, None)
+        .await?;
+
+    DeploymentLog::create(pool, deployment_id, "info", "Deployment stopped", None)
+        .await
+        .ok();
+
+    let updated = state.store.find_hosted_mock_by_id(deployment_id).await?.ok_or_else(|| {
+        ApiError::Internal(anyhow::anyhow!("Failed to retrieve updated deployment"))
+    })?;
+
+    Ok(Json(DeploymentResponse::from(updated)))
+}
+
+/// Start a stopped hosted mock deployment.
+pub async fn start_deployment(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(deployment_id): Path<Uuid>,
+) -> ApiResult<Json<DeploymentResponse>> {
+    let pool = state.db.pool();
+
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    let checker = PermissionChecker::new(&state);
+    checker
+        .require_permission(user_id, org_ctx.org_id, Permission::HostedMockUpdate)
+        .await?;
+
+    let deployment = state
+        .store
+        .find_hosted_mock_by_id(deployment_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Deployment not found".to_string()))?;
+
+    if deployment.org_id != org_ctx.org_id {
+        return Err(ApiError::InvalidRequest("Deployment not found".to_string()));
+    }
+
+    let status = deployment.status();
+    if !matches!(status, DeploymentStatus::Stopped) {
+        return Err(ApiError::InvalidRequest(format!(
+            "Cannot start a deployment with status '{}'. Must be 'stopped'.",
+            status
+        )));
+    }
+
+    if let Ok(flyio_token) = std::env::var("FLYIO_API_TOKEN") {
+        let flyio_client = FlyioClient::new(flyio_token);
+        let app_name = deployment_app_name(&deployment);
+        let machine_id = deployment.metadata_json.get("flyio_machine_id").and_then(|v| v.as_str());
+
+        if let Some(machine_id) = machine_id {
+            flyio_client.start_machine(&app_name, machine_id).await.map_err(|e| {
+                ApiError::Internal(anyhow::anyhow!("Failed to start machine: {}", e))
+            })?;
+        } else {
+            return Err(ApiError::InvalidRequest(
+                "No Fly.io machine ID found in deployment metadata; cannot start".to_string(),
+            ));
+        }
+    }
+
+    state
+        .store
+        .update_hosted_mock_status(deployment_id, DeploymentStatus::Active, None)
+        .await?;
+
+    DeploymentLog::create(pool, deployment_id, "info", "Deployment started", None)
+        .await
+        .ok();
+
+    let updated = state.store.find_hosted_mock_by_id(deployment_id).await?.ok_or_else(|| {
+        ApiError::Internal(anyhow::anyhow!("Failed to retrieve updated deployment"))
+    })?;
+
+    Ok(Json(DeploymentResponse::from(updated)))
+}
+
 /// Get deployment logs
 pub async fn get_deployment_logs(
     State(state): State<AppState>,
@@ -991,6 +1145,8 @@ pub struct DeploymentResponse {
     pub status: String,
     pub deployment_url: Option<String>,
     pub openapi_spec_url: Option<String>,
+    pub region: String,
+    pub instance_type: String,
     pub health_status: String,
     pub error_message: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
@@ -1011,6 +1167,8 @@ impl From<HostedMock> for DeploymentResponse {
             status,
             deployment_url: mock.deployment_url,
             openapi_spec_url: mock.openapi_spec_url,
+            region: mock.region,
+            instance_type: mock.instance_type,
             health_status,
             error_message: mock.error_message,
             created_at: mock.created_at,

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -20,6 +20,7 @@ pub mod organizations;
 pub mod password_reset;
 pub mod pillar_analytics;
 pub mod plugins;
+pub mod projects;
 pub mod public_keys;
 pub mod reviews;
 pub mod scenario_promotions;

--- a/crates/mockforge-registry-server/src/handlers/projects.rs
+++ b/crates/mockforge-registry-server/src/handlers/projects.rs
@@ -1,0 +1,55 @@
+//! Project management handlers
+//!
+//! Exposes a read-only list endpoint so UI surfaces (e.g. the hosted-mocks
+//! create dialog) can populate a project picker scoped to the caller's org.
+
+use axum::{extract::State, http::HeaderMap, Json};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    AppState,
+};
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct ProjectResponse {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub slug: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub visibility: String,
+    pub default_env: String,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// List projects for the caller's organization
+pub async fn list_projects(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+) -> ApiResult<Json<Vec<ProjectResponse>>> {
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    let projects = sqlx::query_as::<_, ProjectResponse>(
+        r#"
+        SELECT id, org_id, slug, name, description, visibility, default_env,
+               created_at, updated_at
+        FROM projects
+        WHERE org_id = $1
+        ORDER BY name
+        "#,
+    )
+    .bind(org_ctx.org_id)
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(projects))
+}

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -145,8 +145,12 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/hosted-mocks/{deployment_id}", delete(handlers::hosted_mocks::delete_deployment))
         .route("/api/v1/hosted-mocks/{deployment_id}/redeploy", post(handlers::hosted_mocks::redeploy_deployment))
         .route("/api/v1/hosted-mocks/{deployment_id}/set-domain", post(handlers::hosted_mocks::set_domain))
+        .route("/api/v1/hosted-mocks/{deployment_id}/stop", post(handlers::hosted_mocks::stop_deployment))
+        .route("/api/v1/hosted-mocks/{deployment_id}/start", post(handlers::hosted_mocks::start_deployment))
         .route("/api/v1/hosted-mocks/{deployment_id}/logs", get(handlers::hosted_mocks::get_deployment_logs))
         .route("/api/v1/hosted-mocks/{deployment_id}/metrics", get(handlers::hosted_mocks::get_deployment_metrics))
+        // Projects list (for UI pickers)
+        .route("/api/v1/projects", get(handlers::projects::list_projects))
         // API token management routes
         .route("/api/v1/tokens", post(handlers::tokens::create_token))
         .route("/api/v1/tokens", get(handlers::tokens::list_tokens))

--- a/crates/mockforge-ui/ui/e2e/hosted-mocks-deployed.spec.ts
+++ b/crates/mockforge-ui/ui/e2e/hosted-mocks-deployed.spec.ts
@@ -385,33 +385,27 @@ test.describe('Hosted Mocks — Deployed Site', () => {
 
     test('Row actions include Redeploy/Stop/Start when applicable (skip if none)', async ({ page }) => {
       const main = mainContent(page);
-      const hasRow = await main
-        .getByRole('row')
-        .nth(1)
-        .isVisible({ timeout: 3000 })
-        .catch(() => false);
+      const firstDataRow = main.getByRole('row').nth(1);
+      const hasRow = await firstDataRow.isVisible({ timeout: 3000 }).catch(() => false);
       test.skip(!hasRow, 'No deployments — lifecycle buttons only render per-row.');
 
-      // View Details button is always present; redeploy/stop/start depend on
-      // status. We just assert that at least the View/Delete pair is still
-      // there (regression guard for the row action toolbar).
-      await expect(main.getByRole('button', { name: /View Details/i }).first()).toBeVisible();
-      await expect(main.getByRole('button', { name: /Delete/i }).first()).toBeVisible();
+      // Status cell is column 2 (0-indexed). Read it so we know which
+      // lifecycle buttons must be present.
+      const firstRowStatus = (await firstDataRow.locator('td').nth(1).textContent()) ?? '';
 
-      // If the first row is active, Redeploy and Stop should be visible.
-      const firstRowStatus = await main
-        .getByRole('row')
-        .nth(1)
-        .locator('td')
-        .nth(1)
-        .textContent();
-      if (firstRowStatus && /active/i.test(firstRowStatus)) {
-        await expect(main.getByRole('button', { name: 'Redeploy' }).first()).toBeVisible();
-        await expect(main.getByRole('button', { name: 'Stop' }).first()).toBeVisible();
+      if (/active/i.test(firstRowStatus)) {
+        // Redeploy + Stop buttons expose their labels via the MUI Tooltip's
+        // `aria-label`. Scope to the first row so we don't pick up matches
+        // from other rows.
+        await expect(firstDataRow.getByLabel('Redeploy')).toBeVisible();
+        await expect(firstDataRow.getByLabel('Stop')).toBeVisible();
+      } else if (/stopped/i.test(firstRowStatus)) {
+        await expect(firstDataRow.getByLabel('Start')).toBeVisible();
+      } else if (/failed/i.test(firstRowStatus)) {
+        await expect(firstDataRow.getByLabel('Redeploy')).toBeVisible();
       }
-      if (firstRowStatus && /stopped/i.test(firstRowStatus)) {
-        await expect(main.getByRole('button', { name: 'Start' }).first()).toBeVisible();
-      }
+      // If pending/deploying/deleting, no lifecycle buttons are expected
+      // yet — the test simply passes without additional assertions.
     });
   });
 

--- a/crates/mockforge-ui/ui/e2e/hosted-mocks-deployed.spec.ts
+++ b/crates/mockforge-ui/ui/e2e/hosted-mocks-deployed.spec.ts
@@ -281,6 +281,141 @@ test.describe('Hosted Mocks — Deployed Site', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // 4b. New UI Controls (spec upload, region, project picker, custom domain,
+  //     redeploy/stop/start row actions)
+  // ---------------------------------------------------------------------------
+  test.describe('New UI Controls', () => {
+    test('Deploy dialog should show Project (optional) selector', async ({ page }) => {
+      await mainContent(page).getByRole('button', { name: 'Deploy Mock' }).click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await expect(
+        dialog.getByRole('combobox', { name: /Project \(optional\)/ }),
+      ).toBeVisible();
+
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+    });
+
+    test('Deploy dialog should show Region selector with a default value', async ({ page }) => {
+      await mainContent(page).getByRole('button', { name: 'Deploy Mock' }).click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      const region = dialog.getByRole('combobox', { name: 'Region' });
+      await expect(region).toBeVisible();
+      // Default is "iad" — the Select renders the full "Label (code)" string
+      await expect(region).toContainText('iad');
+
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+    });
+
+    test('Region selector should offer multiple Fly.io regions', async ({ page }) => {
+      await mainContent(page).getByRole('button', { name: 'Deploy Mock' }).click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('combobox', { name: 'Region' }).click();
+      await page.waitForTimeout(300);
+
+      // Menu renders as a listbox outside the dialog
+      const listbox = page.getByRole('listbox');
+      await expect(listbox.getByRole('option', { name: /iad/ })).toBeVisible();
+      await expect(listbox.getByRole('option', { name: /lhr/ })).toBeVisible();
+      await expect(listbox.getByRole('option', { name: /nrt/ })).toBeVisible();
+
+      // Close the menu without changing the selection
+      await page.keyboard.press('Escape');
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+    });
+
+    test('Deploy dialog should show a Spec Upload button', async ({ page }) => {
+      await mainContent(page).getByRole('button', { name: 'Deploy Mock' }).click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await expect(dialog.getByRole('button', { name: 'Upload' })).toBeVisible();
+      await expect(
+        dialog.getByText('Paste a URL or upload a JSON/YAML spec'),
+      ).toBeVisible();
+
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+    });
+
+    test('Deploy dialog should still show existing fields alongside new ones', async ({ page }) => {
+      await mainContent(page).getByRole('button', { name: 'Deploy Mock' }).click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await expect(dialog.getByRole('textbox', { name: 'Name' })).toBeVisible();
+      await expect(dialog.getByRole('textbox', { name: 'Slug' })).toBeVisible();
+      await expect(dialog.getByRole('textbox', { name: 'Description' })).toBeVisible();
+      await expect(
+        dialog.getByRole('textbox', { name: 'OpenAPI Spec URL (optional)' }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByRole('textbox', { name: 'Configuration (JSON)' }),
+      ).toBeVisible();
+
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+    });
+
+    test('Custom domain form renders when a deployment exists (skip if none)', async ({ page }) => {
+      const main = mainContent(page);
+      // Find a View Details button — one per row. Skip if the org has none.
+      const viewButtons = main.getByRole('button', { name: /View Details/i });
+      const hasRow = await viewButtons.first().isVisible({ timeout: 3000 }).catch(() => false);
+      test.skip(!hasRow, 'No deployments in this org — custom domain UI only renders in details.');
+
+      await viewButtons.first().click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await expect(dialog.getByRole('heading', { name: 'Custom Domain' })).toBeVisible();
+      await expect(dialog.getByRole('button', { name: /Set Domain/ })).toBeVisible();
+      await expect(
+        dialog.getByText(/The registry wildcard TLS cert terminates traffic/),
+      ).toBeVisible();
+
+      // Set Domain should be disabled for an empty input
+      await expect(dialog.getByRole('button', { name: /Set Domain/ })).toBeDisabled();
+
+      await dialog.getByRole('button', { name: 'Close' }).click();
+    });
+
+    test('Row actions include Redeploy/Stop/Start when applicable (skip if none)', async ({ page }) => {
+      const main = mainContent(page);
+      const hasRow = await main
+        .getByRole('row')
+        .nth(1)
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+      test.skip(!hasRow, 'No deployments — lifecycle buttons only render per-row.');
+
+      // View Details button is always present; redeploy/stop/start depend on
+      // status. We just assert that at least the View/Delete pair is still
+      // there (regression guard for the row action toolbar).
+      await expect(main.getByRole('button', { name: /View Details/i }).first()).toBeVisible();
+      await expect(main.getByRole('button', { name: /Delete/i }).first()).toBeVisible();
+
+      // If the first row is active, Redeploy and Stop should be visible.
+      const firstRowStatus = await main
+        .getByRole('row')
+        .nth(1)
+        .locator('td')
+        .nth(1)
+        .textContent();
+      if (firstRowStatus && /active/i.test(firstRowStatus)) {
+        await expect(main.getByRole('button', { name: 'Redeploy' }).first()).toBeVisible();
+        await expect(main.getByRole('button', { name: 'Stop' }).first()).toBeVisible();
+      }
+      if (firstRowStatus && /stopped/i.test(firstRowStatus)) {
+        await expect(main.getByRole('button', { name: 'Start' }).first()).toBeVisible();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // 5. Deploy Lifecycle CRUD Flow
   // ---------------------------------------------------------------------------
   test.describe('Deploy Lifecycle Flow', () => {

--- a/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
@@ -39,6 +39,10 @@ import {
   Divider,
   Tooltip,
   CircularProgress,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -53,7 +57,26 @@ import {
   Visibility as ViewIcon,
   Code as CodeIcon,
   Assessment as AssessmentIcon,
+  Replay as ReplayIcon,
+  Language as LanguageIcon,
+  UploadFile as UploadFileIcon,
+  PlayArrow as PlayArrowIcon,
 } from '@mui/icons-material';
+
+const FLY_REGIONS: { code: string; label: string }[] = [
+  { code: 'iad', label: 'Ashburn, Virginia (US East)' },
+  { code: 'ord', label: 'Chicago, Illinois (US Central)' },
+  { code: 'sjc', label: 'San Jose, California (US West)' },
+  { code: 'sea', label: 'Seattle, Washington (US West)' },
+  { code: 'lhr', label: 'London, United Kingdom' },
+  { code: 'fra', label: 'Frankfurt, Germany' },
+  { code: 'ams', label: 'Amsterdam, Netherlands' },
+  { code: 'cdg', label: 'Paris, France' },
+  { code: 'nrt', label: 'Tokyo, Japan' },
+  { code: 'sin', label: 'Singapore' },
+  { code: 'syd', label: 'Sydney, Australia' },
+  { code: 'gru', label: 'São Paulo, Brazil' },
+];
 
 interface Deployment {
   id: string;
@@ -65,6 +88,8 @@ interface Deployment {
   status: 'pending' | 'deploying' | 'active' | 'stopped' | 'failed' | 'deleting';
   deployment_url?: string;
   openapi_spec_url?: string;
+  region?: string;
+  instance_type?: string;
   health_status: 'healthy' | 'unhealthy' | 'unknown';
   error_message?: string;
   created_at: string;
@@ -87,6 +112,12 @@ interface DeploymentMetrics {
   egress_bytes: number;
   avg_response_time_ms: number;
   period_start: string;
+}
+
+interface ProjectOption {
+  id: string;
+  name: string;
+  slug: string;
 }
 
 export const HostedMocksPage: React.FC = () => {
@@ -123,8 +154,17 @@ export const HostedMocksPage: React.FC = () => {
     description: '',
     config_json: '{}',
     openapi_spec_url: '',
+    region: 'iad',
+    project_id: '',
   });
   const [creating, setCreating] = useState(false);
+  const [uploadingSpec, setUploadingSpec] = useState(false);
+  const [redeployingId, setRedeployingId] = useState<string | null>(null);
+  const [lifecycleId, setLifecycleId] = useState<string | null>(null);
+  const [customDomain, setCustomDomain] = useState('');
+  const [settingDomain, setSettingDomain] = useState(false);
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+  const [projectsLoadError, setProjectsLoadError] = useState<string | null>(null);
 
   // Real-time stream for the selected hosted mock deployment
   const streamEnabled = detailsOpen && selectedDeployment?.status === 'active';
@@ -137,7 +177,41 @@ export const HostedMocksPage: React.FC = () => {
 
   useEffect(() => {
     loadDeployments();
+    loadProjects();
   }, []);
+
+  const loadProjects = async () => {
+    setProjectsLoadError(null);
+    try {
+      const token = localStorage.getItem('auth_token');
+      if (!token) return;
+
+      const response = await fetch('/api/v1/projects', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        // Non-fatal: project_id is optional
+        setProjectsLoadError(`Failed to load projects (HTTP ${response.status})`);
+        return;
+      }
+
+      const data = await response.json();
+      setProjects(
+        Array.isArray(data)
+          ? data.map((p: { id: string; name: string; slug: string }) => ({
+              id: p.id,
+              name: p.name,
+              slug: p.slug,
+            }))
+          : [],
+      );
+    } catch {
+      setProjectsLoadError('Failed to load projects');
+    }
+  };
 
   // Auto-refresh deployments while any are pending/deploying.
   useEffect(() => {
@@ -208,6 +282,8 @@ export const HostedMocksPage: React.FC = () => {
         description: formData.description || undefined,
         config_json: configJson,
         openapi_spec_url: formData.openapi_spec_url || undefined,
+        region: formData.region || undefined,
+        project_id: formData.project_id || undefined,
       };
 
       const response = await fetch('/api/v1/hosted-mocks', {
@@ -242,6 +318,8 @@ export const HostedMocksPage: React.FC = () => {
         description: '',
         config_json: '{}',
         openapi_spec_url: '',
+        region: 'iad',
+        project_id: '',
       });
       loadDeployments();
     } catch (err) {
@@ -279,12 +357,191 @@ export const HostedMocksPage: React.FC = () => {
     }
   };
 
+  const handleUploadSpec = async (file: File) => {
+    setUploadingSpec(true);
+    setError(null);
+    try {
+      const token = localStorage.getItem('auth_token');
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const body = new FormData();
+      body.append('file', file);
+
+      const response = await fetch('/api/v1/hosted-mocks/specs/upload', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Upload failed' }));
+        const raw = errorData?.error ?? errorData?.message;
+        const message =
+          typeof raw === 'string'
+            ? raw
+            : raw
+              ? JSON.stringify(raw)
+              : `Spec upload failed (HTTP ${response.status})`;
+        throw new Error(message);
+      }
+
+      const data = await response.json();
+      if (typeof data?.url === 'string') {
+        setFormData((prev) => ({ ...prev, openapi_spec_url: data.url }));
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to upload spec');
+    } finally {
+      setUploadingSpec(false);
+    }
+  };
+
+  const handleLifecycleAction = async (
+    id: string,
+    action: 'stop' | 'start',
+  ) => {
+    const label = action === 'stop' ? 'Stop' : 'Start';
+    const confirmMsg =
+      action === 'stop'
+        ? 'Stop this mock service? Requests will be refused until it is started again.'
+        : 'Start this mock service?';
+    if (!confirm(confirmMsg)) return;
+
+    setLifecycleId(id);
+    setError(null);
+    try {
+      const token = localStorage.getItem('auth_token');
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await fetch(`/api/v1/hosted-mocks/${id}/${action}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: `${label} failed` }));
+        const raw = errorData?.error ?? errorData?.message;
+        const message =
+          typeof raw === 'string'
+            ? raw
+            : raw
+              ? JSON.stringify(raw)
+              : `${label} failed (HTTP ${response.status})`;
+        throw new Error(message);
+      }
+
+      loadDeployments();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to ${action} deployment`);
+    } finally {
+      setLifecycleId(null);
+    }
+  };
+
+  const handleRedeployDeployment = async (id: string) => {
+    if (!confirm('Redeploy this mock service? Active traffic may be briefly interrupted.')) {
+      return;
+    }
+    setRedeployingId(id);
+    setError(null);
+    try {
+      const token = localStorage.getItem('auth_token');
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await fetch(`/api/v1/hosted-mocks/${id}/redeploy`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Redeploy failed' }));
+        const raw = errorData?.error ?? errorData?.message;
+        const message =
+          typeof raw === 'string'
+            ? raw
+            : raw
+              ? JSON.stringify(raw)
+              : `Redeploy failed (HTTP ${response.status})`;
+        throw new Error(message);
+      }
+
+      loadDeployments();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to redeploy');
+    } finally {
+      setRedeployingId(null);
+    }
+  };
+
+  const handleSetDomain = async () => {
+    if (!selectedDeployment || !customDomain.trim()) return;
+    setSettingDomain(true);
+    setError(null);
+    try {
+      const token = localStorage.getItem('auth_token');
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await fetch(
+        `/api/v1/hosted-mocks/${selectedDeployment.id}/set-domain`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ domain: customDomain.trim() }),
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Set domain failed' }));
+        const raw = errorData?.error ?? errorData?.message;
+        const message =
+          typeof raw === 'string'
+            ? raw
+            : raw
+              ? JSON.stringify(raw)
+              : `Set domain failed (HTTP ${response.status})`;
+        throw new Error(message);
+      }
+
+      const data = await response.json();
+      if (typeof data?.deployment_url === 'string') {
+        setSelectedDeployment({ ...selectedDeployment, deployment_url: data.deployment_url });
+      }
+      setCustomDomain('');
+      loadDeployments();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to set custom domain');
+    } finally {
+      setSettingDomain(false);
+    }
+  };
+
   const handleViewDetails = async (deployment: Deployment) => {
     setSelectedDeployment(deployment);
     setDetailsOpen(true);
     setDetailsTab(0);
     setLogs([]);
     setMetrics(null);
+    setCustomDomain('');
 
     // Load logs and metrics
     await Promise.all([
@@ -503,6 +760,58 @@ export const HostedMocksPage: React.FC = () => {
                           <ViewIcon />
                         </IconButton>
                       </Tooltip>
+                      {(deployment.status === 'active' || deployment.status === 'failed') && (
+                        <Tooltip title="Redeploy">
+                          <span>
+                            <IconButton
+                              size="small"
+                              onClick={() => handleRedeployDeployment(deployment.id)}
+                              disabled={redeployingId === deployment.id}
+                            >
+                              {redeployingId === deployment.id ? (
+                                <CircularProgress size={18} />
+                              ) : (
+                                <ReplayIcon />
+                              )}
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
+                      {deployment.status === 'active' && (
+                        <Tooltip title="Stop">
+                          <span>
+                            <IconButton
+                              size="small"
+                              onClick={() => handleLifecycleAction(deployment.id, 'stop')}
+                              disabled={lifecycleId === deployment.id}
+                            >
+                              {lifecycleId === deployment.id ? (
+                                <CircularProgress size={18} />
+                              ) : (
+                                <StopIcon />
+                              )}
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
+                      {deployment.status === 'stopped' && (
+                        <Tooltip title="Start">
+                          <span>
+                            <IconButton
+                              size="small"
+                              color="success"
+                              onClick={() => handleLifecycleAction(deployment.id, 'start')}
+                              disabled={lifecycleId === deployment.id}
+                            >
+                              {lifecycleId === deployment.id ? (
+                                <CircularProgress size={18} />
+                              ) : (
+                                <PlayArrowIcon />
+                              )}
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
                       <Tooltip title="Delete">
                         <IconButton
                           size="small"
@@ -571,13 +880,82 @@ export const HostedMocksPage: React.FC = () => {
               placeholder="Description of the mock service"
             />
 
-            <TextField
-              label="OpenAPI Spec URL (optional)"
-              fullWidth
-              value={formData.openapi_spec_url}
-              onChange={(e) => setFormData({ ...formData, openapi_spec_url: e.target.value })}
-              placeholder="https://example.com/openapi.json"
-            />
+            <FormControl fullWidth>
+              <InputLabel id="hosted-mock-project-label">Project (optional)</InputLabel>
+              <Select
+                labelId="hosted-mock-project-label"
+                label="Project (optional)"
+                value={formData.project_id}
+                onChange={(e) =>
+                  setFormData({ ...formData, project_id: e.target.value as string })
+                }
+                displayEmpty
+              >
+                <MenuItem value="">
+                  <em>No project</em>
+                </MenuItem>
+                {projects.map((p) => (
+                  <MenuItem key={p.id} value={p.id}>
+                    {p.name}
+                    {p.slug ? ` (${p.slug})` : ''}
+                  </MenuItem>
+                ))}
+              </Select>
+              {projectsLoadError && (
+                <Typography variant="caption" color="warning.main" sx={{ mt: 0.5 }}>
+                  {projectsLoadError}
+                </Typography>
+              )}
+            </FormControl>
+
+            <FormControl fullWidth>
+              <InputLabel id="hosted-mock-region-label">Region</InputLabel>
+              <Select
+                labelId="hosted-mock-region-label"
+                label="Region"
+                value={formData.region}
+                onChange={(e) => setFormData({ ...formData, region: e.target.value as string })}
+              >
+                {FLY_REGIONS.map((r) => (
+                  <MenuItem key={r.code} value={r.code}>
+                    {r.label} ({r.code})
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+              <TextField
+                label="OpenAPI Spec URL (optional)"
+                fullWidth
+                value={formData.openapi_spec_url}
+                onChange={(e) => setFormData({ ...formData, openapi_spec_url: e.target.value })}
+                placeholder="https://example.com/openapi.json"
+                helperText="Paste a URL or upload a JSON/YAML spec"
+              />
+              <Button
+                variant="outlined"
+                component="label"
+                startIcon={uploadingSpec ? <CircularProgress size={16} /> : <UploadFileIcon />}
+                disabled={uploadingSpec}
+                sx={{ whiteSpace: 'nowrap', mt: 1 }}
+              >
+                {uploadingSpec ? 'Uploading…' : 'Upload'}
+                <input
+                  type="file"
+                  accept=".json,.yaml,.yml,application/json,application/yaml,text/yaml"
+                  hidden
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) {
+                      handleUploadSpec(file);
+                    }
+                    // Reset so selecting the same file again still fires onChange
+                    e.target.value = '';
+                  }}
+                />
+              </Button>
+            </Box>
 
             <TextField
               label="Configuration (JSON)"
@@ -682,6 +1060,34 @@ export const HostedMocksPage: React.FC = () => {
                     </Grid>
                     <Grid item xs={6}>
                       <Typography variant="caption" color="text.secondary">
+                        OpenAPI Spec
+                      </Typography>
+                      <Typography variant="body2">
+                        {selectedDeployment.openapi_spec_url ? (
+                          <Button
+                            size="small"
+                            startIcon={<OpenInNewIcon />}
+                            href={selectedDeployment.openapi_spec_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            View spec
+                          </Button>
+                        ) : (
+                          'Not provided'
+                        )}
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={6}>
+                      <Typography variant="caption" color="text.secondary">
+                        Region
+                      </Typography>
+                      <Typography variant="body2">
+                        {selectedDeployment.region || 'Unknown'}
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={6}>
+                      <Typography variant="caption" color="text.secondary">
                         Created
                       </Typography>
                       <Typography variant="body2">
@@ -705,6 +1111,37 @@ export const HostedMocksPage: React.FC = () => {
                       </Typography>
                     </Grid>
                   </Grid>
+
+                  <Divider sx={{ my: 3 }} />
+
+                  <Box>
+                    <Typography variant="subtitle2" gutterBottom>
+                      Custom Domain
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                      Map this deployment to <strong>{selectedDeployment.slug}.&lt;your-domain&gt;</strong>.
+                      The registry wildcard TLS cert terminates traffic and proxies to the deployment.
+                    </Typography>
+                    <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                      <TextField
+                        size="small"
+                        fullWidth
+                        placeholder="mocks.example.com"
+                        value={customDomain}
+                        onChange={(e) => setCustomDomain(e.target.value)}
+                        disabled={settingDomain}
+                      />
+                      <Button
+                        variant="contained"
+                        startIcon={settingDomain ? <CircularProgress size={16} /> : <LanguageIcon />}
+                        onClick={handleSetDomain}
+                        disabled={settingDomain || !customDomain.trim()}
+                        sx={{ whiteSpace: 'nowrap' }}
+                      >
+                        {settingDomain ? 'Applying…' : 'Set Domain'}
+                      </Button>
+                    </Box>
+                  </Box>
                 </Box>
               )}
 


### PR DESCRIPTION
## Summary
Closes the gap audit on `/hosted-mocks`: every backend endpoint on `/api/v1/hosted-mocks/*` now has a UI counterpart, and every create-time field the backend accepts is exposed in the Deploy dialog. Also adds a new `GET /api/v1/projects` endpoint (there wasn't one before) and wires it into the create-dialog project picker.

## Backend (`mockforge-registry-server`)
- Expose `region` and `instance_type` on `DeploymentResponse` so the UI can round-trip them.
- Add `GET /api/v1/projects` — org-scoped list so UI pickers can populate.
- Add `POST /{id}/stop` and `POST /{id}/start` — status-gated (`active → stopped`, `stopped → active`), requires `HostedMockUpdate`.
- Add `FlyioClient::stop_machine` / `start_machine` hitting Fly.io machines API so lifecycle actions take effect on live deployments.

## UI (`HostedMocksPage`)
- **Spec file upload** next to the URL field → `POST /api/v1/hosted-mocks/specs/upload`, auto-populates the URL.
- **Region** Select (12 Fly.io regions, default `iad`).
- **Project picker** populated from `/api/v1/projects`; non-fatal on error.
- **Redeploy** row action for `active`/`failed` deployments → `POST /{id}/redeploy`.
- **Stop / Start** row actions that appear based on current status.
- **Custom Domain** section in the details dialog → `POST /{id}/set-domain`.
- Overview tab now surfaces `openapi_spec_url` and `region`.

## E2E (`hosted-mocks-deployed.spec.ts`)
Added a `New UI Controls` describe block covering:
- Project (optional) selector visible in the Deploy dialog.
- Region selector shows default `iad` and exposes multiple Fly.io regions (`iad`, `lhr`, `nrt`).
- Upload button and helper text render.
- Custom-domain form renders in details dialog (skips when org has no deployments).
- Redeploy/Stop/Start row actions render when applicable (skips when empty).

## Test plan
- [x] `cargo check -p mockforge-registry-server`
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo fmt --check -p mockforge-registry-server`
- [x] `cargo test -p mockforge-registry-server --lib` (228 passed)
- [x] `pnpm type-check` (mockforge-ui/ui)
- [x] `pnpm lint src/pages/HostedMocksPage.tsx` (no new warnings)
- [ ] `pnpm test:e2e e2e/hosted-mocks-deployed.spec.ts` — requires `E2E_EMAIL`/`E2E_PASSWORD` against deployed `app.mockforge.dev`; runs post-deploy