### PR TITLE
feat(kafka): implement Fetch v12 so consumers can read produced records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8320,6 +8320,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "crc32c",
  "criterion",
  "mockforge-core",
  "rand 0.9.2",

--- a/crates/mockforge-kafka/Cargo.toml
+++ b/crates/mockforge-kafka/Cargo.toml
@@ -26,6 +26,10 @@ async-trait = { workspace = true }
 rand = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+# CRC-32/Castagnoli (CRC32C) for RecordBatch v2. librdkafka validates the
+# batch CRC and drops batches where it doesn't match, so Fetch responses
+# need an accurate implementation.
+crc32c = "0.6"
 
 [[bench]]
 name = "kafka_benchmarks"

--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -307,7 +307,7 @@ impl KafkaMockBroker {
         match request.request_type {
             KafkaRequestType::Metadata => self.handle_metadata().await,
             KafkaRequestType::Produce => self.handle_produce(message_buf, &request).await,
-            KafkaRequestType::Fetch => self.handle_fetch().await,
+            KafkaRequestType::Fetch => self.handle_fetch(message_buf, &request).await,
             KafkaRequestType::ListGroups => self.handle_list_groups().await,
             KafkaRequestType::DescribeGroups => self.handle_describe_groups().await,
             KafkaRequestType::ApiVersions => self.handle_api_versions().await,
@@ -451,15 +451,131 @@ impl KafkaMockBroker {
         Ok(KafkaResponse::Preserialized(body))
     }
 
-    async fn handle_fetch(&self) -> Result<KafkaResponse> {
-        let topics = self.topics.read().await;
-        if let Some(topic) = topics.get("default-topic") {
-            for partition in &topic.partitions {
-                let _ = partition.fetch(0, 1024 * 1024);
-            }
+    /// Handle a Fetch v12 request: parse the flexible body, pull records
+    /// from topic/partition storage starting at each requested fetch_offset,
+    /// and serialize a v12 response with real RecordBatch v2 blobs
+    /// (CRC32C-validated so consumers accept them).
+    async fn handle_fetch(
+        &self,
+        message_buf: &[u8],
+        request: &KafkaRequest,
+    ) -> Result<KafkaResponse> {
+        use crate::fetch_codec::{
+            parse_fetch_v12, serialize_fetch_v12_response, serialize_record_batch_v2,
+            FetchPartitionResponse, FetchTopicResponse,
+        };
+
+        const ERR_UNKNOWN_TOPIC_OR_PARTITION: i16 = 3;
+        const ERR_OFFSET_OUT_OF_RANGE: i16 = 1;
+
+        if request.api_version != 12 {
+            let body = serialize_fetch_v12_response(request.correlation_id, 0, &[]);
+            tracing::warn!("rejecting Fetch v{} (only v12 supported)", request.api_version);
+            return Ok(KafkaResponse::Preserialized(body));
         }
 
-        Ok(KafkaResponse::Fetch)
+        let body_slice = message_buf.get(request.body_offset..).ok_or_else(|| {
+            mockforge_core::Error::internal("fetch request body_offset past end of buffer")
+        })?;
+
+        let parsed = parse_fetch_v12(body_slice).map_err(|e| {
+            mockforge_core::Error::internal(format!("failed to parse Fetch v12: {e}"))
+        })?;
+
+        let topics_guard = self.topics.read().await;
+        let mut topic_responses = Vec::with_capacity(parsed.topics.len());
+        for t in &parsed.topics {
+            let mut partition_responses = Vec::with_capacity(t.partitions.len());
+            let topic = topics_guard.get(&t.topic);
+            for p in &t.partitions {
+                let Some(topic) = topic else {
+                    partition_responses.push(FetchPartitionResponse {
+                        partition_index: p.partition_index,
+                        error_code: ERR_UNKNOWN_TOPIC_OR_PARTITION,
+                        high_watermark: -1,
+                        log_start_offset: -1,
+                        records: Vec::new(),
+                    });
+                    continue;
+                };
+                let Some(part) = topic.get_partition(p.partition_index) else {
+                    partition_responses.push(FetchPartitionResponse {
+                        partition_index: p.partition_index,
+                        error_code: ERR_UNKNOWN_TOPIC_OR_PARTITION,
+                        high_watermark: -1,
+                        log_start_offset: -1,
+                        records: Vec::new(),
+                    });
+                    continue;
+                };
+
+                // Validate offset: fetch_offset > high_watermark is
+                // OFFSET_OUT_OF_RANGE; == high_watermark is a valid empty
+                // fetch (consumer is caught up).
+                if p.fetch_offset > part.high_watermark {
+                    partition_responses.push(FetchPartitionResponse {
+                        partition_index: p.partition_index,
+                        error_code: ERR_OFFSET_OUT_OF_RANGE,
+                        high_watermark: part.high_watermark,
+                        log_start_offset: part.log_start_offset,
+                        records: Vec::new(),
+                    });
+                    continue;
+                }
+
+                // Collect records with offset >= fetch_offset, respecting
+                // partition_max_bytes. Kafka requires at least one record be
+                // returned when any are available past fetch_offset, even
+                // when that exceeds max_bytes.
+                let max_bytes = p.partition_max_bytes.max(0) as usize;
+                let mut selected: Vec<&crate::partitions::KafkaMessage> = Vec::new();
+                let mut estimated_size: usize = 0;
+                for msg in &part.messages {
+                    if msg.offset < p.fetch_offset {
+                        continue;
+                    }
+                    // Rough pre-serialize size estimate: key+value+headers
+                    // + 16 byte record framing. Accurate enough for the
+                    // soft-limit behavior.
+                    let headers_size: usize =
+                        msg.headers.iter().map(|(k, v)| k.len() + v.len() + 8).sum();
+                    let record_size = msg.key.as_ref().map_or(0, |k| k.len())
+                        + msg.value.len()
+                        + headers_size
+                        + 16;
+                    if !selected.is_empty() && estimated_size + record_size > max_bytes {
+                        break;
+                    }
+                    estimated_size += record_size;
+                    selected.push(msg);
+                }
+
+                let records_blob = if selected.is_empty() {
+                    Vec::new()
+                } else {
+                    serialize_record_batch_v2(&selected)
+                };
+
+                partition_responses.push(FetchPartitionResponse {
+                    partition_index: p.partition_index,
+                    error_code: 0,
+                    high_watermark: part.high_watermark,
+                    log_start_offset: part.log_start_offset,
+                    records: records_blob,
+                });
+            }
+            topic_responses.push(FetchTopicResponse {
+                topic: t.topic.clone(),
+                partitions: partition_responses,
+            });
+        }
+
+        let body = serialize_fetch_v12_response(
+            request.correlation_id,
+            parsed.session_id,
+            &topic_responses,
+        );
+        Ok(KafkaResponse::Preserialized(body))
     }
 
     async fn handle_api_versions(&self) -> Result<KafkaResponse> {

--- a/crates/mockforge-kafka/src/fetch_codec.rs
+++ b/crates/mockforge-kafka/src/fetch_codec.rs
@@ -1,0 +1,366 @@
+//! Fetch v12 wire-format codec.
+//!
+//! Fetch v12 is flexible: compact arrays, tag buffers. Consumers call Fetch
+//! with `(topic, partition, fetch_offset)` triples and expect RecordBatch v2
+//! blobs in response. This module:
+//!
+//!   1. Parses a flexible v12 request into topic/partition fetch slots.
+//!   2. Serializes a v12 response that includes fresh, CRC32C-validated
+//!      RecordBatch v2 blobs — librdkafka validates CRC and drops batches
+//!      that don't match.
+//!
+//! The broker is responsible for looking records up in partition storage;
+//! this module just decodes the request and encodes the response.
+
+use crate::partitions::KafkaMessage;
+use crate::produce_codec::{
+    push_compact_string, push_empty_tag_buffer, push_signed_varint, push_unsigned_varint,
+    read_compact_string, read_i32, read_i64, read_i8, read_unsigned_varint, skip_tag_buffer, take,
+};
+
+/// One partition's fetch slot extracted from a Fetch v12 request.
+#[derive(Debug, Clone)]
+pub struct FetchPartitionRequest {
+    pub partition_index: i32,
+    pub fetch_offset: i64,
+    pub partition_max_bytes: i32,
+}
+
+/// One topic's worth of fetch requests.
+#[derive(Debug, Clone)]
+pub struct FetchTopicRequest {
+    pub topic: String,
+    pub partitions: Vec<FetchPartitionRequest>,
+}
+
+/// Parsed Fetch v12 request body.
+#[derive(Debug, Clone)]
+pub struct FetchRequestV12 {
+    pub max_wait_ms: i32,
+    pub min_bytes: i32,
+    pub max_bytes: i32,
+    pub session_id: i32,
+    pub topics: Vec<FetchTopicRequest>,
+}
+
+/// Per-partition response slot the broker assembles.
+#[derive(Debug, Clone)]
+pub struct FetchPartitionResponse {
+    pub partition_index: i32,
+    pub error_code: i16,
+    pub high_watermark: i64,
+    pub log_start_offset: i64,
+    /// Pre-serialized RecordBatch v2 bytes (empty = no records).
+    pub records: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchTopicResponse {
+    pub topic: String,
+    pub partitions: Vec<FetchPartitionResponse>,
+}
+
+// =========================================================================
+// Fetch v12 request parser
+// =========================================================================
+
+/// Parse a Fetch v12 (flexible) request body. Returns the fields the broker
+/// needs to service the fetch.
+pub fn parse_fetch_v12(body: &[u8]) -> Result<FetchRequestV12, String> {
+    let mut cur = body;
+
+    let _replica_id = read_i32(&mut cur)?;
+    let max_wait_ms = read_i32(&mut cur)?;
+    let min_bytes = read_i32(&mut cur)?;
+    let max_bytes = read_i32(&mut cur)?;
+    let _isolation_level = read_i8(&mut cur)?;
+    let session_id = read_i32(&mut cur)?;
+    let _session_epoch = read_i32(&mut cur)?;
+
+    let topics_len_plus_one = read_unsigned_varint(&mut cur)?;
+    if topics_len_plus_one == 0 {
+        return Err("fetch topics array is null".into());
+    }
+    let topics_len = (topics_len_plus_one - 1) as usize;
+    let mut topics = Vec::with_capacity(topics_len);
+
+    for _ in 0..topics_len {
+        let topic = read_compact_string(&mut cur)?;
+
+        let parts_len_plus_one = read_unsigned_varint(&mut cur)?;
+        if parts_len_plus_one == 0 {
+            return Err(format!("fetch partitions array for {topic} is null"));
+        }
+        let parts_len = (parts_len_plus_one - 1) as usize;
+        let mut partitions = Vec::with_capacity(parts_len);
+        for _ in 0..parts_len {
+            let partition_index = read_i32(&mut cur)?;
+            let _current_leader_epoch = read_i32(&mut cur)?;
+            let fetch_offset = read_i64(&mut cur)?;
+            let _last_fetched_epoch = read_i32(&mut cur)?;
+            let _log_start_offset = read_i64(&mut cur)?;
+            let partition_max_bytes = read_i32(&mut cur)?;
+            skip_tag_buffer(&mut cur)?;
+            partitions.push(FetchPartitionRequest {
+                partition_index,
+                fetch_offset,
+                partition_max_bytes,
+            });
+        }
+        skip_tag_buffer(&mut cur)?;
+        topics.push(FetchTopicRequest { topic, partitions });
+    }
+
+    // forgotten_topics_data (skip content)
+    let forgotten_len_plus_one = read_unsigned_varint(&mut cur)?;
+    if forgotten_len_plus_one > 0 {
+        for _ in 0..(forgotten_len_plus_one - 1) {
+            let _forgotten_topic = read_compact_string(&mut cur)?;
+            let plen_plus_one = read_unsigned_varint(&mut cur)?;
+            if plen_plus_one > 0 {
+                for _ in 0..(plen_plus_one - 1) {
+                    let _ = read_i32(&mut cur)?;
+                }
+            }
+            skip_tag_buffer(&mut cur)?;
+        }
+    }
+
+    // rack_id (compact string, may be empty)
+    let rack_len_plus_one = read_unsigned_varint(&mut cur)?;
+    if rack_len_plus_one > 0 {
+        let rack_len = (rack_len_plus_one - 1) as usize;
+        let _ = take(&mut cur, rack_len)?;
+    }
+
+    skip_tag_buffer(&mut cur)?;
+
+    Ok(FetchRequestV12 {
+        max_wait_ms,
+        min_bytes,
+        max_bytes,
+        session_id,
+        topics,
+    })
+}
+
+// =========================================================================
+// RecordBatch v2 serializer
+// =========================================================================
+
+/// Serialize a set of stored `KafkaMessage`s (with absolute offsets already
+/// assigned) as one RecordBatch v2 blob suitable for inclusion in a Fetch
+/// response. The CRC32C is computed over the canonical range
+/// `[attributes..end]` as the Kafka spec requires.
+pub fn serialize_record_batch_v2(records: &[&KafkaMessage]) -> Vec<u8> {
+    if records.is_empty() {
+        return Vec::new();
+    }
+    let base_offset = records[0].offset;
+    let base_timestamp = records[0].timestamp;
+    let max_timestamp = records.iter().map(|r| r.timestamp).max().unwrap_or(base_timestamp);
+    let last_offset_delta = (records.last().unwrap().offset - base_offset) as i32;
+
+    // Build the records blob first.
+    let mut records_blob = Vec::new();
+    for r in records {
+        let mut rec = Vec::new();
+        rec.push(0i8 as u8); // attributes
+        push_signed_varint(&mut rec, r.timestamp - base_timestamp); // timestamp_delta
+        push_signed_varint(&mut rec, r.offset - base_offset); // offset_delta
+        match &r.key {
+            None => push_signed_varint(&mut rec, -1),
+            Some(k) => {
+                push_signed_varint(&mut rec, k.len() as i64);
+                rec.extend_from_slice(k);
+            }
+        }
+        push_signed_varint(&mut rec, r.value.len() as i64);
+        rec.extend_from_slice(&r.value);
+        push_signed_varint(&mut rec, r.headers.len() as i64);
+        for (hk, hv) in &r.headers {
+            push_signed_varint(&mut rec, hk.len() as i64);
+            rec.extend_from_slice(hk.as_bytes());
+            push_signed_varint(&mut rec, hv.len() as i64);
+            rec.extend_from_slice(hv);
+        }
+        let mut framed = Vec::new();
+        push_signed_varint(&mut framed, rec.len() as i64);
+        framed.extend_from_slice(&rec);
+        records_blob.extend_from_slice(&framed);
+    }
+
+    // Body-after-CRC: everything from `attributes` to the end of `records`.
+    // attributes (2) + last_offset_delta (4) + base_timestamp (8) +
+    // max_timestamp (8) + producer_id (8) + producer_epoch (2) +
+    // base_sequence (4) + records_count (4) + records_blob
+    let mut body = Vec::new();
+    body.extend_from_slice(&0i16.to_be_bytes()); // attributes = 0 (no compression, create-timestamp)
+    body.extend_from_slice(&last_offset_delta.to_be_bytes());
+    body.extend_from_slice(&base_timestamp.to_be_bytes());
+    body.extend_from_slice(&max_timestamp.to_be_bytes());
+    body.extend_from_slice(&(-1i64).to_be_bytes()); // producer_id
+    body.extend_from_slice(&(-1i16).to_be_bytes()); // producer_epoch
+    body.extend_from_slice(&(-1i32).to_be_bytes()); // base_sequence
+    body.extend_from_slice(&(records.len() as i32).to_be_bytes());
+    body.extend_from_slice(&records_blob);
+
+    let crc = crc32c::crc32c(&body);
+
+    // Full batch: base_offset + batch_length + partition_leader_epoch +
+    // magic + crc + body
+    let mut batch = Vec::new();
+    batch.extend_from_slice(&base_offset.to_be_bytes());
+    // batch_length = size of [partition_leader_epoch..end]
+    // partition_leader_epoch(4) + magic(1) + crc(4) + body.len()
+    let batch_length = 4 + 1 + 4 + body.len() as i32;
+    batch.extend_from_slice(&batch_length.to_be_bytes());
+    batch.extend_from_slice(&(-1i32).to_be_bytes()); // partition_leader_epoch
+    batch.push(2); // magic = 2
+    batch.extend_from_slice(&crc.to_be_bytes());
+    batch.extend_from_slice(&body);
+    batch
+}
+
+// =========================================================================
+// Fetch v12 response serializer
+// =========================================================================
+
+/// Serialize a full Fetch v12 response including flexible response header.
+pub fn serialize_fetch_v12_response(
+    correlation_id: i32,
+    session_id: i32,
+    topics: &[FetchTopicResponse],
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    // Response header v1 (flexible)
+    out.extend_from_slice(&correlation_id.to_be_bytes());
+    push_empty_tag_buffer(&mut out);
+
+    // Body
+    out.extend_from_slice(&0i32.to_be_bytes()); // throttle_time_ms
+    out.extend_from_slice(&0i16.to_be_bytes()); // top-level error_code
+    out.extend_from_slice(&session_id.to_be_bytes());
+
+    // responses compact array
+    push_unsigned_varint(&mut out, (topics.len() as u32) + 1);
+    for topic in topics {
+        push_compact_string(&mut out, &topic.topic);
+        push_unsigned_varint(&mut out, (topic.partitions.len() as u32) + 1);
+        for p in &topic.partitions {
+            out.extend_from_slice(&p.partition_index.to_be_bytes());
+            out.extend_from_slice(&p.error_code.to_be_bytes());
+            out.extend_from_slice(&p.high_watermark.to_be_bytes());
+            out.extend_from_slice(&p.high_watermark.to_be_bytes()); // last_stable_offset = HWM
+            out.extend_from_slice(&p.log_start_offset.to_be_bytes());
+            // aborted_transactions: empty compact array
+            push_unsigned_varint(&mut out, 1);
+            // preferred_read_replica = -1 (no preference)
+            out.extend_from_slice(&(-1i32).to_be_bytes());
+            // records compact_bytes: null when empty, else len+1 + bytes
+            if p.records.is_empty() {
+                push_unsigned_varint(&mut out, 0);
+            } else {
+                push_unsigned_varint(&mut out, (p.records.len() as u32) + 1);
+                out.extend_from_slice(&p.records);
+            }
+            push_empty_tag_buffer(&mut out);
+        }
+        push_empty_tag_buffer(&mut out);
+    }
+    push_empty_tag_buffer(&mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::partitions::KafkaMessage;
+    use crate::produce_codec::parse_record_batch;
+
+    fn stored_msg(offset: i64, ts: i64, key: Option<&[u8]>, value: &[u8]) -> KafkaMessage {
+        KafkaMessage {
+            offset,
+            timestamp: ts,
+            key: key.map(|k| k.to_vec()),
+            value: value.to_vec(),
+            headers: vec![],
+        }
+    }
+
+    #[test]
+    fn record_batch_roundtrips_through_parser() {
+        let msgs = [
+            stored_msg(10, 1_000, Some(b"k1"), b"v1"),
+            stored_msg(11, 1_500, None, b"v2"),
+        ];
+        let refs: Vec<&KafkaMessage> = msgs.iter().collect();
+        let batch = serialize_record_batch_v2(&refs);
+        let (decoded, attrs) = parse_record_batch(&batch).expect("parse");
+        assert_eq!(attrs & 0x7, 0);
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].value, b"v1");
+        assert_eq!(decoded[0].key.as_deref(), Some(b"k1".as_ref()));
+        assert_eq!(decoded[0].timestamp_ms, 1_000);
+        assert_eq!(decoded[1].value, b"v2");
+        assert!(decoded[1].key.is_none());
+        assert_eq!(decoded[1].timestamp_ms, 1_500);
+    }
+
+    #[test]
+    fn record_batch_crc_matches_spec() {
+        let msgs = [stored_msg(0, 0, None, b"x")];
+        let refs: Vec<&KafkaMessage> = msgs.iter().collect();
+        let batch = serialize_record_batch_v2(&refs);
+        // CRC is big-endian at offset 17 (base_offset[8] + batch_length[4] +
+        // partition_leader_epoch[4] + magic[1]). The value must equal
+        // crc32c over bytes [21..] (everything after the CRC itself).
+        let crc_in_batch = u32::from_be_bytes([batch[17], batch[18], batch[19], batch[20]]);
+        let expected = crc32c::crc32c(&batch[21..]);
+        assert_eq!(crc_in_batch, expected, "CRC in serialized batch must match crc32c of body");
+    }
+
+    #[test]
+    fn empty_records_serialize_to_empty_blob() {
+        let v: Vec<&KafkaMessage> = Vec::new();
+        assert!(serialize_record_batch_v2(&v).is_empty());
+    }
+
+    #[test]
+    fn fetch_v12_request_parses_single_topic() {
+        // Build a minimal valid v12 request body and round-trip.
+        let mut body = Vec::new();
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // replica_id
+        body.extend_from_slice(&500i32.to_be_bytes()); // max_wait_ms
+        body.extend_from_slice(&1i32.to_be_bytes()); // min_bytes
+        body.extend_from_slice(&1_048_576i32.to_be_bytes()); // max_bytes
+        body.push(0); // isolation_level
+        body.extend_from_slice(&0i32.to_be_bytes()); // session_id
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // session_epoch
+
+        push_unsigned_varint(&mut body, 2); // topics len=1 → 1+1
+        push_compact_string(&mut body, "orders");
+        push_unsigned_varint(&mut body, 2); // partitions len=1 → 1+1
+        body.extend_from_slice(&3i32.to_be_bytes()); // partition_index
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // current_leader_epoch
+        body.extend_from_slice(&42i64.to_be_bytes()); // fetch_offset
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // last_fetched_epoch
+        body.extend_from_slice(&(-1i64).to_be_bytes()); // log_start_offset
+        body.extend_from_slice(&65_536i32.to_be_bytes()); // partition_max_bytes
+        push_empty_tag_buffer(&mut body); // partition tags
+        push_empty_tag_buffer(&mut body); // topic tags
+
+        push_unsigned_varint(&mut body, 1); // forgotten_topics = empty
+        push_unsigned_varint(&mut body, 1); // rack_id = empty string
+        push_empty_tag_buffer(&mut body); // top-level tags
+
+        let parsed = parse_fetch_v12(&body).unwrap();
+        assert_eq!(parsed.max_wait_ms, 500);
+        assert_eq!(parsed.max_bytes, 1_048_576);
+        assert_eq!(parsed.topics.len(), 1);
+        assert_eq!(parsed.topics[0].topic, "orders");
+        assert_eq!(parsed.topics[0].partitions[0].partition_index, 3);
+        assert_eq!(parsed.topics[0].partitions[0].fetch_offset, 42);
+        assert_eq!(parsed.topics[0].partitions[0].partition_max_bytes, 65_536);
+    }
+}

--- a/crates/mockforge-kafka/src/lib.rs
+++ b/crates/mockforge-kafka/src/lib.rs
@@ -126,6 +126,7 @@
 
 pub mod broker;
 pub mod consumer_groups;
+pub mod fetch_codec;
 pub mod fixture_file;
 pub mod fixtures;
 pub mod metrics;

--- a/crates/mockforge-kafka/src/produce_codec.rs
+++ b/crates/mockforge-kafka/src/produce_codec.rs
@@ -82,7 +82,7 @@ pub struct TopicProduceResult {
 // Wire-format primitives (cursor-style)
 // =========================================================================
 
-fn take<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], String> {
+pub(crate) fn take<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], String> {
     if buf.len() < n {
         return Err(format!("short read: wanted {n}, have {}", buf.len()));
     }
@@ -91,21 +91,21 @@ fn take<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], String> {
     Ok(head)
 }
 
-fn read_i8(buf: &mut &[u8]) -> Result<i8, String> {
+pub(crate) fn read_i8(buf: &mut &[u8]) -> Result<i8, String> {
     Ok(take(buf, 1)?[0] as i8)
 }
 
-fn read_i16(buf: &mut &[u8]) -> Result<i16, String> {
+pub(crate) fn read_i16(buf: &mut &[u8]) -> Result<i16, String> {
     let b = take(buf, 2)?;
     Ok(i16::from_be_bytes([b[0], b[1]]))
 }
 
-fn read_i32(buf: &mut &[u8]) -> Result<i32, String> {
+pub(crate) fn read_i32(buf: &mut &[u8]) -> Result<i32, String> {
     let b = take(buf, 4)?;
     Ok(i32::from_be_bytes([b[0], b[1], b[2], b[3]]))
 }
 
-fn read_i64(buf: &mut &[u8]) -> Result<i64, String> {
+pub(crate) fn read_i64(buf: &mut &[u8]) -> Result<i64, String> {
     let b = take(buf, 8)?;
     Ok(i64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
 }
@@ -159,7 +159,7 @@ pub fn read_signed_varint(buf: &mut &[u8]) -> Result<i64, String> {
 
 /// Read a compact string. `unsigned_varint(len + 1)` then bytes.
 /// A leading 0 means null; 1 means empty string.
-fn read_compact_nullable_string(buf: &mut &[u8]) -> Result<Option<String>, String> {
+pub(crate) fn read_compact_nullable_string(buf: &mut &[u8]) -> Result<Option<String>, String> {
     let len_plus_one = read_unsigned_varint(buf)?;
     if len_plus_one == 0 {
         return Ok(None);
@@ -171,12 +171,14 @@ fn read_compact_nullable_string(buf: &mut &[u8]) -> Result<Option<String>, Strin
         .map_err(|e| format!("invalid utf8: {e}"))
 }
 
-fn read_compact_string(buf: &mut &[u8]) -> Result<String, String> {
+pub(crate) fn read_compact_string(buf: &mut &[u8]) -> Result<String, String> {
     read_compact_nullable_string(buf)?.ok_or_else(|| "expected non-null compact string".into())
 }
 
 /// Read a compact bytes field. A leading 0 means null.
-fn read_compact_nullable_bytes<'a>(buf: &mut &'a [u8]) -> Result<Option<&'a [u8]>, String> {
+pub(crate) fn read_compact_nullable_bytes<'a>(
+    buf: &mut &'a [u8],
+) -> Result<Option<&'a [u8]>, String> {
     let len_plus_one = read_unsigned_varint(buf)?;
     if len_plus_one == 0 {
         return Ok(None);
@@ -189,7 +191,7 @@ fn read_compact_nullable_bytes<'a>(buf: &mut &'a [u8]) -> Result<Option<&'a [u8]
 /// Tag buffer: read the count, then for each tag, skip its length+1 bytes.
 /// We don't act on any tagged fields today — this just advances the cursor
 /// past them.
-fn skip_tag_buffer(buf: &mut &[u8]) -> Result<(), String> {
+pub(crate) fn skip_tag_buffer(buf: &mut &[u8]) -> Result<(), String> {
     let count = read_unsigned_varint(buf)?;
     for _ in 0..count {
         let _tag_id = read_unsigned_varint(buf)?;
@@ -203,7 +205,7 @@ fn skip_tag_buffer(buf: &mut &[u8]) -> Result<(), String> {
 // Output helpers
 // =========================================================================
 
-fn push_unsigned_varint(buf: &mut Vec<u8>, mut value: u32) {
+pub(crate) fn push_unsigned_varint(buf: &mut Vec<u8>, mut value: u32) {
     while (value & !0x7F) != 0 {
         buf.push(((value & 0x7F) | 0x80) as u8);
         value >>= 7;
@@ -211,12 +213,22 @@ fn push_unsigned_varint(buf: &mut Vec<u8>, mut value: u32) {
     buf.push(value as u8);
 }
 
-fn push_compact_string(buf: &mut Vec<u8>, s: &str) {
+pub(crate) fn push_signed_varint(buf: &mut Vec<u8>, value: i64) {
+    let zz = ((value << 1) ^ (value >> 63)) as u64;
+    let mut v = zz;
+    while (v & !0x7F) != 0 {
+        buf.push(((v & 0x7F) | 0x80) as u8);
+        v >>= 7;
+    }
+    buf.push(v as u8);
+}
+
+pub(crate) fn push_compact_string(buf: &mut Vec<u8>, s: &str) {
     push_unsigned_varint(buf, (s.len() as u32) + 1);
     buf.extend_from_slice(s.as_bytes());
 }
 
-fn push_empty_tag_buffer(buf: &mut Vec<u8>) {
+pub(crate) fn push_empty_tag_buffer(buf: &mut Vec<u8>) {
     buf.push(0);
 }
 

--- a/crates/mockforge-kafka/src/protocol.rs
+++ b/crates/mockforge-kafka/src/protocol.rs
@@ -58,11 +58,13 @@ impl KafkaProtocolHandler {
                 max_version: 9,
             },
         ); // Produce
+           // Fetch capped at v12 — the first flexible version, which is the one
+           // our codec emits. Auto-negotiating clients land on v12.
         api_versions.insert(
             1,
             ApiVersion {
                 min_version: 0,
-                max_version: 16,
+                max_version: 12,
             },
         ); // Fetch
            // Metadata: we only implement v4 response encoding. Advertising max=4
@@ -533,9 +535,10 @@ mod tests {
     fn test_is_api_version_supported_fetch() {
         let handler = KafkaProtocolHandler::new();
         // Fetch API (key 1) supports versions 0-16
+        // Fetch capped at v12 (first flexible version — what our codec emits).
         assert!(handler.is_api_version_supported(1, 0));
-        assert!(handler.is_api_version_supported(1, 16));
-        assert!(!handler.is_api_version_supported(1, 17));
+        assert!(handler.is_api_version_supported(1, 12));
+        assert!(!handler.is_api_version_supported(1, 13));
     }
 
     #[test]
@@ -1012,7 +1015,7 @@ mod tests {
         // Test all configured API versions
         let api_configs = vec![
             (0, 0, 9),  // Produce (capped at v9 — see serialize_response)
-            (1, 0, 16), // Fetch
+            (1, 0, 12), // Fetch (capped at v12 — see serialize_response)
             (3, 0, 4),  // Metadata (capped at v4 — see serialize_response)
             (9, 0, 5),  // ListGroups
             (15, 0, 9), // DescribeGroups

--- a/crates/mockforge-kafka/tests/fetch_e2e.rs
+++ b/crates/mockforge-kafka/tests/fetch_e2e.rs
@@ -1,0 +1,117 @@
+//! End-to-end regression: a real librdkafka-based client produces a record
+//! and then fetches it back through the mock broker. Before this PR, Fetch
+//! returned a stub that clients couldn't parse; after, a consumer using
+//! manual partition assignment reads the exact record it just produced.
+//!
+//! Consumer groups (FindCoordinator/JoinGroup/Heartbeat/OffsetCommit) are
+//! still stubs, so this test uses `BaseConsumer::assign()` rather than a
+//! group-coordinated `StreamConsumer`. Group support is a later PR.
+
+use mockforge_core::config::KafkaConfig;
+use mockforge_kafka::{KafkaMockBroker, Topic, TopicConfig};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::{Message, TopicPartitionList};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+async fn bind_free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn librdkafka_produce_then_fetch_round_trip() {
+    let port = bind_free_port().await;
+    let config = KafkaConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..KafkaConfig::default()
+    };
+
+    let broker = Arc::new(KafkaMockBroker::new(config.clone()).await.expect("broker init"));
+
+    // Pre-register the topic with one partition so Metadata + Fetch both
+    // find it; auto-create is only done on produce.
+    {
+        let mut topics = broker.topics.write().await;
+        topics.insert(
+            "fetch-topic".to_string(),
+            Topic::new(
+                "fetch-topic".to_string(),
+                TopicConfig {
+                    num_partitions: 1,
+                    replication_factor: 1,
+                    ..Default::default()
+                },
+            ),
+        );
+    }
+
+    let server = Arc::clone(&broker);
+    let server_handle = tokio::spawn(async move { server.start().await });
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    // --- Produce one record ---------------------------------------------
+    let mut producer_cfg = ClientConfig::new();
+    producer_cfg.set("bootstrap.servers", format!("127.0.0.1:{port}"));
+    producer_cfg.set("message.timeout.ms", "5000");
+    producer_cfg.set("linger.ms", "0");
+    producer_cfg.set("acks", "1");
+    producer_cfg.set("enable.idempotence", "false");
+    let producer: FutureProducer = producer_cfg.create().expect("producer");
+
+    producer
+        .send(
+            FutureRecord::<str, [u8]>::to("fetch-topic").payload(b"record-one").key("k1"),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("produce ok");
+
+    // --- Consume via manual assignment ----------------------------------
+    // Run the blocking BaseConsumer::poll on spawn_blocking so we don't tie
+    // up the single-threaded test runtime.
+    let port_c = port;
+    let received = tokio::task::spawn_blocking(move || {
+        let mut consumer_cfg = ClientConfig::new();
+        consumer_cfg.set("bootstrap.servers", format!("127.0.0.1:{port_c}"));
+        consumer_cfg.set("group.id", "e2e-fetch-test-group");
+        consumer_cfg.set("enable.auto.commit", "false");
+        consumer_cfg.set("session.timeout.ms", "6000");
+        consumer_cfg.set("fetch.min.bytes", "1");
+        consumer_cfg.set("fetch.wait.max.ms", "50");
+        let consumer: BaseConsumer = consumer_cfg.create().expect("consumer");
+
+        // Explicit Offset::Offset(0) (rather than Offset::Beginning) avoids
+        // the ListOffsets API which this PR doesn't implement yet.
+        let mut assignment = TopicPartitionList::new();
+        assignment
+            .add_partition_offset("fetch-topic", 0, rdkafka::Offset::Offset(0))
+            .unwrap();
+        consumer.assign(&assignment).expect("assign");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if Instant::now() >= deadline {
+                panic!("consumer timed out waiting for produced record");
+            }
+            if let Some(result) = consumer.poll(Duration::from_millis(100)) {
+                let msg = result.expect("no broker error");
+                let payload = msg.payload().expect("payload").to_vec();
+                let key = msg.key().map(|k| k.to_vec());
+                return (payload, key);
+            }
+        }
+    })
+    .await
+    .expect("consumer task did not panic");
+
+    assert_eq!(received.0, b"record-one");
+    assert_eq!(received.1.as_deref(), Some(b"k1".as_ref()));
+
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary

**PR 4 of the Kafka real-implementation plan — closes the produce → consume loop.** Previously Fetch returned the generic stub `correlation_id + error_code i16`, so a real librdkafka consumer got `UnsupportedFeature` / `PROTOUFLOW` on every poll and no data produced via PR #152 could ever be read back.

This PR implements Fetch v12 end-to-end: parse the flexible request, pull records from partition storage at the requested `fetch_offset`, serialize them as a **CRC32C-validated RecordBatch v2**, and respond in the v12 wire format.

## What works after this PR

\`\`\`rust
// tests/fetch_e2e.rs — a real librdkafka client round-trips through the mock
let producer: FutureProducer = /* ... */;
producer.send(FutureRecord::to("fetch-topic").payload(b"record-one").key("k1"), ...).await?;

let consumer: BaseConsumer = /* ... */;
consumer.assign(&TopicPartitionList::from([("fetch-topic", 0, Offset::Offset(0))]))?;
// consumer.poll() returns the exact record that was produced
\`\`\`

The test completes in ~0.55s and asserts the exact value and key survive the round-trip.

## Changes

### New module `fetch_codec`

- **`parse_fetch_v12`**: flexible request body — `replica_id`, `max_wait_ms`, `min_bytes`, `max_bytes`, `isolation_level`, `session_id`, `session_epoch`, topics compact array (per-topic partitions compact array with `partition_index`, `fetch_offset`, `partition_max_bytes`), plus optional `forgotten_topics_data`, `rack_id`, tag buffers.
- **`serialize_record_batch_v2`**: writes a full RecordBatch v2 blob from stored `KafkaMessage`s. Computes the CRC32C over the canonical `[attributes..end]` range — librdkafka drops batches where CRC doesn't match, so this has to be exact.
- **`serialize_fetch_v12_response`**: flexible response with `throttle_time_ms`, top-level `error_code`, `session_id`, and a compact array of per-topic per-partition slots carrying `{partition_index, error_code, high_watermark, last_stable_offset, log_start_offset, aborted_transactions[], preferred_read_replica, records, tags}`.

### Broker wiring

- **`handle_fetch`** now takes the raw message buffer, parses the v12 body, looks up each `(topic, partition, fetch_offset)` in the shared topic map, collects records with `offset >= fetch_offset` respecting `partition_max_bytes` (with Kafka's "always return at least one record when available" rule), serializes them, and builds the response. `OFFSET_OUT_OF_RANGE` / `UNKNOWN_TOPIC_OR_PARTITION` are returned with the proper error codes.
- **Fetch `max_version` narrowed from 16 to 12** so auto-negotiating clients land on exactly v12.
- **Wire-format helpers in `produce_codec` exposed as `pub(crate)`** so `fetch_codec` can share them (reads + new `push_signed_varint` for RecordBatch serialization).

### Dependencies

- Added `crc32c = "0.6"` to `mockforge-kafka`.

## Test plan

- [x] `cargo clippy -p mockforge-kafka --all-targets -- -D warnings` → clean
- [x] `cargo test -p mockforge-kafka` → **261 passed** (240 lib + 1 new fetch e2e + 1 pre-existing produce e2e + 2 fixture schema + 10 existing integration + 7 doc)
- [x] `cargo fmt --all --check` → clean
- [x] Byte-level unit tests for RecordBatch v2 roundtrip, CRC32C correctness, empty batch, and Fetch v12 request parse
- [x] End-to-end: rdkafka `FutureProducer::send` + `BaseConsumer::poll` round-trip against a live mock broker

## Out of scope (remaining plan)

- **`ListOffsets` (API key 2)** — needed for `Offset::Beginning` / `Offset::End`, consumer offset management, seek. Without it `StreamConsumer` + `auto.offset.reset` still can't work; the e2e test uses explicit `Offset::Offset(0)` instead.
- **Consumer groups** — FindCoordinator / JoinGroup / SyncGroup / Heartbeat / OffsetCommit / OffsetFetch.
- **Compression** (gzip/snappy/lz4/zstd). Compressed batches respond with `UNSUPPORTED_COMPRESSION_TYPE`.
- **Fetch v0–v11 (non-flexible)**. Modern rdkafka/confluent clients use v12+, so this is fine for the common case.

## Plan status

1. ✅ PR #150 — YAML schema reconciled
2. ✅ PR #151 — Metadata v4 advertises fixture topics
3. ✅ PR #152 — Produce v9 stores records
4. ✅ **This PR — Fetch v12 returns them**
5. ⏭ Remaining: ListOffsets, consumer groups, compression, then the protocol sweep across WS/gRPC/MQTT/AMQP/SMTP/GraphQL/FTP/TCP