### PR TITLE
fix(smtp): capture every delivered message + stop parsing body as commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8921,6 +8921,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "criterion",
+ "lettre",
  "mail-parser",
  "mockforge-core",
  "regex",

--- a/crates/mockforge-smtp/Cargo.toml
+++ b/crates/mockforge-smtp/Cargo.toml
@@ -39,6 +39,9 @@ rustls = "0.23"
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tempfile = "3.0"
 criterion = { workspace = true }
+# Real SMTP client for the end-to-end regression test — sends a message
+# via the mock server and we then inspect the captured mailbox.
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "builder", "tokio1"] }
 
 [[bench]]
 name = "smtp_benchmarks"

--- a/crates/mockforge-smtp/src/server.rs
+++ b/crates/mockforge-smtp/src/server.rs
@@ -157,6 +157,32 @@ async fn handle_smtp_session(
         let command = line.trim();
         debug!("SMTP command from {}: {}", peer_addr, command);
 
+        // DATA mode bypasses command parsing entirely. Without this, the
+        // first word of every body line would be matched against the SMTP
+        // verb table — any body beginning with "Hello ..." / "Data ..." /
+        // "Quit ..." / etc. was being re-interpreted as a command and
+        // dropped on the floor. Inside DATA mode, only the bare "." ends
+        // the message; everything else (headers, blank separator, body
+        // lines, verbatim) accumulates.
+        if session_state.in_data_mode {
+            if command == "." {
+                session_state.in_data_mode = false;
+                let response =
+                    process_email(&session_state, &registry, &middleware, peer_addr).await?;
+                writer.write_all(response.as_bytes()).await?;
+                session_state.reset();
+            } else {
+                // Preserve the raw line (minus trailing \r\n) so headers
+                // and body content survive byte-for-byte.
+                session_state.data.push_str(line.trim_end_matches(['\r', '\n']));
+                session_state.data.push('\n');
+            }
+            line.clear();
+            continue;
+        }
+
+        // Skip blank lines outside DATA mode — otherwise idle keep-alive
+        // newlines would reach the verb parser.
         if command.is_empty() {
             line.clear();
             continue;
@@ -283,19 +309,19 @@ async fn handle_smtp_command<W: AsyncWriteExt + Unpin>(
         }
 
         _ => {
-            // Handle data mode or unknown command
+            // DATA-mode lines are short-circuited before `handle_smtp_command`
+            // is called (see `handle_smtp_session`), so we only land here for
+            // genuinely unknown verbs.
             if state.in_data_mode {
+                // Defensive fallback in case the short-circuit is ever
+                // bypassed — keep the original accumulator behavior so the
+                // session doesn't derail.
                 if command == "." {
-                    // End of data
                     state.in_data_mode = false;
-
-                    // Process the email
                     let response = process_email(state, registry, middleware, peer_addr).await?;
-
                     writer.write_all(response.as_bytes()).await?;
                     state.reset();
                 } else {
-                    // Accumulate email data
                     state.data.push_str(command);
                     state.data.push('\n');
                 }
@@ -325,6 +351,33 @@ async fn process_email(
     // Extract subject from data
     let subject = extract_subject(&state.data);
 
+    // Capture the delivered message in the in-memory mailbox before we
+    // touch fixture-driven response generation. The spec-registry's
+    // storage logic used to live inside `generate_mock_response` gated on
+    // `fixture.storage.save_to_mailbox`, which meant that if no fixture
+    // matched (the common case: users running the mock SMTP to inspect
+    // outgoing mail from their application) the message would silently
+    // disappear AND the server would return a 500 to the client. Capture
+    // is the primary contract of a mock SMTP; fixture matching should only
+    // affect the reply.
+    let captured = crate::fixtures::StoredEmail {
+        id: uuid::Uuid::new_v4().to_string(),
+        from: from.clone(),
+        to: state.rcpt_to.clone(),
+        subject: subject.clone(),
+        body: state.data.clone(),
+        headers: HashMap::from([
+            ("from".to_string(), from.clone()),
+            ("to".to_string(), to.clone()),
+            ("subject".to_string(), subject.clone()),
+        ]),
+        received_at: chrono::Utc::now(),
+        raw: Some(state.data.as_bytes().to_vec()),
+    };
+    if let Err(e) = registry.store_email(captured) {
+        warn!("Failed to store email in mailbox: {}", e);
+    }
+
     // Create protocol request
     let mut request = ProtocolRequest {
         protocol: Protocol::Smtp,
@@ -349,14 +402,18 @@ async fn process_email(
         return Ok(String::from_utf8_lossy(&short_circuit_response.body).to_string());
     }
 
-    // Generate response
-    let mut response = registry.generate_mock_response(&request)?;
+    // Ask the spec registry for a fixture-driven reply. When no fixture
+    // matches, fall back to the standard 250 OK so clients accept the
+    // message (the message has already been captured above).
+    let response = match registry.generate_mock_response(&request) {
+        Ok(mut resp) => {
+            middleware.process_response(&request, &mut resp).await?;
+            String::from_utf8_lossy(&resp.body).to_string()
+        }
+        Err(_) => "250 OK\r\n".to_string(),
+    };
 
-    // Process response through middleware
-    middleware.process_response(&request, &mut response).await?;
-
-    // Return SMTP response
-    Ok(String::from_utf8_lossy(&response.body).to_string())
+    Ok(response)
 }
 
 /// Extract email address from SMTP command parameter

--- a/crates/mockforge-smtp/src/spec_registry.rs
+++ b/crates/mockforge-smtp/src/spec_registry.rs
@@ -14,7 +14,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::RwLock;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 /// Email search filters
 #[derive(Debug, Clone, Default)]
@@ -341,24 +341,10 @@ impl SpecRegistry for SmtpSpecRegistry {
             mockforge_core::Error::internal("No matching fixture found for email")
         })?;
 
-        // Store email if configured
-        if fixture.storage.save_to_mailbox {
-            let email = StoredEmail {
-                id: uuid::Uuid::new_v4().to_string(),
-                from: from.clone(),
-                to: to.split(',').map(|s| s.trim().to_string()).collect(),
-                subject: subject.clone(),
-                body: String::from_utf8_lossy(request.body.as_ref().unwrap_or(&Vec::new()))
-                    .to_string(),
-                headers: request.metadata.clone(),
-                received_at: chrono::Utc::now(),
-                raw: request.body.clone(),
-            };
-
-            if let Err(e) = self.store_email(email) {
-                error!("Failed to store email: {}", e);
-            }
-        }
+        // Storage lives in `server::process_email` now so every delivered
+        // message is captured whether or not a fixture matched. The old
+        // fixture-gated storage here caused silent drops in the common case
+        // of running the mock without any fixtures loaded.
 
         // Generate response
         let response_message =

--- a/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
+++ b/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
@@ -1,0 +1,108 @@
+//! End-to-end regression: a real `lettre` SMTP client delivers a message
+//! through the mock server and we verify it landed in the in-memory
+//! mailbox with the expected sender / recipient / subject / body.
+//!
+//! The pre-existing SMTP tests cover fixture loading, mailbox stats, and
+//! spec-registry search at the Rust level, but none of them binds the
+//! TCP listener and drives a real SMTP client. A regression in the
+//! HELO/EHLO, MAIL FROM, RCPT TO, DATA, or message-capture path would
+//! ship silently. This locks in the end-to-end deliver-and-inspect
+//! contract.
+
+use lettre::message::{header::ContentType, Mailbox, Message};
+use lettre::{AsyncSmtpTransport, AsyncTransport, Tokio1Executor};
+use mockforge_smtp::{SmtpConfig, SmtpServer, SmtpSpecRegistry};
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16, max: Duration) {
+    let deadline = tokio::time::Instant::now() + max;
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("smtp server never started listening on 127.0.0.1:{port}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn smtp_real_client_delivers_and_message_is_captured() {
+    let port = free_port().await;
+    let config = SmtpConfig {
+        port,
+        host: "127.0.0.1".into(),
+        // Disable TLS / fixtures so the test drives only the MAIL/RCPT/DATA
+        // path — that's what we're pinning down.
+        enable_starttls: false,
+        fixtures_dir: None,
+        ..SmtpConfig::default()
+    };
+    let spec_registry = Arc::new(SmtpSpecRegistry::new());
+    let server = SmtpServer::new(config, spec_registry.clone()).expect("server builds cleanly");
+    let server_handle = tokio::spawn(async move {
+        server.start().await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    // Use lettre in plaintext mode — the mock doesn't require auth or TLS.
+    let transport: AsyncSmtpTransport<Tokio1Executor> =
+        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("127.0.0.1")
+            .port(port)
+            .build();
+
+    let email = Message::builder()
+        .from("sender@example.test".parse::<Mailbox>().unwrap())
+        .to("receiver@example.test".parse::<Mailbox>().unwrap())
+        .subject("MockForge SMTP E2E")
+        .header(ContentType::TEXT_PLAIN)
+        .body("Hello from the e2e test".to_string())
+        .unwrap();
+
+    transport.send(email).await.expect("lettre delivers via mock SMTP");
+
+    // Mailbox stores emails synchronously once DATA completes on the server
+    // side, but `send` returns as soon as the 250 arrives back — so give
+    // the handler task a brief chance to store the message.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let captured = loop {
+        let emails = spec_registry.get_emails().expect("mailbox read");
+        if !emails.is_empty() {
+            break emails;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("message never made it into the mock mailbox");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    assert_eq!(captured.len(), 1, "expected exactly one delivered message");
+    let mail = &captured[0];
+    assert!(
+        mail.from.contains("sender@example.test"),
+        "expected sender address preserved, got {:?}",
+        mail.from
+    );
+    assert!(
+        mail.to.iter().any(|r| r.contains("receiver@example.test")),
+        "expected recipient preserved, got {:?}",
+        mail.to
+    );
+    assert_eq!(mail.subject, "MockForge SMTP E2E");
+    assert!(
+        mail.body.contains("Hello from the e2e test"),
+        "expected body preserved, got {:?}",
+        mail.body
+    );
+
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary

**PR 10 of the protocol verification sweep.** First real-`lettre` round-trip against the SMTP mock surfaced **three genuine bugs**, all of which caused delivered messages to silently vanish from the mailbox:

1. **`process_email` never called `registry.store_email()`.** Storage lived inside `spec_registry::generate_mock_response` gated on `fixture.storage.save_to_mailbox` — which meant that if no fixture was loaded (the common case for a mock SMTP used as a delivery inspector) the message was dropped AND the server returned a 500 to the client. Fix: capture unconditionally in `server::process_email` before consulting fixtures. The fixture branch now only controls the SMTP reply (falling back to `250 OK` when no fixture matches). Storage was removed from `generate_mock_response` so capture happens in exactly one place.

2. **Blank lines were dropped by the session loop before they reached DATA mode**, erasing the RFC-822 header/body separator AND any legitimate intra-body blank lines. Fix: only skip blank lines *outside* DATA mode.

3. **DATA-mode lines went through SMTP command dispatch.** Any body line starting with a word that matched a verb (most commonly `"Hello…"` matching `HELLO`, but also `Data`, `Quit`, `Help`, etc.) got re-interpreted as a command and lost. Fix: short-circuit DATA-mode lines directly to the accumulator / `.` terminator check before touching the command parser.

Taken together: before this PR, a client that sent any message whose body began with `"Hello …"` (every "Hello, world" test case ever) against a fixture-less mock got 500 errors and nothing captured; body content was shredded even when fixtures existed. After, the full raw message (headers + blank separator + body) lands in the mailbox byte-for-byte and the client sees `250 OK`.

## Regression coverage

`tests/smtp_deliver_e2e.rs` spins up a real `SmtpServer` on an ephemeral port with no fixtures, uses `lettre::AsyncSmtpTransport::builder_dangerous` (plain-TCP) to send a minimal `Message` with a `"Hello from the e2e test"` body, polls `registry.get_emails()`, and asserts the sender, recipient, subject, and body text all survived the round-trip.

## Test plan

- [x] `cargo test -p mockforge-smtp` → **79 passed** (61 lib + 16 pre-existing integration + 1 new e2e + 1 doc)
- [x] `cargo clippy -p mockforge-smtp --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean
- [x] Before any of the fixes: test failed with `"expected body preserved, got "From: sender...\nDate: ...\n\n""` — zero body content. After: body round-trips intact.

## Sweep status

| # | Protocol | PR | Outcome |
|---|---|---|---|
| 1 | HTTP | — | curl |
| 2 | WS | #154 | replay |
| 3 | gRPC | #155 | SayHello |
| 4 | Kafka | #150–153 | rdkafka roundtrip |
| 5 | GraphQL | #156 | query |
| 6 | MQTT | #157 | bug fixed (packet_id=0) |
| 7 | AMQP | #158 | pub/sub |
| 8 | **SMTP** | **this PR** | **3 bugs fixed** (capture gap, blank-line eating, body-as-command) |
| 9 | TCP | next | framed echo |
| 10 | FTP | | curl ftp:// |