### PR TITLE
fix(mqtt): forwarded QoS>0 PUBLISH now carries a real packet_id

### DIFF
--- a/crates/mockforge-mqtt/src/session.rs
+++ b/crates/mockforge-mqtt/src/session.rs
@@ -430,16 +430,20 @@ impl SessionManager {
                 let delivery_qos = std::cmp::min(publish.qos as u8, sub.qos);
                 let delivery_qos = QoS::try_from(delivery_qos).unwrap_or(QoS::AtMostOnce);
 
+                // Leave `packet_id = None` for QoS > 0 forwards — the writer
+                // task picks up `is_none()` and calls `assign_packet_id`
+                // against the subscriber's session. A previous version set
+                // this to `Some(0)` expecting the writer to overwrite it,
+                // but the writer only fills `is_none()`, so the PUBLISH
+                // shipped with packet_id=0 on the wire, which MQTT spec
+                // forbids for QoS > 0 (librdkafka/rumqttc clients reject
+                // with "Packet id Zero" and drop the connection).
                 let packet = Packet::Publish(PublishPacket {
                     dup: false,
                     qos: delivery_qos,
                     retain: false, // Only first delivery can have retain
                     topic: publish.topic.clone(),
-                    packet_id: if delivery_qos != QoS::AtMostOnce {
-                        Some(0) // Will be assigned by receiver
-                    } else {
-                        None
-                    },
+                    packet_id: None,
                     payload: publish.payload.clone(),
                 });
 

--- a/crates/mockforge-mqtt/tests/mqtt_pubsub_e2e.rs
+++ b/crates/mockforge-mqtt/tests/mqtt_pubsub_e2e.rs
@@ -1,0 +1,163 @@
+//! End-to-end regression: a real `rumqttc` publisher and subscriber
+//! exchange a message through the mock broker.
+//!
+//! The existing integration tests cover topic-tree matching, registry
+//! operations, and broker struct construction — but none of them binds
+//! the TCP listener and none of them drives a real MQTT client. A
+//! regression in the CONNECT / SUBSCRIBE / PUBLISH wire protocol could
+//! ship silently. This locks in the end-to-end pub/sub contract.
+
+use mockforge_mqtt::broker::MqttConfig;
+use mockforge_mqtt::start_mqtt_server;
+use rumqttc::{AsyncClient, Event, EventLoop, Incoming, MqttOptions, QoS};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+async fn free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16, max: Duration) {
+    let deadline = tokio::time::Instant::now() + max;
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("mqtt broker never started listening on 127.0.0.1:{port}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Drain an MQTT client's event loop, forwarding the first PUBLISH packet
+/// we see to a channel. Pings/CONNACKs/SUBACKs are allowed through.
+fn drain_until_publish(
+    mut eventloop: EventLoop,
+    tx: mpsc::UnboundedSender<Vec<u8>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match eventloop.poll().await {
+                Ok(Event::Incoming(Incoming::Publish(p))) => {
+                    let _ = tx.send(p.payload.to_vec());
+                }
+                Ok(_) => { /* CONNACK / SUBACK / ping / etc. */ }
+                Err(e) => {
+                    eprintln!("rumqttc eventloop terminated: {e}");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Pump a publisher client's event loop so operations aren't blocked on
+/// backpressure. We don't need to observe its incoming traffic.
+fn pump(mut eventloop: EventLoop) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move { while let Ok(_event) = eventloop.poll().await {} })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mqtt_publish_subscribe_round_trip() {
+    let port = free_port().await;
+    let config = MqttConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..MqttConfig::default()
+    };
+
+    let server = tokio::spawn(async move {
+        start_mqtt_server(config).await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    // --- Subscriber -----------------------------------------------------
+    let mut sub_opts = MqttOptions::new("test-subscriber", "127.0.0.1", port);
+    sub_opts.set_keep_alive(Duration::from_secs(30));
+    let (sub_client, sub_eventloop) = AsyncClient::new(sub_opts, 16);
+    let (received_tx, mut received_rx) = mpsc::unbounded_channel();
+    let sub_pump = drain_until_publish(sub_eventloop, received_tx);
+
+    // Subscribe and wait a tick so the SUBSCRIBE is on the wire before we
+    // publish. Without this gap the broker would forward the PUBLISH to
+    // nobody.
+    sub_client.subscribe("sensors/temperature", QoS::AtLeastOnce).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // --- Publisher ------------------------------------------------------
+    let mut pub_opts = MqttOptions::new("test-publisher", "127.0.0.1", port);
+    pub_opts.set_keep_alive(Duration::from_secs(30));
+    let (pub_client, pub_eventloop) = AsyncClient::new(pub_opts, 16);
+    let pub_pump = pump(pub_eventloop);
+
+    pub_client
+        .publish("sensors/temperature", QoS::AtLeastOnce, false, b"22.4C".to_vec())
+        .await
+        .unwrap();
+
+    // --- Observe --------------------------------------------------------
+    let payload = tokio::time::timeout(Duration::from_secs(5), received_rx.recv())
+        .await
+        .expect("subscriber should receive published message within 5s")
+        .expect("eventloop should have forwarded the payload");
+    assert_eq!(payload, b"22.4C");
+
+    // Tidy up so sibling tests aren't hogging the broker task.
+    sub_client.disconnect().await.ok();
+    pub_client.disconnect().await.ok();
+    sub_pump.abort();
+    pub_pump.abort();
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mqtt_wildcard_subscription_matches_published_topic() {
+    // A `+` wildcard subscription must receive messages from any single-
+    // segment topic that matches. This validates the topic tree is
+    // actually consulted on PUBLISH (not just on SUBSCRIBE registration).
+    let port = free_port().await;
+    let config = MqttConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..MqttConfig::default()
+    };
+    let server = tokio::spawn(async move {
+        start_mqtt_server(config).await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    let mut sub_opts = MqttOptions::new("wildcard-sub", "127.0.0.1", port);
+    sub_opts.set_keep_alive(Duration::from_secs(30));
+    let (sub_client, sub_eventloop) = AsyncClient::new(sub_opts, 16);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sub_pump = drain_until_publish(sub_eventloop, tx);
+
+    sub_client.subscribe("devices/+/status", QoS::AtMostOnce).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let mut pub_opts = MqttOptions::new("wildcard-pub", "127.0.0.1", port);
+    pub_opts.set_keep_alive(Duration::from_secs(30));
+    let (pub_client, pub_eventloop) = AsyncClient::new(pub_opts, 16);
+    let pub_pump = pump(pub_eventloop);
+
+    pub_client
+        .publish("devices/sensor-1/status", QoS::AtMostOnce, false, b"online".to_vec())
+        .await
+        .unwrap();
+
+    let payload = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("wildcard subscriber should receive within 5s")
+        .expect("eventloop forwarded payload");
+    assert_eq!(payload, b"online");
+
+    sub_client.disconnect().await.ok();
+    pub_client.disconnect().await.ok();
+    sub_pump.abort();
+    pub_pump.abort();
+    server.abort();
+}


### PR DESCRIPTION
## Summary

**PR 8 of the protocol verification sweep.** First real-client round-trip against the MQTT broker surfaced a genuine wire-protocol bug: any QoS 1 or QoS 2 PUBLISH forwarded from the broker to a subscriber shipped with `packet_id = 0`, which the MQTT spec reserves. Every modern client (rumqttc, paho-mqtt, Eclipse Mosquitto's own cli tools) rejects with `"Packet id Zero"` and drops the connection before the application ever sees the message.

## Root cause

In `session.rs::route_message`, the outgoing `PublishPacket` for each subscriber was built as:

```rust
packet_id: if delivery_qos != QoS::AtMostOnce {
    Some(0) // Will be assigned by receiver
} else {
    None
}
```

The "will be assigned by receiver" comment referred to the writer task in `server.rs`, which does:

```rust
if publish.packet_id.is_none() {
    publish.packet_id = session_manager.assign_packet_id(...);
}
```

The `is_none()` guard means the writer **skips** assignment when the packet already has `Some(0)`, so the zero shipped on the wire verbatim. The fix is a one-line change: leave `packet_id = None` for QoS>0 forwards and let the writer assign — that's the contract it's already implementing for publisher-originated packets.

## Regression coverage

New `tests/mqtt_pubsub_e2e.rs` drives real `rumqttc::AsyncClient` instances through the mock broker:

1. **`mqtt_publish_subscribe_round_trip`**: subscriber + publisher on the same topic, both QoS `AtLeastOnce`, asserts the subscriber's eventloop receives the exact payload within 5 s. **Fails before the fix with `"Packet id Zero"`** and passes after.
2. **`mqtt_wildcard_subscription_matches_published_topic`**: `devices/+/status` subscriber gets a message published to `devices/sensor-1/status`. QoS `AtMostOnce` (which always worked) — guards the topic-tree → deliver path so a future refactor of `route_message` can't silently break wildcards.

## Test plan

- [x] `cargo test -p mockforge-mqtt` → **226 passed** (213 lib + 10 pre-existing integration + 2 new + 1 doc; 1 pre-existing ignored)
- [x] `cargo clippy -p mockforge-mqtt --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean
- [x] Before the fix, the QoS-1 test fails with exactly `"Packet id Zero"` in the rumqttc eventloop output — confirmed the bug and the test catches it.

## Sweep status

| # | Protocol | PR | Outcome |
|---|---|---|---|
| 1 | HTTP | — | curl works |
| 2 | WS | #154 | tokio-tungstenite replay roundtrip |
| 3 | gRPC | #155 | tonic SayHello roundtrip |
| 4 | Kafka | #150–153 | rdkafka produce+consume |
| 5 | GraphQL | #156 | reqwest query roundtrip |
| 6 | **MQTT** | **this PR** | **rumqttc QoS-1 pub/sub roundtrip — bug found + fixed** |
| 7 | AMQP | next | lapin publish/consume |
| 8 | SMTP | | lettre deliver |
| 9 | TCP | | framed echo |
| 10 | FTP | | curl ftp:// |