### PR TITLE
feat(kafka): implement ListOffsets v7 so Offset::Beginning actually resolves

### DIFF
--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -308,6 +308,7 @@ impl KafkaMockBroker {
             KafkaRequestType::Metadata => self.handle_metadata().await,
             KafkaRequestType::Produce => self.handle_produce(message_buf, &request).await,
             KafkaRequestType::Fetch => self.handle_fetch(message_buf, &request).await,
+            KafkaRequestType::ListOffsets => self.handle_list_offsets(message_buf, &request).await,
             KafkaRequestType::ListGroups => self.handle_list_groups().await,
             KafkaRequestType::DescribeGroups => self.handle_describe_groups().await,
             KafkaRequestType::ApiVersions => self.handle_api_versions().await,
@@ -575,6 +576,96 @@ impl KafkaMockBroker {
             parsed.session_id,
             &topic_responses,
         );
+        Ok(KafkaResponse::Preserialized(body))
+    }
+
+    /// Handle a ListOffsets v7 request. Resolves each partition's
+    /// `timestamp` field to a real offset by consulting the storage layer:
+    /// `-2` (earliest) → `partition.log_start_offset`, `-1` (latest) →
+    /// `partition.high_watermark`, positive timestamps → first message at
+    /// or after that timestamp (best-effort linear scan since we keep
+    /// messages in insertion order).
+    async fn handle_list_offsets(
+        &self,
+        message_buf: &[u8],
+        request: &KafkaRequest,
+    ) -> Result<KafkaResponse> {
+        use crate::listoffsets_codec::{
+            parse_listoffsets_v7, serialize_listoffsets_v7_response, ListOffsetsPartitionResponse,
+            ListOffsetsTopicResponse,
+        };
+
+        const ERR_UNKNOWN_TOPIC_OR_PARTITION: i16 = 3;
+        const TS_EARLIEST: i64 = -2;
+        const TS_LATEST: i64 = -1;
+
+        if request.api_version != 7 {
+            let body = serialize_listoffsets_v7_response(request.correlation_id, &[]);
+            tracing::warn!("rejecting ListOffsets v{} (only v7 supported)", request.api_version);
+            return Ok(KafkaResponse::Preserialized(body));
+        }
+
+        let body_slice = message_buf.get(request.body_offset..).ok_or_else(|| {
+            mockforge_core::Error::internal("listoffsets body_offset past end of buffer")
+        })?;
+
+        let parsed = parse_listoffsets_v7(body_slice).map_err(|e| {
+            mockforge_core::Error::internal(format!("failed to parse ListOffsets v7: {e}"))
+        })?;
+
+        let topics_guard = self.topics.read().await;
+        let mut topic_responses = Vec::with_capacity(parsed.topics.len());
+        for t in &parsed.topics {
+            let mut partition_responses = Vec::with_capacity(t.partitions.len());
+            let topic = topics_guard.get(&t.topic);
+            for p in &t.partitions {
+                let Some(topic) = topic else {
+                    partition_responses.push(ListOffsetsPartitionResponse {
+                        partition_index: p.partition_index,
+                        error_code: ERR_UNKNOWN_TOPIC_OR_PARTITION,
+                        timestamp: -1,
+                        offset: -1,
+                    });
+                    continue;
+                };
+                let Some(part) = topic.get_partition(p.partition_index) else {
+                    partition_responses.push(ListOffsetsPartitionResponse {
+                        partition_index: p.partition_index,
+                        error_code: ERR_UNKNOWN_TOPIC_OR_PARTITION,
+                        timestamp: -1,
+                        offset: -1,
+                    });
+                    continue;
+                };
+
+                let (offset, ts) = match p.timestamp {
+                    TS_EARLIEST => (part.log_start_offset, -1),
+                    TS_LATEST => (part.high_watermark, -1),
+                    needle => {
+                        // Best-effort timestamp lookup: return the first message
+                        // whose timestamp >= needle. If none, fall back to the
+                        // high watermark (caller will just get an empty fetch).
+                        let found = part.messages.iter().find(|m| m.timestamp >= needle);
+                        match found {
+                            Some(m) => (m.offset, m.timestamp),
+                            None => (part.high_watermark, -1),
+                        }
+                    }
+                };
+                partition_responses.push(ListOffsetsPartitionResponse {
+                    partition_index: p.partition_index,
+                    error_code: 0,
+                    timestamp: ts,
+                    offset,
+                });
+            }
+            topic_responses.push(ListOffsetsTopicResponse {
+                topic: t.topic.clone(),
+                partitions: partition_responses,
+            });
+        }
+
+        let body = serialize_listoffsets_v7_response(request.correlation_id, &topic_responses);
         Ok(KafkaResponse::Preserialized(body))
     }
 

--- a/crates/mockforge-kafka/src/lib.rs
+++ b/crates/mockforge-kafka/src/lib.rs
@@ -129,6 +129,7 @@ pub mod consumer_groups;
 pub mod fetch_codec;
 pub mod fixture_file;
 pub mod fixtures;
+pub mod listoffsets_codec;
 pub mod metrics;
 pub mod partitions;
 pub mod produce_codec;

--- a/crates/mockforge-kafka/src/listoffsets_codec.rs
+++ b/crates/mockforge-kafka/src/listoffsets_codec.rs
@@ -1,0 +1,199 @@
+//! ListOffsets v7 wire-format codec.
+//!
+//! ListOffsets is how consumers resolve `Offset::Beginning` / `Offset::End`
+//! and `auto.offset.reset` into a real starting offset. Without it,
+//! `rdkafka::StreamConsumer` and manual-assignment consumers using
+//! `Offset::Beginning` get `UnsupportedFeature (Required feature not
+//! supported by broker)` and refuse to start.
+//!
+//! v7 is the first flexible version (compact arrays + tag buffers). We only
+//! implement v7; auto-negotiating clients will pick it from the advertised
+//! range 0..=7.
+
+use crate::produce_codec::{
+    push_compact_string, push_empty_tag_buffer, push_unsigned_varint, read_compact_string,
+    read_i32, read_i64, read_i8, read_unsigned_varint, skip_tag_buffer,
+};
+
+/// One partition's timestamp lookup in a ListOffsets request.
+#[derive(Debug, Clone)]
+pub struct ListOffsetsPartitionRequest {
+    pub partition_index: i32,
+    /// Special values:
+    ///   -1 = latest (high_watermark)
+    ///   -2 = earliest (log_start_offset)
+    ///   other = lookup the first message at or after this timestamp
+    pub timestamp: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListOffsetsTopicRequest {
+    pub topic: String,
+    pub partitions: Vec<ListOffsetsPartitionRequest>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListOffsetsRequestV7 {
+    pub topics: Vec<ListOffsetsTopicRequest>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ListOffsetsPartitionResponse {
+    pub partition_index: i32,
+    pub error_code: i16,
+    /// Timestamp of the returned offset, or -1 if not applicable.
+    pub timestamp: i64,
+    pub offset: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListOffsetsTopicResponse {
+    pub topic: String,
+    pub partitions: Vec<ListOffsetsPartitionResponse>,
+}
+
+pub fn parse_listoffsets_v7(body: &[u8]) -> Result<ListOffsetsRequestV7, String> {
+    let mut cur = body;
+
+    let _replica_id = read_i32(&mut cur)?;
+    let _isolation_level = read_i8(&mut cur)?;
+
+    let topics_len_plus_one = read_unsigned_varint(&mut cur)?;
+    if topics_len_plus_one == 0 {
+        return Err("listoffsets topics array is null".into());
+    }
+    let topics_len = (topics_len_plus_one - 1) as usize;
+    let mut topics = Vec::with_capacity(topics_len);
+
+    for _ in 0..topics_len {
+        let name = read_compact_string(&mut cur)?;
+
+        let parts_len_plus_one = read_unsigned_varint(&mut cur)?;
+        if parts_len_plus_one == 0 {
+            return Err(format!("listoffsets partitions array for {name} is null"));
+        }
+        let parts_len = (parts_len_plus_one - 1) as usize;
+        let mut partitions = Vec::with_capacity(parts_len);
+        for _ in 0..parts_len {
+            let partition_index = read_i32(&mut cur)?;
+            let _current_leader_epoch = read_i32(&mut cur)?;
+            let timestamp = read_i64(&mut cur)?;
+            skip_tag_buffer(&mut cur)?;
+            partitions.push(ListOffsetsPartitionRequest {
+                partition_index,
+                timestamp,
+            });
+        }
+        skip_tag_buffer(&mut cur)?;
+        topics.push(ListOffsetsTopicRequest {
+            topic: name,
+            partitions,
+        });
+    }
+
+    skip_tag_buffer(&mut cur)?;
+
+    Ok(ListOffsetsRequestV7 { topics })
+}
+
+/// Serialize a full ListOffsets v7 response (flexible response header).
+pub fn serialize_listoffsets_v7_response(
+    correlation_id: i32,
+    topics: &[ListOffsetsTopicResponse],
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    // Response header v1 (flexible)
+    out.extend_from_slice(&correlation_id.to_be_bytes());
+    push_empty_tag_buffer(&mut out);
+
+    // throttle_time_ms
+    out.extend_from_slice(&0i32.to_be_bytes());
+    // topics compact array
+    push_unsigned_varint(&mut out, (topics.len() as u32) + 1);
+    for t in topics {
+        push_compact_string(&mut out, &t.topic);
+        push_unsigned_varint(&mut out, (t.partitions.len() as u32) + 1);
+        for p in &t.partitions {
+            out.extend_from_slice(&p.partition_index.to_be_bytes());
+            out.extend_from_slice(&p.error_code.to_be_bytes());
+            out.extend_from_slice(&p.timestamp.to_be_bytes());
+            out.extend_from_slice(&p.offset.to_be_bytes());
+            // leader_epoch (v4+) — we don't track leader epochs, return -1.
+            out.extend_from_slice(&(-1i32).to_be_bytes());
+            push_empty_tag_buffer(&mut out);
+        }
+        push_empty_tag_buffer(&mut out);
+    }
+    push_empty_tag_buffer(&mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_v7_single_topic() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // replica_id
+        body.push(0); // isolation_level = read_committed off
+        push_unsigned_varint(&mut body, 2); // topics len = 1
+        push_compact_string(&mut body, "t");
+        push_unsigned_varint(&mut body, 2); // partitions len = 1
+        body.extend_from_slice(&0i32.to_be_bytes()); // partition_index
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // current_leader_epoch
+        body.extend_from_slice(&(-2i64).to_be_bytes()); // timestamp = earliest
+        push_empty_tag_buffer(&mut body);
+        push_empty_tag_buffer(&mut body);
+        push_empty_tag_buffer(&mut body);
+
+        let parsed = parse_listoffsets_v7(&body).unwrap();
+        assert_eq!(parsed.topics.len(), 1);
+        assert_eq!(parsed.topics[0].topic, "t");
+        assert_eq!(parsed.topics[0].partitions[0].partition_index, 0);
+        assert_eq!(parsed.topics[0].partitions[0].timestamp, -2);
+    }
+
+    #[test]
+    fn response_v7_layout_is_sane() {
+        let resp = serialize_listoffsets_v7_response(
+            7,
+            &[ListOffsetsTopicResponse {
+                topic: "t".into(),
+                partitions: vec![ListOffsetsPartitionResponse {
+                    partition_index: 0,
+                    error_code: 0,
+                    timestamp: -1,
+                    offset: 42,
+                }],
+            }],
+        );
+        // correlation_id
+        assert_eq!(&resp[0..4], &7i32.to_be_bytes());
+        // header tag buffer
+        assert_eq!(resp[4], 0);
+        // throttle_time_ms
+        assert_eq!(&resp[5..9], &0i32.to_be_bytes());
+        // topics array length (1+1)
+        assert_eq!(resp[9], 2);
+        // topic name "t" (len 1, compact = 2)
+        assert_eq!(resp[10], 2);
+        assert_eq!(resp[11], b't');
+        // partitions array length (1+1)
+        assert_eq!(resp[12], 2);
+        // partition_index, error_code, timestamp, offset
+        assert_eq!(&resp[13..17], &0i32.to_be_bytes());
+        assert_eq!(&resp[17..19], &0i16.to_be_bytes());
+        assert_eq!(&resp[19..27], &(-1i64).to_be_bytes());
+        assert_eq!(&resp[27..35], &42i64.to_be_bytes());
+        // leader_epoch = -1
+        assert_eq!(&resp[35..39], &(-1i32).to_be_bytes());
+        // per-partition tag buffer
+        assert_eq!(resp[39], 0);
+        // per-topic tag buffer
+        assert_eq!(resp[40], 0);
+        // top-level tag buffer
+        assert_eq!(resp[41], 0);
+        assert_eq!(resp.len(), 42);
+    }
+}

--- a/crates/mockforge-kafka/src/protocol.rs
+++ b/crates/mockforge-kafka/src/protocol.rs
@@ -67,6 +67,16 @@ impl KafkaProtocolHandler {
                 max_version: 12,
             },
         ); // Fetch
+           // ListOffsets capped at v7 (first flexible version). Required so
+           // consumers can resolve `Offset::Beginning` / `Offset::End` and
+           // honor `auto.offset.reset`.
+        api_versions.insert(
+            2,
+            ApiVersion {
+                min_version: 0,
+                max_version: 7,
+            },
+        ); // ListOffsets
            // Metadata: we only implement v4 response encoding. Advertising max=4
            // forces auto-negotiating clients (librdkafka, kafka-python, etc.) to
            // pick a version we can actually serialize.
@@ -203,6 +213,7 @@ impl KafkaProtocolHandler {
         let request_type = match api_key {
             0 => KafkaRequestType::Produce,
             1 => KafkaRequestType::Fetch,
+            2 => KafkaRequestType::ListOffsets,
             3 => KafkaRequestType::Metadata,
             9 => KafkaRequestType::ListGroups,
             15 => KafkaRequestType::DescribeGroups,
@@ -394,6 +405,7 @@ pub enum KafkaRequestType {
     Metadata,
     Produce,
     Fetch,
+    ListOffsets,
     ListGroups,
     DescribeGroups,
     ApiVersions,
@@ -445,6 +457,7 @@ fn is_flexible_request(api_key: i16, api_version: i16) -> bool {
     let min_flex = match api_key {
         0 => 9,  // Produce
         1 => 12, // Fetch
+        2 => 6,  // ListOffsets
         3 => 9,  // Metadata
         9 => 3,  // ListGroups
         15 => 6, // DescribeGroups
@@ -643,6 +656,7 @@ mod tests {
             match t {
                 KafkaRequestType::Produce => "Produce",
                 KafkaRequestType::Fetch => "Fetch",
+                KafkaRequestType::ListOffsets => "ListOffsets",
                 KafkaRequestType::Metadata => "Metadata",
                 KafkaRequestType::ListGroups => "ListGroups",
                 KafkaRequestType::DescribeGroups => "DescribeGroups",
@@ -654,6 +668,7 @@ mod tests {
         }
         let cases = [
             (0i16, "Produce"),
+            (2, "ListOffsets"),
             (1, "Fetch"),
             (3, "Metadata"),
             (9, "ListGroups"),
@@ -1098,11 +1113,12 @@ mod tests {
         // Body: error_code int16 = 0
         assert_eq!(&data[4..6], &0i16.to_be_bytes());
 
-        // Compact array length (unsigned varint): handler registers 11 api
-        // entries, varint(11 + 1) = 0x0C in a single byte.
+        // Compact array length (unsigned varint): handler registers 12 api
+        // entries (bumped from 11 when ListOffsets (key 2) was added);
+        // varint(12 + 1) = 0x0D in a single byte.
         let n = handler.api_versions.len() as u32;
-        assert_eq!(n, 11);
-        assert_eq!(data[6], 0x0C);
+        assert_eq!(n, 12);
+        assert_eq!(data[6], 0x0D);
 
         // Each entry: api_key(i16) + min(i16) + max(i16) + tag_buffer(0x00) = 7 bytes.
         let entries_start = 7;

--- a/crates/mockforge-kafka/tests/fetch_e2e.rs
+++ b/crates/mockforge-kafka/tests/fetch_e2e.rs
@@ -86,11 +86,13 @@ async fn librdkafka_produce_then_fetch_round_trip() {
         consumer_cfg.set("fetch.wait.max.ms", "50");
         let consumer: BaseConsumer = consumer_cfg.create().expect("consumer");
 
-        // Explicit Offset::Offset(0) (rather than Offset::Beginning) avoids
-        // the ListOffsets API which this PR doesn't implement yet.
+        // `Offset::Beginning` drives librdkafka through the ListOffsets API
+        // (key 2, earliest timestamp = -2). Before ListOffsets was
+        // implemented this test hardcoded `Offset::Offset(0)` to bypass it;
+        // now we exercise the real consumer-oriented resolution path.
         let mut assignment = TopicPartitionList::new();
         assignment
-            .add_partition_offset("fetch-topic", 0, rdkafka::Offset::Offset(0))
+            .add_partition_offset("fetch-topic", 0, rdkafka::Offset::Beginning)
             .unwrap();
         consumer.assign(&assignment).expect("assign");
 


### PR DESCRIPTION
## Summary

**Closes #162.** First of the follow-up issues filed after the protocol verification sweep.

Before this PR, a real librdkafka consumer that tried to use `Offset::Beginning`, `Offset::End`, or `auto.offset.reset=earliest/latest` errored out immediately with `UnsupportedFeature (Required feature not supported by broker)` — because ListOffsets (API key 2) wasn't advertised in ApiVersions at all. The existing `fetch_e2e.rs` had to hardcode `Offset::Offset(0)` to work around this.

## Implementation

**New module `listoffsets_codec`**:
- `parse_listoffsets_v7`: flexible request body — `replica_id`, `isolation_level`, topics compact array (per-topic partitions compact array with `partition_index`, `current_leader_epoch`, `timestamp`).
- `serialize_listoffsets_v7_response`: flexible response — `throttle_time_ms`, topics compact array of per-partition slots carrying `{partition_index, error_code, timestamp, offset, leader_epoch, tags}`.
- Byte-for-byte unit tests for both directions.

**Broker wiring**:
- ApiVersions advertises key 2 with max=7 so auto-negotiating clients land on v7.
- `is_flexible_request` knows key 2 goes flexible at v6.
- `handle_list_offsets` resolves each `(topic, partition, timestamp)` against `self.topics`:
  - `timestamp = -2` (earliest) → `partition.log_start_offset`
  - `timestamp = -1` (latest)   → `partition.high_watermark`
  - positive timestamp → first message with `timestamp >= needle` (linear scan; falls back to high_watermark if no match)
- Unknown topic / partition returns `UNKNOWN_TOPIC_OR_PARTITION` (3).

**Regression coverage**: `tests/fetch_e2e.rs` updated to use `Offset::Beginning` instead of the workaround `Offset::Offset(0)`. This drives librdkafka through the real ListOffsets request path before the Fetch, proving the API is actually honored end-to-end.

## Test plan

- [x] `cargo test -p mockforge-kafka` → **263 passed** (242 lib + 2 new listoffsets_codec unit tests + 2 fixture-schema + 10 pre-existing integration + 1 produce e2e + 1 fetch e2e + 7 docs; +1 dispatch discriminant in the test table)
- [x] `cargo clippy -p mockforge-kafka --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean

## Next

Unblocks #163 (consumer-group coordination) — the next API keys (`FindCoordinator` 10, `JoinGroup` 11, `SyncGroup` 14, `Heartbeat` 12, `OffsetCommit` 8, `OffsetFetch` 9) build on the same flexible codec helpers in `produce_codec` and the same preserialized-response pattern used here.