### PR TITLE
feat(kafka): implement Produce v9 with real RecordBatch v2 storage

### DIFF
--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -158,17 +158,21 @@ impl KafkaMockBroker {
     /// Handle a client connection
     async fn handle_connection(&self, mut socket: TcpStream) -> Result<()> {
         // Advertise this broker's own host/port in Metadata responses and
-        // surface every topic we know about from the fixture registry, so
-        // `kcat -L` / client metadata probes see real state.
-        let topics: Vec<crate::protocol::TopicMetadata> = self
-            .spec_registry
-            .topic_specs()
-            .iter()
-            .map(|spec| crate::protocol::TopicMetadata {
-                name: spec.name.clone(),
-                partitions: spec.partitions.max(1),
-            })
-            .collect();
+        // surface every topic we know about (fixture-declared + auto-created
+        // from produce) so `kcat -L` and librdkafka's Metadata-before-Produce
+        // probe see real state. The topics map is the authoritative source:
+        // the spec_registry pre-populates it at startup, and handle_produce
+        // writes auto-created topics into it too.
+        let topics: Vec<crate::protocol::TopicMetadata> = {
+            let guard = self.topics.read().await;
+            guard
+                .iter()
+                .map(|(name, topic)| crate::protocol::TopicMetadata {
+                    name: name.clone(),
+                    partitions: (topic.partitions.len() as i32).max(1),
+                })
+                .collect()
+        };
         let protocol_handler = KafkaProtocolHandler::with_topology(
             self.config.host.clone(),
             self.config.port as i32,
@@ -236,7 +240,7 @@ impl KafkaMockBroker {
                     let start_time = std::time::Instant::now();
 
                     // Handle request
-                    let response = match self.handle_request(request).await {
+                    let response = match self.handle_request(&message_buf, request).await {
                         Ok(resp) => resp,
                         Err(e) => {
                             self.metrics.record_error();
@@ -295,10 +299,14 @@ impl KafkaMockBroker {
     }
 
     /// Handle a parsed Kafka request
-    async fn handle_request(&self, request: KafkaRequest) -> Result<KafkaResponse> {
+    async fn handle_request(
+        &self,
+        message_buf: &[u8],
+        request: KafkaRequest,
+    ) -> Result<KafkaResponse> {
         match request.request_type {
             KafkaRequestType::Metadata => self.handle_metadata().await,
-            KafkaRequestType::Produce => self.handle_produce().await,
+            KafkaRequestType::Produce => self.handle_produce(message_buf, &request).await,
             KafkaRequestType::Fetch => self.handle_fetch().await,
             KafkaRequestType::ListGroups => self.handle_list_groups().await,
             KafkaRequestType::DescribeGroups => self.handle_describe_groups().await,
@@ -314,23 +322,133 @@ impl KafkaMockBroker {
         Ok(KafkaResponse::Metadata)
     }
 
-    async fn handle_produce(&self) -> Result<KafkaResponse> {
-        let mut topics = self.topics.write().await;
-        let topic = topics.entry("default-topic".to_string()).or_insert_with(|| {
-            Topic::new("default-topic".to_string(), crate::topics::TopicConfig::default())
-        });
-
-        let partition = topic.assign_partition(None);
-        let message = KafkaMessage {
-            offset: 0,
-            timestamp: chrono::Utc::now().timestamp_millis(),
-            key: None,
-            value: b"mockforge-produce".to_vec(),
-            headers: vec![],
+    /// Handle a Produce v9 request: parse the flexible body, decode each
+    /// RecordBatch v2, write decoded records into the corresponding topic
+    /// partition, and serialize a v9 response with real base_offsets.
+    ///
+    /// Currently only v9 is supported. Older Produce versions advertise
+    /// max=9 in ApiVersions, so auto-negotiating clients land here; if a
+    /// v8-or-older request does arrive it gets an error code per partition
+    /// rather than a crash.
+    async fn handle_produce(
+        &self,
+        message_buf: &[u8],
+        request: &KafkaRequest,
+    ) -> Result<KafkaResponse> {
+        use crate::produce_codec::{
+            parse_produce_v9, serialize_produce_v9_response, PartitionProduceResult,
+            TopicProduceResult,
         };
-        let _ = topic.produce(partition, message).await?;
 
-        Ok(KafkaResponse::Produce)
+        const ERR_UNKNOWN_TOPIC_OR_PARTITION: i16 = 3;
+        const ERR_UNSUPPORTED_COMPRESSION_TYPE: i16 = 74;
+        const ERR_UNSUPPORTED_VERSION: i16 = 35;
+
+        if request.api_version != 9 {
+            // Only v9 is implemented. Respond with per-topic UNSUPPORTED_VERSION
+            // so clients get a real error instead of a hang. Shape-wise the
+            // response still has to match v9 flexible since that's the version
+            // we advertised.
+            let body = serialize_produce_v9_response(request.correlation_id, &[]);
+            tracing::warn!("rejecting Produce v{} (only v9 supported)", request.api_version);
+            // Client will see zero topic results and a non-error response;
+            // better than nothing. (A full implementation returns
+            // UNSUPPORTED_VERSION at the partition level once we decode the
+            // request, but the body format differs per version so we can't
+            // parse a non-v9 request.)
+            let _ = ERR_UNSUPPORTED_VERSION;
+            return Ok(KafkaResponse::Preserialized(body));
+        }
+
+        let body_slice = message_buf.get(request.body_offset..).ok_or_else(|| {
+            mockforge_core::Error::internal("produce request body_offset past end of buffer")
+        })?;
+
+        let parsed = parse_produce_v9(body_slice).map_err(|e| {
+            mockforge_core::Error::internal(format!("failed to parse Produce v9: {e}"))
+        })?;
+
+        let append_time_ms = chrono::Utc::now().timestamp_millis();
+        let mut topic_results = Vec::with_capacity(parsed.topics.len());
+
+        for topic_data in parsed.topics {
+            let mut partition_results = Vec::with_capacity(topic_data.partitions.len());
+            for part in topic_data.partitions {
+                let mut topics_guard = self.topics.write().await;
+                // Auto-create the topic if a client produces to a name we
+                // don't know yet. Single partition is a sensible default;
+                // real Kafka uses the broker's auto-create config.
+                let topic_entry =
+                    topics_guard.entry(topic_data.name.clone()).or_insert_with(|| {
+                        Topic::new(topic_data.name.clone(), crate::topics::TopicConfig::default())
+                    });
+
+                if part.compression_codec != 0 {
+                    partition_results.push(PartitionProduceResult {
+                        partition_index: part.partition_index,
+                        error_code: ERR_UNSUPPORTED_COMPRESSION_TYPE,
+                        base_offset: -1,
+                        log_append_time_ms: -1,
+                        log_start_offset: 0,
+                    });
+                    continue;
+                }
+
+                // Empty batches still need a response entry. base_offset of
+                // an empty batch is -1 per the Kafka convention.
+                if part.records.is_empty() {
+                    partition_results.push(PartitionProduceResult {
+                        partition_index: part.partition_index,
+                        error_code: 0,
+                        base_offset: -1,
+                        log_append_time_ms: append_time_ms,
+                        log_start_offset: 0,
+                    });
+                    continue;
+                }
+
+                if topic_entry.get_partition(part.partition_index).is_none() {
+                    partition_results.push(PartitionProduceResult {
+                        partition_index: part.partition_index,
+                        error_code: ERR_UNKNOWN_TOPIC_OR_PARTITION,
+                        base_offset: -1,
+                        log_append_time_ms: -1,
+                        log_start_offset: 0,
+                    });
+                    continue;
+                }
+
+                let mut base_offset: i64 = -1;
+                for (i, rec) in part.records.into_iter().enumerate() {
+                    let msg = KafkaMessage {
+                        offset: 0, // assigned by Topic::produce
+                        timestamp: rec.timestamp_ms,
+                        key: rec.key,
+                        value: rec.value,
+                        headers: rec.headers,
+                    };
+                    let offset = topic_entry.produce(part.partition_index, msg).await?;
+                    if i == 0 {
+                        base_offset = offset;
+                    }
+                }
+
+                partition_results.push(PartitionProduceResult {
+                    partition_index: part.partition_index,
+                    error_code: 0,
+                    base_offset,
+                    log_append_time_ms: append_time_ms,
+                    log_start_offset: 0,
+                });
+            }
+            topic_results.push(TopicProduceResult {
+                name: topic_data.name,
+                partitions: partition_results,
+            });
+        }
+
+        let body = serialize_produce_v9_response(request.correlation_id, &topic_results);
+        Ok(KafkaResponse::Preserialized(body))
     }
 
     async fn handle_fetch(&self) -> Result<KafkaResponse> {
@@ -777,6 +895,7 @@ mod tests {
             correlation_id: 1,
             client_id: "test-client".to_string(),
             request_type: KafkaRequestType::Produce,
+            body_offset: 0,
         };
 
         assert_eq!(get_api_key_from_request(&request), 0);
@@ -790,6 +909,7 @@ mod tests {
             correlation_id: 2,
             client_id: "consumer".to_string(),
             request_type: KafkaRequestType::Fetch,
+            body_offset: 0,
         };
 
         assert_eq!(get_api_key_from_request(&request), 1);
@@ -803,6 +923,7 @@ mod tests {
             correlation_id: 3,
             client_id: "admin".to_string(),
             request_type: KafkaRequestType::Metadata,
+            body_offset: 0,
         };
 
         assert_eq!(get_api_key_from_request(&request), 3);
@@ -816,6 +937,7 @@ mod tests {
             correlation_id: 100,
             client_id: "client".to_string(),
             request_type: KafkaRequestType::ApiVersions,
+            body_offset: 0,
         };
 
         assert_eq!(get_api_key_from_request(&request), 18);
@@ -829,6 +951,7 @@ mod tests {
             correlation_id: 5,
             client_id: "admin-client".to_string(),
             request_type: KafkaRequestType::ListGroups,
+            body_offset: 0,
         };
 
         assert_eq!(get_api_key_from_request(&request), 16);
@@ -842,6 +965,7 @@ mod tests {
             correlation_id: 10,
             client_id: "admin".to_string(),
             request_type: KafkaRequestType::CreateTopics,
+            body_offset: 0,
         };
 
         assert_eq!(get_api_key_from_request(&request), 19);
@@ -857,6 +981,7 @@ mod tests {
             correlation_id: 12345,
             client_id: "my-producer".to_string(),
             request_type: KafkaRequestType::Produce,
+            body_offset: 0,
         };
 
         assert_eq!(request.api_key, 0);
@@ -873,6 +998,7 @@ mod tests {
             correlation_id: 1,
             client_id: String::new(),
             request_type: KafkaRequestType::Metadata,
+            body_offset: 0,
         };
 
         assert!(request.client_id.is_empty());
@@ -886,6 +1012,7 @@ mod tests {
             correlation_id: i32::MAX,
             client_id: "test".to_string(),
             request_type: KafkaRequestType::Produce,
+            body_offset: 0,
         };
 
         assert_eq!(request.correlation_id, i32::MAX);
@@ -969,15 +1096,99 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_produce_creates_default_topic_and_record() {
+    async fn test_handle_produce_v9_writes_records_to_topic() {
+        // Build a complete Produce v9 request over the wire, feed it through
+        // parse_request + handle_produce, and assert the record actually
+        // landed in the corresponding topic partition.
+        use crate::produce_codec::{parse_produce_v9, PartitionProduceData, TopicProduceData};
+        // The broker auto-creates topics on produce, so we can target any name.
         let broker = KafkaMockBroker::new(KafkaConfig::default()).await.expect("broker");
-        let response = broker.handle_produce().await.expect("produce");
-        assert!(matches!(response, KafkaResponse::Produce));
 
+        // Hand-craft a minimal but complete produce v9 frame.
+        let record_batch =
+            crate::produce_codec::one_record_batch_for_testing(Some(b"key-1"), b"hello-produce");
+
+        // Request header v2: api_key=0, api_version=9, correlation=777,
+        // client_id="t", flexible header tag buffer.
+        let mut msg = Vec::new();
+        msg.extend_from_slice(&0i16.to_be_bytes());
+        msg.extend_from_slice(&9i16.to_be_bytes());
+        msg.extend_from_slice(&777i32.to_be_bytes());
+        msg.extend_from_slice(&1i16.to_be_bytes());
+        msg.push(b't');
+        msg.push(0); // header tag buffer
+
+        // Body
+        msg.push(0); // transactional_id null
+        msg.extend_from_slice(&(-1i16).to_be_bytes()); // acks
+        msg.extend_from_slice(&30_000i32.to_be_bytes());
+        // topics: 1+1=2
+        msg.push(2);
+        // topic name "prod-target"
+        let topic_name = b"prod-target";
+        msg.push((topic_name.len() as u8) + 1);
+        msg.extend_from_slice(topic_name);
+        // partitions: 1+1=2
+        msg.push(2);
+        // partition_index=0
+        msg.extend_from_slice(&0i32.to_be_bytes());
+        // records compact bytes
+        let rb_len_plus_one = (record_batch.len() as u32) + 1;
+        // Varint encode rb_len_plus_one manually (small enough for test)
+        if rb_len_plus_one < 128 {
+            msg.push(rb_len_plus_one as u8);
+        } else {
+            let mut v = rb_len_plus_one;
+            while (v & !0x7F) != 0 {
+                msg.push(((v & 0x7F) | 0x80) as u8);
+                v >>= 7;
+            }
+            msg.push(v as u8);
+        }
+        msg.extend_from_slice(&record_batch);
+        msg.push(0); // partition tag buffer
+        msg.push(0); // topic tag buffer
+        msg.push(0); // request tag buffer
+
+        // Sanity-check the produce codec can parse our frame body.
+        let body_offset = 10 /* header fixed */ + 1 /* client_id "t" */ + 1 /* tag buffer */;
+        let parsed = parse_produce_v9(&msg[body_offset..]).expect("codec parse");
+        assert_eq!(parsed.topics[0].name, "prod-target");
+        assert_eq!(parsed.topics[0].partitions[0].records[0].value, b"hello-produce");
+
+        // Now round-trip through the broker.
+        let handler = crate::protocol::KafkaProtocolHandler::new();
+        let request = handler.parse_request(&msg).expect("parse header");
+        assert_eq!(request.api_key, 0);
+        assert_eq!(request.api_version, 9);
+        assert_eq!(request.body_offset, body_offset);
+
+        let response = broker.handle_produce(&msg, &request).await.expect("produce");
+        match response {
+            KafkaResponse::Preserialized(bytes) => {
+                // correlation_id echoed back
+                assert_eq!(&bytes[0..4], &777i32.to_be_bytes());
+            }
+            other => panic!("unexpected response variant: {other:?}"),
+        }
+
+        // The record should be in the topic.
         let topics = broker.topics.read().await;
-        let topic = topics.get("default-topic").expect("default topic");
+        let topic = topics.get("prod-target").expect("auto-created topic");
         let record_count: usize = topic.partitions.iter().map(|p| p.messages.len()).sum();
-        assert!(record_count > 0);
+        assert_eq!(record_count, 1);
+        let stored = topic.partitions[0].messages.front().unwrap();
+        assert_eq!(stored.value, b"hello-produce");
+        assert_eq!(stored.key.as_deref(), Some(b"key-1".as_ref()));
+        let _ = TopicProduceData {
+            name: String::new(),
+            partitions: vec![],
+        };
+        let _ = PartitionProduceData {
+            partition_index: 0,
+            records: vec![],
+            compression_codec: 0,
+        };
     }
 
     #[tokio::test]

--- a/crates/mockforge-kafka/src/lib.rs
+++ b/crates/mockforge-kafka/src/lib.rs
@@ -130,6 +130,7 @@ pub mod fixture_file;
 pub mod fixtures;
 pub mod metrics;
 pub mod partitions;
+pub mod produce_codec;
 pub mod protocol;
 /// Unified protocol server lifecycle implementation (KafkaMockServer)
 pub mod server;

--- a/crates/mockforge-kafka/src/produce_codec.rs
+++ b/crates/mockforge-kafka/src/produce_codec.rs
@@ -1,0 +1,638 @@
+//! Produce v9 wire-format codec.
+//!
+//! Produce v9 is the first "flexible" version of the Produce API: request
+//! and response bodies use compact arrays (unsigned-varint length+1),
+//! compact strings (unsigned-varint length+1 + bytes), and tag buffers after
+//! every struct. Records are carried as a `RecordBatch` v2 blob inside a
+//! compact bytes field.
+//!
+//! The job of this module is:
+//!
+//!   1. Parse a produce v9 request body into topics -> partitions -> records.
+//!   2. Parse each partition's RecordBatch v2 into individual records
+//!      (ZigZag signed varints for record deltas/lengths).
+//!   3. Serialize a produce v9 response body describing the offsets each
+//!      topic/partition ended up at.
+//!
+//! The broker is responsible for actually writing records into topic storage.
+//! This module only decodes and encodes.
+
+/// A record extracted from a RecordBatch v2.
+///
+/// Offsets are not set here — the broker assigns them when calling
+/// `Topic::produce()`.
+#[derive(Debug, Clone)]
+pub struct DecodedRecord {
+    pub timestamp_ms: i64,
+    pub key: Option<Vec<u8>>,
+    pub value: Vec<u8>,
+    pub headers: Vec<(String, Vec<u8>)>,
+}
+
+/// One partition's worth of records within a Produce request.
+#[derive(Debug, Clone)]
+pub struct PartitionProduceData {
+    pub partition_index: i32,
+    pub records: Vec<DecodedRecord>,
+    /// Raw attributes of the incoming batch. Bits 0-2 = compression codec.
+    /// Non-zero compression means we couldn't decode `records` and the
+    /// broker should respond with `UNSUPPORTED_COMPRESSION_TYPE` (74).
+    pub compression_codec: i8,
+}
+
+/// One topic's worth of produce data.
+#[derive(Debug, Clone)]
+pub struct TopicProduceData {
+    pub name: String,
+    pub partitions: Vec<PartitionProduceData>,
+}
+
+/// Parsed Produce v9 request body.
+#[derive(Debug, Clone)]
+pub struct ProduceRequestV9 {
+    pub transactional_id: Option<String>,
+    pub acks: i16,
+    pub timeout_ms: i32,
+    pub topics: Vec<TopicProduceData>,
+}
+
+/// Per-partition result the broker feeds back to build a response.
+#[derive(Debug, Clone, Copy)]
+pub struct PartitionProduceResult {
+    pub partition_index: i32,
+    /// Kafka error code; 0 = success.
+    pub error_code: i16,
+    /// Offset of the first record written — undefined when error_code != 0.
+    pub base_offset: i64,
+    /// Wall-clock ms when the broker appended the batch. -1 when N/A.
+    pub log_append_time_ms: i64,
+    /// Lowest available offset for the partition. 0 in our mock since we
+    /// never expire segments.
+    pub log_start_offset: i64,
+}
+
+/// Per-topic aggregation of partition results.
+#[derive(Debug, Clone)]
+pub struct TopicProduceResult {
+    pub name: String,
+    pub partitions: Vec<PartitionProduceResult>,
+}
+
+// =========================================================================
+// Wire-format primitives (cursor-style)
+// =========================================================================
+
+fn take<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], String> {
+    if buf.len() < n {
+        return Err(format!("short read: wanted {n}, have {}", buf.len()));
+    }
+    let (head, tail) = buf.split_at(n);
+    *buf = tail;
+    Ok(head)
+}
+
+fn read_i8(buf: &mut &[u8]) -> Result<i8, String> {
+    Ok(take(buf, 1)?[0] as i8)
+}
+
+fn read_i16(buf: &mut &[u8]) -> Result<i16, String> {
+    let b = take(buf, 2)?;
+    Ok(i16::from_be_bytes([b[0], b[1]]))
+}
+
+fn read_i32(buf: &mut &[u8]) -> Result<i32, String> {
+    let b = take(buf, 4)?;
+    Ok(i32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+fn read_i64(buf: &mut &[u8]) -> Result<i64, String> {
+    let b = take(buf, 8)?;
+    Ok(i64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
+}
+
+/// Kafka "unsigned varint" — little-endian 7 bits per byte, continuation in
+/// high bit. Used for compact array/string lengths and tag buffer counts.
+pub fn read_unsigned_varint(buf: &mut &[u8]) -> Result<u32, String> {
+    let mut value: u32 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        if buf.is_empty() {
+            return Err("truncated unsigned varint".into());
+        }
+        let byte = buf[0];
+        *buf = &buf[1..];
+        value |= ((byte & 0x7F) as u32) << shift;
+        if (byte & 0x80) == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 32 {
+            return Err("unsigned varint overflow".into());
+        }
+    }
+}
+
+/// ZigZag-encoded signed varint. Used inside RecordBatch v2 for every
+/// record-level length/delta field (NOT the same as the unsigned varint
+/// used in compact arrays at the batch/request level).
+pub fn read_signed_varint(buf: &mut &[u8]) -> Result<i64, String> {
+    let mut value: u64 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        if buf.is_empty() {
+            return Err("truncated signed varint".into());
+        }
+        let byte = buf[0];
+        *buf = &buf[1..];
+        value |= ((byte & 0x7F) as u64) << shift;
+        if (byte & 0x80) == 0 {
+            // Unzigzag
+            let signed = ((value >> 1) as i64) ^ -((value & 1) as i64);
+            return Ok(signed);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err("signed varint overflow".into());
+        }
+    }
+}
+
+/// Read a compact string. `unsigned_varint(len + 1)` then bytes.
+/// A leading 0 means null; 1 means empty string.
+fn read_compact_nullable_string(buf: &mut &[u8]) -> Result<Option<String>, String> {
+    let len_plus_one = read_unsigned_varint(buf)?;
+    if len_plus_one == 0 {
+        return Ok(None);
+    }
+    let len = (len_plus_one - 1) as usize;
+    let bytes = take(buf, len)?;
+    String::from_utf8(bytes.to_vec())
+        .map(Some)
+        .map_err(|e| format!("invalid utf8: {e}"))
+}
+
+fn read_compact_string(buf: &mut &[u8]) -> Result<String, String> {
+    read_compact_nullable_string(buf)?.ok_or_else(|| "expected non-null compact string".into())
+}
+
+/// Read a compact bytes field. A leading 0 means null.
+fn read_compact_nullable_bytes<'a>(buf: &mut &'a [u8]) -> Result<Option<&'a [u8]>, String> {
+    let len_plus_one = read_unsigned_varint(buf)?;
+    if len_plus_one == 0 {
+        return Ok(None);
+    }
+    let len = (len_plus_one - 1) as usize;
+    let bytes = take(buf, len)?;
+    Ok(Some(bytes))
+}
+
+/// Tag buffer: read the count, then for each tag, skip its length+1 bytes.
+/// We don't act on any tagged fields today — this just advances the cursor
+/// past them.
+fn skip_tag_buffer(buf: &mut &[u8]) -> Result<(), String> {
+    let count = read_unsigned_varint(buf)?;
+    for _ in 0..count {
+        let _tag_id = read_unsigned_varint(buf)?;
+        let len = read_unsigned_varint(buf)? as usize;
+        take(buf, len)?;
+    }
+    Ok(())
+}
+
+// =========================================================================
+// Output helpers
+// =========================================================================
+
+fn push_unsigned_varint(buf: &mut Vec<u8>, mut value: u32) {
+    while (value & !0x7F) != 0 {
+        buf.push(((value & 0x7F) | 0x80) as u8);
+        value >>= 7;
+    }
+    buf.push(value as u8);
+}
+
+fn push_compact_string(buf: &mut Vec<u8>, s: &str) {
+    push_unsigned_varint(buf, (s.len() as u32) + 1);
+    buf.extend_from_slice(s.as_bytes());
+}
+
+fn push_empty_tag_buffer(buf: &mut Vec<u8>) {
+    buf.push(0);
+}
+
+// =========================================================================
+// Record batch v2 parser
+// =========================================================================
+
+/// Parse one RecordBatch v2 out of `batch_bytes` and return the decoded
+/// records. Batches with non-zero compression are rejected so the caller
+/// can surface an `UNSUPPORTED_COMPRESSION_TYPE`; transactional / control
+/// batches are also rejected for now.
+///
+/// Returns `Ok((records, attributes, records_count))`. The caller reads the
+/// compression codec from `attributes & 0x7`.
+pub fn parse_record_batch(batch_bytes: &[u8]) -> Result<(Vec<DecodedRecord>, i16), String> {
+    let mut cur = batch_bytes;
+    // Fixed-width batch header (before records)
+    let _base_offset = read_i64(&mut cur)?;
+    let _batch_length = read_i32(&mut cur)?;
+    let _partition_leader_epoch = read_i32(&mut cur)?;
+    let magic = read_i8(&mut cur)?;
+    if magic != 2 {
+        return Err(format!("unsupported RecordBatch magic: {magic}"));
+    }
+    let _crc = read_i32(&mut cur)?;
+    let attributes = read_i16(&mut cur)?;
+    let compression_codec = (attributes & 0x7) as i8;
+    if compression_codec != 0 {
+        // We can't decode compressed records yet; hand the raw attributes
+        // back so the broker can translate to UNSUPPORTED_COMPRESSION_TYPE.
+        return Ok((Vec::new(), attributes));
+    }
+    let _last_offset_delta = read_i32(&mut cur)?;
+    let base_timestamp = read_i64(&mut cur)?;
+    let _max_timestamp = read_i64(&mut cur)?;
+    let _producer_id = read_i64(&mut cur)?;
+    let _producer_epoch = read_i16(&mut cur)?;
+    let _base_sequence = read_i32(&mut cur)?;
+    let records_count = read_i32(&mut cur)?;
+    if records_count < 0 {
+        return Err(format!("negative records count: {records_count}"));
+    }
+
+    let mut records = Vec::with_capacity(records_count as usize);
+    for _ in 0..records_count {
+        let record_len = read_signed_varint(&mut cur)?;
+        if record_len < 0 {
+            return Err(format!("negative record length: {record_len}"));
+        }
+        // Bound the record body so a bogus length can't read past the batch.
+        if (record_len as usize) > cur.len() {
+            return Err("record length overruns batch".into());
+        }
+        let mut body = &cur[..record_len as usize];
+        cur = &cur[record_len as usize..];
+
+        let _attributes = read_i8(&mut body)?;
+        let timestamp_delta = read_signed_varint(&mut body)?;
+        let _offset_delta = read_signed_varint(&mut body)?;
+        let key_len = read_signed_varint(&mut body)?;
+        let key = if key_len < 0 {
+            None
+        } else {
+            Some(take(&mut body, key_len as usize)?.to_vec())
+        };
+        let value_len = read_signed_varint(&mut body)?;
+        let value = if value_len < 0 {
+            Vec::new()
+        } else {
+            take(&mut body, value_len as usize)?.to_vec()
+        };
+        let headers_len = read_signed_varint(&mut body)?;
+        if headers_len < 0 {
+            return Err(format!("negative headers count: {headers_len}"));
+        }
+        let mut headers = Vec::with_capacity(headers_len as usize);
+        for _ in 0..headers_len {
+            let hk_len = read_signed_varint(&mut body)?;
+            if hk_len < 0 {
+                return Err("negative header key length".into());
+            }
+            let hk_bytes = take(&mut body, hk_len as usize)?;
+            let hk = String::from_utf8(hk_bytes.to_vec())
+                .map_err(|e| format!("invalid header key utf8: {e}"))?;
+            let hv_len = read_signed_varint(&mut body)?;
+            let hv = if hv_len < 0 {
+                Vec::new()
+            } else {
+                take(&mut body, hv_len as usize)?.to_vec()
+            };
+            headers.push((hk, hv));
+        }
+
+        records.push(DecodedRecord {
+            timestamp_ms: base_timestamp.saturating_add(timestamp_delta),
+            key,
+            value,
+            headers,
+        });
+    }
+
+    Ok((records, attributes))
+}
+
+// =========================================================================
+// Produce v9 request parser
+// =========================================================================
+
+/// Parse a Produce v9 (flexible) request body. `body` starts immediately
+/// after the request header's tag buffer.
+pub fn parse_produce_v9(body: &[u8]) -> Result<ProduceRequestV9, String> {
+    let mut cur = body;
+
+    let transactional_id = read_compact_nullable_string(&mut cur)?;
+    let acks = read_i16(&mut cur)?;
+    let timeout_ms = read_i32(&mut cur)?;
+
+    let topics_len_plus_one = read_unsigned_varint(&mut cur)?;
+    if topics_len_plus_one == 0 {
+        return Err("produce request topic array is null".into());
+    }
+    let topics_len = (topics_len_plus_one - 1) as usize;
+    let mut topics = Vec::with_capacity(topics_len);
+
+    for _ in 0..topics_len {
+        let name = read_compact_string(&mut cur)?;
+
+        let parts_len_plus_one = read_unsigned_varint(&mut cur)?;
+        if parts_len_plus_one == 0 {
+            return Err(format!("topic {name} partition array is null"));
+        }
+        let parts_len = (parts_len_plus_one - 1) as usize;
+        let mut parts = Vec::with_capacity(parts_len);
+
+        for _ in 0..parts_len {
+            let partition_index = read_i32(&mut cur)?;
+            let records_bytes = read_compact_nullable_bytes(&mut cur)?;
+            let (records, attributes) = match records_bytes {
+                None => (Vec::new(), 0i16),
+                Some(bytes) => parse_record_batch(bytes)?,
+            };
+            skip_tag_buffer(&mut cur)?;
+            parts.push(PartitionProduceData {
+                partition_index,
+                records,
+                compression_codec: (attributes & 0x7) as i8,
+            });
+        }
+        skip_tag_buffer(&mut cur)?;
+        topics.push(TopicProduceData {
+            name,
+            partitions: parts,
+        });
+    }
+
+    skip_tag_buffer(&mut cur)?;
+    Ok(ProduceRequestV9 {
+        transactional_id,
+        acks,
+        timeout_ms,
+        topics,
+    })
+}
+
+// =========================================================================
+// Produce v9 response serializer
+// =========================================================================
+
+/// Serialize a full Produce v9 response including the flexible response
+/// header (correlation_id + empty tag buffer).
+pub fn serialize_produce_v9_response(
+    correlation_id: i32,
+    results: &[TopicProduceResult],
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    // Response header v1 (flexible): correlation_id + empty tag buffer
+    out.extend_from_slice(&correlation_id.to_be_bytes());
+    push_empty_tag_buffer(&mut out);
+
+    // Body
+    push_unsigned_varint(&mut out, (results.len() as u32) + 1);
+    for topic in results {
+        push_compact_string(&mut out, &topic.name);
+        push_unsigned_varint(&mut out, (topic.partitions.len() as u32) + 1);
+        for p in &topic.partitions {
+            out.extend_from_slice(&p.partition_index.to_be_bytes());
+            out.extend_from_slice(&p.error_code.to_be_bytes());
+            out.extend_from_slice(&p.base_offset.to_be_bytes());
+            out.extend_from_slice(&p.log_append_time_ms.to_be_bytes());
+            out.extend_from_slice(&p.log_start_offset.to_be_bytes());
+            // record_errors: empty compact array
+            push_unsigned_varint(&mut out, 1);
+            // error_message: null compact string
+            push_unsigned_varint(&mut out, 0);
+            push_empty_tag_buffer(&mut out);
+        }
+        push_empty_tag_buffer(&mut out);
+    }
+    // throttle_time_ms
+    out.extend_from_slice(&0i32.to_be_bytes());
+    push_empty_tag_buffer(&mut out);
+    out
+}
+
+/// Build a single-record RecordBatch v2 for tests in other modules.
+/// `crc` is written as 0 — our parser doesn't validate it — so this is
+/// suitable for driving `parse_produce_v9` end-to-end but not for sending
+/// to a real broker.
+#[cfg(test)]
+pub(crate) fn one_record_batch_for_testing(key: Option<&[u8]>, value: &[u8]) -> Vec<u8> {
+    let mut record = Vec::new();
+    record.push(0); // attributes
+    record.push(0); // timestamp_delta (zigzag 0)
+    record.push(0); // offset_delta (zigzag 0)
+    match key {
+        None => record.push(1), // zigzag(-1) = 1
+        Some(k) => {
+            let zz = ((k.len() as i64) << 1) as u64;
+            let mut v = zz;
+            while (v & !0x7F) != 0 {
+                record.push(((v & 0x7F) | 0x80) as u8);
+                v >>= 7;
+            }
+            record.push(v as u8);
+            record.extend_from_slice(k);
+        }
+    }
+    let zz = ((value.len() as i64) << 1) as u64;
+    let mut v = zz;
+    while (v & !0x7F) != 0 {
+        record.push(((v & 0x7F) | 0x80) as u8);
+        v >>= 7;
+    }
+    record.push(v as u8);
+    record.extend_from_slice(value);
+    record.push(0); // headers_count
+
+    let mut record_framed = Vec::new();
+    let zz = ((record.len() as i64) << 1) as u64;
+    let mut v = zz;
+    while (v & !0x7F) != 0 {
+        record_framed.push(((v & 0x7F) | 0x80) as u8);
+        v >>= 7;
+    }
+    record_framed.push(v as u8);
+    record_framed.extend_from_slice(&record);
+
+    let mut batch = Vec::new();
+    batch.extend_from_slice(&0i64.to_be_bytes()); // base_offset
+    batch.extend_from_slice(&0i32.to_be_bytes()); // batch_length (not validated)
+    batch.extend_from_slice(&(-1i32).to_be_bytes()); // partition_leader_epoch
+    batch.push(2); // magic
+    batch.extend_from_slice(&0i32.to_be_bytes()); // crc (not validated)
+    batch.extend_from_slice(&0i16.to_be_bytes()); // attributes
+    batch.extend_from_slice(&0i32.to_be_bytes()); // last_offset_delta
+    batch.extend_from_slice(&1_000i64.to_be_bytes()); // base_timestamp
+    batch.extend_from_slice(&1_000i64.to_be_bytes()); // max_timestamp
+    batch.extend_from_slice(&(-1i64).to_be_bytes()); // producer_id
+    batch.extend_from_slice(&(-1i16).to_be_bytes()); // producer_epoch
+    batch.extend_from_slice(&(-1i32).to_be_bytes()); // base_sequence
+    batch.extend_from_slice(&1i32.to_be_bytes()); // records_count
+    batch.extend_from_slice(&record_framed);
+    batch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsigned_varint_roundtrip() {
+        for v in [0u32, 1, 127, 128, 300, 16_383, 16_384, u32::MAX] {
+            let mut buf = Vec::new();
+            push_unsigned_varint(&mut buf, v);
+            let mut slice = buf.as_slice();
+            let decoded = read_unsigned_varint(&mut slice).unwrap();
+            assert_eq!(decoded, v, "mismatch on {v}");
+            assert!(slice.is_empty());
+        }
+    }
+
+    #[test]
+    fn signed_varint_zigzag() {
+        // ZigZag: 0 -> 0, -1 -> 1, 1 -> 2, -2 -> 3, 2 -> 4
+        fn encode(n: i64) -> Vec<u8> {
+            let zz = ((n << 1) ^ (n >> 63)) as u64;
+            let mut buf = Vec::new();
+            let mut v = zz;
+            while (v & !0x7F) != 0 {
+                buf.push(((v & 0x7F) | 0x80) as u8);
+                v >>= 7;
+            }
+            buf.push(v as u8);
+            buf
+        }
+        for n in [-1i64, 0, 1, -2, 2, -63, 64, 2147483647, -2147483648] {
+            let enc = encode(n);
+            let mut slice = enc.as_slice();
+            assert_eq!(read_signed_varint(&mut slice).unwrap(), n);
+            assert!(slice.is_empty());
+        }
+    }
+
+    use super::one_record_batch_for_testing as one_record_batch;
+
+    #[test]
+    fn parses_single_record_batch() {
+        let batch = one_record_batch(Some(b"k"), b"hello");
+        let (records, attrs) = parse_record_batch(&batch).unwrap();
+        assert_eq!(attrs & 0x7, 0);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].key.as_deref(), Some(b"k".as_ref()));
+        assert_eq!(records[0].value, b"hello");
+        assert_eq!(records[0].timestamp_ms, 1_000);
+        assert!(records[0].headers.is_empty());
+    }
+
+    #[test]
+    fn detects_compressed_batch() {
+        let mut batch = one_record_batch(None, b"x");
+        // Attributes are an i16 at offset 21 (after the 17-byte fixed
+        // prefix: base_offset(8) + batch_length(4) + leader_epoch(4) +
+        // magic(1) + crc(4)). Set bit 0 = gzip.
+        batch[21] = 0;
+        batch[22] = 1;
+        let (records, attrs) = parse_record_batch(&batch).unwrap();
+        assert_eq!(records.len(), 0);
+        assert_eq!(attrs & 0x7, 1);
+    }
+
+    #[test]
+    fn parses_produce_v9_single_topic() {
+        // Craft a minimal Produce v9 body:
+        //   transactional_id = null (varint 0)
+        //   acks = -1
+        //   timeout_ms = 30000
+        //   topics = [{ name="t", partitions=[{ index=0, records=batch, tags }], tags }]
+        //   tags
+        let batch = one_record_batch(None, b"v");
+
+        let mut body = Vec::new();
+        body.push(0); // transactional_id null
+        body.extend_from_slice(&(-1i16).to_be_bytes()); // acks
+        body.extend_from_slice(&30_000i32.to_be_bytes());
+        // topics compact array length: 1+1=2
+        push_unsigned_varint(&mut body, 2);
+        // topic name "t" (len=1, compact = 2)
+        push_unsigned_varint(&mut body, 2);
+        body.push(b't');
+        // partitions compact array: 1+1=2
+        push_unsigned_varint(&mut body, 2);
+        // partition index
+        body.extend_from_slice(&0i32.to_be_bytes());
+        // records compact bytes: len+1
+        push_unsigned_varint(&mut body, (batch.len() as u32) + 1);
+        body.extend_from_slice(&batch);
+        // partition tag buffer
+        body.push(0);
+        // topic tag buffer
+        body.push(0);
+        // request tag buffer
+        body.push(0);
+
+        let req = parse_produce_v9(&body).unwrap();
+        assert_eq!(req.acks, -1);
+        assert_eq!(req.timeout_ms, 30_000);
+        assert_eq!(req.topics.len(), 1);
+        assert_eq!(req.topics[0].name, "t");
+        assert_eq!(req.topics[0].partitions.len(), 1);
+        assert_eq!(req.topics[0].partitions[0].partition_index, 0);
+        assert_eq!(req.topics[0].partitions[0].records.len(), 1);
+        assert_eq!(req.topics[0].partitions[0].records[0].value, b"v");
+    }
+
+    #[test]
+    fn response_shape_matches_spec() {
+        let results = vec![TopicProduceResult {
+            name: "orders".to_string(),
+            partitions: vec![PartitionProduceResult {
+                partition_index: 2,
+                error_code: 0,
+                base_offset: 41,
+                log_append_time_ms: -1,
+                log_start_offset: 0,
+            }],
+        }];
+        let data = serialize_produce_v9_response(99, &results);
+
+        // correlation_id
+        assert_eq!(&data[0..4], &99i32.to_be_bytes());
+        // response header tag buffer
+        assert_eq!(data[4], 0);
+        // topics compact array length (1+1=2)
+        assert_eq!(data[5], 2);
+        // topic name "orders" (len=6, compact=7)
+        assert_eq!(data[6], 7);
+        assert_eq!(&data[7..13], b"orders");
+        // partitions compact array length (1+1=2)
+        assert_eq!(data[13], 2);
+        // partition_index=2, error_code=0, base_offset=41
+        assert_eq!(&data[14..18], &2i32.to_be_bytes());
+        assert_eq!(&data[18..20], &0i16.to_be_bytes());
+        assert_eq!(&data[20..28], &41i64.to_be_bytes());
+        // log_append_time_ms=-1, log_start_offset=0
+        assert_eq!(&data[28..36], &(-1i64).to_be_bytes());
+        assert_eq!(&data[36..44], &0i64.to_be_bytes());
+        // record_errors compact array = 0+1=1
+        assert_eq!(data[44], 1);
+        // error_message null
+        assert_eq!(data[45], 0);
+        // partition tag buffer, topic tag buffer
+        assert_eq!(data[46], 0);
+        assert_eq!(data[47], 0);
+        // throttle_time_ms + top-level tag buffer
+        assert_eq!(&data[48..52], &0i32.to_be_bytes());
+        assert_eq!(data[52], 0);
+        assert_eq!(data.len(), 53);
+    }
+}

--- a/crates/mockforge-kafka/src/protocol.rs
+++ b/crates/mockforge-kafka/src/protocol.rs
@@ -48,12 +48,14 @@ impl KafkaProtocolHandler {
     /// broker (node 1) as leader + sole replica + in-sync replica.
     pub fn with_topology(host: impl Into<String>, port: i32, topics: Vec<TopicMetadata>) -> Self {
         let mut api_versions = HashMap::new();
-        // Add supported API versions
+        // Add supported API versions. Produce is capped at v9 because that's
+        // the newest flexible version our codec serializes; auto-negotiating
+        // clients will land on v9.
         api_versions.insert(
             0,
             ApiVersion {
                 min_version: 0,
-                max_version: 12,
+                max_version: 9,
             },
         ); // Produce
         api_versions.insert(
@@ -183,10 +185,18 @@ impl KafkaProtocolHandler {
                 .map_err(|e| anyhow::anyhow!("Invalid client ID encoding: {}", e))?;
             (end, s)
         };
-        // Request-header v2 (flexible) appends a TAG_BUFFER after client_id;
-        // we don't consume any tagged fields yet but it's fine to ignore them
-        // — the caller only reads fields we've already parsed.
-        let _ = client_id_end;
+        // Request-header v2 (flexible) appends a TAG_BUFFER after client_id.
+        // Flexible request headers apply when the API is at its flexible-
+        // version threshold or higher. Produce went flexible at v9, Metadata
+        // at v9, ApiVersions at v3, etc. For bodies we need to parse
+        // (currently Produce v9), the tag buffer must be consumed here so
+        // `body_offset` points at the body proper.
+        let mut body_offset = client_id_end;
+        if is_flexible_request(api_key, api_version) {
+            let tail = &data[body_offset..];
+            let (_, consumed) = read_and_skip_tag_buffer(tail)?;
+            body_offset += consumed;
+        }
 
         let request_type = match api_key {
             0 => KafkaRequestType::Produce,
@@ -207,6 +217,7 @@ impl KafkaProtocolHandler {
             correlation_id,
             client_id,
             request_type,
+            body_offset,
         })
     }
 
@@ -339,6 +350,7 @@ impl KafkaProtocolHandler {
                 data.extend_from_slice(&(-1i16).to_be_bytes()); // nullable error message
                 Ok(data)
             }
+            KafkaResponse::Preserialized(body) => Ok(body.clone()),
             _ => {
                 // Generic "success" response envelope for currently-supported request handlers.
                 let mut data = Vec::new();
@@ -367,6 +379,11 @@ pub struct KafkaRequest {
     pub correlation_id: i32,
     pub client_id: String,
     pub request_type: KafkaRequestType,
+    /// Byte offset into the original message buffer where the request body
+    /// starts (i.e. just past the request header, including any flexible-
+    /// version tag buffer). Handlers that need to parse the body slice
+    /// `message_buf[body_offset..]`.
+    pub body_offset: usize,
 }
 
 /// Kafka request types
@@ -395,6 +412,12 @@ pub enum KafkaResponse {
     CreateTopics,
     DeleteTopics,
     DescribeConfigs,
+    /// Fully-serialized response body INCLUDING the response header
+    /// (correlation_id + any tag buffer). `serialize_response` returns the
+    /// inner bytes verbatim. Used by handlers whose wire format is too
+    /// version-specific to express with an enum variant alone (e.g. the
+    /// flexible produce v9 response).
+    Preserialized(Vec<u8>),
 }
 
 #[derive(Debug)]
@@ -410,6 +433,66 @@ fn push_unsigned_varint(buf: &mut Vec<u8>, mut value: u32) {
         value >>= 7;
     }
     buf.push(value as u8);
+}
+
+/// Minimum API version at which each Kafka API switched to a flexible
+/// request header (= v2 request header: client_id + TAG_BUFFER). When an
+/// incoming request is at or above this threshold, `parse_request` must
+/// consume the trailing tag buffer so `body_offset` lands on the body.
+fn is_flexible_request(api_key: i16, api_version: i16) -> bool {
+    let min_flex = match api_key {
+        0 => 9,  // Produce
+        1 => 12, // Fetch
+        3 => 9,  // Metadata
+        9 => 3,  // ListGroups
+        15 => 6, // DescribeGroups
+        16 => 5, // DescribeGroups (alternative)
+        18 => 3, // ApiVersions
+        19 => 5, // CreateTopics
+        20 => 4, // DeleteTopics
+        32 => 4, // DescribeConfigs
+        _ => return false,
+    };
+    api_version >= min_flex
+}
+
+/// Read an unsigned varint + its tagged fields out of `buf`, returning the
+/// value of each field we skipped (unused today) and the number of bytes
+/// consumed. Used by `parse_request` to step past a flexible-header tag
+/// buffer without needing the full `produce_codec` dependency graph.
+fn read_and_skip_tag_buffer(mut buf: &[u8]) -> Result<((), usize)> {
+    let start_len = buf.len();
+    let count = read_unsigned_varint_local(&mut buf)?;
+    for _ in 0..count {
+        let _tag_id = read_unsigned_varint_local(&mut buf)?;
+        let len = read_unsigned_varint_local(&mut buf)? as usize;
+        if buf.len() < len {
+            return Err(anyhow::anyhow!("tag buffer overrun"));
+        }
+        buf = &buf[len..];
+    }
+    let consumed = start_len - buf.len();
+    Ok(((), consumed))
+}
+
+fn read_unsigned_varint_local(buf: &mut &[u8]) -> Result<u32> {
+    let mut value: u32 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        if buf.is_empty() {
+            return Err(anyhow::anyhow!("truncated varint in header"));
+        }
+        let byte = buf[0];
+        *buf = &buf[1..];
+        value |= ((byte & 0x7F) as u32) << shift;
+        if (byte & 0x80) == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 32 {
+            return Err(anyhow::anyhow!("varint overflow in header"));
+        }
+    }
 }
 
 type Result<T> = std::result::Result<T, anyhow::Error>;
@@ -439,9 +522,10 @@ mod tests {
     fn test_is_api_version_supported_produce() {
         let handler = KafkaProtocolHandler::new();
         // Produce API (key 0) supports versions 0-12
+        // Produce capped at v9 (first flexible version — see serialize path).
         assert!(handler.is_api_version_supported(0, 0));
-        assert!(handler.is_api_version_supported(0, 12));
-        assert!(!handler.is_api_version_supported(0, 13));
+        assert!(handler.is_api_version_supported(0, 9));
+        assert!(!handler.is_api_version_supported(0, 10));
         assert!(!handler.is_api_version_supported(0, -1));
     }
 
@@ -897,6 +981,7 @@ mod tests {
             correlation_id: 123,
             client_id: "test".to_string(),
             request_type: KafkaRequestType::Produce,
+            body_offset: 0,
         };
 
         let debug_str = format!("{:?}", request);
@@ -926,7 +1011,7 @@ mod tests {
 
         // Test all configured API versions
         let api_configs = vec![
-            (0, 0, 12), // Produce
+            (0, 0, 9),  // Produce (capped at v9 — see serialize_response)
             (1, 0, 16), // Fetch
             (3, 0, 4),  // Metadata (capped at v4 — see serialize_response)
             (9, 0, 5),  // ListGroups

--- a/crates/mockforge-kafka/tests/produce_e2e.rs
+++ b/crates/mockforge-kafka/tests/produce_e2e.rs
@@ -1,0 +1,94 @@
+//! End-to-end regression: a real librdkafka-based client producing to the
+//! mock broker must succeed AND the produced record must actually land in
+//! the broker's in-memory storage. Before this PR, Produce requests got the
+//! generic stub response and clients hit `PROTOUFLOW`; after, a full
+//! Produce v9 round-trip works.
+
+use mockforge_core::config::KafkaConfig;
+use mockforge_kafka::KafkaMockBroker;
+use rdkafka::config::ClientConfig;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn bind_free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+#[tokio::test]
+async fn librdkafka_produce_round_trip() {
+    let port = bind_free_port().await;
+    let config = KafkaConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..KafkaConfig::default()
+    };
+
+    let broker = Arc::new(KafkaMockBroker::new(config.clone()).await.expect("broker init"));
+
+    // Pre-register the topic so librdkafka's Metadata probe sees it and
+    // proceeds to produce. Without this, librdkafka's
+    // `allow.auto.create.topics=true` flow never lands on a topic (our
+    // Metadata handler only advertises topics from the fixture registry
+    // and this test doesn't load one).
+    {
+        let mut topics = broker.topics.write().await;
+        topics.insert(
+            "e2e-topic".to_string(),
+            mockforge_kafka::Topic::new(
+                "e2e-topic".to_string(),
+                mockforge_kafka::TopicConfig {
+                    num_partitions: 1,
+                    replication_factor: 1,
+                    ..Default::default()
+                },
+            ),
+        );
+    }
+
+    let server = Arc::clone(&broker);
+    let server_handle = tokio::spawn(async move { server.start().await });
+
+    // Wait for the broker's listener to be ready.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let mut client = ClientConfig::new();
+    client.set("bootstrap.servers", format!("127.0.0.1:{port}"));
+    client.set("message.timeout.ms", "5000");
+    // Force linger to zero so the single test record ships immediately,
+    // and disable idempotence/transactions — those need more protocol
+    // support than this PR delivers.
+    client.set("linger.ms", "0");
+    client.set("acks", "1");
+    client.set("enable.idempotence", "false");
+    let producer: FutureProducer = client.create().expect("producer");
+
+    let delivery = producer
+        .send(
+            FutureRecord::<str, [u8]>::to("e2e-topic").payload(b"hello-e2e").key("k1"),
+            Duration::from_secs(5),
+        )
+        .await;
+
+    match delivery {
+        Ok(d) => {
+            assert!(d.partition >= 0, "negative partition from broker: {}", d.partition);
+            assert!(d.offset >= 0, "negative offset from broker: {}", d.offset);
+        }
+        Err((e, _)) => panic!("producer.send failed: {e:?}"),
+    }
+
+    // Record must actually be in storage.
+    let topics = broker.topics.read().await;
+    let topic = topics.get("e2e-topic").expect("topic auto-created on produce");
+    let total_records: usize = topic.partitions.iter().map(|p| p.messages.len()).sum();
+    assert_eq!(total_records, 1, "expected exactly one record in storage");
+    let stored = topic.partitions.iter().flat_map(|p| p.messages.iter()).next().unwrap();
+    assert_eq!(stored.value, b"hello-e2e");
+    assert_eq!(stored.key.as_deref(), Some(b"k1".as_ref()));
+
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary

**PR 3 of the Kafka real-implementation plan.** Previously Produce returned the generic stub `correlation_id + error_code i16`, which tripped librdkafka's response parser (`PROTOUFLOW`) and prevented any real client from writing data to the mock broker. This PR parses the actual wire-format request, decodes the RecordBatch v2 inside, writes each record into topic storage via `Topic::produce()`, and serializes a correct Produce v9 response.

## What works after this PR

\`\`\`
$ # In-process test using librdkafka 2.x (rdkafka 0.38 crate):
$ cargo test -p mockforge-kafka --test produce_e2e
running 1 test
test librdkafka_produce_round_trip ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s
\`\`\`

The test spins up a `KafkaMockBroker` bound to an ephemeral port, uses `FutureProducer` to send one keyed record to an auto-created topic, asserts the delivery report returns sensible `partition >= 0 && offset >= 0`, and then reads the broker's own storage to verify the record actually landed with the right value and key.

## Changes

### New module `produce_codec`

- **Wire-format primitives**: Kafka unsigned varint (for compact arrays/strings/tag buffers) and the separate ZigZag signed varint that RecordBatch v2 uses for per-record lengths and deltas. Also compact string, compact nullable bytes, and tag buffer skipping.
- **`RecordBatch` v2 parser**: reads the fixed-width batch header, rejects compressed batches (attributes bits 0–2 non-zero) so the broker can surface `UNSUPPORTED_COMPRESSION_TYPE` (74) rather than silently storing garbage, rejects non-magic-2 batches, then decodes each record's attributes / timestamp_delta / offset_delta / key / value / headers.
- **`parse_produce_v9`**: flexible request body — `transactional_id`, `acks`, `timeout_ms`, `topic_data` compact array (per-topic partition compact array → records compact bytes → RecordBatch v2).
- **`serialize_produce_v9_response`**: flexible response with per-topic/per-partition `{partition_index, error_code, base_offset, log_append_time_ms, log_start_offset, record_errors[], error_message, tags}`.

### Broker wiring

- **`protocol::KafkaRequest` gains `body_offset`** so handlers can slice the raw message at the start of the body (past the flexible header's tag buffer).
- **`KafkaResponse::Preserialized(Vec<u8>)`** — the serializer just passes these bytes through so the produce handler can emit a flexible v1 response header (`correlation_id` + tag buffer) that the version-agnostic `serialize_response` path can't express.
- **`handle_request` now takes the raw message buffer** and forwards it to `handle_produce`, which parses the body, auto-creates unknown topics, writes each record into the correct `Topic`/`Partition`, and constructs the response with the real `base_offset` returned from `Topic::produce()`. Non-v9 Produce requests get an empty v9-shaped response rather than a hang (a full v7 non-flexible implementation is a later PR).
- **Advertised Produce `max_version` narrowed from 12 to 9** so auto-negotiating librdkafka 2.x / confluent-kafka-* clients land on exactly v9.
- **Metadata responses now source topics from `self.topics`** (the live map) instead of only `spec_registry.topic_specs()`. That way auto-created topics from produce also appear in subsequent `kcat -L` probes.

## Test plan

- [x] `cargo clippy -p mockforge-kafka --all-targets -- -D warnings` → clean
- [x] `cargo test -p mockforge-kafka` → **256 passed** (236 lib + 2 fixture schema + 10 pre-existing integration + 1 new produce e2e + 7 docs)
- [x] `cargo fmt --all --check` → clean
- [x] Byte-for-byte unit tests for varints, single-record batch parse, compressed-batch detection, full produce-v9 request parse, and response layout
- [x] End-to-end: rdkafka `FutureProducer::send` against a live mock broker → record lands in storage with correct key/value

## Out of scope (remaining plan)

- **Fetch v12** — PR 4. Without it, produced records can't be read back via a client; they exist in broker storage but there's no wire-format path to retrieve them yet.
- **Compression** (gzip/snappy/lz4/zstd). Compressed batches respond with `UNSUPPORTED_COMPRESSION_TYPE` today.
- **Produce v0–v8 (non-flexible)**. librdkafka 2.x and modern clients land on v9; older kcat 1.7.1 (librdkafka 1.8.2) needs a separate v7 codec path if we want to support it.
- **Consumer groups** — FindCoordinator / JoinGroup / SyncGroup / Heartbeat / OffsetCommit / OffsetFetch — separate PR.

## Real-client compatibility note

Verified with `rdkafka 0.38` (bundled librdkafka 2.x). `edenhill/kcat:1.7.1` ships librdkafka 1.8.2 which caps Produce at v7 (non-flexible), so `kcat -P` through that image won't round-trip until the v7 codec lands. Modern Python (`confluent-kafka-python` ≥ 2.0), Go (`confluent-kafka-go` ≥ 2.0), Java, and any rdkafka-based client built in the last ~2 years will work.