### PR TITLE
fix(ftp): storage backend no longer panics on every client operation

### DIFF
--- a/crates/mockforge-ftp/src/storage.rs
+++ b/crates/mockforge-ftp/src/storage.rs
@@ -32,12 +32,12 @@ impl<U: libunftp::auth::UserDetail + Send + Sync + 'static> StorageBackend<U> fo
     ) -> Result<Self::Metadata> {
         let path = path.as_ref();
 
-        if let Some(file) = self.vfs.get_file(path) {
+        if let Some(file) = self.vfs.get_file_async(path).await {
             Ok(MockForgeMetadata {
                 file: Some(file),
                 is_dir: false,
             })
-        } else if self.vfs.directory_exists(path) {
+        } else if self.vfs.directory_exists_async(path).await {
             Ok(MockForgeMetadata {
                 file: None,
                 is_dir: true,
@@ -53,7 +53,7 @@ impl<U: libunftp::auth::UserDetail + Send + Sync + 'static> StorageBackend<U> fo
         path: P,
     ) -> Result<Vec<Fileinfo<PathBuf, Self::Metadata>>> {
         let path = path.as_ref();
-        let files = self.vfs.list_files(path);
+        let files = self.vfs.list_files_async(path).await;
 
         let mut result = Vec::new();
         for file in files {
@@ -77,7 +77,7 @@ impl<U: libunftp::auth::UserDetail + Send + Sync + 'static> StorageBackend<U> fo
     ) -> Result<Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin>> {
         let path = path.as_ref();
 
-        if let Some(file) = self.vfs.get_file(path) {
+        if let Some(file) = self.vfs.get_file_async(path).await {
             let content =
                 file.render_content().map_err(|e| Error::new(ErrorKind::LocalError, e))?;
             Ok(Box::new(std::io::Cursor::new(content)))
@@ -126,7 +126,8 @@ impl<U: libunftp::auth::UserDetail + Send + Sync + 'static> StorageBackend<U> fo
                 );
 
                 self.vfs
-                    .add_file(path.to_path_buf(), file)
+                    .add_file_async(path.to_path_buf(), file)
+                    .await
                     .map_err(|e| Error::new(ErrorKind::LocalError, e))?;
 
                 // Record the upload
@@ -147,8 +148,11 @@ impl<U: libunftp::auth::UserDetail + Send + Sync + 'static> StorageBackend<U> fo
     async fn del<P: AsRef<Path> + Send + Debug>(&self, _user: &U, path: P) -> Result<()> {
         let path = path.as_ref();
 
-        if self.vfs.get_file(path).is_some() {
-            self.vfs.remove_file(path).map_err(|e| Error::new(ErrorKind::LocalError, e))?;
+        if self.vfs.get_file_async(path).await.is_some() {
+            self.vfs
+                .remove_file_async(path)
+                .await
+                .map_err(|e| Error::new(ErrorKind::LocalError, e))?;
             Ok(())
         } else {
             Err(Error::from(ErrorKind::PermanentFileNotAvailable))
@@ -157,14 +161,15 @@ impl<U: libunftp::auth::UserDetail + Send + Sync + 'static> StorageBackend<U> fo
 
     async fn mkd<P: AsRef<Path> + Send + Debug>(&self, _user: &U, path: P) -> Result<()> {
         let path = path.as_ref();
-        if self.vfs.directory_exists(path) {
+        if self.vfs.directory_exists_async(path).await {
             return Err(Error::new(
                 ErrorKind::PermanentFileNotAvailable,
                 "Directory already exists",
             ));
         }
         self.vfs
-            .create_directory(path.to_path_buf())
+            .create_directory_async(path.to_path_buf())
+            .await
             .map_err(|e| Error::new(ErrorKind::LocalError, e))
     }
 
@@ -172,13 +177,17 @@ impl<U: libunftp::auth::UserDetail + Send + Sync + 'static> StorageBackend<U> fo
         let from = from.as_ref();
         let to = to.as_ref();
 
-        if let Some(file) = self.vfs.get_file(from) {
-            self.vfs.remove_file(from).map_err(|e| Error::new(ErrorKind::LocalError, e))?;
+        if let Some(file) = self.vfs.get_file_async(from).await {
             self.vfs
-                .add_file(
+                .remove_file_async(from)
+                .await
+                .map_err(|e| Error::new(ErrorKind::LocalError, e))?;
+            self.vfs
+                .add_file_async(
                     to.to_path_buf(),
                     VirtualFile::new(to.to_path_buf(), file.content, file.metadata),
                 )
+                .await
                 .map_err(|e| Error::new(ErrorKind::LocalError, e))
         } else {
             Err(Error::from(ErrorKind::PermanentFileNotAvailable))
@@ -187,17 +196,18 @@ impl<U: libunftp::auth::UserDetail + Send + Sync + 'static> StorageBackend<U> fo
 
     async fn rmd<P: AsRef<Path> + Send + Debug>(&self, _user: &U, path: P) -> Result<()> {
         let path = path.as_ref();
-        if !self.vfs.directory_exists(path) {
+        if !self.vfs.directory_exists_async(path).await {
             return Err(Error::from(ErrorKind::PermanentFileNotAvailable));
         }
         self.vfs
-            .remove_directory(path)
+            .remove_directory_async(path)
+            .await
             .map_err(|e| Error::new(ErrorKind::PermissionDenied, e))
     }
 
     async fn cwd<P: AsRef<Path> + Send + Debug>(&self, _user: &U, path: P) -> Result<()> {
         let path = path.as_ref();
-        if self.vfs.directory_exists(path) {
+        if self.vfs.directory_exists_async(path).await {
             Ok(())
         } else {
             Err(Error::from(ErrorKind::PermanentFileNotAvailable))

--- a/crates/mockforge-ftp/src/vfs.rs
+++ b/crates/mockforge-ftp/src/vfs.rs
@@ -131,6 +131,60 @@ impl VirtualFileSystem {
         Ok(())
     }
 
+    /// Async version of list_files — use from async contexts.
+    pub async fn list_files_async(&self, path: &Path) -> Vec<VirtualFile> {
+        let files = self.files.read().await;
+        files
+            .iter()
+            .filter(|(file_path, _)| file_path.starts_with(path))
+            .map(|(_, file)| file.clone())
+            .collect()
+    }
+
+    /// Async version of remove_file — use from async contexts.
+    pub async fn remove_file_async(&self, path: &Path) -> Result<()> {
+        let mut files = self.files.write().await;
+        files.remove(path);
+        Ok(())
+    }
+
+    /// Async version of directory_exists — use from async contexts.
+    pub async fn directory_exists_async(&self, path: &Path) -> bool {
+        let dirs = self.directories.read().await;
+        dirs.contains(path)
+    }
+
+    /// Async version of create_directory — use from async contexts.
+    pub async fn create_directory_async(&self, path: PathBuf) -> Result<()> {
+        let mut dirs = self.directories.write().await;
+        dirs.insert(path);
+        Ok(())
+    }
+
+    /// Async version of is_directory_empty — use from async contexts.
+    pub async fn is_directory_empty_async(&self, path: &Path) -> bool {
+        let files = self.files.read().await;
+        let has_files =
+            files.keys().any(|file_path| file_path != path && file_path.starts_with(path));
+        if has_files {
+            return false;
+        }
+
+        let dirs = self.directories.read().await;
+        !dirs.iter().any(|dir_path| dir_path != path && dir_path.starts_with(path))
+    }
+
+    /// Async version of remove_directory — use from async contexts.
+    pub async fn remove_directory_async(&self, path: &Path) -> Result<()> {
+        if self.is_directory_empty_async(path).await {
+            let mut dirs = self.directories.write().await;
+            dirs.remove(path);
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Directory is not empty"))
+        }
+    }
+
     /// Async version of get_file - use this in async contexts
     pub async fn get_file_async(&self, path: &Path) -> Option<VirtualFile> {
         let files = self.files.read().await;

--- a/crates/mockforge-ftp/tests/ftp_client_e2e.rs
+++ b/crates/mockforge-ftp/tests/ftp_client_e2e.rs
@@ -1,0 +1,97 @@
+//! End-to-end regression: a real `suppaftp` client lists and downloads
+//! files from the mock FTP server.
+//!
+//! The existing integration tests cover fixture loading and VFS
+//! construction, but nothing binds the libunftp listener and drives a
+//! real FTP client. A regression in anonymous login, LIST, or RETR
+//! would ship silently. This locks in the on-the-wire contract.
+
+use mockforge_core::config::FtpConfig;
+use mockforge_ftp::{FileContent, FileMetadata, FtpServer, VirtualFile};
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::time::Duration;
+
+fn free_port() -> u16 {
+    // libunftp listens synchronously on a string address; bind a probe
+    // socket first to grab an ephemeral port, then drop it so libunftp
+    // can bind the same port. There's a tiny race here but it's reliable
+    // for serial-test runs.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16, max: Duration) {
+    let deadline = tokio::time::Instant::now() + max;
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("ftp server never started listening on 127.0.0.1:{port}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ftp_anonymous_list_and_retrieve() {
+    let port = free_port();
+    let config = FtpConfig {
+        port,
+        host: "127.0.0.1".into(),
+        allow_anonymous: true,
+        virtual_root: PathBuf::from("/"),
+        ..FtpConfig::default()
+    };
+
+    let server = FtpServer::new(config);
+
+    // Pre-seed a virtual file before starting the server.
+    let payload = b"mockforge ftp e2e content".to_vec();
+    let file = VirtualFile::new(
+        PathBuf::from("/hello.txt"),
+        FileContent::Static(payload.clone()),
+        FileMetadata {
+            size: payload.len() as u64,
+            ..Default::default()
+        },
+    );
+    server.vfs().add_file_async(PathBuf::from("/hello.txt"), file).await.unwrap();
+
+    let server_handle = tokio::spawn(async move {
+        server.start().await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    // Drive the FTP conversation on a blocking thread — suppaftp's
+    // default client is sync.
+    let port_c = port;
+    let retrieved = tokio::task::spawn_blocking(move || {
+        use suppaftp::FtpStream;
+
+        let mut ftp =
+            FtpStream::connect(format!("127.0.0.1:{port_c}")).expect("connect to mock ftp");
+        ftp.login("anonymous", "anon@example.test").expect("anonymous login");
+
+        // LIST the root — we should see our pre-seeded file.
+        let entries = ftp.list(None).expect("LIST root");
+        let joined = entries.join("\n");
+        assert!(joined.contains("hello.txt"), "LIST must show pre-seeded file, got:\n{joined}");
+
+        // RETR the file and read its full contents.
+        let mut reader = ftp.retr_as_buffer("hello.txt").expect("RETR hello.txt");
+        let mut buf = Vec::new();
+        std::io::copy(&mut reader, &mut Cursor::new(&mut buf)).expect("read RETR payload");
+        ftp.quit().ok();
+        buf
+    })
+    .await
+    .expect("blocking FTP task did not panic");
+
+    assert_eq!(retrieved, b"mockforge ftp e2e content");
+
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary

**PR 12 of the protocol verification sweep — last protocol, another real bug.** First real FTP client (`suppaftp`) round-trip against the mock broker surfaced a genuine bug that hit **every single async handler** in `MockForgeStorage`:

\`\`\`
thread 'tokio-runtime-worker' panicked at crates/mockforge-ftp/src/vfs.rs:61:32:
  Cannot block the current thread from within a runtime. This happens
  because a function attempted to block the current thread while the
  thread is being used to drive asynchronous tasks.
\`\`\`

libunftp's `StorageBackend` trait methods are all `async`, and every one of them (`metadata`, `list`, `get`, `put`, `del`, `mkd`, `rmd`, `rename`, `cwd`) called `VirtualFileSystem` through a sync API that internally used `tokio::sync::RwLock::blocking_read()` / `blocking_write()`. Calling those inside a tokio runtime thread panics by design.

**Net effect**: any real FTP client got the connection dropped on its first `LIST` / `RETR` / `STOR` — the mock was completely unusable as a file server despite looking OK at the Rust API level.

## Fix

The VFS had `add_file_async` and `get_file_async` helpers but was missing async counterparts for `list_files`, `remove_file`, `directory_exists`, `create_directory`, `remove_directory`, and `is_directory_empty`. Added them (line-for-line the same logic, swapping `blocking_*` for `.await`), and switched every call site in `MockForgeStorage` over. The sync methods are kept for callers outside an async context (e.g. the existing unit tests in `vfs.rs`).

## Regression coverage

`crates/mockforge-ftp/tests/ftp_client_e2e.rs`:

1. Pre-seeds a virtual file `/hello.txt` via `server.vfs()`.
2. Spawns the libunftp server on an ephemeral port.
3. Uses `suppaftp::FtpStream` (on `tokio::task::spawn_blocking` since suppaftp is sync) to `LIST` the root and `RETR` the file.
4. Asserts the file appears in LIST output and its bytes round-trip verbatim.

**Fails before the fix** with the blocking-lock panic on the `list` handler. **Passes after** in ~0.14s.

## Test plan

- [x] `cargo test -p mockforge-ftp` → **115 passed** (108 lib + 5 pre-existing integration + 1 new e2e + 1 doc)
- [x] `cargo clippy -p mockforge-ftp --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean

## Final sweep status — 12/12 protocols verified

| Protocol | PR | Outcome |
|---|---|---|
| HTTP | earlier | curl works |
| WS | #154 | **1 bug fixed** (CLI flag ignored) |
| gRPC (unary) | #155 | clean |
| Kafka produce/consume | #150–153 | **6 bugs fixed** (parse offsets, correlation_id=0, non-flexible ApiVersions, Metadata topics, Produce v9, Fetch v12) |
| GraphQL | #156 | clean |
| MQTT | #157 | **1 bug fixed** (QoS>0 packet_id=0) |
| AMQP | #158 | clean |
| SMTP | #159 | **3 bugs fixed** (capture gap, blank-line eating, body-as-command) |
| TCP | #160 | clean |
| **FTP** | **this PR** | **1 bug fixed** (blocking-lock panic on every op) |

**Total**: 12 protocols swept, 6 real bugs found and fixed, all caught by real-client integration tests that lock the contract in against future regressions.