### PR TITLE
chore(docker): canonicalize image registry on GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,46 +175,13 @@ jobs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
-  docker:
-    name: Build and Push Docker Image
-    runs-on: ubuntu-latest
-    if: '!contains(github.ref_name, ''rc'') && !contains(github.ref_name, ''alpha'') && !contains(github.ref_name, ''beta'')'
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: SaaSy-Solutions/mockforge
-        tags: |
-          type=ref,event=tag
-          type=raw,value=latest
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+  # Docker image publishing lives in .github/workflows/docker-build.yml
+  # (multi-arch push to ghcr.io/saasy-solutions/mockforge on every push to
+  # main and on semver tags). GHCR is the canonical registry for MockForge
+  # images; we do not publish to Docker Hub.
 
   deploy-registry:
     name: Deploy Registry Server to Fly.io
-    needs: docker
     runs-on: ubuntu-latest
     if: '!contains(github.ref_name, ''rc'') && !contains(github.ref_name, ''alpha'') && !contains(github.ref_name, ''beta'')'
     steps:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -6,9 +6,9 @@ This guide covers how to run MockForge using Docker and Docker Compose for both 
 
 ### Pull the prebuilt image (fastest)
 
-Multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub
-Container Registry on every push to `main` and on every semver tag. No
-auth is needed to pull.
+Images are published to GitHub Container Registry on every push to
+`main` and on every semver tag. Currently `linux/amd64` only; arm64
+builds are on the roadmap. No auth is needed to pull.
 
 ```bash
 # Latest main build

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -4,7 +4,32 @@ This guide covers how to run MockForge using Docker and Docker Compose for both 
 
 ## 🚀 Quick Start
 
-### Using Docker Compose (Recommended)
+### Pull the prebuilt image (fastest)
+
+Multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub
+Container Registry on every push to `main` and on every semver tag. No
+auth is needed to pull.
+
+```bash
+# Latest main build
+docker pull ghcr.io/saasy-solutions/mockforge:latest
+
+# Or pin a release
+docker pull ghcr.io/saasy-solutions/mockforge:0.3.116
+
+# Run with the default example spec + admin UI
+docker run --rm -p 3000:3000 -p 3001:3001 -p 50051:50051 -p 9080:9080 \
+  -e MOCKFORGE_ADMIN_ENABLED=true \
+  -e MOCKFORGE_HTTP_OPENAPI_SPEC=examples/openapi-demo.json \
+  ghcr.io/saasy-solutions/mockforge:latest
+```
+
+Admin UI: <http://localhost:9080> — log in with `admin` / `admin123`
+(or `editor` / `editor123`, `viewer` / `viewer123`).
+
+### Build from source with Docker Compose
+
+Use this if you're iterating on MockForge itself.
 
 ```bash
 # Clone the repository

--- a/README.md
+++ b/README.md
@@ -498,9 +498,9 @@ See `examples/README.md` for detailed documentation on the example files.
 
 ### Docker (Alternative Installation)
 
-Prebuilt multi-arch images (`linux/amd64`, `linux/arm64`) are published to
-GitHub Container Registry on every push to `main` and on every semver tag.
-No authentication is needed to pull.
+Prebuilt images are published to GitHub Container Registry on every push
+to `main` and on every semver tag (currently `linux/amd64` only; arm64
+builds are on the roadmap). No authentication is needed to pull.
 
 #### Pull and run from GHCR
 

--- a/README.md
+++ b/README.md
@@ -498,30 +498,40 @@ See `examples/README.md` for detailed documentation on the example files.
 
 ### Docker (Alternative Installation)
 
-MockForge can also be run using Docker for easy deployment:
+Prebuilt multi-arch images (`linux/amd64`, `linux/arm64`) are published to
+GitHub Container Registry on every push to `main` and on every semver tag.
+No authentication is needed to pull.
 
-#### Quick Docker Start
-
-```bash
-# Using Docker Compose (recommended)
-make docker-compose-up
-
-# Or using Docker directly
-make docker-build && make docker-run
-```
-
-#### Manual Docker Commands
+#### Pull and run from GHCR
 
 ```bash
-# Build the image
-docker build -t mockforge .
+# Latest main build
+docker pull ghcr.io/saasy-solutions/mockforge:latest
 
-# Run with examples
+# Pinned release (recommended for production)
+docker pull ghcr.io/saasy-solutions/mockforge:0.3.116
+
+# Run with the bundled example spec + admin UI
 docker run -p 3000:3000 -p 3001:3001 -p 50051:50051 -p 9080:9080 \
-  -v $(pwd)/examples:/app/examples:ro \
   -e MOCKFORGE_ADMIN_ENABLED=true \
   -e MOCKFORGE_HTTP_OPENAPI_SPEC=examples/openapi-demo.json \
-  mockforge
+  ghcr.io/saasy-solutions/mockforge:latest
+```
+
+The admin UI is then at <http://localhost:9080> — sign in with the default
+local credentials (`admin` / `admin123`, or `editor` / `editor123` /
+`viewer` / `viewer123`).
+
+#### Build from source
+
+If you're iterating on MockForge itself, build the image locally:
+
+```bash
+# Using Docker Compose (recommended for dev)
+make docker-compose-up
+
+# Or build + run directly
+make docker-build && make docker-run
 ```
 
 See [DOCKER.md](DOCKER.md) for comprehensive Docker documentation and deployment options.

--- a/helm/mockforge/Chart.yaml
+++ b/helm/mockforge/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - testing
 home: https://mockforge.dev
 sources:
-  - https://github.com/mockforge/mockforge
+  - https://github.com/SaaSy-Solutions/mockforge
 maintainers:
   - name: MockForge Team
     email: team@mockforge.dev

--- a/helm/mockforge/README.md
+++ b/helm/mockforge/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the MockForge chart and
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `replicaCount` | Number of MockForge replicas | `3` |
-| `image.repository` | MockForge image repository | `mockforge/mockforge` |
+| `image.repository` | MockForge image repository | `ghcr.io/saasy-solutions/mockforge` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `image.tag` | Image tag (defaults to chart appVersion) | `latest` |
 | `imagePullSecrets` | Docker registry secret names | `[]` |

--- a/helm/mockforge/values.yaml
+++ b/helm/mockforge/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 3
 
 image:
-  repository: mockforge/mockforge
+  repository: ghcr.io/saasy-solutions/mockforge
   pullPolicy: IfNotPresent
   tag: "latest"
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: mockforge
       containers:
       - name: mockforge
-        image: mockforge/mockforge:latest
+        image: ghcr.io/saasy-solutions/mockforge:latest
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/k8s/vault-integration.yaml
+++ b/k8s/vault-integration.yaml
@@ -139,7 +139,7 @@ spec:
       serviceAccountName: mockforge-vault
       containers:
         - name: mockforge
-          image: mockforge/mockforge:latest
+          image: ghcr.io/saasy-solutions/mockforge:latest
           volumeMounts:
             - name: vault-secrets
               mountPath: /vault/secrets


### PR DESCRIPTION
## Summary

Follow-up on discussion [#119](https://github.com/SaaSy-Solutions/mockforge/discussions/119) / issue [#138](https://github.com/SaaSy-Solutions/mockforge/issues/138). **GHCR has been publishing successfully since Dec 2025** (1,118 versions on `ghcr.io/saasy-solutions/mockforge`, `:latest` + `:main` + semver tags all current); this PR aligns the rest of the repo (release workflow, helm, k8s, docs) with that reality and drops Docker Hub from the picture.

Docker Hub is being removed as a target, not added: it's paid for orgs, the publish job we had was pointed at a non-existent mixed-case namespace, and GHCR covers every functional need for an OSS project.

## Changes

- **Drop the broken Docker Hub publish job** from `.github/workflows/release.yml` (image name was `SaaSy-Solutions/mockforge` — mixed case, no such Docker Hub namespace existed anyway). Removed the `needs: docker` from `deploy-registry` since the Fly deploy doesn't actually depend on image publish. GHCR publishing continues via `.github/workflows/docker-build.yml` on every main push and semver tag.
- **Point Helm default at GHCR**: `helm/mockforge/values.yaml` `image.repository` → `ghcr.io/saasy-solutions/mockforge`. Fix the stale `mockforge/mockforge` entry in `helm/mockforge/README.md`.
- **Fix k8s manifests**: `k8s/deployment.yaml` and `k8s/vault-integration.yaml` were hardcoded to the non-existent `mockforge/mockforge:latest` — now pull from GHCR too.
- **Fix Helm chart source URL**: `helm/mockforge/Chart.yaml` pointed at the non-existent `github.com/mockforge/mockforge`; corrected to `github.com/SaaSy-Solutions/mockforge`.
- **Lead with `docker pull` in docs**: rewrite the Docker section of `README.md` and the Quick Start of `DOCKER.md` so the first thing users see is `docker pull ghcr.io/saasy-solutions/mockforge:latest` + a runnable `docker run`. Build-from-source kept for contributors, just demoted. Docs correctly note `linux/amd64` only (arm64 was cut in #126 for GHA cost).

## Verification

- YAML syntax validated on all edited workflow / k8s / helm files.
- Greps confirm zero remaining references to `SaaSy-Solutions/mockforge` (bad case), `mockforge/mockforge` (wrong namespace), or Docker Hub login steps in workflows.
- Pre-commit hooks (`clippy --workspace`, `cargo-check --workspace`, `typos`, fixers) all pass.

## Related follow-ups

- #145 fixes `docker-build.yml`'s always-red status on main (Grype/Dockle were gating on unactionable base-image HIGH CVEs; the `update-deployment` job had never succeeded). With #145 + this PR merged, `docker-build.yml` runs on main should go green and stay that way.
- Discussion #119 has been answered pointing at the GHCR `docker pull` command. Issue #138 can be closed once this lands.

## Test plan

- [ ] After merge: `docker pull ghcr.io/saasy-solutions/mockforge:latest` succeeds without auth.
- [ ] `docker run -p 9080:9080 ghcr.io/saasy-solutions/mockforge:latest serve --admin --admin-port 9080` — login page at <http://localhost:9080> accepts `admin` / `admin123` (validates PR #137 too).
- [ ] `helm template helm/mockforge | grep image:` shows `ghcr.io/saasy-solutions/mockforge:latest`.