### PR TITLE
fix(docker,config): build with all-protocols so WS/gRPC/Kafka actually listen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,11 @@ COPY config.example.yaml ./
 COPY --from=ui-builder /ui/dist/ crates/mockforge-ui/ui/dist/
 RUN rm -f crates/mockforge-ui/build_ui.sh
 
-# Build the application in release mode
-RUN cargo build --release --bin mockforge
+# Build the application in release mode with all protocol features enabled.
+# Default features are HTTP-only; without `all-protocols` the ws/grpc/kafka/
+# mqtt/amqp/smtp/tcp/graphql/ftp server spawns are cfg-gated out of the binary
+# and the CLI silently runs as HTTP-only despite printing "configured" lines.
+RUN cargo build --release --bin mockforge --features all-protocols
 
 # Stage 2: Create the runtime image
 # Use debian:trixie-slim to match builder's GLIBC version (2.39+)

--- a/crates/mockforge-core/src/config/mod.rs
+++ b/crates/mockforge-core/src/config/mod.rs
@@ -433,6 +433,29 @@ pub fn apply_env_overrides(mut config: ServerConfig) -> ServerConfig {
         }
     }
 
+    if let Ok(enabled) = std::env::var("MOCKFORGE_GRPC_ENABLED") {
+        config.grpc.enabled = enabled == "1" || enabled.eq_ignore_ascii_case("true");
+    }
+
+    // Kafka broker overrides
+    if let Ok(port) = std::env::var("MOCKFORGE_KAFKA_PORT") {
+        if let Ok(port_num) = port.parse() {
+            config.kafka.port = port_num;
+        }
+    }
+
+    if let Ok(host) = std::env::var("MOCKFORGE_KAFKA_HOST") {
+        config.kafka.host = host;
+    }
+
+    if let Ok(enabled) = std::env::var("MOCKFORGE_KAFKA_ENABLED") {
+        config.kafka.enabled = enabled == "1" || enabled.eq_ignore_ascii_case("true");
+    }
+
+    if let Ok(dir) = std::env::var("MOCKFORGE_KAFKA_FIXTURES_DIR") {
+        config.kafka.fixtures_dir = Some(std::path::PathBuf::from(dir));
+    }
+
     // SMTP server overrides
     if let Ok(port) = std::env::var("MOCKFORGE_SMTP_PORT") {
         if let Ok(port_num) = port.parse() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "8000:3000"   # HTTP server (mapped to 8000 to avoid conflicts)
       - "8001:3001"   # WebSocket server (mapped to 8001 to avoid conflicts)
       - "50051:50051" # gRPC server
+      - "9092:9092"   # Kafka broker
       - "9080:9080"   # Admin UI
     volumes:
       - ./examples:/app/examples:ro  # Mount examples as read-only
@@ -34,6 +35,11 @@ services:
 
       # gRPC configuration
       - MOCKFORGE_GRPC_PORT=50051
+
+      # Kafka broker (disabled by default in config; flip on + point at baked-in demo fixtures)
+      - MOCKFORGE_KAFKA_ENABLED=true
+      - MOCKFORGE_KAFKA_PORT=9092
+      - MOCKFORGE_KAFKA_FIXTURES_DIR=/app/examples/protocols/kafka
 
       # Admin UI configuration
       - MOCKFORGE_ADMIN_ENABLED=true


### PR DESCRIPTION
## Summary

- `crates/mockforge-cli/Cargo.toml` default features are HTTP-only. The Dockerfile ran `cargo build --release --bin mockforge` (no `--features`), so the ws/grpc/kafka/mqtt/amqp/smtp/tcp/graphql/ftp server spawns in `crates/mockforge-cli/src/serve.rs` were all `cfg`-gated out of the binary. The CLI still printed `✅ WebSocket server configured` etc. (those `println!`s run before the feature-gated `tokio::spawn`), so the image looked healthy but only HTTP actually bound. In-container probe before the fix: **3001, 9092, 50051 all NOT listening**; Docker's port-proxy accepted TCP and then RST'd every client, which is why anyone running `docker-compose up` saw `Connection reset by peer` on WS, gRPC, or Kafka clients.
- Rebuild with `--features all-protocols` so the protocol crates are compiled in. Build time goes up because this pulls `rdkafka`/librdkafka (C++), `lapin` (AMQP), etc. — but it's the only way the shipped image delivers what the README advertises.
- Add Kafka + gRPC env-var overrides in `mockforge-core::apply_env_overrides`: `MOCKFORGE_KAFKA_ENABLED`, `MOCKFORGE_KAFKA_PORT`, `MOCKFORGE_KAFKA_HOST`, `MOCKFORGE_KAFKA_FIXTURES_DIR`, `MOCKFORGE_GRPC_ENABLED`. `KafkaConfig::default().enabled` is `false` and there was previously no env path to flip it without mounting a config file. Follows the existing SMTP/TCP env-override pattern in the same function.
- Update `docker-compose.yml`: add `9092:9092` port mapping and `MOCKFORGE_KAFKA_ENABLED=true` + `MOCKFORGE_KAFKA_FIXTURES_DIR=/app/examples/protocols/kafka` so Kafka works out of the box against the baked-in demo fixture.

## Test plan

Verified on a fresh `docker build` + `docker run` off this branch:

- [x] `cargo clippy -p mockforge-core --all-targets -- -D warnings` → clean
- [x] `cargo clippy -p mockforge-cli --all-targets -- -D warnings` → clean
- [x] `cargo test -p mockforge-core --lib` → 1580 passed
- [x] `cargo test -p mockforge-cli --bins --tests` → 18 passed
- [x] `cargo fmt --all --check` → clean
- [x] In-container port audit with `for p in 3000 3001 9080 9090 9092 50051; do bash -c 'echo >/dev/tcp/127.0.0.1/$p'; done` → **all 6 LISTENING** (was 3/6 before).
- [x] HTTP: `GET /ping` → `200 application/json`, real UUID + timestamp via template expansion.
- [x] WebSocket: handshake at `ws://localhost:3001/ws` succeeds; with `MOCKFORGE_WS_REPLAY_FILE=/app/examples/ws-demo.jsonl` the first replay frame arrives with a real UUID and expanded timestamp (`HELLO 5eb63201-... at 2026-04-22T17:06:53...`).
- [x] gRPC: `✅ gRPC server listening on localhost:50051`, dynamic `mockforge.greeter.Greeter` service registered from `proto/gretter.proto`.
- [x] Kafka: `📨 Kafka broker listening on 0.0.0.0:9092`, `edenhill/kcat:1.7.1 -b localhost:9092 -L` establishes the TCP connection. The subsequent ApiVersions request is closed by the broker — a separate **pre-existing** wire-protocol compatibility issue in `crates/mockforge-kafka/src/protocol.rs` vs. librdkafka, **not** introduced by this change. Filing this as a follow-up is worth doing if consumers need real Kafka client compatibility.

## Known limitation (pre-existing, not in scope)

`mockforge-kafka` advertises ApiVersions (key 18, versions 0–4) but librdkafka-based clients (kcat, confluent-kafka-*) disconnect immediately after the handshake. Users who just need the broker port open for their own protocol-level tests are unblocked by this PR; users who need to point a real Kafka client at it will still be blocked until the handshake code is fixed separately.