### PR TITLE
ci(deps): bump github/codeql-action from 3 to 4

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -100,7 +100,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: github.event_name != 'pull_request' && steps.trivy.outcome == 'success'
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -106,7 +106,7 @@ jobs:
           output_file_path: checkov-results.sarif
 
       - name: Upload Checkov results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: checkov-results.sarif


### PR DESCRIPTION
Replaces dependabot #86 which was in conflict. Updates upload-sarif refs in docker-build.yml and k8s-tests.yml to v4.