### PR TITLE
fix(ui): default OSS/docker builds to local admin mode

### DIFF
--- a/book/src/user-guide/admin-ui.md
+++ b/book/src/user-guide/admin-ui.md
@@ -29,12 +29,18 @@ Access the interface at `http://localhost:9080/admin` (or your configured admin 
 
 ### Authentication
 
-The Admin UI includes secure authentication with two built-in roles:
+The Admin UI includes secure authentication with three built-in roles:
 
 #### Admin Role
 - **Username**: `admin`
 - **Password**: `admin123`
 - **Permissions**: Full access to all features
+
+#### Editor Role
+- **Username**: `editor`
+- **Password**: `editor123`
+- **Permissions**: Create/edit fixtures, routes, and configuration (no user
+  management)
 
 #### Viewer Role
 - **Username**: `viewer`
@@ -292,42 +298,39 @@ The Admin UI supports light and dark themes with CSS custom properties:
 
 The Admin UI communicates with MockForge through RESTful APIs:
 
+The embedded admin server exposes its API under `/__mockforge/*` (the
+hosted cloud registry uses a different `/api/v1/*` prefix; see the Cloud
+Workspaces guide for that surface).
+
 ```http
-# Service management
-GET    /api/v2/services
-PUT    /api/v2/services/{id}
-POST   /api/v2/services/bulk
+# Service & route listing
+GET    /__mockforge/routes
+GET    /__mockforge/server-info
 
 # Fixture management
-GET    /api/v2/fixtures
-POST   /api/v2/fixtures
-PUT    /api/v2/fixtures/{id}
-DELETE /api/v2/fixtures/{id}
+GET    /__mockforge/fixtures
+POST   /__mockforge/fixtures
+PUT    /__mockforge/fixtures/{id}
+DELETE /__mockforge/fixtures/{id}
 
 # Authentication
-POST   /api/v2/auth/login
-POST   /api/v2/auth/refresh
-POST   /api/v2/auth/logout
+POST   /__mockforge/auth/login
+POST   /__mockforge/auth/refresh
+POST   /__mockforge/auth/logout
+GET    /__mockforge/auth/me
 
 # Logs and metrics
-GET    /api/v2/logs
-GET    /api/v2/metrics/latency
-GET    /api/v2/metrics/failures
+GET    /__mockforge/logs
+GET    /__mockforge/metrics
 ```
 
-### WebSocket Endpoints
+### Server-Sent Events
 
-Real-time features use WebSocket connections:
+Real-time features stream over SSE:
 
 ```http
 # Live log streaming
-WS /api/v2/logs/stream
-
-# Metrics updates
-WS /api/v2/metrics/stream
-
-# Configuration changes
-WS /api/v2/config/stream
+GET /__mockforge/logs/sse
 ```
 
 ## Troubleshooting
@@ -339,19 +342,24 @@ WS /api/v2/config/stream
 # Check JWT secret configuration
 MOCKFORGE_ADMIN_JWT_SECRET=your-secret-key
 
-# Verify admin credentials
-curl -X POST http://localhost:9080/api/v2/auth/login \
+# Verify admin credentials against the embedded admin server
+curl -X POST http://localhost:9080/__mockforge/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"admin123"}'
 ```
 
-#### WebSocket Connection Issues
-```bash
-# Check WebSocket endpoint
-wscat -c ws://localhost:9080/api/v2/logs/stream
+If the curl above returns a token but the browser login page still fails,
+the UI bundle was built in *cloud* mode. The OSS docker image must ship a
+*local* bundle — see `crates/mockforge-ui/ui/.env.production.example`;
+`.env.production` is gitignored on purpose.
 
-# Verify proxy configuration if behind reverse proxy
-ProxyPass /api/v2/ ws://localhost:9080/api/v2/
+#### Log Stream Connection Issues
+```bash
+# Check the log SSE endpoint
+curl -N http://localhost:9080/__mockforge/logs/sse
+
+# Verify proxy configuration if behind a reverse proxy
+ProxyPass /__mockforge/ http://localhost:9080/__mockforge/
 ```
 
 #### Performance Issues

--- a/crates/mockforge-ui/ui/.env.production
+++ b/crates/mockforge-ui/ui/.env.production
@@ -1,1 +1,0 @@
-VITE_API_BASE_URL=https://api.mockforge.dev

--- a/crates/mockforge-ui/ui/.env.production.example
+++ b/crates/mockforge-ui/ui/.env.production.example
@@ -1,0 +1,9 @@
+# Copy to `.env.production` to build the cloud-mode bundle that talks to the
+# SaaS registry. Do NOT commit `.env.production` — the OSS / docker-compose
+# image must keep shipping a local-mode bundle that talks to the embedded
+# admin server at /__mockforge/*, or login will fail out of the box
+# (see PR: fix(ui): default OSS builds to local mode).
+#
+# Cloud SaaS builds should set both in CI (Vercel env or a copy of this file).
+VITE_MOCKFORGE_MODE=cloud
+VITE_API_BASE_URL=https://api.mockforge.dev

--- a/crates/mockforge-ui/ui/.gitignore
+++ b/crates/mockforge-ui/ui/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Never commit a real .env.production — it flips the bundle into cloud mode
+# and breaks the OSS / docker-compose login flow. Cloud builds should copy
+# the sibling .env.production.example locally or set these vars in CI.
+.env.production
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/crates/mockforge-ui/ui/src/components/auth/AuthGuard.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/AuthGuard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { LoginForm } from './LoginForm';
+import { isCloudMode } from '../../utils/cloudMode';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -10,15 +11,14 @@ interface AuthGuardProps {
 
 /**
  * Paths that carry their own auth flow and must bypass the SaaS
- * AuthGuard entirely. In **self-hosted mode** (no VITE_API_BASE_URL),
+ * AuthGuard entirely. In **self-hosted mode** (isCloudMode() === false),
  * the registry-admin module uses a separate JWT signed against the
  * SqliteRegistryStore, so the SaaS auth check would block it. In
  * **cloud mode**, the registry-admin pages live inside the normal SaaS
  * auth flow — the user logs in once via the SaaS login, and the
  * RegistryAdminPage reuses that JWT. So we only bypass in self-hosted.
  */
-const isCloud = !!import.meta.env.VITE_API_BASE_URL;
-const SELF_AUTHED_PREFIXES = isCloud ? [] : ['/registry-login', '/registry-admin'];
+const SELF_AUTHED_PREFIXES = isCloudMode() ? [] : ['/registry-login', '/registry-admin'];
 
 export function AuthGuard({ children, requiredRole }: AuthGuardProps) {
   const location = useLocation();

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -64,6 +64,7 @@ import {
   Lock as LockIcon,
 } from 'lucide-react';
 import { GlobalConnectionStatus } from './ConnectionStatus';
+import { isCloudMode as detectCloudMode } from '../../utils/cloudMode';
 
 interface AppShellProps {
   children: React.ReactNode;
@@ -187,7 +188,7 @@ const navSections = [
 ];
 
 // Cloud mode: only show functional nav items when running on the cloud app
-const isCloudMode = !!import.meta.env.VITE_API_BASE_URL;
+const isCloudMode = detectCloudMode();
 
 const cloudNavItemIds = new Set([
   'dashboard',

--- a/crates/mockforge-ui/ui/src/pages/FixturesPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FixturesPage.tsx
@@ -42,8 +42,9 @@ import {
   DialogClose,
 } from '../components/ui/Dialog';
 import { toast } from 'sonner';
+import { isCloudMode } from '../utils/cloudMode';
 
-const isCloud = !!import.meta.env.VITE_API_BASE_URL;
+const isCloud = isCloudMode();
 
 interface FixtureFormState {
   name: string;

--- a/crates/mockforge-ui/ui/src/services/api/dashboard.ts
+++ b/crates/mockforge-ui/ui/src/services/api/dashboard.ts
@@ -4,8 +4,9 @@
 import type { DashboardData, HealthCheck } from '../../types';
 import { DashboardResponseSchema } from '../../schemas/api';
 import { fetchJson, fetchJsonWithValidation } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
 
-const isCloud = !!import.meta.env.VITE_API_BASE_URL;
+const isCloud = isCloudMode();
 
 class DashboardApiService {
   async getDashboard(): Promise<DashboardData> {

--- a/crates/mockforge-ui/ui/src/services/api/fixtures.ts
+++ b/crates/mockforge-ui/ui/src/services/api/fixtures.ts
@@ -6,8 +6,9 @@
 import type { FixtureInfo } from '../../types';
 import { FixturesResponseSchema } from '../../schemas/api';
 import { fetchJson, fetchJsonWithValidation, authenticatedFetch } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
 
-const isCloud = !!import.meta.env.VITE_API_BASE_URL;
+const isCloud = isCloudMode();
 const CLOUD_BASE = '/api/v1/fixtures';
 const LOCAL_BASE = '/__mockforge/fixtures';
 const FIXTURE_API_BASE = isCloud ? CLOUD_BASE : LOCAL_BASE;

--- a/crates/mockforge-ui/ui/src/services/api/routes.ts
+++ b/crates/mockforge-ui/ui/src/services/api/routes.ts
@@ -3,8 +3,9 @@
  */
 import type { RouteInfo } from '../../types';
 import { fetchJson } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
 
-const isCloud = !!import.meta.env.VITE_API_BASE_URL;
+const isCloud = isCloudMode();
 const ROUTES_API_BASE = isCloud ? '/api/v1/services' : '/__mockforge/routes';
 
 class RoutesApiService {

--- a/crates/mockforge-ui/ui/src/services/api/workspaces.ts
+++ b/crates/mockforge-ui/ui/src/services/api/workspaces.ts
@@ -36,8 +36,9 @@ import {
   type WorkspaceSummary,
 } from '../../schemas/api';
 import { fetchJson, fetchJsonWithValidation } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
 
-const isCloud = !!import.meta.env.VITE_API_BASE_URL;
+const isCloud = isCloudMode();
 const WORKSPACE_API_BASE = isCloud ? '/api/v1/workspaces' : '/__mockforge/workspaces';
 
 class WorkspacesApiMixin {

--- a/crates/mockforge-ui/ui/src/services/authApi.ts
+++ b/crates/mockforge-ui/ui/src/services/authApi.ts
@@ -4,6 +4,7 @@
 
 import type { User } from '../types';
 import { apiErrorMessage } from '@/utils/errorHandling';
+import { isCloudMode } from '../utils/cloudMode';
 
 export interface LoginResponse {
   token: string;
@@ -23,12 +24,6 @@ interface LocalApiResponse<T> {
   error: string | null;
   timestamp: string;
 }
-
-// Detect cloud mode: VITE_API_BASE_URL is set in .env.production
-const isCloudMode = (): boolean => {
-  const apiBase = import.meta.env.VITE_API_BASE_URL;
-  return !!apiBase && apiBase !== '';
-};
 
 class AuthApiService {
   private cloud = isCloudMode();

--- a/crates/mockforge-ui/ui/src/services/conformanceApi.ts
+++ b/crates/mockforge-ui/ui/src/services/conformanceApi.ts
@@ -5,6 +5,7 @@ import type {
   ConformanceProgress,
 } from '../types/conformance';
 import { authenticatedFetch } from '../utils/apiClient';
+import { isCloudMode } from '../utils/cloudMode';
 
 const BASE_URL = '/api/conformance';
 
@@ -59,8 +60,7 @@ export function streamConformanceProgress(
   onEvent: (event: ConformanceProgress) => void,
   onError?: (error: Event) => void
 ): EventSource | null {
-  const isCloud = !!import.meta.env.VITE_API_BASE_URL;
-  if (isCloud) return null;
+  if (isCloudMode()) return null;
 
   // EventSource doesn't support Authorization headers natively.
   // The SSE endpoint is best-effort — we also poll via getConformanceRun.

--- a/crates/mockforge-ui/ui/src/services/registryAdminApi.ts
+++ b/crates/mockforge-ui/ui/src/services/registryAdminApi.ts
@@ -1,21 +1,20 @@
 // Registry admin API client.
 //
-// In **cloud mode** (VITE_API_BASE_URL set): calls go to the SaaS
+// In **cloud mode** (VITE_MOCKFORGE_MODE=cloud): calls go to the SaaS
 // backend at /api/v1/* and use the existing SaaS JWT from useAuthStore
 // (stored under `auth_token` in localStorage).
 //
-// In **self-hosted mode** (no VITE_API_BASE_URL): calls go to the
-// embedded SQLite-backed endpoints at /api/admin/registry/* and use a
-// separate JWT stored under `mockforge_registry_admin_token`.
+// In **self-hosted mode** (default): calls go to the embedded
+// SQLite-backed endpoints at /api/admin/registry/* and use a separate
+// JWT stored under `mockforge_registry_admin_token`.
+
+import { isCloudMode as detectCloudMode } from '../utils/cloudMode';
 
 const TOKEN_STORAGE_KEY = 'mockforge_registry_admin_token';
 const SAAS_TOKEN_KEY = 'auth_token'; // matches useAuthStore's persist key
 
 /** True when the frontend is served by Vercel with a cloud API backend. */
-export const isCloudMode = (): boolean => {
-  const apiBase = import.meta.env.VITE_API_BASE_URL;
-  return !!apiBase && apiBase !== '';
-};
+export const isCloudMode = detectCloudMode;
 
 export interface RegistryUser {
   id: string;

--- a/crates/mockforge-ui/ui/src/stores/useAnalyticsStore.ts
+++ b/crates/mockforge-ui/ui/src/stores/useAnalyticsStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { isCloudMode } from '../utils/cloudMode';
 
 // Types matching the backend API responses
 export interface SummaryMetrics {
@@ -81,7 +82,7 @@ export interface AnalyticsStore {
 }
 
 const BASE_URL = '__mockforge/analytics';
-const isCloud = !!import.meta.env.VITE_API_BASE_URL;
+const isCloud = isCloudMode();
 
 export const useAnalyticsStore = create<AnalyticsStore>((set, get) => ({
   // Initial state

--- a/crates/mockforge-ui/ui/src/utils/apiClient.ts
+++ b/crates/mockforge-ui/ui/src/utils/apiClient.ts
@@ -2,15 +2,12 @@
 // Intercepts all fetch requests to add Authorization header
 
 import { useAuthStore } from '../stores/useAuthStore';
+import { isCloudMode } from './cloudMode';
 
 // Store the original fetch function
 const originalFetch = globalThis.fetch;
 
-// Detect cloud mode (same logic as authApi.ts)
-const isCloud = (() => {
-  const apiBase = import.meta.env.VITE_API_BASE_URL;
-  return !!apiBase && apiBase !== '';
-})();
+const isCloud = isCloudMode();
 
 // In cloud mode, /__mockforge/ endpoints don't exist on the registry server.
 // The main API services (dashboard, workspaces, services, fixtures, federation)

--- a/crates/mockforge-ui/ui/src/utils/cloudMode.ts
+++ b/crates/mockforge-ui/ui/src/utils/cloudMode.ts
@@ -1,0 +1,24 @@
+// Single source of truth for "is this bundle talking to the SaaS registry
+// (cloud mode) or to the embedded admin server (local / self-hosted mode)".
+//
+// Cloud mode is opt-in via VITE_MOCKFORGE_MODE=cloud. That keeps OSS and
+// docker-compose builds in local mode by default, which is what the embedded
+// /__mockforge/auth/* endpoints expect. Historically detection keyed off
+// VITE_API_BASE_URL being set; we still honor that as a fallback so existing
+// cloud deploys keep working, but new cloud builds should set the explicit
+// flag.
+
+export const isCloudMode = (): boolean => {
+  const mode = import.meta.env.VITE_MOCKFORGE_MODE;
+  if (typeof mode === 'string' && mode.toLowerCase() === 'cloud') {
+    return true;
+  }
+  // Legacy fallback: treat a non-empty VITE_API_BASE_URL as cloud mode.
+  const apiBase = import.meta.env.VITE_API_BASE_URL;
+  return typeof apiBase === 'string' && apiBase.trim() !== '';
+};
+
+export const getCloudApiBase = (): string => {
+  const apiBase = import.meta.env.VITE_API_BASE_URL;
+  return typeof apiBase === 'string' ? apiBase : '';
+};


### PR DESCRIPTION
## Summary

Kiran reported on Discord that `docker compose up` from `main` produces a login page where `admin` / `admin123` (as documented in `book/src/user-guide/admin-ui.md`) always fails. Same symptom would hit anyone following the OSS docker quickstart.

**Root cause:** `crates/mockforge-ui/ui/.env.production` was checked in with `VITE_API_BASE_URL=https://api.mockforge.dev`. `vite build` auto-loads `.env.production`, baking that URL into the bundle. The cloud-mode detector (`!!import.meta.env.VITE_API_BASE_URL`) then flipped any production build into cloud mode, so the login form POSTed to `https://api.mockforge.dev/api/v1/auth/login` with `{email, password}` instead of the embedded `/__mockforge/auth/login` with `{username, password}`. The backend seed (`crates/mockforge-ui/src/auth.rs:319-345`) was fine all along — credentials just never reached it.

## Changes

- Delete `crates/mockforge-ui/ui/.env.production`; ship `.env.production.example` instead and gitignore the real `.env.production` so the cloud flip stays opt-in.
- Add `crates/mockforge-ui/ui/src/utils/cloudMode.ts` as the single source of truth. Primary signal: explicit `VITE_MOCKFORGE_MODE=cloud`. Legacy fallback: non-empty `VITE_API_BASE_URL` (so existing SaaS deploys keep working during cutover).
- Replace every ad-hoc `!!import.meta.env.VITE_API_BASE_URL` check (`authApi`, `apiClient`, `registryAdminApi`, `AuthGuard`, `AppShell`, `services/api/{dashboard,fixtures,routes,workspaces}`, `FixturesPage`, `useAnalyticsStore`, `conformanceApi`) with the shared `isCloudMode()`.
- Fix `book/src/user-guide/admin-ui.md`: endpoints are `/__mockforge/auth/*`, not `/api/v2/auth/*`. Update the troubleshooting `curl` and log-stream guidance to match the routes registered in `crates/mockforge-ui/src/routes.rs`. Document the third seeded role (`editor` / `editor123`).

## Verification

1. **Bug reproduction on clean `main`**: `pnpm build` → `grep 'api.mockforge.dev' dist/assets/index.js` → 2 hits. That's the cloud base URL shipped in the OSS bundle.
2. **Fix at artifact level**: same build after this PR → only `docs.mockforge.dev` remains (doc links, not API base).
3. **End-to-end through the browser**: served `dist/` via `python3 -m http.server` and drove the login form in Playwright. `browser_network_requests` confirmed the form POSTs to `http://localhost:8765/__mockforge/auth/login` with body `{"username":"admin","password":"admin123"}` — exactly what the embedded admin server expects. (Static server 501s because only mockforge serves that path; the real container will answer it.)
4. `pnpm type-check` clean. `pnpm lint` clean for the files touched (no new warnings). Vitest: same pass/fail set as clean `main` (the pre-existing Router-less `AuthGuard.test.tsx` failures are unrelated).
5. Pre-commit hooks (`clippy --workspace`, `cargo-check --workspace`, `typos`, fixers) all pass.

## Follow-ups (not in this PR)

- Discussion [#119](https://github.com/SaaSy-Solutions/mockforge/discussions/119): no images are actually published to Docker Hub or GHCR yet. Tracked as a separate issue (linked in a sibling comment) — the quickest unblock is flushing a main-branch run of `.github/workflows/docker-build.yml` so `ghcr.io/saasy-solutions/mockforge` starts to exist.

## Test plan

- [ ] Reviewer: `pnpm build` in `crates/mockforge-ui/ui`, then `grep 'api\.mockforge\.dev' dist/assets/index.js | grep -v docs` returns 0 hits.
- [ ] Reviewer: `docker compose up` from repo root, open `http://localhost:9080`, sign in with `admin` / `admin123`, land on the dashboard.
- [ ] Cloud SaaS smoke: set `VITE_MOCKFORGE_MODE=cloud` + `VITE_API_BASE_URL=…`, build, verify the login form targets the cloud endpoint unchanged.