### PR TITLE
fix(kafka): load the nested-topology fixture YAML the examples ship

### DIFF
--- a/crates/mockforge-kafka/src/fixture_file.rs
+++ b/crates/mockforge-kafka/src/fixture_file.rs
@@ -1,0 +1,293 @@
+//! Nested "topology" YAML fixture format for Kafka.
+//!
+//! The older `KafkaFixture` shape is a flat record describing one message
+//! template. Realistic fixture files want to describe a whole cluster:
+//! multiple topics with partition counts, per-topic configs, and a list of
+//! message templates under each topic. This module defines that richer
+//! structure and a `flatten()` method that expands it into:
+//!
+//!   * `Vec<KafkaTopicSpec>` — one entry per topic, used by the Metadata
+//!     response to advertise real topics/partitions.
+//!   * `Vec<KafkaFixture>`  — one entry per message template, fed into the
+//!     existing `KafkaSpecRegistry` so nothing else has to change to keep
+//!     working.
+//!
+//! Unknown fields are silently ignored so advanced YAML sections (scenarios,
+//! state_machine triggers, relationships, failure_simulation, monitoring)
+//! don't break the load — they'll be implemented in later PRs.
+
+use crate::fixtures::{AutoProduceConfig, KafkaFixture};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Top-level shape of a Kafka fixture YAML file.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KafkaFixtureFile {
+    /// Human-readable metadata about the fixture file. Optional.
+    #[serde(default)]
+    pub fixture: Option<FixtureMeta>,
+    /// Cluster-level configuration. Optional.
+    #[serde(default)]
+    pub cluster: Option<ClusterSpec>,
+    /// Topics described by this file.
+    #[serde(default)]
+    pub topics: Vec<KafkaTopicSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FixtureMeta {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub protocol: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ClusterSpec {
+    #[serde(default)]
+    pub bootstrap_servers: Option<String>,
+    #[serde(default)]
+    pub cluster_id: Option<String>,
+}
+
+/// One topic described in the YAML file. `partitions` / `replication_factor`
+/// flow into the Metadata response; `messages` flow into `KafkaFixture`s.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KafkaTopicSpec {
+    pub name: String,
+    #[serde(default = "default_partitions")]
+    pub partitions: i32,
+    #[serde(default = "default_replication_factor")]
+    pub replication_factor: i16,
+    #[serde(default)]
+    pub partitioning: Option<serde_json::Value>,
+    #[serde(default)]
+    pub config: Option<serde_json::Value>,
+    #[serde(default)]
+    pub messages: Vec<KafkaMessageSpec>,
+}
+
+fn default_partitions() -> i32 {
+    1
+}
+fn default_replication_factor() -> i16 {
+    1
+}
+
+/// One message template under a topic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KafkaMessageSpec {
+    #[serde(default)]
+    pub key_template: Option<String>,
+    pub value: serde_json::Value,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    #[serde(default)]
+    pub partition: Option<i32>,
+    #[serde(default)]
+    pub auto_produce: Option<MessageAutoProduce>,
+}
+
+/// A superset of `AutoProduceConfig`. Simple rate-limited auto-produce fields
+/// are first-class; advanced trigger configs (state_machine, scenarios) are
+/// parsed but not yet executed — preserved so a later PR can wire them up
+/// without another schema change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageAutoProduce {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub rate_per_second: Option<u64>,
+    #[serde(default)]
+    pub duration_seconds: Option<u64>,
+    #[serde(default)]
+    pub total_count: Option<usize>,
+    #[serde(default)]
+    pub partition: Option<i32>,
+    /// "rate" (default), "state_machine", or custom triggers. Only "rate" is
+    /// honored today; other values flow through without causing a load error.
+    #[serde(default)]
+    pub trigger: Option<String>,
+}
+
+/// Result of expanding a `KafkaFixtureFile` for consumption downstream.
+#[derive(Debug, Default)]
+pub struct FlattenedFixtures {
+    /// Topic definitions — used by the Metadata response.
+    pub topics: Vec<KafkaTopicSpec>,
+    /// Message-level fixtures — stored in `KafkaSpecRegistry` keyed by topic.
+    pub fixtures: Vec<KafkaFixture>,
+}
+
+impl KafkaFixtureFile {
+    /// Expand this file into `(topic specs, flat fixtures)`.
+    ///
+    /// Each `KafkaMessageSpec` becomes exactly one `KafkaFixture` with a
+    /// synthetic identifier of the form `{topic}#{index}`. Only the
+    /// rate-based auto_produce branch is forwarded; state-machine-driven
+    /// messages load cleanly but don't emit an `AutoProduceConfig`.
+    pub fn flatten(self) -> FlattenedFixtures {
+        let mut fixtures = Vec::new();
+        for topic in &self.topics {
+            for (i, msg) in topic.messages.iter().enumerate() {
+                fixtures.push(message_to_fixture(topic, i, msg));
+            }
+        }
+        FlattenedFixtures {
+            topics: self.topics,
+            fixtures,
+        }
+    }
+}
+
+fn message_to_fixture(
+    topic: &KafkaTopicSpec,
+    index: usize,
+    msg: &KafkaMessageSpec,
+) -> KafkaFixture {
+    let auto = msg.auto_produce.as_ref().and_then(|ap| {
+        // Only forward rate-based triggers into the existing AutoProducer.
+        // Anything else is preserved at the file level but not yet honored.
+        match ap.trigger.as_deref() {
+            None | Some("rate") => ap.rate_per_second.map(|rate| AutoProduceConfig {
+                enabled: ap.enabled,
+                rate_per_second: rate,
+                duration_seconds: ap.duration_seconds,
+                total_count: ap.total_count,
+            }),
+            _ => None,
+        }
+    });
+
+    KafkaFixture {
+        identifier: format!("{}#{}", topic.name, index),
+        name: format!("{} message {}", topic.name, index),
+        topic: topic.name.clone(),
+        partition: msg.partition.or_else(|| msg.auto_produce.as_ref().and_then(|a| a.partition)),
+        key_pattern: msg.key_template.clone(),
+        value_template: msg.value.clone(),
+        headers: msg.headers.clone(),
+        auto_produce: auto,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_yaml() -> &'static str {
+        r#"
+fixture:
+  name: "E-commerce Order Events"
+  description: "demo"
+  protocol: kafka
+
+cluster:
+  bootstrap_servers: "localhost:9092"
+  cluster_id: "mockforge-cluster"
+
+topics:
+  - name: "orders.created"
+    partitions: 3
+    replication_factor: 1
+    partitioning:
+      strategy: "key_hash"
+    config:
+      retention_ms: 604800000
+    messages:
+      - key_template: "order-{{uuid}}"
+        value:
+          event_type: "order.created"
+          order_id: "{{uuid}}"
+        headers:
+          event_version: "1.0"
+        auto_produce:
+          enabled: true
+          rate_per_second: 10
+          partition: null
+
+  - name: "orders.status-updated"
+    partitions: 3
+    messages:
+      - key_template: "{{context.order_id}}"
+        value:
+          event_type: "order.status_updated"
+        auto_produce:
+          enabled: true
+          trigger: "state_machine"
+          state_machine:
+            initial_state: "pending"
+"#
+    }
+
+    #[test]
+    fn parses_nested_topology() {
+        let file: KafkaFixtureFile = serde_yaml::from_str(sample_yaml()).unwrap();
+        assert_eq!(file.fixture.as_ref().unwrap().name, "E-commerce Order Events");
+        assert_eq!(file.cluster.as_ref().unwrap().cluster_id.as_deref(), Some("mockforge-cluster"));
+        assert_eq!(file.topics.len(), 2);
+        assert_eq!(file.topics[0].name, "orders.created");
+        assert_eq!(file.topics[0].partitions, 3);
+        assert_eq!(file.topics[0].messages.len(), 1);
+    }
+
+    #[test]
+    fn flatten_keeps_topics_and_emits_one_fixture_per_message() {
+        let file: KafkaFixtureFile = serde_yaml::from_str(sample_yaml()).unwrap();
+        let flat = file.flatten();
+        assert_eq!(flat.topics.len(), 2);
+        assert_eq!(flat.fixtures.len(), 2);
+        assert_eq!(flat.fixtures[0].identifier, "orders.created#0");
+        assert_eq!(flat.fixtures[0].topic, "orders.created");
+        assert!(flat.fixtures[0].auto_produce.as_ref().unwrap().enabled);
+        assert_eq!(flat.fixtures[0].auto_produce.as_ref().unwrap().rate_per_second, 10);
+    }
+
+    #[test]
+    fn state_machine_trigger_loads_without_auto_produce() {
+        // Advanced triggers should parse successfully but not emit an
+        // AutoProduceConfig (the rate-based executor would misinterpret them).
+        let file: KafkaFixtureFile = serde_yaml::from_str(sample_yaml()).unwrap();
+        let flat = file.flatten();
+        let sm = &flat.fixtures[1];
+        assert_eq!(sm.topic, "orders.status-updated");
+        assert!(sm.auto_produce.is_none());
+    }
+
+    #[test]
+    fn missing_optional_fields_parse_with_defaults() {
+        let yaml = r#"
+topics:
+  - name: "plain"
+    messages:
+      - value: { k: "v" }
+"#;
+        let file: KafkaFixtureFile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(file.topics[0].partitions, 1);
+        assert_eq!(file.topics[0].replication_factor, 1);
+        assert!(file.topics[0].messages[0].key_template.is_none());
+    }
+
+    #[test]
+    fn unknown_top_level_sections_are_ignored() {
+        // Real fixtures include relationships/scenarios/failure_simulation —
+        // those aren't implemented yet and must not break the load.
+        let yaml = r#"
+topics:
+  - name: "t"
+    messages:
+      - value: {}
+scenarios:
+  - name: "Ignored"
+failure_simulation:
+  broker_failures:
+    enabled: true
+monitoring:
+  prometheus:
+    enabled: true
+"#;
+        let file: KafkaFixtureFile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(file.topics.len(), 1);
+    }
+}

--- a/crates/mockforge-kafka/src/fixtures.rs
+++ b/crates/mockforge-kafka/src/fixtures.rs
@@ -1,5 +1,5 @@
+use crate::fixture_file::{FlattenedFixtures, KafkaFixtureFile};
 use chrono::Utc;
-use mockforge_core::fixture_store::{load_fixtures_from_dir, FixtureLoadOptions};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -124,11 +124,98 @@ impl AutoProducer {
 }
 
 impl KafkaFixture {
-    /// Load fixtures from a directory
+    /// Load flat `KafkaFixture` records from every `.yaml` / `.yml` file in
+    /// `dir`. Each file may be either the legacy flat-array shape or the
+    /// nested-topology shape described in [`crate::fixture_file`]; both are
+    /// accepted transparently so existing fixtures keep working while richer
+    /// files (topics + partitions + messages) can now load too.
+    ///
+    /// If you also need the topic-level metadata (partition counts etc.),
+    /// use [`load_kafka_fixtures_from_dir`] — it returns both.
     pub fn load_from_dir(dir: &Path) -> mockforge_core::Result<Vec<Self>> {
-        load_fixtures_from_dir(dir, &FixtureLoadOptions::yaml_array_strict())
+        Ok(load_kafka_fixtures_from_dir(dir)?.fixtures)
+    }
+}
+
+/// Load every Kafka fixture file under `dir` and merge the results.
+///
+/// Each file is parsed twice-ish: first as the nested [`KafkaFixtureFile`]
+/// shape (since that's what realistic fixtures look like), falling back to
+/// the legacy flat `Vec<KafkaFixture>` shape when the top-level keys don't
+/// match. Partially-valid files hard-fail so users see real parse errors
+/// instead of silent drops — matching the previous behavior of
+/// `FixtureLoadOptions::yaml_array_strict()`.
+pub fn load_kafka_fixtures_from_dir(dir: &Path) -> mockforge_core::Result<FlattenedFixtures> {
+    if !dir.exists() {
+        tracing::debug!("Kafka fixture directory does not exist: {}", dir.display());
+        return Ok(FlattenedFixtures::default());
     }
 
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        mockforge_core::Error::io_with_context(
+            format!("reading kafka fixture directory {}", dir.display()),
+            e.to_string(),
+        )
+    })?;
+
+    let mut merged = FlattenedFixtures::default();
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!("Failed to read directory entry: {}", e);
+                continue;
+            }
+        };
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let is_yaml = matches!(path.extension().and_then(|e| e.to_str()), Some("yaml" | "yml"));
+        if !is_yaml {
+            continue;
+        }
+
+        let content = std::fs::read_to_string(&path).map_err(|e| {
+            mockforge_core::Error::io_with_context(
+                format!("reading fixture {}", path.display()),
+                e.to_string(),
+            )
+        })?;
+
+        // Try the nested-topology shape first — that's what realistic
+        // fixtures look like. Fall back to the legacy flat array. If both
+        // fail, surface the nested error since its schema guidance is more
+        // useful to a user writing a new file.
+        let nested = serde_yaml::from_str::<KafkaFixtureFile>(&content);
+        match nested {
+            Ok(file) if !file.topics.is_empty() => {
+                let flat = file.flatten();
+                merged.topics.extend(flat.topics);
+                merged.fixtures.extend(flat.fixtures);
+            }
+            _ => match serde_yaml::from_str::<Vec<KafkaFixture>>(&content) {
+                Ok(fixtures) => merged.fixtures.extend(fixtures),
+                Err(flat_err) => {
+                    let err = match nested {
+                        Err(nested_err) => nested_err,
+                        Ok(_) => flat_err,
+                    };
+                    return Err(mockforge_core::Error::from(err));
+                }
+            },
+        }
+    }
+    tracing::info!(
+        "Loaded {} kafka topics and {} fixtures from {}",
+        merged.topics.len(),
+        merged.fixtures.len(),
+        dir.display()
+    );
+    Ok(merged)
+}
+
+impl KafkaFixture {
     /// Generate a message using the fixture
     pub fn generate_message(
         &self,

--- a/crates/mockforge-kafka/src/lib.rs
+++ b/crates/mockforge-kafka/src/lib.rs
@@ -126,6 +126,7 @@
 
 pub mod broker;
 pub mod consumer_groups;
+pub mod fixture_file;
 pub mod fixtures;
 pub mod metrics;
 pub mod partitions;
@@ -138,6 +139,9 @@ pub mod topics;
 // Re-export main types
 pub use broker::KafkaMockBroker;
 pub use consumer_groups::{ConsumerGroup, ConsumerGroupManager};
+pub use fixture_file::{
+    FlattenedFixtures, KafkaFixtureFile, KafkaMessageSpec, KafkaTopicSpec, MessageAutoProduce,
+};
 pub use fixtures::{AutoProduceConfig, KafkaFixture};
 pub use metrics::{KafkaMetrics, MetricsExporter, MetricsSnapshot};
 pub use partitions::{KafkaMessage, Partition};

--- a/crates/mockforge-kafka/src/spec_registry.rs
+++ b/crates/mockforge-kafka/src/spec_registry.rs
@@ -13,6 +13,11 @@ use mockforge_core::{Protocol, Result};
 #[derive(Debug)]
 pub struct KafkaSpecRegistry {
     fixtures: Vec<Arc<crate::fixtures::KafkaFixture>>,
+    /// Topic-level specs loaded from the nested-topology YAML (partition
+    /// counts, replication factor, config). Empty when only the legacy
+    /// flat-array fixture form was provided. The Metadata v4 response reads
+    /// from here to advertise real topics to clients.
+    topic_specs: Vec<Arc<crate::fixture_file::KafkaTopicSpec>>,
     template_engine: mockforge_core::templating::TemplateEngine,
     topics: Arc<tokio::sync::RwLock<HashMap<String, crate::topics::Topic>>>,
 }
@@ -23,19 +28,38 @@ impl KafkaSpecRegistry {
         config: mockforge_core::config::KafkaConfig,
         topics: Arc<tokio::sync::RwLock<HashMap<String, crate::topics::Topic>>>,
     ) -> Result<Self> {
-        let fixtures = if let Some(fixtures_dir) = &config.fixtures_dir {
-            crate::fixtures::KafkaFixture::load_from_dir(fixtures_dir)?
-                .into_iter()
-                .map(Arc::new)
-                .collect()
+        let (topic_specs, fixtures) = if let Some(fixtures_dir) = &config.fixtures_dir {
+            let flat = crate::fixtures::load_kafka_fixtures_from_dir(fixtures_dir)?;
+            let specs: Vec<_> = flat.topics.into_iter().map(Arc::new).collect();
+            let fixtures: Vec<_> = flat.fixtures.into_iter().map(Arc::new).collect();
+            (specs, fixtures)
         } else {
-            vec![]
+            (vec![], vec![])
         };
+
+        // Pre-register every topic we know about from the fixture file so
+        // Produce/Fetch routing and Metadata responses see consistent state.
+        // (No messages are pre-populated — only the topic shell with the
+        // right partition count.)
+        {
+            let mut topic_map = topics.write().await;
+            for spec in &topic_specs {
+                topic_map.entry(spec.name.clone()).or_insert_with(|| {
+                    let cfg = crate::topics::TopicConfig {
+                        num_partitions: spec.partitions.max(1),
+                        replication_factor: spec.replication_factor.max(1),
+                        ..Default::default()
+                    };
+                    crate::topics::Topic::new(spec.name.clone(), cfg)
+                });
+            }
+        }
 
         let template_engine = mockforge_core::templating::TemplateEngine::new();
 
         Ok(Self {
             fixtures,
+            topic_specs,
             template_engine,
             topics,
         })
@@ -44,6 +68,12 @@ impl KafkaSpecRegistry {
     /// Find fixture by topic
     pub fn find_fixture_by_topic(&self, topic: &str) -> Option<Arc<crate::fixtures::KafkaFixture>> {
         self.fixtures.iter().find(|f| f.topic == topic).cloned()
+    }
+
+    /// Topic specs loaded from the nested-topology fixture file, in file
+    /// order. Consumed by the Metadata response wiring in a follow-up PR.
+    pub fn topic_specs(&self) -> &[Arc<crate::fixture_file::KafkaTopicSpec>] {
+        &self.topic_specs
     }
 
     /// Produce a message to a topic

--- a/crates/mockforge-kafka/tests/fixture_schema.rs
+++ b/crates/mockforge-kafka/tests/fixture_schema.rs
@@ -1,0 +1,95 @@
+//! Regression coverage for nested-topology fixture loading against the
+//! bundled example file. If this test fails, a Kafka docker run pointed at
+//! `/app/examples/protocols/kafka` would silently start with zero topics
+//! (or worse, fail to bind entirely) — exactly the symptom this PR fixes.
+
+use mockforge_core::config::KafkaConfig;
+use mockforge_kafka::fixtures::load_kafka_fixtures_from_dir;
+use mockforge_kafka::KafkaSpecRegistry;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+fn bundled_fixtures_dir() -> PathBuf {
+    // Walk up from CARGO_MANIFEST_DIR (crates/mockforge-kafka) to the repo
+    // root so this works from either cargo-test in-place or a worktree.
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().unwrap().parent().unwrap().join("examples/protocols/kafka")
+}
+
+#[test]
+fn loads_bundled_order_events_yaml() {
+    let flat = load_kafka_fixtures_from_dir(&bundled_fixtures_dir())
+        .expect("bundled examples/protocols/kafka should load cleanly");
+
+    let topic_names: Vec<_> = flat.topics.iter().map(|t| t.name.as_str()).collect();
+    assert!(topic_names.contains(&"orders.created"), "got {topic_names:?}");
+    assert!(topic_names.contains(&"orders.status-updated"), "got {topic_names:?}");
+    assert!(topic_names.contains(&"payments.processed"), "got {topic_names:?}");
+    assert!(topic_names.contains(&"inventory.updated"), "got {topic_names:?}");
+
+    // inventory.updated is declared with 5 partitions in the YAML — check the
+    // partition count actually made it through the parser.
+    let inventory = flat
+        .topics
+        .iter()
+        .find(|t| t.name == "inventory.updated")
+        .expect("inventory topic");
+    assert_eq!(inventory.partitions, 5);
+
+    // Every topic has at least one message template in the example file.
+    assert_eq!(flat.fixtures.len(), flat.topics.len());
+
+    // orders.created is the only one with rate-based auto_produce; the
+    // state-machine-driven topics load but don't emit an AutoProduceConfig.
+    let orders = flat
+        .fixtures
+        .iter()
+        .find(|f| f.topic == "orders.created")
+        .expect("orders.created fixture");
+    let ap = orders.auto_produce.as_ref().expect("rate auto_produce");
+    assert!(ap.enabled);
+    assert_eq!(ap.rate_per_second, 10);
+
+    let status = flat
+        .fixtures
+        .iter()
+        .find(|f| f.topic == "orders.status-updated")
+        .expect("orders.status-updated fixture");
+    assert!(
+        status.auto_produce.is_none(),
+        "state_machine-triggered messages must not emit a rate-based AutoProduceConfig"
+    );
+}
+
+#[tokio::test]
+async fn spec_registry_preregisters_topics_from_bundled_yaml() {
+    // Also exercise the KafkaSpecRegistry path — when the registry is built
+    // with the bundled fixtures_dir, the topic store should have all four
+    // topics with their declared partition counts, so subsequent Metadata
+    // handling (future PR) has real state to serialize.
+    let config = KafkaConfig {
+        fixtures_dir: Some(bundled_fixtures_dir()),
+        ..KafkaConfig::default()
+    };
+
+    let topic_map = Arc::new(RwLock::new(HashMap::new()));
+    let registry = KafkaSpecRegistry::new(config, topic_map.clone())
+        .await
+        .expect("registry should build against bundled fixture");
+
+    let topics = topic_map.read().await;
+    assert!(topics.contains_key("orders.created"));
+    assert!(topics.contains_key("orders.status-updated"));
+    assert!(topics.contains_key("payments.processed"));
+    let inventory = topics.get("inventory.updated").expect("inventory topic pre-registered");
+    assert_eq!(inventory.partitions.len(), 5);
+
+    // The registry's accessor should expose the same topic specs the
+    // Metadata handler will consume.
+    assert!(registry
+        .topic_specs()
+        .iter()
+        .any(|t| t.name == "inventory.updated" && t.partitions == 5));
+}


### PR DESCRIPTION
## Summary

**PR 1 of the Kafka real-implementation plan.** Before this, pointing `MOCKFORGE_KAFKA_FIXTURES_DIR` at the bundled `examples/protocols/kafka/` crashed fixture loading with `Yaml(Error("invalid type: map, expected a sequence", line: 6, column: 1))`. The underlying problem: `KafkaFixture::load_from_dir` expected a flat \`Vec<KafkaFixture>\` per file — one message template per record — but every real-world fixture (including the one we ship) describes a *cluster topology*:

\`\`\`yaml
fixture: { name, protocol }
cluster: { bootstrap_servers, cluster_id }
topics:
  - name
    partitions
    replication_factor
    partitioning
    config
    messages:
      - key_template
        value
        headers
        auto_produce
\`\`\`

The two shapes never lined up. This PR reconciles them.

## Changes

- **New module `fixture_file`** defining the real schema — `KafkaFixtureFile`, `KafkaTopicSpec`, `KafkaMessageSpec`, `MessageAutoProduce`, `ClusterSpec`, `FixtureMeta`. Advanced top-level sections (`scenarios`, `relationships`, `failure_simulation`, `monitoring`) deserialize through `#[serde(default)]` and tolerate unknown fields, so the file loads cleanly and later PRs can wire those features without another schema migration.
- **`KafkaFixtureFile::flatten()`** expands the nested shape into both a `Vec<KafkaTopicSpec>` (for the Metadata handler's follow-up PR) and a `Vec<KafkaFixture>` (one per message template, preserving the existing registry + auto-produce contract). Message identifiers are synthetic `{topic}#{index}`. State-machine and other non-rate triggers parse through but don't emit an `AutoProduceConfig` — the rate-based executor would misinterpret them.
- **`load_kafka_fixtures_from_dir`** replaces the old hardcoded `FixtureLoadOptions::yaml_array_strict()` path. Each YAML file is tried as the nested shape first; if the top level has no `topics:`, falls back to the legacy flat-array form. When *both* parses fail, the nested error is surfaced since its schema guidance is more actionable. `KafkaFixture::load_from_dir` is kept as a backward-compatible wrapper.
- **`KafkaSpecRegistry::new`** now takes the flattened output and pre-registers every declared topic in the shared topic map with its declared `partitions` / `replication_factor`, so subsequent handlers see consistent state. Adds a `topic_specs()` accessor for the Metadata handler coming in PR 2.
- **Regression test** (`tests/fixture_schema.rs`) loads `examples/protocols/kafka/order-events.yaml` directly and asserts: all four topics present, `inventory.updated` has 5 partitions, rate-based `auto_produce` on `orders.created` preserved, state-machine trigger on `orders.status-updated` loads without emitting `AutoProduceConfig`.

## Test plan

- [x] `cargo clippy -p mockforge-kafka --all-targets -- -D warnings` → clean
- [x] `cargo test -p mockforge-kafka` → **247 passed** (228 lib + 2 new integration + 10 pre-existing integration + 7 doc)
- [x] `cargo fmt --all --check` → clean
- [x] Standalone probe against the bundled fixture:
\`\`\`
topics: 4
  orders.created -> partitions=3 messages=1
  orders.status-updated -> partitions=3 messages=1
  payments.processed -> partitions=3 messages=1
  inventory.updated -> partitions=5 messages=1
fixtures: 4
  id=orders.created#0 topic=orders.created auto_produce_rate=Some(10)
  id=orders.status-updated#0 topic=orders.status-updated auto_produce_rate=None
  id=payments.processed#0 topic=payments.processed auto_produce_rate=None
  id=inventory.updated#0 topic=inventory.updated auto_produce_rate=None
\`\`\`

## Next in the plan (separate PRs)

2. Wire `topic_specs()` into the Metadata v4 response so `kcat -L` prints these four topics.
3. Implement real Produce v9 (RecordBatch v2 parse) so `kcat -P` writes to `Topic::produce()`.
4. Implement real Fetch v12 so `kcat -C` reads what was produced.
5. Execute state-machine / scenario triggers (the file loads them today; nothing runs them yet).