### PR TITLE
test(amqp): add real lapin-client pub/sub round-trips

### DIFF
--- a/crates/mockforge-amqp/tests/amqp_pubsub_e2e.rs
+++ b/crates/mockforge-amqp/tests/amqp_pubsub_e2e.rs
@@ -1,0 +1,192 @@
+//! End-to-end regression: a real `lapin` client publishes and consumes
+//! through the mock AMQP broker.
+//!
+//! The existing integration tests cover fixture loading, exchange/queue
+//! managers, and channel state — but none of them binds the TCP listener
+//! and drives a real AMQP client. A regression in the frame parser /
+//! exchange-to-queue routing / delivery path could ship silently. This
+//! locks in the end-to-end pub/sub contract.
+
+use lapin::options::{
+    BasicConsumeOptions, BasicPublishOptions, QueueBindOptions, QueueDeclareOptions,
+};
+use lapin::types::FieldTable;
+use lapin::{BasicProperties, Connection, ConnectionProperties};
+use mockforge_amqp::broker::AmqpBroker;
+use mockforge_amqp::spec_registry::AmqpSpecRegistry;
+use mockforge_core::config::AmqpConfig;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+
+async fn free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16, max: Duration) {
+    let deadline = tokio::time::Instant::now() + max;
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("amqp broker never started listening on 127.0.0.1:{port}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn spawn_broker() -> (u16, tokio::task::JoinHandle<()>) {
+    let port = free_port().await;
+    let config = AmqpConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..AmqpConfig::default()
+    };
+    let spec_registry =
+        Arc::new(AmqpSpecRegistry::new(config.clone()).await.expect("spec registry"));
+    let broker = Arc::new(AmqpBroker::new(config, spec_registry));
+    let handle = tokio::spawn(async move {
+        broker.start().await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+    (port, handle)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn amqp_publish_consume_round_trip_via_default_exchange() {
+    let (port, server) = spawn_broker().await;
+
+    let uri = format!("amqp://127.0.0.1:{port}/%2f");
+    let conn = Connection::connect(&uri, ConnectionProperties::default())
+        .await
+        .expect("lapin connects to mock broker");
+    let channel = conn.create_channel().await.expect("open channel");
+
+    let queue_name = "e2e-queue";
+    channel
+        .queue_declare(
+            queue_name,
+            QueueDeclareOptions {
+                durable: false,
+                exclusive: false,
+                auto_delete: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .expect("queue_declare");
+
+    // Start the consumer BEFORE publishing so the delivery isn't
+    // dropped on the floor.
+    let mut consumer = channel
+        .basic_consume(
+            queue_name,
+            "e2e-consumer",
+            BasicConsumeOptions {
+                no_ack: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .expect("basic_consume");
+
+    channel
+        .basic_publish(
+            "",         // default exchange
+            queue_name, // routing_key == queue name goes direct on default exchange
+            BasicPublishOptions::default(),
+            b"hello-amqp",
+            BasicProperties::default(),
+        )
+        .await
+        .expect("basic_publish");
+
+    let delivery = tokio::time::timeout(Duration::from_secs(5), consumer.next())
+        .await
+        .expect("consumer should receive a delivery within 5s")
+        .expect("consumer stream produced an item")
+        .expect("delivery parses cleanly");
+    assert_eq!(delivery.data, b"hello-amqp");
+
+    let _ = conn.close(0, "bye").await;
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn amqp_topic_exchange_routes_wildcard_binding() {
+    // Declare a topic exchange, bind a queue with a wildcard routing key,
+    // publish a message whose routing key matches the wildcard, confirm
+    // the consumer receives it. Guards the exchange->binding->queue path.
+    let (port, server) = spawn_broker().await;
+
+    let uri = format!("amqp://127.0.0.1:{port}/%2f");
+    let conn = Connection::connect(&uri, ConnectionProperties::default()).await.unwrap();
+    let channel = conn.create_channel().await.unwrap();
+
+    // Use the built-in amq.topic exchange the broker declares at startup.
+    let queue_name = "topic-queue";
+    channel
+        .queue_declare(
+            queue_name,
+            QueueDeclareOptions {
+                durable: false,
+                exclusive: false,
+                auto_delete: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+    channel
+        .queue_bind(
+            queue_name,
+            "amq.topic",
+            "sensors.*.temperature", // matches sensors.{anything}.temperature
+            QueueBindOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    let mut consumer = channel
+        .basic_consume(
+            queue_name,
+            "topic-consumer",
+            BasicConsumeOptions {
+                no_ack: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    channel
+        .basic_publish(
+            "amq.topic",
+            "sensors.kitchen.temperature",
+            BasicPublishOptions::default(),
+            b"21.3C",
+            BasicProperties::default(),
+        )
+        .await
+        .unwrap();
+
+    let delivery = tokio::time::timeout(Duration::from_secs(5), consumer.next())
+        .await
+        .expect("wildcard consumer should receive within 5s")
+        .expect("stream produced")
+        .expect("delivery");
+    assert_eq!(delivery.data, b"21.3C");
+
+    let _ = conn.close(0, "bye").await;
+    server.abort();
+}


### PR DESCRIPTION
## Summary

**PR 9 of the protocol verification sweep.** Existing AMQP integration tests cover fixture loading, exchange/queue managers, and channel state at the Rust level, but nothing binds the TCP listener and drives a real AMQP client. A regression in the frame parser / exchange-to-queue routing / delivery path could ship silently.

Two `lapin`-driven round-trips lock the contract in:

1. **`amqp_publish_consume_round_trip_via_default_exchange`** — declare an auto-delete queue, subscribe via `basic_consume`, publish to the default exchange with `routing_key == queue_name`, assert the delivery body matches.
2. **`amqp_topic_exchange_routes_wildcard_binding`** — bind the auto-declared `amq.topic` exchange with `sensors.*.temperature`, publish to `sensors.kitchen.temperature`, assert the wildcard binding actually routes the message through.

Both pass first try — **no AMQP bugs found** (unlike MQTT in PR #157, which needed a `packet_id=0` fix). Completes in ~310ms. The mock broker's AMQP frame parsing, exchange routing, and delivery path all work correctly for the main cases.

## Test plan

- [x] `cargo test -p mockforge-amqp` → **206 passed** (184 lib + 2 new + 20 pre-existing integration)
- [x] `cargo clippy -p mockforge-amqp --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean

## Sweep status

| # | Protocol | PR | Outcome |
|---|---|---|---|
| 1 | HTTP | — | curl works |
| 2 | WS | #154 | replay roundtrip |
| 3 | gRPC | #155 | SayHello roundtrip |
| 4 | Kafka | #150–153 | rdkafka produce+consume |
| 5 | GraphQL | #156 | query roundtrip |
| 6 | MQTT | #157 | **bug found + fixed** (QoS>0 packet_id) |
| 7 | **AMQP** | **this PR** | lapin pub/sub roundtrip + topic wildcards |
| 8 | SMTP | next | lettre deliver |
| 9 | TCP | | framed echo |
| 10 | FTP | | curl ftp:// |