### PR TITLE
fix(ui): import cloudServicesApi from services/api barrel

### DIFF
--- a/crates/mockforge-ui/ui/src/stores/useServiceStore.ts
+++ b/crates/mockforge-ui/ui/src/stores/useServiceStore.ts
@@ -2,11 +2,11 @@ import { logger } from '@/utils/logger';
 import { create } from 'zustand';
 import type { ServiceInfo, RouteInfo } from '../types';
 import { authenticatedFetch } from '../utils/apiClient';
-import {
-  cloudServicesApi,
-  type CloudService,
-  type CloudServiceCreatePayload,
-  type CloudServiceUpdatePayload,
+import { cloudServicesApi } from '../services/api';
+import type {
+  CloudService,
+  CloudServiceCreatePayload,
+  CloudServiceUpdatePayload,
 } from '../services/api/cloudServices';
 
 const isCloud = !!import.meta.env.VITE_API_BASE_URL;


### PR DESCRIPTION
## Summary

- Production UI build fails on main: Rollup rejects the `cloudServicesApi` named import because `useServiceStore.ts` imports it from `src/services/api/cloudServices.ts` where only the `CloudServicesApiService` class is exported.
- The actual instance (`new CloudServicesApiService()`) lives in the `services/api/index.ts` barrel.
- TSC tolerates this because the barrel re-exports everything, but Rollup is stricter.

## Changes

Move the value import to the barrel; keep the type imports from the source file.

## Test plan

- [x] `pnpm build` in `crates/mockforge-ui/ui` now completes
- [x] `pnpm type-check` still passes
- [ ] Blocks `make deploy-ui` — this PR unblocks it