### PR TITLE
ci(docker-build): make Grype/Dockle advisory and drop dead update-deployment job

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -149,54 +149,34 @@ jobs:
       security-events: write
 
     steps:
+      # Advisory only. Trivy (in build-and-push) already uploads
+      # CRITICAL/HIGH SARIF to the Security tab; Grype is here as a
+      # second-opinion scanner, but should not gate the pipeline — a
+      # HIGH CVE in a base image (glibc, openssl) is typically not
+      # actionable same-day and would otherwise red every main run.
       - name: Run Grype vulnerability scanner
         uses: anchore/scan-action@v3
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          fail-build: true
+          fail-build: false
           severity-cutoff: high
 
+      # Advisory only. Dockle at --exit-level=warn fails on benign
+      # findings (e.g. CIS-DI-0001 for missing explicit USER) — useful
+      # as signal, not as a gate.
       - name: Run Dockle security linter
+        continue-on-error: true
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             goodwithtech/dockle:latest \
-            --exit-code 1 \
-            --exit-level warn \
+            --exit-level fatal \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
-  update-deployment:
-    name: Update Kubernetes Deployment
-    needs: build-and-push
-    runs-on: [self-hosted, linux, x64, rust]
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Update Kubernetes manifests
-        run: |
-          # Update image tag in deployment
-          sed -i "s|image: .*|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}|g" k8s/deployment.yaml
-
-          # Update Helm values
-          sed -i "s|tag: .*|tag: ${{ steps.meta.outputs.version }}|g" helm/mockforge/values.yaml
-
-      - name: Commit and push changes
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add k8s/deployment.yaml helm/mockforge/values.yaml
-          git diff --quiet && git diff --staged --quiet || git commit -m "chore: update Docker image to ${{ steps.meta.outputs.version }}"
-          git push
+  # Removed: the old `update-deployment` job that auto-committed image
+  # tag bumps to k8s/deployment.yaml and helm/mockforge/values.yaml. It
+  # had zero successful runs since Feb 2026 — the default GITHUB_TOKEN
+  # cannot push to protected main, and the sed rewrite fought with the
+  # pinned tags the manifests carry. For GitOps-style image bumps, open
+  # a PR via peter-evans/create-pull-request or use an external image
+  # automation controller (Flux, ArgoCD Image Updater).


### PR DESCRIPTION
## Summary

`docker-build.yml` has reported `failure` on every push to `main` since Feb 2026 even though the GHCR image publish itself has been succeeding (1,118 versions on `ghcr.io/saasy-solutions/mockforge` as of today, `:latest` + `:main` tags current). Two downstream jobs were the sole cause — fix both.

### Build-and-push job → unchanged
Image build, GHCR push, Trivy scan (SARIF → Security tab), SBOM, Cosign signing, Docker prune all keep running as-is.

### `scan-and-analyze` → make advisory
- **Grype**: `fail-build: true` + `severity-cutoff: high` was killing every run on base-image HIGH CVEs (glibc, openssl). Trivy already uploads CRITICAL/HIGH SARIF to the Security tab from the publish job, so Grype gating was pure noise. Now `fail-build: false` — still runs, still surfaces findings in logs, doesn't gate.
- **Dockle**: `--exit-code 1` + `--exit-level warn` had never passed (Grype failed first). Relaxed to `--exit-level fatal` + `continue-on-error: true`. Useful as signal, not as a gate.

### `update-deployment` → removed
Zero successful runs since Feb 2026. The default `GITHUB_TOKEN` can't push to protected `main`, and the `sed` rewrite fought with the pinned tags the k8s/helm manifests now carry (see #141). If we ever want GitOps-style image bumps, the right shape is a PR flow (`peter-evans/create-pull-request`) or an external controller (Flux, ArgoCD Image Updater) — not a direct `git push` from CI.

## Effect

- Main-branch `docker-build.yml` runs go green when the image pushes cleanly.
- Same artifacts published — tags, signing, SBOM, Trivy SARIF all intact.
- Unblocks confident interpretation of red CI on main (the red bar stops being a false positive).

## Test plan

- [ ] This PR's own `docker-build.yml` run builds (no push — PR event).
- [ ] After merge: next push to `main` produces a green `docker-build.yml` run.
- [ ] `ghcr.io/saasy-solutions/mockforge:latest` digest advances with the merge SHA.
- [ ] Security tab continues to get Trivy SARIF uploads.