### PR TITLE
docs: update Discord invite link to non-expiring URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1706,7 +1706,7 @@ See the [complete troubleshooting guide](https://docs.mockforge.dev/reference/tr
 
 - **[GitHub Issues](https://github.com/SaaSy-Solutions/mockforge/issues)** - Report bugs or request features
 - **[GitHub Discussions](https://github.com/SaaSy-Solutions/mockforge/discussions)** - Ask questions and share ideas
-- **[Discord](https://discord.gg/2FxXqKpa)** - Join our community chat
+- **[Discord](https://discord.gg/vk22xwxug3)** - Join our community chat
 - **[Contributing Guide](CONTRIBUTING.md)** - Contribute to MockForge development
 
 ### Need Help?

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -89,7 +89,7 @@ MockForge is organized around five product pillars: **Reality**, **Contracts**, 
 
 - [GitHub Issues](https://github.com/SaaSy-Solutions/mockforge/issues) - Report bugs and request features
 - [GitHub Discussions](https://github.com/SaaSy-Solutions/mockforge/discussions) - Ask questions and share ideas
-- [Discord](https://discord.gg/2FxXqKpa) - Join our community chat
+- [Discord](https://discord.gg/vk22xwxug3) - Join our community chat
 
 ## License
 

--- a/book/src/contributing/release.md
+++ b/book/src/contributing/release.md
@@ -446,7 +446,7 @@ gh issue list --label bug --state open --limit 10
 
 - **GitHub Issues**: Bug reports and feature requests
 - **GitHub Discussions**: General questions and support
-- **Discord**: [Join our community chat](https://discord.gg/2FxXqKpa) - Real-time community support
+- **Discord**: [Join our community chat](https://discord.gg/vk22xwxug3) - Real-time community support
 - **Documentation**: Self-service troubleshooting
 
 ### 3. Follow-up Releases

--- a/book/src/contributing/setup.md
+++ b/book/src/contributing/setup.md
@@ -379,7 +379,7 @@ git push origin feature/your-feature
 
 - **GitHub Issues**: For bugs, features, and general discussion
 - **GitHub Discussions**: For questions and longer-form discussion
-- **Discord**: [Join our community chat](https://discord.gg/2FxXqKpa) - For real-time chat
+- **Discord**: [Join our community chat](https://discord.gg/vk22xwxug3) - For real-time chat
 
 ### When to Ask for Help
 

--- a/book/src/reference/faq.md
+++ b/book/src/reference/faq.md
@@ -660,7 +660,7 @@ Please include:
 
 - **GitHub Discussions**: [Community Forum](https://github.com/SaaSy-Solutions/mockforge/discussions)
 - **GitHub Issues**: [Bug Reports & Feature Requests](https://github.com/SaaSy-Solutions/mockforge/issues)
-- **Discord**: [Join our community chat](https://discord.gg/2FxXqKpa)
+- **Discord**: [Join our community chat](https://discord.gg/vk22xwxug3)
 
 ---
 

--- a/crates/mockforge-ui/ui/src/pages/FAQPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FAQPage.tsx
@@ -194,7 +194,7 @@ export function FAQPage() {
               View Documentation
             </a>
             <a
-              href="https://discord.gg/mockforge"
+              href="https://discord.gg/vk22xwxug3"
               target="_blank"
               rel="noopener noreferrer"
               className="px-4 py-2 border border-border rounded-md hover:bg-muted transition-colors flex items-center gap-2"

--- a/crates/mockforge-ui/ui/src/pages/SupportPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/SupportPage.tsx
@@ -143,7 +143,7 @@ export function SupportPage() {
                 FAQ →
               </button>
               <a
-                href="https://discord.gg/mockforge"
+                href="https://discord.gg/vk22xwxug3"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary hover:underline text-sm"
@@ -308,7 +308,7 @@ export function SupportPage() {
                 Join our Discord server to chat with other users, get real-time help, and share your projects.
               </p>
               <a
-                href="https://discord.gg/mockforge"
+                href="https://discord.gg/vk22xwxug3"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary hover:underline font-medium"

--- a/docs/AI_DRIVEN_MOCKING.md
+++ b/docs/AI_DRIVEN_MOCKING.md
@@ -763,4 +763,4 @@ prompt: |
 - Explore [Advanced Examples](./examples/ai-driven/)
 - Read [API Reference](./api/ai-features.md)
 - Check [Performance Guide](./performance.md)
-- Join [Community Discord](https://discord.gg/mockforge)
+- Join [Community Discord](https://discord.gg/vk22xwxug3)

--- a/docs/AUDIT_TRAILS.md
+++ b/docs/AUDIT_TRAILS.md
@@ -487,7 +487,7 @@ logging:
 For issues or questions:
 - [GitHub Issues](https://github.com/SaaSy-Solutions/mockforge/issues)
 - [GitHub Discussions](https://github.com/SaaSy-Solutions/mockforge/discussions)
-- [Discord](https://discord.gg/2FxXqKpa)
+- [Discord](https://discord.gg/vk22xwxug3)
 
 ---
 

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -853,5 +853,5 @@ kubectl set resources deployment mockforge -n mockforge --limits=memory=1Gi
 For issues or questions:
 - GitHub Issues: https://github.com/SaaSy-Solutions/mockforge/issues
 - GitHub Discussions: https://github.com/SaaSy-Solutions/mockforge/discussions
-- Discord: https://discord.gg/2FxXqKpa
+- Discord: https://discord.gg/vk22xwxug3
 - Documentation: https://docs.mockforge.dev

--- a/docs/INTEGRATION_ECOSYSTEM.md
+++ b/docs/INTEGRATION_ECOSYSTEM.md
@@ -626,7 +626,7 @@ Terraform modules for cloud deployments are available:
 
 - [GitHub Issues](https://github.com/SaaSy-Solutions/mockforge/issues)
 - [GitHub Discussions](https://github.com/SaaSy-Solutions/mockforge/discussions)
-- [Discord](https://discord.gg/2FxXqKpa) - Join our community chat
+- [Discord](https://discord.gg/vk22xwxug3) - Join our community chat
 - [Contributing Guide](../CONTRIBUTING.md)
 
 ### Examples

--- a/docs/PLUGIN_MARKETPLACE_IMPLEMENTATION.md
+++ b/docs/PLUGIN_MARKETPLACE_IMPLEMENTATION.md
@@ -836,7 +836,7 @@ To get your plugin featured on the marketplace homepage:
 ## Support
 
 - **Documentation**: https://docs.mockforge.dev/plugins
-- **Discord**: https://discord.gg/mockforge
+- **Discord**: https://discord.gg/vk22xwxug3
 - **GitHub Discussions**: https://github.com/SaaSy-Solutions/mockforge/discussions
 \`\`\`
 

--- a/docs/RBAC_GUIDE.md
+++ b/docs/RBAC_GUIDE.md
@@ -430,7 +430,7 @@ Invalid token: Token verification failed
 For issues or questions:
 - [GitHub Issues](https://github.com/SaaSy-Solutions/mockforge/issues)
 - [GitHub Discussions](https://github.com/SaaSy-Solutions/mockforge/discussions)
-- [Discord](https://discord.gg/2FxXqKpa)
+- [Discord](https://discord.gg/vk22xwxug3)
 
 ---
 

--- a/docs/cloud/PRICING.md
+++ b/docs/cloud/PRICING.md
@@ -375,7 +375,7 @@ Not sure which plan is right for you? We're here to help:
 
 - **Email**: support@mockforge.dev
 - **Schedule a call**: [book a demo](https://calendly.com/mockforge)
-- **Chat**: Join our [Discord community](https://discord.gg/mockforge)
+- **Chat**: Join our [Discord community](https://discord.gg/vk22xwxug3)
 
 ---
 

--- a/docs/mTLS_CONFIGURATION.md
+++ b/docs/mTLS_CONFIGURATION.md
@@ -468,7 +468,7 @@ services:
 For issues or questions:
 - [GitHub Issues](https://github.com/SaaSy-Solutions/mockforge/issues)
 - [GitHub Discussions](https://github.com/SaaSy-Solutions/mockforge/discussions)
-- [Discord](https://discord.gg/2FxXqKpa)
+- [Discord](https://discord.gg/vk22xwxug3)
 
 ---
 

--- a/docs/plugins/POLYGLOT_QUICK_START.md
+++ b/docs/plugins/POLYGLOT_QUICK_START.md
@@ -469,7 +469,7 @@ mockforge plugin test my-as-plugin
 
 - 💬 [GitHub Discussions](https://github.com/mockforge/mockforge/discussions)
 - 🐛 [Report Issues](https://github.com/mockforge/mockforge/issues)
-- 💬 [Discord Community](https://discord.gg/mockforge)
+- 💬 [Discord Community](https://discord.gg/vk22xwxug3)
 
 ## Troubleshooting
 

--- a/examples/plugins/auth-python-oauth/README.md
+++ b/examples/plugins/auth-python-oauth/README.md
@@ -346,4 +346,4 @@ MIT OR Apache-2.0
 
 - GitHub Issues: [Report bugs](https://github.com/mockforge/mockforge/issues)
 - GitHub Discussions: [Ask questions](https://github.com/mockforge/mockforge/discussions)
-- Discord: [Join community](https://discord.gg/mockforge)
+- Discord: [Join community](https://discord.gg/vk22xwxug3)

--- a/sdk/go/mockforge/README.md
+++ b/sdk/go/mockforge/README.md
@@ -395,4 +395,4 @@ MIT OR Apache-2.0
 
 - GitHub Issues: [Report bugs](https://github.com/mockforge/mockforge/issues)
 - GitHub Discussions: [Ask questions](https://github.com/mockforge/mockforge/discussions)
-- Discord: [Join community](https://discord.gg/mockforge)
+- Discord: [Join community](https://discord.gg/vk22xwxug3)


### PR DESCRIPTION
## Summary
- Replace expired/placeholder Discord invites (`2FxXqKpa`, `mockforge`) with the permanent invite `https://discord.gg/vk22xwxug3`.
- Updated across README, docs, book chapters, UI pages (SupportPage, FAQPage), and SDK READMEs.

## Test plan
- [x] Grep confirms no remaining `2FxXqKpa` / `discord.gg/mockforge` references in source (only generated `book/book/*.html` artifacts remain)
- [x] Pre-commit hooks passed (clippy, cargo-check, typos)