### PR TITLE
test(graphql): add real reqwest-client round-trip against users/user queries

### DIFF
--- a/crates/mockforge-graphql/tests/graphql_client_e2e.rs
+++ b/crates/mockforge-graphql/tests/graphql_client_e2e.rs
@@ -1,0 +1,97 @@
+//! End-to-end regression: a real HTTP client (`reqwest`) posts a GraphQL
+//! query to the mock server and validates the JSON response against the
+//! schema.
+//!
+//! Existing tests in this crate exercise the Rust-level handler registry
+//! and schema builders but never hit the `/graphql` HTTP endpoint with a
+//! real request, so a regression in the router / executor / serializer
+//! could ship silently. This locks in the on-the-wire contract.
+
+use mockforge_graphql::create_graphql_router;
+use serde_json::json;
+use std::time::Duration;
+
+async fn spawn_server() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let router = create_graphql_router(None).await.expect("router builds cleanly");
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    // Give axum a tick to start accepting.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    format!("http://{addr}/graphql")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_real_client_users_query_returns_structured_list() {
+    let url = spawn_server().await;
+
+    let client = reqwest::Client::new();
+    let body = json!({
+        "query": "query($limit: Int!) { users(limit: $limit) { id name email } }",
+        "variables": { "limit": 3 },
+    });
+    let response =
+        tokio::time::timeout(Duration::from_secs(5), client.post(&url).json(&body).send())
+            .await
+            .expect("request should complete within 5s")
+            .expect("reqwest transport ok");
+
+    assert!(response.status().is_success(), "HTTP {}", response.status());
+    let value: serde_json::Value = response.json().await.expect("response must be JSON");
+
+    // No errors field (or if present, empty array).
+    if let Some(errs) = value.get("errors") {
+        assert!(
+            errs.as_array().map(|a| a.is_empty()).unwrap_or(false),
+            "expected no GraphQL errors, got: {errs}"
+        );
+    }
+
+    let users = value
+        .pointer("/data/users")
+        .and_then(|v| v.as_array())
+        .expect("response.data.users must be an array");
+    assert_eq!(users.len(), 3, "limit=3 was requested; got {} users", users.len());
+
+    for (i, u) in users.iter().enumerate() {
+        let id = u.pointer("/id").and_then(|v| v.as_str()).unwrap();
+        let name = u.pointer("/name").and_then(|v| v.as_str()).unwrap();
+        let email = u.pointer("/email").and_then(|v| v.as_str()).unwrap();
+        assert_eq!(id, format!("user-{i}"));
+        assert_eq!(name, format!("User {i}"));
+        assert!(email.ends_with("@example.com"), "unexpected email shape: {email}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_real_client_user_by_id_returns_single_record() {
+    let url = spawn_server().await;
+    let client = reqwest::Client::new();
+    let body = json!({
+        "query": r#"{ user(id: "42") { id name email } }"#,
+    });
+    let response = client.post(&url).json(&body).send().await.expect("reqwest transport ok");
+    assert!(response.status().is_success());
+    let value: serde_json::Value = response.json().await.unwrap();
+
+    let user = value.pointer("/data/user").expect("data.user present");
+    assert_eq!(user.pointer("/id").and_then(|v| v.as_str()), Some("42"));
+    assert!(user.pointer("/name").and_then(|v| v.as_str()).is_some());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_syntactically_invalid_query_surfaces_error_field() {
+    let url = spawn_server().await;
+    let client = reqwest::Client::new();
+    let body = json!({ "query": "{ this is not graphql" });
+    let response = client.post(&url).json(&body).send().await.expect("reqwest transport ok");
+    // GraphQL returns 200 with an errors array for parse errors (per spec).
+    let value: serde_json::Value = response.json().await.unwrap();
+    let errors = value.pointer("/errors").and_then(|v| v.as_array());
+    assert!(
+        errors.is_some_and(|e| !e.is_empty()),
+        "expected non-empty errors array for invalid query, got: {value}"
+    );
+}


### PR DESCRIPTION
## Summary

**PR 7 of the protocol verification sweep.** Existing GraphQL tests exercise the Rust-level handler registry and schema builders but never POST to `/graphql` with a real HTTP request, so a regression in the router / executor / JSON serializer could ship silently.

This adds three `reqwest`-driven round-trip tests against the server assembled by `create_graphql_router`:

1. **`users(limit: 3)`** — returns a structured 3-element array with the `id` / `name` / `email` shape the mock resolver produces, validated by deep JSON-pointer asserts.
2. **`user(id: "42")`** — returns a single record with the requested id echoed back.
3. **Syntactically invalid query** — surfaces a non-empty `errors` array per the GraphQL-over-HTTP spec (200 with errors, not 4xx).

No code changes beyond the test. Like the gRPC PR before it, the on-the-wire path was already working — the gap was only that nothing exercised it through HTTP.

## Test plan

- [x] `cargo test -p mockforge-graphql` → 184 passed (120 lib + 11 + 3 new + 15 + 9 + 11 + 13 + 2 across integration test files)
- [x] `cargo clippy -p mockforge-graphql --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean

## Out of scope

- **Subscriptions (SSE / WebSocket)** — separate dispatch path, deserves its own test
- **Mutations** — the default `QueryRoot` has no mutations wired; when they're added, a mutation round-trip should join this test file
- **Introspection** — covered by `introspection_test.rs` already at the handler level; adding an HTTP-level introspection roundtrip would be a nice complement but isn't strictly a regression target