### PR TITLE
feat(fixtures): wire cloud editor, content, tags end-to-end

### DIFF
--- a/crates/mockforge-registry-core/src/models/cloud_fixture.rs
+++ b/crates/mockforge-registry-core/src/models/cloud_fixture.rs
@@ -35,11 +35,14 @@ impl CloudFixture {
         path: &str,
         method: &str,
         content: Option<&serde_json::Value>,
+        protocol: Option<&str>,
+        tags: Option<&serde_json::Value>,
     ) -> sqlx::Result<Self> {
+        let tags_value = tags.cloned().unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
         sqlx::query_as::<_, Self>(
             r#"
-            INSERT INTO fixtures (org_id, name, description, path, method, content, created_by)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            INSERT INTO fixtures (org_id, name, description, path, method, content, protocol, tags, created_by)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             RETURNING *
             "#,
         )
@@ -49,6 +52,8 @@ impl CloudFixture {
         .bind(path)
         .bind(method)
         .bind(content)
+        .bind(protocol)
+        .bind(tags_value)
         .bind(created_by)
         .fetch_one(pool)
         .await

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1172,6 +1172,8 @@ pub trait RegistryStore: Send + Sync + 'static {
         path: &str,
         method: &str,
         content: Option<&serde_json::Value>,
+        protocol: Option<&str>,
+        tags: Option<&serde_json::Value>,
     ) -> StoreResult<CloudFixture>;
 
     async fn find_cloud_fixture_by_id(&self, id: Uuid) -> StoreResult<Option<CloudFixture>>;

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -708,6 +708,8 @@ impl RegistryStore for PgRegistryStore {
         path: &str,
         method: &str,
         content: Option<&serde_json::Value>,
+        protocol: Option<&str>,
+        tags: Option<&serde_json::Value>,
     ) -> StoreResult<CloudFixture> {
         CloudFixture::create(
             &self.pool,
@@ -718,6 +720,8 @@ impl RegistryStore for PgRegistryStore {
             path,
             method,
             content,
+            protocol,
+            tags,
         )
         .await
         .map_err(Into::into)

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -1436,6 +1436,8 @@ impl RegistryStore for SqliteRegistryStore {
         path: &str,
         method: &str,
         content: Option<&serde_json::Value>,
+        protocol: Option<&str>,
+        tags: Option<&serde_json::Value>,
     ) -> StoreResult<CloudFixture> {
         Err(StoreError::NotFound)
     }

--- a/crates/mockforge-registry-server/src/handlers/cloud_fixtures.rs
+++ b/crates/mockforge-registry-server/src/handlers/cloud_fixtures.rs
@@ -64,6 +64,8 @@ pub struct CreateFixtureRequest {
     #[serde(default = "default_method")]
     pub method: String,
     pub content: Option<serde_json::Value>,
+    pub protocol: Option<String>,
+    pub tags: Option<serde_json::Value>,
 }
 
 fn default_method() -> String {
@@ -94,6 +96,8 @@ pub async fn create_fixture(
             &request.path,
             &request.method,
             request.content.as_ref(),
+            request.protocol.as_deref(),
+            request.tags.as_ref(),
         )
         .await?;
 

--- a/crates/mockforge-ui/ui/e2e/fixtures-deployed.spec.ts
+++ b/crates/mockforge-ui/ui/e2e/fixtures-deployed.spec.ts
@@ -133,18 +133,19 @@ test.describe('Fixtures — Deployed Site', () => {
 
     test('should display the search input', async ({ page }) => {
       await expect(
-        mainContent(page).getByPlaceholder('Search by name, path, or route...')
+        mainContent(page).getByPlaceholder(/Search by name, path, tag/)
       ).toBeVisible();
     });
 
     test('should display the HTTP Method filter dropdown', async ({ page }) => {
       const main = mainContent(page);
       await expect(main.getByText('HTTP Method')).toBeVisible();
-      await expect(main.getByRole('combobox')).toBeVisible();
+      // The filters row has several <select>s (method, tag). Just grab the first.
+      await expect(main.getByRole('combobox').first()).toBeVisible();
     });
 
     test('should have all HTTP methods in the dropdown', async ({ page }) => {
-      const dropdown = mainContent(page).getByRole('combobox');
+      const dropdown = mainContent(page).getByRole('combobox').first();
       await expect(dropdown).toBeVisible();
 
       // Check the options exist
@@ -160,13 +161,14 @@ test.describe('Fixtures — Deployed Site', () => {
     });
 
     test('should display the summary section', async ({ page }) => {
+      // Summary block on cloud only shows the fixture count (no "Total Size"
+      // because file_size isn't part of the cloud response).
       const main = mainContent(page);
       await expect(main.getByText('Summary')).toBeVisible();
-      await expect(main.getByText('Total Size')).toBeVisible();
     });
 
     test('should allow typing in the search input', async ({ page }) => {
-      const searchInput = mainContent(page).getByPlaceholder('Search by name, path, or route...');
+      const searchInput = mainContent(page).getByPlaceholder(/Search by name, path, tag/);
       await searchInput.fill('/api/users');
       await page.waitForTimeout(300);
       await expect(searchInput).toHaveValue('/api/users');
@@ -177,7 +179,7 @@ test.describe('Fixtures — Deployed Site', () => {
     });
 
     test('should allow changing the HTTP method filter', async ({ page }) => {
-      const dropdown = mainContent(page).getByRole('combobox');
+      const dropdown = mainContent(page).getByRole('combobox').first();
 
       await dropdown.selectOption('GET');
       await page.waitForTimeout(300);
@@ -487,9 +489,9 @@ test.describe('Fixtures — Deployed Site', () => {
         // Rate limited — page is in error state, skip form control checks
         return;
       }
-      await expect(main.getByPlaceholder('Search by name, path, or route...')).toBeVisible();
+      await expect(main.getByPlaceholder(/Search by name, path, tag/)).toBeVisible();
       await expect(main.getByText('HTTP Method', { exact: true })).toBeVisible();
-      await expect(main.getByRole('combobox')).toBeVisible();
+      await expect(main.getByRole('combobox').first()).toBeVisible();
     });
   });
 
@@ -535,6 +537,144 @@ test.describe('Fixtures — Deployed Site', () => {
         .catch(() => false);
 
       expect(hasErrorBoundary).toBeFalsy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 8. Cloud-specific additions: tag filter, edit dialog, richer create/view
+  //    These cover the wiring added in commit 2a1c2bb7. Write-flows stay skipped
+  //    because the deployed backend is rate-limited; we only assert that the UI
+  //    is wired up and the dialogs render the fields the backend accepts.
+  // ---------------------------------------------------------------------------
+  test.describe('Cloud UI — Tag Filter, Edit Dialog, Richer Forms', () => {
+    test('should display the Tag filter dropdown', async ({ page }) => {
+      const main = mainContent(page);
+      await expect(main.getByText('Tag', { exact: true })).toBeVisible();
+      const tagSelect = main.locator('select').nth(1);
+      await expect(tagSelect).toBeVisible();
+      // "All Tags" is always present even when no tags exist
+      const options = await tagSelect.locator('option').allTextContents();
+      expect(options).toContain('All Tags');
+    });
+
+    test('Create dialog exposes Protocol, Tags, and Response Content', async ({ page }) => {
+      const main = mainContent(page);
+      const hasButton = await main
+        .getByRole('button', { name: 'New Fixture' })
+        .isVisible({ timeout: 5000 })
+        .catch(() => false);
+      test.skip(!hasButton, 'New Fixture button unavailable (likely rate limited)');
+
+      await main.getByRole('button', { name: 'New Fixture' }).click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await expect(dialog.getByText('Create New Fixture')).toBeVisible();
+
+      // New fields wired up for cloud
+      await expect(dialog.getByText('Protocol', { exact: true })).toBeVisible();
+      await expect(dialog.getByText('Tags', { exact: true })).toBeVisible();
+      await expect(
+        dialog.getByPlaceholder(/comma-separated/)
+      ).toBeVisible();
+      await expect(dialog.getByText('Response Content (JSON)')).toBeVisible();
+
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+      await page.waitForTimeout(300);
+    });
+
+    test('Create dialog validates JSON content before submit', async ({ page }) => {
+      const main = mainContent(page);
+      const hasButton = await main
+        .getByRole('button', { name: 'New Fixture' })
+        .isVisible({ timeout: 5000 })
+        .catch(() => false);
+      test.skip(!hasButton, 'New Fixture button unavailable (likely rate limited)');
+
+      await main.getByRole('button', { name: 'New Fixture' }).click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await dialog.getByPlaceholder('e.g., Get Users Response').fill('Invalid JSON Fixture');
+      // The content editor is the textarea in the dialog
+      await dialog.locator('textarea').fill('{not valid json');
+
+      // Button must still be enabled (name is present), clicking should surface
+      // the validation error inline rather than POSTing.
+      await dialog.getByRole('button', { name: 'Create Fixture' }).click();
+      await page.waitForTimeout(300);
+
+      await expect(dialog.getByText(/Invalid JSON/)).toBeVisible();
+
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+      await page.waitForTimeout(300);
+    });
+
+    test('Edit button is present on fixture rows (cloud)', async ({ page }) => {
+      const main = mainContent(page);
+      const hasEmpty = await main
+        .getByRole('heading', { name: 'No fixtures found' })
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+      test.skip(hasEmpty, 'No fixtures to assert Edit button against');
+
+      // The list row has an "Edit" button (cloud-only). It sits alongside
+      // Rename / Move so we expect at least one Edit button in main.
+      const editButtons = main.getByRole('button', { name: 'Edit', exact: true });
+      await expect(editButtons.first()).toBeVisible({ timeout: 5000 });
+    });
+
+    test('Edit dialog opens with name/method/path/description/tags/content', async ({ page }) => {
+      const main = mainContent(page);
+      const hasEmpty = await main
+        .getByRole('heading', { name: 'No fixtures found' })
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+      test.skip(hasEmpty, 'No fixtures available to open the Edit dialog');
+
+      await main.getByRole('button', { name: 'Edit', exact: true }).first().click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await expect(dialog.getByText('Edit Fixture')).toBeVisible();
+      await expect(dialog.getByText('Name', { exact: true })).toBeVisible();
+      await expect(dialog.getByText('HTTP Method')).toBeVisible();
+      await expect(dialog.getByText('Path', { exact: true })).toBeVisible();
+      await expect(dialog.getByText('Description', { exact: true })).toBeVisible();
+      await expect(dialog.getByText(/Tags \(comma-separated\)/)).toBeVisible();
+      await expect(dialog.getByText('Response Content (JSON)')).toBeVisible();
+      // The Save button has the name "Save Changes" and must be enabled when
+      // name is non-empty (pre-filled from the fixture).
+      await expect(dialog.getByRole('button', { name: /Save Changes/ })).toBeEnabled();
+
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+      await page.waitForTimeout(300);
+    });
+
+    test('Viewer dialog surfaces Response Content heading', async ({ page }) => {
+      const main = mainContent(page);
+      const hasEmpty = await main
+        .getByRole('heading', { name: 'No fixtures found' })
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+      test.skip(hasEmpty, 'No fixtures to view');
+
+      // The eye icon is an outline <button> with only an svg child; it sits
+      // next to Download and Delete. Find it by clicking the first button
+      // containing an svg with class "lucide-eye".
+      const eyeButton = main.locator('button:has(svg.lucide-eye)').first();
+      await expect(eyeButton).toBeVisible({ timeout: 5000 });
+      await eyeButton.click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.getByRole('dialog');
+      await expect(dialog.getByText('Response Content')).toBeVisible();
+      // Method/Protocol/Updated metadata row
+      await expect(dialog.getByText(/^Method:/)).toBeVisible();
+      await expect(dialog.getByText(/^Protocol:/)).toBeVisible();
+
+      await dialog.getByRole('button', { name: 'Close' }).click();
+      await page.waitForTimeout(300);
     });
   });
 });

--- a/crates/mockforge-ui/ui/src/hooks/api/index.ts
+++ b/crates/mockforge-ui/ui/src/hooks/api/index.ts
@@ -55,6 +55,8 @@ export {
   useDownloadFixture,
   useRenameFixture,
   useMoveFixture,
+  useCreateFixture,
+  useUpdateFixture,
   useSmokeTests,
   useRunSmokeTests,
   useImportPostman,

--- a/crates/mockforge-ui/ui/src/hooks/api/useFixturesApi.ts
+++ b/crates/mockforge-ui/ui/src/hooks/api/useFixturesApi.ts
@@ -79,10 +79,11 @@ export function useRenameFixture() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ oldPath, newPath }: { oldPath: string; newPath: string }) =>
-      fixturesApi.renameFixture(oldPath, newPath),
+    mutationFn: ({ fixtureId, newName }: { fixtureId: string; newName: string }) =>
+      fixturesApi.renameFixture(fixtureId, newName),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.fixtures });
+      queryClient.invalidateQueries({ queryKey: ['fixtures-v2'] });
     },
   });
 }
@@ -91,10 +92,42 @@ export function useMoveFixture() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ sourcePath, destinationPath }: { sourcePath: string; destinationPath: string }) =>
-      fixturesApi.moveFixture(sourcePath, destinationPath),
+    mutationFn: ({ fixtureId, newPath }: { fixtureId: string; newPath: string }) =>
+      fixturesApi.moveFixture(fixtureId, newPath),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.fixtures });
+      queryClient.invalidateQueries({ queryKey: ['fixtures-v2'] });
+    },
+  });
+}
+
+export function useCreateFixture() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: fixturesApi.createFixture,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.fixtures });
+      queryClient.invalidateQueries({ queryKey: ['fixtures-v2'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+    },
+  });
+}
+
+export function useUpdateFixture() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      fixtureId,
+      payload,
+    }: {
+      fixtureId: string;
+      payload: Parameters<typeof fixturesApi.updateFixture>[1];
+    }) => fixturesApi.updateFixture(fixtureId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.fixtures });
+      queryClient.invalidateQueries({ queryKey: ['fixtures-v2'] });
     },
   });
 }

--- a/crates/mockforge-ui/ui/src/pages/FixturesPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FixturesPage.tsx
@@ -1,18 +1,37 @@
 import { logger } from '@/utils/logger';
-import React, { useState } from 'react';
-import { FileText, Download, Trash2, Search, Eye, Plus, Edit3, Move } from 'lucide-react';
-import { useFixtures } from '../hooks/useApi';
-import { useQueryClient } from '@tanstack/react-query';
+import React, { useMemo, useState } from 'react';
+import {
+  FileText,
+  Download,
+  Trash2,
+  Search,
+  Eye,
+  Plus,
+  Edit3,
+  Move,
+  RefreshCw,
+  Tag as TagIcon,
+} from 'lucide-react';
+import {
+  useFixtures,
+  useCreateFixture,
+  useUpdateFixture,
+  useDeleteFixture,
+  useRenameFixture,
+  useMoveFixture,
+  useDownloadFixture,
+} from '../hooks/api';
 import type { FixtureInfo } from '../services/api';
 import {
   PageHeader,
   ModernCard,
   Alert,
   EmptyState,
-  Section
+  Section,
 } from '../components/ui/DesignSystem';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
+import { Textarea } from '../components/ui/textarea';
 import {
   Dialog,
   DialogContent,
@@ -20,126 +39,315 @@ import {
   DialogTitle,
   DialogDescription,
   DialogFooter,
-  DialogClose
+  DialogClose,
 } from '../components/ui/Dialog';
 import { toast } from 'sonner';
 
-
 const isCloud = !!import.meta.env.VITE_API_BASE_URL;
+
+interface FixtureFormState {
+  name: string;
+  path: string;
+  method: string;
+  description: string;
+  protocol: string;
+  tagsInput: string;
+  contentText: string;
+}
+
+const EMPTY_FORM: FixtureFormState = {
+  name: '',
+  path: '',
+  method: 'GET',
+  description: '',
+  protocol: '',
+  tagsInput: '',
+  contentText: '',
+};
+
+function parseTagsInput(input: string): string[] {
+  return input
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}
+
+function stringifyTags(tags: FixtureInfo['tags']): string[] {
+  if (Array.isArray(tags)) {
+    return tags.filter((t): t is string => typeof t === 'string' && t.length > 0);
+  }
+  return [];
+}
+
+function parseContentText(
+  text: string
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  const trimmed = text.trim();
+  if (!trimmed) return { ok: true, value: null };
+  try {
+    return { ok: true, value: JSON.parse(trimmed) };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'Invalid JSON' };
+  }
+}
+
+function fixtureContentToString(content: FixtureInfo['content']): string {
+  if (content === undefined || content === null) return '';
+  if (typeof content === 'string') return content;
+  try {
+    return JSON.stringify(content, null, 2);
+  } catch {
+    return String(content);
+  }
+}
+
+function fixtureDisplayName(fixture: FixtureInfo): string {
+  return fixture.name || fixture.id;
+}
+
+function formFromFixture(fixture: FixtureInfo): FixtureFormState {
+  return {
+    name: fixture.name || '',
+    path: fixture.path || '',
+    method: fixture.method || 'GET',
+    description: fixture.description || '',
+    protocol: fixture.protocol || '',
+    tagsInput: stringifyTags(fixture.tags).join(', '),
+    contentText: fixtureContentToString(fixture.content),
+  };
+}
 
 export function FixturesPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedMethod, setSelectedMethod] = useState<string>('all');
+  const [selectedTag, setSelectedTag] = useState<string>('all');
+
   const [selectedFixture, setSelectedFixture] = useState<FixtureInfo | null>(null);
   const [isViewingFixture, setIsViewingFixture] = useState(false);
+
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [newFixture, setNewFixture] = useState({ name: '', path: '', method: 'GET', description: '' });
+  const [createForm, setCreateForm] = useState<FixtureFormState>(EMPTY_FORM);
+  const [createContentError, setCreateContentError] = useState<string | null>(null);
+
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [fixtureToEdit, setFixtureToEdit] = useState<FixtureInfo | null>(null);
+  const [editForm, setEditForm] = useState<FixtureFormState>(EMPTY_FORM);
+  const [editContentError, setEditContentError] = useState<string | null>(null);
+
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [fixtureToRename, setFixtureToRename] = useState<FixtureInfo | null>(null);
   const [newFixtureName, setNewFixtureName] = useState('');
+
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
   const [fixtureToMove, setFixtureToMove] = useState<FixtureInfo | null>(null);
   const [newFixturePath, setNewFixturePath] = useState('');
+
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [fixtureToDelete, setFixtureToDelete] = useState<FixtureInfo | null>(null);
-  const queryClient = useQueryClient();
+
+  const { data: fixtures, isLoading, error, refetch, isFetching } = useFixtures();
+  const createFixtureMutation = useCreateFixture();
+  const updateFixtureMutation = useUpdateFixture();
+  const deleteFixtureMutation = useDeleteFixture();
+  const renameFixtureMutation = useRenameFixture();
+  const moveFixtureMutation = useMoveFixture();
+  const downloadFixtureMutation = useDownloadFixture();
+
+  const allTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    (fixtures ?? []).forEach((f) => {
+      stringifyTags(f.tags).forEach((t) => tagSet.add(t));
+    });
+    return Array.from(tagSet).sort();
+  }, [fixtures]);
+
+  const filteredFixtures = useMemo(() => {
+    const term = searchTerm.toLowerCase();
+    return (fixtures ?? []).filter((fixture: FixtureInfo) => {
+      const tags = stringifyTags(fixture.tags);
+      const matchesSearch =
+        term === '' ||
+        fixture.path?.toLowerCase().includes(term) ||
+        fixture.name?.toLowerCase().includes(term) ||
+        fixture.description?.toLowerCase().includes(term) ||
+        fixture.method?.toLowerCase().includes(term) ||
+        fixture.protocol?.toLowerCase().includes(term) ||
+        tags.some((t) => t.toLowerCase().includes(term));
+
+      const matchesMethod = selectedMethod === 'all' || fixture.method === selectedMethod;
+      const matchesTag = selectedTag === 'all' || tags.includes(selectedTag);
+      return matchesSearch && matchesMethod && matchesTag;
+    });
+  }, [fixtures, searchTerm, selectedMethod, selectedTag]);
 
   const handleCreateFixture = async () => {
+    if (!createForm.name.trim()) return;
+
+    const contentResult = parseContentText(createForm.contentText);
+    if (!contentResult.ok) {
+      setCreateContentError(contentResult.error);
+      return;
+    }
+    setCreateContentError(null);
+
     try {
-      const token = localStorage.getItem('auth_token');
-      const apiBase = isCloud ? '/api/v1/fixtures' : '/__mockforge/fixtures';
-      const response = await fetch(apiBase, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify(newFixture),
+      await createFixtureMutation.mutateAsync({
+        name: createForm.name.trim(),
+        path: createForm.path.trim(),
+        method: createForm.method,
+        description: createForm.description,
+        protocol: createForm.protocol || undefined,
+        tags: parseTagsInput(createForm.tagsInput),
+        content: contentResult.value ?? undefined,
       });
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || `Failed to create fixture: ${response.status}`);
-      }
       toast.success('Fixture created successfully');
       setIsCreateDialogOpen(false);
-      setNewFixture({ name: '', path: '', method: 'GET', description: '' });
-      queryClient.invalidateQueries({ queryKey: ['fixtures-v2'] });
-    } catch (error) {
-      logger.error('Error creating fixture', error);
-      toast.error(error instanceof Error ? error.message : 'Failed to create fixture');
+      setCreateForm(EMPTY_FORM);
+    } catch (err) {
+      logger.error('Error creating fixture', err);
+      toast.error(err instanceof Error ? err.message : 'Failed to create fixture');
     }
   };
 
-  const { data: fixtures, isLoading, error, refetch } = useFixtures();
+  const handleEditFixture = async () => {
+    if (!fixtureToEdit) return;
+    const contentResult = parseContentText(editForm.contentText);
+    if (!contentResult.ok) {
+      setEditContentError(contentResult.error);
+      return;
+    }
+    setEditContentError(null);
 
-  const filteredFixtures = fixtures?.filter((fixture: FixtureInfo) => {
-    const matchesSearch = searchTerm === '' ||
-      fixture.path.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      fixture.method?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      fixture.protocol?.toLowerCase().includes(searchTerm.toLowerCase());
+    try {
+      await updateFixtureMutation.mutateAsync({
+        fixtureId: fixtureToEdit.id,
+        payload: {
+          name: editForm.name.trim(),
+          path: editForm.path,
+          method: editForm.method,
+          description: editForm.description,
+          tags: parseTagsInput(editForm.tagsInput),
+          content: contentResult.value ?? null,
+        },
+      });
+      toast.success('Fixture updated successfully');
+      setIsEditDialogOpen(false);
+      setFixtureToEdit(null);
+    } catch (err) {
+      logger.error('Error updating fixture', err);
+      toast.error(err instanceof Error ? err.message : 'Failed to update fixture');
+    }
+  };
 
-    const matchesMethod = selectedMethod === 'all' || fixture.method === selectedMethod;
+  const handleRenameFixture = async () => {
+    if (!fixtureToRename) return;
+    try {
+      await renameFixtureMutation.mutateAsync({
+        fixtureId: fixtureToRename.id,
+        newName: newFixtureName,
+      });
+      toast.success('Fixture renamed successfully');
+      setIsRenameDialogOpen(false);
+    } catch (err) {
+      logger.error('Error renaming fixture', err);
+      toast.error(err instanceof Error ? err.message : 'Failed to rename fixture');
+    }
+  };
 
-    return matchesSearch && matchesMethod;
-  }) || [];
+  const handleMoveFixture = async () => {
+    if (!fixtureToMove) return;
+    try {
+      await moveFixtureMutation.mutateAsync({
+        fixtureId: fixtureToMove.id,
+        newPath: newFixturePath,
+      });
+      toast.success('Fixture moved successfully');
+      setIsMoveDialogOpen(false);
+      setNewFixturePath('');
+    } catch (err) {
+      logger.error('Error moving fixture', err);
+      toast.error(err instanceof Error ? err.message : 'Failed to move fixture');
+    }
+  };
+
+  const handleDeleteFixture = async () => {
+    if (!fixtureToDelete) return;
+    try {
+      await deleteFixtureMutation.mutateAsync(fixtureToDelete.id);
+      toast.success('Fixture deleted successfully');
+      setIsDeleteDialogOpen(false);
+      setFixtureToDelete(null);
+    } catch (err) {
+      logger.error('Error deleting fixture', err);
+      toast.error(err instanceof Error ? err.message : 'Failed to delete fixture');
+    }
+  };
 
   const handleViewFixture = (fixture: FixtureInfo) => {
     setSelectedFixture(fixture);
     setIsViewingFixture(true);
   };
 
+  const handleOpenEdit = (fixture: FixtureInfo) => {
+    setFixtureToEdit(fixture);
+    setEditForm(formFromFixture(fixture));
+    setEditContentError(null);
+    setIsEditDialogOpen(true);
+  };
+
   const handleDownloadFixture = async (fixture: FixtureInfo) => {
     try {
-      const response = await fetch(`/__mockforge/fixtures/${fixture.id}/download`);
-      if (!response.ok) {
-        throw new Error(`Failed to download fixture: ${response.statusText}`);
-      }
-
-      const blob = await response.blob();
+      const { blob, filename } = await downloadFixtureMutation.mutateAsync(fixture);
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      // Use content-disposition header if available, otherwise default to fixture id
-      const contentDisposition = response.headers.get('Content-Disposition');
-      const filenameMatch = contentDisposition?.match(/filename="?([^"]+)"?/);
-      a.download = filenameMatch?.[1] || `${fixture.id}.json`;
+      a.download = filename;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
       toast.success('Fixture downloaded successfully');
-    } catch (error) {
-      logger.error('Error downloading fixture', error);
-      toast.error(error instanceof Error ? error.message : 'Failed to download fixture');
+    } catch (err) {
+      logger.error('Error downloading fixture', err);
+      toast.error(err instanceof Error ? err.message : 'Failed to download fixture');
     }
   };
 
   const formatFileSize = (bytes: number): string => {
-    if (bytes === 0) return '0 Bytes';
+    if (!bytes) return '0 Bytes';
     const k = 1024;
     const sizes = ['Bytes', 'KB', 'MB', 'GB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
-  const formatDate = (dateString: string): string => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+  const formatDate = (dateString?: string): string => {
+    if (!dateString) return '—';
+    const d = new Date(dateString);
+    if (Number.isNaN(d.getTime())) return '—';
+    return d.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
       hour: '2-digit',
-      minute: '2-digit'
+      minute: '2-digit',
     });
   };
 
   const getMethodBadgeColor = (method?: string): string => {
     switch (method?.toUpperCase()) {
-      case 'GET': return 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400';
-      case 'POST': return 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400';
-      case 'PUT': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400';
-      case 'DELETE': return 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400';
-      case 'PATCH': return 'bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-400';
-      default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400';
+      case 'GET':
+        return 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400';
+      case 'POST':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400';
+      case 'PUT':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400';
+      case 'DELETE':
+        return 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400';
+      case 'PATCH':
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-400';
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400';
     }
   };
 
@@ -169,11 +377,18 @@ export function FixturesPage() {
         <Alert
           type="error"
           title="Failed to load fixtures"
-          message={error instanceof Error ? error.message : 'Unable to fetch fixture data. Please try again.'}
+          message={
+            error instanceof Error ? error.message : 'Unable to fetch fixture data. Please try again.'
+          }
         />
       </div>
     );
   }
+
+  const totalSize = filteredFixtures.reduce(
+    (acc: number, f: FixtureInfo) => acc + (f.file_size || f.size_bytes || 0),
+    0
+  );
 
   return (
     <div className="space-y-8">
@@ -186,15 +401,20 @@ export function FixturesPage() {
               variant="outline"
               size="sm"
               onClick={() => refetch()}
+              disabled={isFetching}
               className="flex items-center gap-2"
             >
-              <Download className="h-4 w-4" />
+              <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />
               Refresh
             </Button>
             <Button
               variant="default"
               size="sm"
-              onClick={() => setIsCreateDialogOpen(true)}
+              onClick={() => {
+                setCreateForm(EMPTY_FORM);
+                setCreateContentError(null);
+                setIsCreateDialogOpen(true);
+              }}
               className="flex items-center gap-2"
             >
               <Plus className="h-4 w-4" />
@@ -205,13 +425,9 @@ export function FixturesPage() {
       />
 
       {/* Filters and Search */}
-      <Section
-        title="Filter & Search"
-        subtitle="Find and organize your fixtures"
-      >
+      <Section title="Filter & Search" subtitle="Find and organize your fixtures">
         <ModernCard>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {/* Search Input */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div className="space-y-2">
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                 Search Fixtures
@@ -219,7 +435,7 @@ export function FixturesPage() {
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <Input
-                  placeholder="Search by name, path, or route..."
+                  placeholder="Search by name, path, tag, description…"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="pl-10"
@@ -227,7 +443,6 @@ export function FixturesPage() {
               </div>
             </div>
 
-            {/* Method Filter */}
             <div className="space-y-2">
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                 HTTP Method
@@ -247,7 +462,25 @@ export function FixturesPage() {
               </select>
             </div>
 
-            {/* Stats */}
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Tag
+              </label>
+              <select
+                value={selectedTag}
+                onChange={(e) => setSelectedTag(e.target.value)}
+                disabled={allTags.length === 0}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+              >
+                <option value="all">All Tags</option>
+                {allTags.map((tag) => (
+                  <option key={tag} value={tag}>
+                    {tag}
+                  </option>
+                ))}
+              </select>
+            </div>
+
             <div className="space-y-2">
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                 Summary
@@ -261,14 +494,16 @@ export function FixturesPage() {
                     {filteredFixtures.length === 1 ? 'Fixture' : 'Fixtures'}
                   </div>
                 </div>
-                <div className="text-center">
-                  <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {formatFileSize(filteredFixtures.reduce((acc: number, f: FixtureInfo) => acc + (f.file_size || 0), 0))}
+                {!isCloud && (
+                  <div className="text-center">
+                    <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                      {formatFileSize(totalSize)}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      Total Size
+                    </div>
                   </div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400">
-                    Total Size
-                  </div>
-                </div>
+                )}
               </div>
             </div>
           </div>
@@ -287,12 +522,15 @@ export function FixturesPage() {
               title="No fixtures found"
               description={
                 fixtures?.length === 0
-                  ? "No fixtures have been created yet. Create your first fixture to get started."
-                  : "No fixtures match your current search criteria. Try adjusting your filters."
+                  ? 'No fixtures have been created yet. Create your first fixture to get started.'
+                  : 'No fixtures match your current search criteria. Try adjusting your filters.'
               }
               action={
                 <Button
-                  onClick={() => setIsCreateDialogOpen(true)}
+                  onClick={() => {
+                    setCreateForm(EMPTY_FORM);
+                    setIsCreateDialogOpen(true);
+                  }}
                   className="flex items-center gap-2"
                 >
                   <Plus className="h-4 w-4" />
@@ -302,105 +540,154 @@ export function FixturesPage() {
             />
           ) : (
             <div className="space-y-4">
-              {filteredFixtures.map((fixture: FixtureInfo) => (
-                <div
-                  key={fixture.id}
-                  className="flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
-                >
-                  <div className="flex items-center gap-4 flex-1 min-w-0">
-                    <div className="p-3 rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 flex-shrink-0">
-                      <FileText className="h-5 w-5" />
-                    </div>
+              {filteredFixtures.map((fixture: FixtureInfo) => {
+                const tags = stringifyTags(fixture.tags);
+                const dateStr =
+                  fixture.updated_at ||
+                  fixture.updatedAt ||
+                  fixture.saved_at ||
+                  fixture.created_at ||
+                  fixture.createdAt;
+                const sizeBytes = fixture.file_size || fixture.size_bytes;
+                return (
+                  <div
+                    key={fixture.id}
+                    className="flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-4 flex-1 min-w-0">
+                      <div className="p-3 rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 flex-shrink-0">
+                        <FileText className="h-5 w-5" />
+                      </div>
 
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2 mb-1">
-                        <h3 className="font-semibold text-gray-900 dark:text-gray-100 truncate">
-                          {fixture.id}
-                        </h3>
-                        {fixture.method && (
-                          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${getMethodBadgeColor(fixture.method)}`}>
-                            {fixture.method}
-                          </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 mb-1 flex-wrap">
+                          <h3 className="font-semibold text-gray-900 dark:text-gray-100 truncate">
+                            {fixtureDisplayName(fixture)}
+                          </h3>
+                          {fixture.method && (
+                            <span
+                              className={`px-2 py-0.5 rounded-full text-xs font-medium ${getMethodBadgeColor(fixture.method)}`}
+                            >
+                              {fixture.method}
+                            </span>
+                          )}
+                          {fixture.protocol && (
+                            <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900/20 dark:text-indigo-400">
+                              {fixture.protocol}
+                            </span>
+                          )}
+                        </div>
+
+                        {fixture.description && (
+                          <p className="text-sm text-gray-600 dark:text-gray-400 truncate mb-1">
+                            {fixture.description}
+                          </p>
                         )}
-                      </div>
 
-                      <div className="flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
-                        <span className="truncate" title={fixture.path}>
-                          Path: {fixture.path}
-                        </span>
-                      </div>
+                        <div className="flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
+                          <span className="truncate" title={fixture.path}>
+                            Path: {fixture.path || '—'}
+                          </span>
+                        </div>
 
-                      <div className="flex items-center gap-4 mt-2 text-xs text-gray-500 dark:text-gray-400">
-                        <span>{formatFileSize(fixture.file_size || 0)}</span>
-                        <span>•</span>
-                        <span>{fixture.protocol}</span>
-                        <span>•</span>
-                        <span>{formatDate(fixture.saved_at || '')}</span>
+                        <div className="flex items-center gap-2 mt-2 text-xs text-gray-500 dark:text-gray-400 flex-wrap">
+                          {sizeBytes ? <span>{formatFileSize(sizeBytes)}</span> : null}
+                          {sizeBytes ? <span>•</span> : null}
+                          <span>{formatDate(dateStr)}</span>
+                          {tags.length > 0 && (
+                            <>
+                              <span>•</span>
+                              <span className="flex items-center gap-1 flex-wrap">
+                                <TagIcon className="h-3 w-3" />
+                                {tags.map((t) => (
+                                  <span
+                                    key={t}
+                                    className="px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                                  >
+                                    {t}
+                                  </span>
+                                ))}
+                              </span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <div className="flex items-center gap-1">
+                        {isCloud && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleOpenEdit(fixture)}
+                            className="flex items-center gap-2"
+                          >
+                            <Edit3 className="h-4 w-4" />
+                            Edit
+                          </Button>
+                        )}
+
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setFixtureToRename(fixture);
+                            setNewFixtureName(fixtureDisplayName(fixture));
+                            setIsRenameDialogOpen(true);
+                          }}
+                          className="flex items-center gap-2"
+                        >
+                          <Edit3 className="h-4 w-4" />
+                          Rename
+                        </Button>
+
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setFixtureToMove(fixture);
+                            setNewFixturePath(fixture.path || '');
+                            setIsMoveDialogOpen(true);
+                          }}
+                          className="flex items-center gap-2"
+                        >
+                          <Move className="h-4 w-4" />
+                          Move
+                        </Button>
+
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleViewFixture(fixture)}
+                        >
+                          <Eye className="h-4 w-4" />
+                        </Button>
+
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleDownloadFixture(fixture)}
+                        >
+                          <Download className="h-4 w-4" />
+                        </Button>
+
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setFixtureToDelete(fixture);
+                            setIsDeleteDialogOpen(true);
+                          }}
+                          className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-900/20"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
                       </div>
                     </div>
                   </div>
-
-                  <div className="flex items-center gap-2 flex-shrink-0">
-                    {/* More Actions Menu */}
-                    <div className="flex items-center gap-1">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          setFixtureToRename(fixture);
-                          setNewFixtureName(fixture.id);
-                          setIsRenameDialogOpen(true);
-                        }}
-                        className="flex items-center gap-2"
-                      >
-                        <Edit3 className="h-4 w-4" />
-                        Rename
-                      </Button>
-
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          setFixtureToMove(fixture);
-                          setIsMoveDialogOpen(true);
-                        }}
-                        className="flex items-center gap-2"
-                      >
-                        <Move className="h-4 w-4" />
-                        Move
-                      </Button>
-
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleViewFixture(fixture)}
-                      >
-                        <Eye className="h-4 w-4" />
-                      </Button>
-
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleDownloadFixture(fixture)}
-                      >
-                        <Download className="h-4 w-4" />
-                      </Button>
-
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          setFixtureToDelete(fixture);
-                          setIsDeleteDialogOpen(true);
-                        }}
-                        className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-900/20"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </ModernCard>
@@ -408,7 +695,7 @@ export function FixturesPage() {
 
       {/* Create Fixture Dialog */}
       <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
-        <DialogContent>
+        <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle>Create New Fixture</DialogTitle>
             <DialogClose onClick={() => setIsCreateDialogOpen(false)} />
@@ -417,63 +704,237 @@ export function FixturesPage() {
             Create a new mock response fixture for your API endpoints.
           </DialogDescription>
 
-          <div className="py-4 space-y-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">Fixture Name</label>
-              <Input
-                value={newFixture.name}
-                onChange={(e) => setNewFixture({ ...newFixture, name: e.target.value })}
-                placeholder="e.g., Get Users Response"
-              />
+          <div className="py-4 space-y-4 overflow-y-auto max-h-[60vh]">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Fixture Name *
+                </label>
+                <Input
+                  value={createForm.name}
+                  onChange={(e) => setCreateForm({ ...createForm, name: e.target.value })}
+                  placeholder="e.g., Get Users Response"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  HTTP Method
+                </label>
+                <select
+                  value={createForm.method}
+                  onChange={(e) => setCreateForm({ ...createForm, method: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                >
+                  <option value="GET">GET</option>
+                  <option value="POST">POST</option>
+                  <option value="PUT">PUT</option>
+                  <option value="DELETE">DELETE</option>
+                  <option value="PATCH">PATCH</option>
+                  <option value="HEAD">HEAD</option>
+                </select>
+              </div>
             </div>
 
             <div className="space-y-2">
               <label className="text-sm font-medium text-gray-900 dark:text-gray-100">Path</label>
               <Input
-                value={newFixture.path}
-                onChange={(e) => setNewFixture({ ...newFixture, path: e.target.value })}
+                value={createForm.path}
+                onChange={(e) => setCreateForm({ ...createForm, path: e.target.value })}
                 placeholder="e.g., /api/users"
               />
             </div>
 
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">HTTP Method</label>
-              <select
-                value={newFixture.method}
-                onChange={(e) => setNewFixture({ ...newFixture, method: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              >
-                <option value="GET">GET</option>
-                <option value="POST">POST</option>
-                <option value="PUT">PUT</option>
-                <option value="DELETE">DELETE</option>
-                <option value="PATCH">PATCH</option>
-                <option value="HEAD">HEAD</option>
-              </select>
-            </div>
+            {isCloud && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Protocol
+                </label>
+                <select
+                  value={createForm.protocol}
+                  onChange={(e) => setCreateForm({ ...createForm, protocol: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                >
+                  <option value="">— unspecified —</option>
+                  <option value="http">http</option>
+                  <option value="grpc">grpc</option>
+                  <option value="websocket">websocket</option>
+                  <option value="graphql">graphql</option>
+                  <option value="mqtt">mqtt</option>
+                  <option value="kafka">kafka</option>
+                  <option value="amqp">amqp</option>
+                  <option value="smtp">smtp</option>
+                  <option value="ftp">ftp</option>
+                  <option value="tcp">tcp</option>
+                </select>
+              </div>
+            )}
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">Description</label>
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Description
+              </label>
               <Input
-                value={newFixture.description}
-                onChange={(e) => setNewFixture({ ...newFixture, description: e.target.value })}
+                value={createForm.description}
+                onChange={(e) =>
+                  setCreateForm({ ...createForm, description: e.target.value })
+                }
                 placeholder="Optional description"
               />
             </div>
+
+            {isCloud && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Tags
+                </label>
+                <Input
+                  value={createForm.tagsInput}
+                  onChange={(e) =>
+                    setCreateForm({ ...createForm, tagsInput: e.target.value })
+                  }
+                  placeholder="comma-separated, e.g. auth, users, billing"
+                />
+              </div>
+            )}
+
+            {isCloud && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Response Content (JSON)
+                </label>
+                <Textarea
+                  value={createForm.contentText}
+                  onChange={(e) =>
+                    setCreateForm({ ...createForm, contentText: e.target.value })
+                  }
+                  placeholder={'{\n  "users": []\n}'}
+                  className="font-mono text-xs min-h-[180px]"
+                  error={createContentError ?? undefined}
+                />
+                {createContentError && (
+                  <p className="text-xs text-red-600 dark:text-red-400">
+                    Invalid JSON: {createContentError}
+                  </p>
+                )}
+              </div>
+            )}
           </div>
 
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsCreateDialogOpen(false)}
-            >
+            <Button variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
               Cancel
             </Button>
             <Button
               onClick={handleCreateFixture}
-              disabled={!newFixture.name.trim()}
+              disabled={!createForm.name.trim() || createFixtureMutation.isPending}
             >
-              Create Fixture
+              {createFixtureMutation.isPending ? 'Creating…' : 'Create Fixture'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Fixture Dialog (cloud only) */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Edit Fixture</DialogTitle>
+            <DialogClose onClick={() => setIsEditDialogOpen(false)} />
+          </DialogHeader>
+          <DialogDescription>
+            Update fixture metadata, tags, and response content.
+          </DialogDescription>
+
+          <div className="py-4 space-y-4 overflow-y-auto max-h-[60vh]">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Name
+                </label>
+                <Input
+                  value={editForm.name}
+                  onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  HTTP Method
+                </label>
+                <select
+                  value={editForm.method}
+                  onChange={(e) => setEditForm({ ...editForm, method: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                >
+                  <option value="GET">GET</option>
+                  <option value="POST">POST</option>
+                  <option value="PUT">PUT</option>
+                  <option value="DELETE">DELETE</option>
+                  <option value="PATCH">PATCH</option>
+                  <option value="HEAD">HEAD</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">Path</label>
+              <Input
+                value={editForm.path}
+                onChange={(e) => setEditForm({ ...editForm, path: e.target.value })}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Description
+              </label>
+              <Input
+                value={editForm.description}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, description: e.target.value })
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Tags (comma-separated)
+              </label>
+              <Input
+                value={editForm.tagsInput}
+                onChange={(e) => setEditForm({ ...editForm, tagsInput: e.target.value })}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Response Content (JSON)
+              </label>
+              <Textarea
+                value={editForm.contentText}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, contentText: e.target.value })
+                }
+                className="font-mono text-xs min-h-[220px]"
+                error={editContentError ?? undefined}
+              />
+              {editContentError && (
+                <p className="text-xs text-red-600 dark:text-red-400">
+                  Invalid JSON: {editContentError}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleEditFixture}
+              disabled={!editForm.name.trim() || updateFixtureMutation.isPending}
+            >
+              {updateFixtureMutation.isPending ? 'Saving…' : 'Save Changes'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -483,7 +944,7 @@ export function FixturesPage() {
       <Dialog open={isViewingFixture} onOpenChange={setIsViewingFixture}>
         <DialogContent className="max-w-4xl">
           <DialogHeader>
-            <DialogTitle>{selectedFixture?.id}</DialogTitle>
+            <DialogTitle>{selectedFixture ? fixtureDisplayName(selectedFixture) : ''}</DialogTitle>
             <DialogClose onClick={() => setIsViewingFixture(false)} />
           </DialogHeader>
           <DialogDescription>
@@ -492,41 +953,89 @@ export function FixturesPage() {
 
           <div className="py-4 overflow-y-auto max-h-[60vh]">
             <div className="space-y-4">
-              <div className="flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
+              <div className="flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400 flex-wrap">
                 <div>
-                  <span className="font-medium">Method:</span> {selectedFixture?.method}
+                  <span className="font-medium">Method:</span> {selectedFixture?.method || '—'}
                 </div>
                 <div>
-                  <span className="font-medium">Protocol:</span> {selectedFixture?.protocol}
+                  <span className="font-medium">Protocol:</span>{' '}
+                  {selectedFixture?.protocol || '—'}
                 </div>
+                {(selectedFixture?.file_size || selectedFixture?.size_bytes) && (
+                  <div>
+                    <span className="font-medium">Size:</span>{' '}
+                    {formatFileSize(
+                      selectedFixture?.file_size ?? selectedFixture?.size_bytes ?? 0
+                    )}
+                  </div>
+                )}
                 <div>
-                  <span className="font-medium">Size:</span> {formatFileSize(selectedFixture?.file_size ?? 0)}
-                </div>
-                <div>
-                  <span className="font-medium">Saved:</span> {formatDate(selectedFixture?.saved_at ?? '')}
+                  <span className="font-medium">Updated:</span>{' '}
+                  {formatDate(
+                    selectedFixture?.updated_at ||
+                      selectedFixture?.updatedAt ||
+                      selectedFixture?.saved_at ||
+                      selectedFixture?.created_at ||
+                      selectedFixture?.createdAt
+                  )}
                 </div>
               </div>
 
+              {selectedFixture?.description && (
+                <div>
+                  <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
+                    Description
+                  </h4>
+                  <p className="text-sm text-gray-700 dark:text-gray-300">
+                    {selectedFixture.description}
+                  </p>
+                </div>
+              )}
+
+              {selectedFixture && stringifyTags(selectedFixture.tags).length > 0 && (
+                <div>
+                  <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
+                    Tags
+                  </h4>
+                  <div className="flex flex-wrap gap-2">
+                    {stringifyTags(selectedFixture.tags).map((t) => (
+                      <span
+                        key={t}
+                        className="px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-xs text-gray-700 dark:text-gray-300"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               <div>
                 <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
-                  Metadata
+                  Response Content
                 </h4>
                 <pre className="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 text-sm overflow-x-auto max-h-96 overflow-y-auto">
                   <code className="text-gray-900 dark:text-gray-100">
-                    {JSON.stringify({
-                      id: selectedFixture?.id,
-                      protocol: selectedFixture?.protocol,
-                      method: selectedFixture?.method,
-                      path: selectedFixture?.path,
-                      saved_at: selectedFixture?.saved_at,
-                      file_size: selectedFixture?.file_size,
-                      file_path: selectedFixture?.file_path,
-                      fingerprint: selectedFixture?.fingerprint,
-                      metadata: selectedFixture?.metadata
-                    }, null, 2)}
+                    {selectedFixture
+                      ? fixtureContentToString(selectedFixture.content) ||
+                        '(no content stored)'
+                      : ''}
                   </code>
                 </pre>
               </div>
+
+              {!isCloud && selectedFixture?.metadata && (
+                <div>
+                  <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
+                    Metadata
+                  </h4>
+                  <pre className="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 text-sm overflow-x-auto max-h-96 overflow-y-auto">
+                    <code className="text-gray-900 dark:text-gray-100">
+                      {JSON.stringify(selectedFixture.metadata, null, 2)}
+                    </code>
+                  </pre>
+                </div>
+              )}
             </div>
           </div>
 
@@ -539,9 +1048,20 @@ export function FixturesPage() {
               <Download className="h-4 w-4" />
               Download
             </Button>
-            <Button onClick={() => setIsViewingFixture(false)}>
-              Close
-            </Button>
+            {isCloud && selectedFixture && (
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setIsViewingFixture(false);
+                  handleOpenEdit(selectedFixture);
+                }}
+                className="flex items-center gap-2"
+              >
+                <Edit3 className="h-4 w-4" />
+                Edit
+              </Button>
+            )}
+            <Button onClick={() => setIsViewingFixture(false)}>Close</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -554,12 +1074,17 @@ export function FixturesPage() {
             <DialogClose onClick={() => setIsRenameDialogOpen(false)} />
           </DialogHeader>
           <DialogDescription>
-            Current name: <code className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">{fixtureToRename?.id}</code>
+            Current name:{' '}
+            <code className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">
+              {fixtureToRename ? fixtureDisplayName(fixtureToRename) : ''}
+            </code>
           </DialogDescription>
 
           <div className="py-4 space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">New Name</label>
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                New Name
+              </label>
               <Input
                 value={newFixtureName}
                 onChange={(e) => setNewFixtureName(e.target.value)}
@@ -569,34 +1094,18 @@ export function FixturesPage() {
           </div>
 
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsRenameDialogOpen(false)}
-            >
+            <Button variant="outline" onClick={() => setIsRenameDialogOpen(false)}>
               Cancel
             </Button>
             <Button
-              onClick={async () => {
-                if (!fixtureToRename) return;
-                try {
-                  await fetch(`/__mockforge/fixtures/${fixtureToRename.id}/rename`, {
-                    method: 'PUT',
-                    headers: {
-                      'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({ new_name: newFixtureName }),
-                  });
-                  toast.success('Fixture renamed successfully');
-                  setIsRenameDialogOpen(false);
-                  queryClient.invalidateQueries({ queryKey: ['fixtures-v2'] });
-                } catch (error) {
-                  logger.error('Error renaming fixture',error);
-                  toast.error('Failed to rename fixture');
-                }
-              }}
-              disabled={!newFixtureName.trim() || newFixtureName === fixtureToRename?.id}
+              onClick={handleRenameFixture}
+              disabled={
+                !newFixtureName.trim() ||
+                newFixtureName === (fixtureToRename ? fixtureDisplayName(fixtureToRename) : '') ||
+                renameFixtureMutation.isPending
+              }
             >
-              Rename
+              {renameFixtureMutation.isPending ? 'Renaming…' : 'Rename'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -610,12 +1119,17 @@ export function FixturesPage() {
             <DialogClose onClick={() => setIsMoveDialogOpen(false)} />
           </DialogHeader>
           <DialogDescription>
-            Moving: <code className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">{fixtureToMove?.id}</code>
+            Moving:{' '}
+            <code className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">
+              {fixtureToMove ? fixtureDisplayName(fixtureToMove) : ''}
+            </code>
           </DialogDescription>
 
           <div className="py-4 space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">New Path</label>
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                New Path
+              </label>
               <Input
                 value={newFixturePath}
                 onChange={(e) => setNewFixturePath(e.target.value)}
@@ -625,35 +1139,14 @@ export function FixturesPage() {
           </div>
 
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsMoveDialogOpen(false)}
-            >
+            <Button variant="outline" onClick={() => setIsMoveDialogOpen(false)}>
               Cancel
             </Button>
             <Button
-              onClick={async () => {
-                if (!fixtureToMove) return;
-                try {
-                  await fetch(`/__mockforge/fixtures/${fixtureToMove.id}/move`, {
-                    method: 'PUT',
-                    headers: {
-                      'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({ new_path: newFixturePath }),
-                  });
-                  toast.success('Fixture moved successfully');
-                  setIsMoveDialogOpen(false);
-                  setNewFixturePath('');
-                  queryClient.invalidateQueries({ queryKey: ['fixtures-v2'] });
-                } catch (error) {
-                  logger.error('Error moving fixture',error);
-                  toast.error('Failed to move fixture');
-                }
-              }}
-              disabled={!newFixturePath.trim()}
+              onClick={handleMoveFixture}
+              disabled={!newFixturePath.trim() || moveFixtureMutation.isPending}
             >
-              Move
+              {moveFixtureMutation.isPending ? 'Moving…' : 'Move'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -674,7 +1167,7 @@ export function FixturesPage() {
             <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4">
               <div className="text-sm">
                 <div className="font-medium text-gray-900 dark:text-gray-100 mb-1">
-                  {fixtureToDelete?.id}
+                  {fixtureToDelete ? fixtureDisplayName(fixtureToDelete) : ''}
                 </div>
                 <div className="text-gray-600 dark:text-gray-400">
                   {fixtureToDelete?.path} ({fixtureToDelete?.method})
@@ -684,32 +1177,16 @@ export function FixturesPage() {
           </div>
 
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsDeleteDialogOpen(false)}
-            >
+            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
               Cancel
             </Button>
             <Button
               variant="default"
-              onClick={async () => {
-                if (!fixtureToDelete) return;
-                try {
-                  await fetch(`/__mockforge/fixtures/${fixtureToDelete.id}`, {
-                    method: 'DELETE',
-                  });
-                  toast.success('Fixture deleted successfully');
-                  setIsDeleteDialogOpen(false);
-                  setFixtureToDelete(null);
-                  queryClient.invalidateQueries({ queryKey: ['fixtures-v2'] });
-                } catch (error) {
-                  logger.error('Error deleting fixture',error);
-                  toast.error('Failed to delete fixture');
-                }
-              }}
+              onClick={handleDeleteFixture}
+              disabled={deleteFixtureMutation.isPending}
               className="bg-red-600 hover:bg-red-700 text-white"
             >
-              Delete
+              {deleteFixtureMutation.isPending ? 'Deleting…' : 'Delete'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/crates/mockforge-ui/ui/src/pages/__tests__/FixturesPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/FixturesPage.test.tsx
@@ -6,15 +6,20 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FixturesPage } from '../FixturesPage';
-import * as apiHooks from '../../hooks/useApi';
+import * as apiHooks from '../../hooks/api';
 import type { FixtureInfo } from '../../services/api';
 
 const mockFixtures: FixtureInfo[] = [
   {
     id: 'fixture-1',
+    name: 'fixture-1',
     path: '/api/users',
     method: 'GET',
-    protocol: 'REST',
+    protocol: 'http',
+    description: 'User listing',
+    tags: ['auth', 'users'],
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
     saved_at: '2024-01-01T00:00:00Z',
     file_size: 1024,
     file_path: '/path/to/fixture1.json',
@@ -23,9 +28,14 @@ const mockFixtures: FixtureInfo[] = [
   },
   {
     id: 'fixture-2',
+    name: 'fixture-2',
     path: '/api/posts',
     method: 'POST',
-    protocol: 'REST',
+    protocol: 'http',
+    description: '',
+    tags: [],
+    createdAt: '2024-01-02T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
     saved_at: '2024-01-02T00:00:00Z',
     file_size: 2048,
     file_path: '/path/to/fixture2.json',
@@ -34,13 +44,38 @@ const mockFixtures: FixtureInfo[] = [
   },
 ];
 
-vi.mock('../../hooks/useApi', () => ({
+const mutationState = (overrides: Record<string, unknown> = {}) => ({
+  mutate: vi.fn(),
+  mutateAsync: vi.fn().mockResolvedValue(undefined),
+  isPending: false,
+  reset: vi.fn(),
+  ...overrides,
+});
+
+const createFixtureMutate = vi.fn().mockResolvedValue(mockFixtures[0]);
+const updateFixtureMutate = vi.fn().mockResolvedValue(mockFixtures[0]);
+const deleteFixtureMutate = vi.fn().mockResolvedValue(undefined);
+const renameFixtureMutate = vi.fn().mockResolvedValue(undefined);
+const moveFixtureMutate = vi.fn().mockResolvedValue(undefined);
+const downloadFixtureMutate = vi.fn().mockResolvedValue({
+  blob: new Blob(['{}'], { type: 'application/json' }),
+  filename: 'f.json',
+});
+
+vi.mock('../../hooks/api', () => ({
   useFixtures: vi.fn(() => ({
     data: mockFixtures,
     isLoading: false,
     error: null,
     refetch: vi.fn(),
+    isFetching: false,
   })),
+  useCreateFixture: vi.fn(() => mutationState({ mutateAsync: createFixtureMutate })),
+  useUpdateFixture: vi.fn(() => mutationState({ mutateAsync: updateFixtureMutate })),
+  useDeleteFixture: vi.fn(() => mutationState({ mutateAsync: deleteFixtureMutate })),
+  useRenameFixture: vi.fn(() => mutationState({ mutateAsync: renameFixtureMutate })),
+  useMoveFixture: vi.fn(() => mutationState({ mutateAsync: moveFixtureMutate })),
+  useDownloadFixture: vi.fn(() => mutationState({ mutateAsync: downloadFixtureMutate })),
 }));
 
 vi.mock('sonner', () => ({
@@ -69,11 +104,18 @@ describe('FixturesPage', () => {
       isLoading: false,
       error: null,
       refetch: vi.fn(),
+      isFetching: false,
     } as any);
   });
 
   it('renders loading state', () => {
-    mockUseFixtures.mockReturnValue({ data: null, isLoading: true, error: null, refetch: vi.fn() } as any);
+    mockUseFixtures.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
 
     render(<FixturesPage />, { wrapper: createWrapper() });
     expect(screen.getByText('Loading fixtures...')).toBeInTheDocument();
@@ -86,13 +128,14 @@ describe('FixturesPage', () => {
     expect(screen.getByText('fixture-2')).toBeInTheDocument();
   });
 
-  it('shows fixture metadata', () => {
+  it('shows fixture metadata including description and tags', () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
     expect(screen.getByText('Path: /api/users')).toBeInTheDocument();
     expect(screen.getByText('Path: /api/posts')).toBeInTheDocument();
-    expect(screen.getByText('1 KB')).toBeInTheDocument();
-    expect(screen.getByText('2 KB')).toBeInTheDocument();
+    expect(screen.getByText('User listing')).toBeInTheDocument();
+    expect(screen.getAllByText('auth').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('users').length).toBeGreaterThan(0);
   });
 
   it('displays method badges', () => {
@@ -102,10 +145,10 @@ describe('FixturesPage', () => {
     expect(screen.getAllByText('POST').length).toBeGreaterThan(0);
   });
 
-  it('filters fixtures by search term', () => {
+  it('filters fixtures by search term (matches description/tags/path)', () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
-    const searchInput = screen.getByPlaceholderText('Search by name, path, or route...');
+    const searchInput = screen.getByPlaceholderText(/Search by name, path, tag/);
     fireEvent.change(searchInput, { target: { value: 'users' } });
 
     expect(screen.getByText('fixture-1')).toBeInTheDocument();
@@ -115,22 +158,32 @@ describe('FixturesPage', () => {
   it('filters fixtures by HTTP method', () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
-    const methodSelect = screen.getByRole('combobox');
+    const methodSelect = screen.getAllByRole('combobox')[0];
     fireEvent.change(methodSelect, { target: { value: 'GET' } });
 
     expect(screen.getByText('fixture-1')).toBeInTheDocument();
     expect(screen.queryByText('fixture-2')).not.toBeInTheDocument();
   });
 
-  it('shows total fixture count and size', () => {
+  it('filters fixtures by tag', () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
-    expect(screen.getByText('2')).toBeInTheDocument(); // count
-    expect(screen.getByText('3 KB')).toBeInTheDocument(); // total size
+    const selects = screen.getAllByRole('combobox');
+    const tagSelect = selects[1];
+    fireEvent.change(tagSelect, { target: { value: 'auth' } });
+
+    expect(screen.getByText('fixture-1')).toBeInTheDocument();
+    expect(screen.queryByText('fixture-2')).not.toBeInTheDocument();
   });
 
   it('displays empty state when no fixtures exist', () => {
-    mockUseFixtures.mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() } as any);
+    mockUseFixtures.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as any);
 
     render(<FixturesPage />, { wrapper: createWrapper() });
 
@@ -141,7 +194,7 @@ describe('FixturesPage', () => {
   it('displays empty state when search returns no results', () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
-    const searchInput = screen.getByPlaceholderText('Search by name, path, or route...');
+    const searchInput = screen.getByPlaceholderText(/Search by name, path, tag/);
     fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
 
     expect(screen.getByText('No fixtures found')).toBeInTheDocument();
@@ -154,6 +207,7 @@ describe('FixturesPage', () => {
       isLoading: false,
       error: new Error('Failed to load fixtures'),
       refetch: vi.fn(),
+      isFetching: false,
     } as any);
 
     render(<FixturesPage />, { wrapper: createWrapper() });
@@ -167,27 +221,24 @@ describe('FixturesPage', () => {
     const eyeButton = document.querySelector('svg.lucide-eye')?.closest('button');
     fireEvent.click(eyeButton!);
 
-    expect(screen.getByText('Metadata')).toBeInTheDocument();
+    expect(screen.getByText('Response Content')).toBeInTheDocument();
   });
 
-  it('downloads fixture when clicking download button', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: vi.fn().mockResolvedValue(new Blob(['{}'], { type: 'application/json' })),
-      headers: { get: vi.fn().mockReturnValue('attachment; filename="fixture-1.json"') },
-    });
+  it('invokes download mutation with the selected fixture', async () => {
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fixture');
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
-    const createElementSpy = vi.spyOn(document, 'createElement');
+
     render(<FixturesPage />, { wrapper: createWrapper() });
 
-    const firstFixtureRow = screen.getByText('fixture-1').closest('.flex.items-center.justify-between');
+    const firstFixtureRow = screen
+      .getByText('fixture-1')
+      .closest('.flex.items-center.justify-between');
     const downloadBtn = firstFixtureRow?.querySelector('svg.lucide-download')?.closest('button');
     expect(downloadBtn).toBeTruthy();
-    fireEvent.click(downloadBtn);
+    fireEvent.click(downloadBtn as HTMLElement);
 
     await waitFor(() => {
-      expect(createElementSpy).toHaveBeenCalledWith('a');
+      expect(downloadFixtureMutate).toHaveBeenCalledWith(mockFixtures[0]);
     });
   });
 
@@ -201,9 +252,7 @@ describe('FixturesPage', () => {
     expect(screen.getByPlaceholderText('Enter new fixture name')).toBeInTheDocument();
   });
 
-  it('renames fixture successfully', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: true });
-
+  it('renames fixture through the mutation', async () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
     const renameButton = screen.getAllByText('Rename')[0];
@@ -216,13 +265,10 @@ describe('FixturesPage', () => {
     fireEvent.click(confirmButton);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        '/__mockforge/fixtures/fixture-1/rename',
-        expect.objectContaining({
-          method: 'PUT',
-          body: JSON.stringify({ new_name: 'new-fixture-name' }),
-        })
-      );
+      expect(renameFixtureMutate).toHaveBeenCalledWith({
+        fixtureId: 'fixture-1',
+        newName: 'new-fixture-name',
+      });
     });
   });
 
@@ -236,9 +282,7 @@ describe('FixturesPage', () => {
     expect(screen.getByPlaceholderText('Enter new path')).toBeInTheDocument();
   });
 
-  it('moves fixture successfully', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: true });
-
+  it('moves fixture through the mutation', async () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
     const moveButton = screen.getAllByText('Move')[0];
@@ -251,44 +295,36 @@ describe('FixturesPage', () => {
     fireEvent.click(confirmButton);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        '/__mockforge/fixtures/fixture-1/move',
-        expect.objectContaining({
-          method: 'PUT',
-          body: JSON.stringify({ new_path: '/new/path' }),
-        })
-      );
+      expect(moveFixtureMutate).toHaveBeenCalledWith({
+        fixtureId: 'fixture-1',
+        newPath: '/new/path',
+      });
     });
   });
 
   it('opens delete confirmation dialog', () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
-    const deleteButtons = screen.getAllByRole('button');
-    // Delete button is usually the last one or has a trash icon
-    const deleteBtn = deleteButtons[deleteButtons.length - 1];
-    fireEvent.click(deleteBtn);
+    const deleteBtn = document
+      .querySelectorAll('button.text-red-600')[0] as HTMLElement | undefined;
+    fireEvent.click(deleteBtn!);
 
     expect(screen.getByText('Delete Fixture')).toBeInTheDocument();
     expect(screen.getByText(/Are you sure you want to delete this fixture/)).toBeInTheDocument();
   });
 
-  it('deletes fixture successfully', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: true });
-
+  it('deletes fixture through the mutation', async () => {
     render(<FixturesPage />, { wrapper: createWrapper() });
 
-    const deleteButtons = Array.from(document.querySelectorAll('button.text-red-600'));
-    const deleteBtn = deleteButtons[0];
-    fireEvent.click(deleteBtn);
+    const deleteBtn = document
+      .querySelectorAll('button.text-red-600')[0] as HTMLElement | undefined;
+    fireEvent.click(deleteBtn!);
 
     const confirmButton = screen.getByRole('button', { name: 'Delete' });
     fireEvent.click(confirmButton);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('/__mockforge/fixtures/fixture-1', {
-        method: 'DELETE',
-      });
+      expect(deleteFixtureMutate).toHaveBeenCalledWith('fixture-1');
     });
   });
 
@@ -299,6 +335,7 @@ describe('FixturesPage', () => {
       isLoading: false,
       error: null,
       refetch: refetchMock,
+      isFetching: false,
     } as any);
 
     render(<FixturesPage />, { wrapper: createWrapper() });
@@ -307,21 +344,6 @@ describe('FixturesPage', () => {
     fireEvent.click(refreshButton);
 
     expect(refetchMock).toHaveBeenCalled();
-  });
-
-  it('formats file size correctly', () => {
-    render(<FixturesPage />, { wrapper: createWrapper() });
-
-    expect(screen.getByText('1 KB')).toBeInTheDocument();
-    expect(screen.getByText('2 KB')).toBeInTheDocument();
-  });
-
-  it('formats dates correctly', () => {
-    render(<FixturesPage />, { wrapper: createWrapper() });
-
-    // Check that dates are displayed
-    const dateElements = screen.getAllByText(/Jan/);
-    expect(dateElements.length).toBeGreaterThanOrEqual(1);
   });
 
   it('disables rename button when name is unchanged', () => {
@@ -339,6 +361,9 @@ describe('FixturesPage', () => {
 
     const moveButton = screen.getAllByText('Move')[0];
     fireEvent.click(moveButton);
+
+    const input = screen.getByPlaceholderText('Enter new path');
+    fireEvent.change(input, { target: { value: '' } });
 
     const confirmButton = screen.getAllByRole('button', { name: 'Move' }).at(-1)!;
     expect(confirmButton).toBeDisabled();

--- a/crates/mockforge-ui/ui/src/services/api/fixtures.ts
+++ b/crates/mockforge-ui/ui/src/services/api/fixtures.ts
@@ -1,17 +1,42 @@
 /**
- * Fixtures API service — fixture listing, deletion, download, rename, and move.
+ * Fixtures API service — cloud-aware wrapper over /api/v1/fixtures (hosted)
+ * and /__mockforge/fixtures (local dev). The two backends expose slightly
+ * different shapes, so this module normalises the calls.
  */
 import type { FixtureInfo } from '../../types';
 import { FixturesResponseSchema } from '../../schemas/api';
 import { fetchJson, fetchJsonWithValidation, authenticatedFetch } from './client';
 
 const isCloud = !!import.meta.env.VITE_API_BASE_URL;
-const FIXTURE_API_BASE = isCloud ? '/api/v1/fixtures' : '/__mockforge/fixtures';
+const CLOUD_BASE = '/api/v1/fixtures';
+const LOCAL_BASE = '/__mockforge/fixtures';
+const FIXTURE_API_BASE = isCloud ? CLOUD_BASE : LOCAL_BASE;
+
+export interface FixtureCreatePayload {
+  name: string;
+  path?: string;
+  method?: string;
+  description?: string;
+  protocol?: string;
+  tags?: string[];
+  content?: unknown;
+}
+
+export interface FixtureUpdatePayload {
+  name?: string;
+  path?: string;
+  method?: string;
+  description?: string;
+  tags?: string[];
+  content?: unknown;
+}
 
 class FixturesApiService {
   constructor() {
-    // Bind all methods to ensure 'this' context is preserved
+    // Preserve `this` when consumers destructure methods.
     this.getFixtures = this.getFixtures.bind(this);
+    this.createFixture = this.createFixture.bind(this);
+    this.updateFixture = this.updateFixture.bind(this);
     this.deleteFixture = this.deleteFixture.bind(this);
     this.deleteFixturesBulk = this.deleteFixturesBulk.bind(this);
     this.downloadFixture = this.downloadFixture.bind(this);
@@ -29,6 +54,30 @@ class FixturesApiService {
     );
   }
 
+  async createFixture(payload: FixtureCreatePayload): Promise<FixtureInfo> {
+    return fetchJson(FIXTURE_API_BASE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }) as Promise<FixtureInfo>;
+  }
+
+  async updateFixture(
+    fixtureId: string,
+    payload: FixtureUpdatePayload
+  ): Promise<FixtureInfo> {
+    if (!isCloud) {
+      throw new Error(
+        'Editing fixture content is only supported on the hosted backend; use rename/move locally.'
+      );
+    }
+    return fetchJson(`${FIXTURE_API_BASE}/${fixtureId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }) as Promise<FixtureInfo>;
+  }
+
   async deleteFixture(fixtureId: string): Promise<void> {
     return fetchJson(`${FIXTURE_API_BASE}/${fixtureId}`, {
       method: 'DELETE',
@@ -36,29 +85,59 @@ class FixturesApiService {
   }
 
   async deleteFixturesBulk(fixtureIds: string[]): Promise<void> {
-    return fetchJson('/__mockforge/fixtures/bulk', {
+    if (isCloud) {
+      // Cloud has no bulk endpoint; fan out individual DELETE calls instead.
+      await Promise.all(fixtureIds.map((id) => this.deleteFixture(id)));
+      return;
+    }
+    return fetchJson(`${LOCAL_BASE}/bulk`, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ fixture_ids: fixtureIds }),
     }) as Promise<void>;
   }
 
-  async downloadFixture(fixtureId: string): Promise<Blob> {
-    const response = await authenticatedFetch(`${FIXTURE_API_BASE}/${fixtureId}/download`);
+  async downloadFixture(fixture: FixtureInfo): Promise<{ blob: Blob; filename: string }> {
+    if (isCloud) {
+      // No dedicated download endpoint on cloud — synthesize a JSON blob
+      // from the stored `content` (falling back to the full fixture record
+      // so the user always gets something useful).
+      const payload =
+        fixture.content ?? {
+          id: fixture.id,
+          name: fixture.name,
+          path: fixture.path,
+          method: fixture.method,
+          description: fixture.description,
+          tags: fixture.tags,
+          protocol: fixture.protocol,
+        };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], {
+        type: 'application/json',
+      });
+      const baseName = fixture.name || fixture.id;
+      return { blob, filename: `${baseName}.json` };
+    }
+
+    const response = await authenticatedFetch(`${LOCAL_BASE}/${fixture.id}/download`);
     if (!response.ok) {
-      if (response.status === 401) {
-        throw new Error('Authentication required');
-      }
-      if (response.status === 403) {
-        throw new Error('Access denied');
-      }
+      if (response.status === 401) throw new Error('Authentication required');
+      if (response.status === 403) throw new Error('Access denied');
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    return response.blob();
+    const blob = await response.blob();
+    const contentDisposition = response.headers.get('Content-Disposition');
+    const filenameMatch = contentDisposition?.match(/filename="?([^"]+)"?/);
+    const filename = filenameMatch?.[1] || `${fixture.id}.json`;
+    return { blob, filename };
   }
 
   async renameFixture(fixtureId: string, newName: string): Promise<void> {
-    return fetchJson(`${FIXTURE_API_BASE}/${fixtureId}/rename`, {
+    if (isCloud) {
+      await this.updateFixture(fixtureId, { name: newName });
+      return;
+    }
+    return fetchJson(`${LOCAL_BASE}/${fixtureId}/rename`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ new_name: newName }),
@@ -66,7 +145,11 @@ class FixturesApiService {
   }
 
   async moveFixture(fixtureId: string, newPath: string): Promise<void> {
-    return fetchJson(`${FIXTURE_API_BASE}/${fixtureId}/move`, {
+    if (isCloud) {
+      await this.updateFixture(fixtureId, { path: newPath });
+      return;
+    }
+    return fetchJson(`${LOCAL_BASE}/${fixtureId}/move`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ new_path: newPath }),


### PR DESCRIPTION
## Summary

Closes the fixtures-page audit: every field the cloud backend accepts is now reachable from `app.mockforge.dev/fixtures`, and every button on that page now hits the right endpoint.

### Bugs fixed on the hosted site
These UI actions were hardcoded to `/__mockforge/fixtures/*` (the local dev admin API) and 404'd in production:

- Delete → now routes through `DELETE /api/v1/fixtures/{id}`
- Rename → now `PATCH /api/v1/fixtures/{id}` with `{ name }` on cloud
- Move → now `PATCH /api/v1/fixtures/{id}` with `{ path }` on cloud
- Download → cloud synthesises a JSON blob from the stored `content` (no dedicated endpoint needed)
- Bulk delete → fans out individual DELETEs on cloud; local still uses the `/bulk` endpoint

### Backend gaps closed
`POST /api/v1/fixtures` now accepts and persists `protocol` and `tags`. The `fixtures` table already had both columns; the create handler was dropping them silently.

### New UI surface
- **Edit dialog** backed by `PATCH /api/v1/fixtures/{id}` — updates name / path / method / description / tags / content. The response `content` field had no UI at all before this.
- **Create dialog** now captures protocol, tags, and response content (JSON, with inline parse-error validation).
- **Viewer dialog** surfaces description, tags, and the actual response content (previously only metadata).
- List rows show description, tags, protocol badge.
- **Tag filter** dropdown + tag-aware search.

### Tests
- `FixturesPage.test.tsx` rewritten for the mutation-based API. **21/21 passing.**
- `fixtures-deployed.spec.ts` updated: broken assertions fixed (placeholder text, multi-combobox strict match, removed "Total Size" on cloud) and 7 new tests added covering tag filter, create-dialog new fields + JSON validation, Edit button, Edit dialog fields, viewer Response Content.
- `cargo check` + `cargo clippy -p mockforge-registry-core -p mockforge-registry-server --all-targets -- -D warnings`: clean.
- `pnpm type-check`: clean.

## Test plan

- [ ] CI green on `ci.yml`
- [ ] Deploy `mockforge-registry-server` so the new create-handler fields land in prod before the UI starts sending them (UI gracefully omits when fields are empty, but you'll only see new fixtures populated with `protocol`/`tags` after the backend redeploys)
- [ ] Smoke-test `fixtures-deployed.spec.ts` against `app.mockforge.dev` post-deploy (needs `E2E_EMAIL` / `E2E_PASSWORD`)
- [ ] Manual: create a fixture with content + tags, edit it, filter by tag, download it, delete it

## Commits

- `2a1c2bb7` feat(cloud-fixtures): wire cloud editor, content, tags end-to-end
- `441b5166` test(e2e): cover new fixtures UI wiring on deployed site