### PR TITLE
fix(ws,cli): --ws-replay-file now actually takes effect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9214,6 +9214,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -1935,6 +1935,16 @@ pub async fn handle_serve(
             let ws_port = config.websocket.port;
             let ws_host = config.websocket.host.clone();
             let ws_shutdown = shutdown_token.clone();
+            // The WS handler reads MOCKFORGE_WS_REPLAY_FILE at connection time
+            // to decide between replay mode and echo mode. Config is the
+            // source of truth — whether it was set by --ws-replay-file, a
+            // YAML file, or the env var itself, push the final value back
+            // into the env so the handler sees it. Without this, the CLI
+            // flag was silently ignored (it wrote to config but the handler
+            // only consulted the env var).
+            if let Some(path) = &config.websocket.replay_file {
+                std::env::set_var("MOCKFORGE_WS_REPLAY_FILE", path);
+            }
             tokio::spawn(async move {
                 println!("🔌 WebSocket server listening on ws://{}:{}", ws_host, ws_port);
                 tokio::select! {

--- a/crates/mockforge-core/src/config/mod.rs
+++ b/crates/mockforge-core/src/config/mod.rs
@@ -426,6 +426,14 @@ pub fn apply_env_overrides(mut config: ServerConfig) -> ServerConfig {
         }
     }
 
+    if let Ok(host) = std::env::var("MOCKFORGE_WS_HOST") {
+        config.websocket.host = host;
+    }
+
+    if let Ok(replay) = std::env::var("MOCKFORGE_WS_REPLAY_FILE") {
+        config.websocket.replay_file = Some(replay);
+    }
+
     // gRPC server overrides
     if let Ok(port) = std::env::var("MOCKFORGE_GRPC_PORT") {
         if let Ok(port_num) = port.parse() {

--- a/crates/mockforge-ws/Cargo.toml
+++ b/crates/mockforge-ws/Cargo.toml
@@ -45,6 +45,7 @@ futures-util = "0.3"
 tokio-tungstenite = { version = "0.28", features=["rustls-tls-native-roots"] }
 axum = { version = "0.8" }
 opentelemetry_sdk = "0.22"
+tempfile = "3.14"
 
 [features]
 default = []

--- a/crates/mockforge-ws/tests/ws_replay_cli_path.rs
+++ b/crates/mockforge-ws/tests/ws_replay_cli_path.rs
@@ -1,0 +1,84 @@
+//! Regression test for the CLI replay-file plumbing.
+//!
+//! Before this PR, passing `--ws-replay-file` to `mockforge serve` wrote to
+//! `config.websocket.replay_file` but never reached the WS handler (which
+//! only consulted `MOCKFORGE_WS_REPLAY_FILE` directly). The fix in
+//! `mockforge-cli` now pushes the resolved config value back into the env
+//! var before spawning the WS server, so all three input paths (CLI flag,
+//! YAML config, direct env) converge.
+//!
+//! This test pins the contract: given the env var set to a custom replay
+//! file (the same way the fix sets it from config), a real
+//! `tokio-tungstenite` client sees the scripted replay instead of the
+//! fallback echo mode.
+
+use futures_util::{SinkExt, StreamExt};
+use std::time::Duration;
+use tempfile::NamedTempFile;
+use tokio_tungstenite::tungstenite::protocol::Message;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cli_replay_file_path_reaches_the_handler() {
+    // Custom replay file in a temp location that the default demo path
+    // couldn't find — proves the env var is actually read (not the default
+    // examples/ws-demo.jsonl).
+    let replay = NamedTempFile::new().unwrap();
+    let replay_path = replay.path().to_path_buf();
+    std::fs::write(
+        &replay_path,
+        // {{uuid}} so we can assert template expansion happened AND that
+        // this specific file's contents shipped (no accidental fallback).
+        r#"{"ts":0,"dir":"out","text":"CLI-REPLAY-MARKER {{uuid}}","waitFor":"^CLIENT_READY$"}
+"#,
+    )
+    .unwrap();
+
+    // Simulate what `mockforge-cli::serve` does after resolving
+    // `config.websocket.replay_file`:
+    std::env::set_var("MOCKFORGE_WS_REPLAY_FILE", &replay_path);
+    std::env::set_var("MOCKFORGE_RESPONSE_TEMPLATE_EXPAND", "true");
+
+    // Spin up the WS server on an ephemeral port.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let _server =
+        tokio::spawn(async move { axum::serve(listener, mockforge_ws::router()).await.unwrap() });
+
+    // Give axum a tick to start accepting connections.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Connect, send the replay's `waitFor` trigger, and read the scripted
+    // reply with timeout.
+    let url = format!("ws://{}/ws", addr);
+    let (mut ws, _) =
+        tokio::time::timeout(Duration::from_secs(3), tokio_tungstenite::connect_async(url))
+            .await
+            .expect("ws handshake should not time out")
+            .expect("ws handshake ok");
+
+    ws.send(Message::Text("CLIENT_READY".into())).await.unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("replay frame should arrive")
+        .expect("stream produced a message")
+        .expect("no transport error");
+    let text = match got {
+        Message::Text(t) => t.to_string(),
+        other => panic!("expected text frame, got {other:?}"),
+    };
+
+    // Content must come from OUR file (the marker string), not the bundled
+    // demo replay and not the fallback echo.
+    assert!(
+        text.contains("CLI-REPLAY-MARKER"),
+        "expected replay content from the temp file, got: {text}"
+    );
+    // Template expansion must have happened — the literal `{{uuid}}` token
+    // should NOT survive the round-trip.
+    assert!(!text.contains("{{uuid}}"), "template token should have been expanded: {text}");
+
+    // Clean up so we don't leak env into sibling tests.
+    std::env::remove_var("MOCKFORGE_WS_REPLAY_FILE");
+    std::env::remove_var("MOCKFORGE_RESPONSE_TEMPLATE_EXPAND");
+}


### PR DESCRIPTION
## Summary

**PR 5 of the protocol verification sweep.** Before this PR the `--ws-replay-file` CLI flag and the `websocket.replay_file` YAML key were silently ignored. The WS handler in `mockforge-ws::handle_socket` consulted `MOCKFORGE_WS_REPLAY_FILE` directly to choose replay vs. echo mode, and `mockforge-cli::serve` wrote the flag value to `config.websocket.replay_file` but never surfaced that back to the handler. Users running `docker-compose up` got replay because the compose file sets the env var; anyone running the CLI without exporting the var saw plain echo.

## Fix

Config is now the single source of truth. Three input paths converge there:

- `--ws-replay-file` → `config.websocket.replay_file` (already worked)
- YAML `websocket.replay_file` → `config.websocket.replay_file` (already worked)
- `MOCKFORGE_WS_REPLAY_FILE` env → `config.websocket.replay_file` (new — `apply_env_overrides` handles this, plus `MOCKFORGE_WS_HOST` for symmetry)

Just before spawning the WS server, `mockforge-cli::serve` pushes `config.websocket.replay_file` back into `MOCKFORGE_WS_REPLAY_FILE` so the handler sees the final value regardless of entry point. No `mockforge-ws` API churn — the env var is still the transport, just reliably populated now.

## Regression test

`crates/mockforge-ws/tests/ws_replay_cli_path.rs` writes a unique replay file to a `tempfile::NamedTempFile`, sets `MOCKFORGE_WS_REPLAY_FILE` (mirroring what the CLI fix does), spins up a real WS server via `mockforge_ws::router()`, and drives a `tokio-tungstenite` client through the handshake + `waitFor` trigger. Asserts:

1. Response contains the file's unique marker string — proves the custom replay file loaded, not the bundled demo fallback or the echo-mode default.
2. The `{{uuid}}` template token was expanded — proves template rendering ran.
3. Cleans up env vars at teardown so sibling tests aren't affected.

## Test plan

- [x] `cargo test -p mockforge-ws` → 109 passed (including the new one)
- [x] `cargo test -p mockforge-core --lib` → 1580 passed
- [x] `cargo clippy -p mockforge-ws -p mockforge-cli -p mockforge-core --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean