### PR TITLE
fix(docker): build admin UI inside image instead of shipping placeholder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,6 +33,12 @@ lcov.info
 *.jpg
 *.jpeg
 *.gif
+# …but UI public assets must reach the build context — Vite copies them into
+# dist/ and build.rs embeds the icons via include_bytes!
+!crates/mockforge-ui/ui/public/*.png
+!crates/mockforge-ui/ui/public/*.jpg
+!crates/mockforge-ui/ui/public/*.jpeg
+!crates/mockforge-ui/ui/public/*.gif
 
 # Local configuration (use mounted volumes instead)
 config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,22 @@
 # Multi-stage Docker build for MockForge
+# Stage 0: Build the React Admin UI bundle so the Rust build can embed real assets
+FROM node:22-slim AS ui-builder
+
+WORKDIR /ui
+
+# pnpm via Corepack — pnpm-lock.yaml is the source of truth for the UI workspace
+RUN corepack enable
+
+# Install deps first for layer caching. Skip the Playwright browser download —
+# the image only needs Vite/TS build tooling, not the e2e runner.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+COPY crates/mockforge-ui/ui/package.json crates/mockforge-ui/ui/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Copy UI source and build the production bundle (outputs to /ui/dist)
+COPY crates/mockforge-ui/ui/ ./
+RUN pnpm build
+
 # Stage 1: Build the Rust application
 # Use rust:1.90-slim (Trixie/testing-based) which has GLIBC 2.39+ required by native dependencies
 FROM rust:1.90-slim AS builder
@@ -34,23 +52,12 @@ COPY examples/ ./examples/
 COPY proto/ ./proto/
 COPY config.example.yaml ./
 
-# Create placeholder UI files if they don't exist (UI build requires Node.js which we don't install in Docker)
-RUN mkdir -p crates/mockforge-ui/ui/dist/assets && \
-    if [ ! -f crates/mockforge-ui/ui/dist/index.html ]; then \
-      echo '<!DOCTYPE html><html><head><title>MockForge Admin</title></head><body><h1>MockForge Admin UI</h1><p>UI build required. Run: cd crates/mockforge-ui && bash build_ui.sh</p></body></html>' > crates/mockforge-ui/ui/dist/index.html; \
-    fi && \
-    if [ ! -f crates/mockforge-ui/ui/dist/assets/index.css ]; then \
-      echo '/* MockForge Admin UI CSS - build required */' > crates/mockforge-ui/ui/dist/assets/index.css; \
-    fi && \
-    if [ ! -f crates/mockforge-ui/ui/dist/assets/index.js ]; then \
-      echo '// MockForge Admin UI JS - build required' > crates/mockforge-ui/ui/dist/assets/index.js; \
-    fi && \
-    if [ ! -f crates/mockforge-ui/ui/dist/pwa-manifest.json ]; then \
-      echo '{}' > crates/mockforge-ui/ui/dist/pwa-manifest.json; \
-    fi && \
-    if [ ! -f crates/mockforge-ui/ui/dist/sw.js ]; then \
-      echo '// Service Worker placeholder' > crates/mockforge-ui/ui/dist/sw.js; \
-    fi
+# Drop the real UI bundle from the ui-builder stage into the expected path so
+# build.rs embeds it via include_str!. Also remove build_ui.sh — build.rs
+# invokes it during cargo build, but Node isn't installed here and dist/ is
+# already built. build.rs only runs the script `if ui_build_script.exists()`.
+COPY --from=ui-builder /ui/dist/ crates/mockforge-ui/ui/dist/
+RUN rm -f crates/mockforge-ui/build_ui.sh
 
 # Build the application in release mode
 RUN cargo build --release --bin mockforge


### PR DESCRIPTION
## Summary

- The Dockerfile never installed Node, so when `crates/mockforge-ui/ui/dist/` was empty it wrote stub HTML/CSS/JS files. `crates/mockforge-ui/build.rs` then baked those placeholders into the binary via `include_str!`, so `docker run` landed on `UI build required. Run: cd crates/mockforge-ui && bash build_ui.sh` at `:9080` unless the user pre-built the UI on the host.
- Add a `node:22-slim` `ui-builder` stage that runs `pnpm install --frozen-lockfile && pnpm build` (with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` to avoid the ~500 MB e2e browser download), `COPY --from=ui-builder` the real `dist/` into the Rust builder, and `rm -f build_ui.sh` so `build.rs` skips its shell-out.
- Add `.dockerignore` negations so `crates/mockforge-ui/ui/public/*.{png,jpg,jpeg,gif}` bypass the global `*.png` rule — Vite needs them for `dist/`, and `build.rs` embeds the icon PNGs via `include_bytes!`.

## Test plan

- [x] `docker build -t mockforge-fix-verify:latest -f Dockerfile .` succeeds (ui-builder stage builds full Vite bundle, Rust release builds against real `dist/`).
- [x] `docker run -d -p 9080:9080 mockforge-fix-verify:latest` then probes:
  - [x] `GET /` → `200`, 1581 B real Vite `<!doctype html>`, no "UI build required" marker
  - [x] `GET /assets/index.js` → `200`, 615 859 B `application/javascript`
  - [x] `GET /mockforge-icon-32.png` → `200`, 786 B `image/png` (proves the `.dockerignore` negation works — without it `build.rs` would embed an empty byte array)
  - [x] `GET /manifest.json` → `200`, 1928 B `application/manifest+json`
- [x] Pre-commit `clippy` + `cargo-check` + `typos` hooks pass (twice — the hook config triggers on both pre-commit and commit-msg).