### PR TITLE
feat(kafka): persist committed offsets + LeaveGroup so consumers can resume (#163)

### DIFF
--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -322,6 +322,7 @@ impl KafkaMockBroker {
             KafkaRequestType::JoinGroup => self.handle_join_group(message_buf, &request).await,
             KafkaRequestType::SyncGroup => self.handle_sync_group(message_buf, &request).await,
             KafkaRequestType::Heartbeat => self.handle_heartbeat(message_buf, &request).await,
+            KafkaRequestType::LeaveGroup => self.handle_leave_group(message_buf, &request).await,
             KafkaRequestType::OffsetCommit => {
                 self.handle_offset_commit(message_buf, &request).await
             }
@@ -822,7 +823,7 @@ impl KafkaMockBroker {
 
         let err = self
             .group_coordinator
-            .read()
+            .write()
             .await
             .heartbeat(&parsed.group_id, parsed.generation_id, &parsed.member_id)
             .err()
@@ -831,10 +832,56 @@ impl KafkaMockBroker {
         Ok(KafkaResponse::Preserialized(body))
     }
 
-    /// Handle OffsetCommit v7 (non-flexible) — minimum stub: accept every
-    /// partition with success. Real commit persistence is a follow-up PR;
-    /// this just unblocks librdkafka's consumer group flow which sends
-    /// periodic commits even when `enable.auto.commit=false`.
+    /// Handle LeaveGroup v0..=v3 (non-flexible). Removes each listed
+    /// member from the group; committed offsets are intentionally kept
+    /// so a new consumer joining the same group resumes from them.
+    ///
+    /// librdkafka 2.x picks v1 (single-member) against us even though
+    /// we advertise max=3 — so we accept any supported version and let
+    /// the codec pick the right wire shape.
+    async fn handle_leave_group(
+        &self,
+        message_buf: &[u8],
+        request: &KafkaRequest,
+    ) -> Result<KafkaResponse> {
+        use crate::group_codec::{parse_leave_group, serialize_leave_group_response};
+        if !(0..=3).contains(&request.api_version) {
+            let body = serialize_leave_group_response(3, request.correlation_id, &[]);
+            tracing::warn!(
+                "rejecting LeaveGroup v{} (only v0..=v3 supported)",
+                request.api_version
+            );
+            return Ok(KafkaResponse::Preserialized(body));
+        }
+        let body_slice = message_buf.get(request.body_offset..).ok_or_else(|| {
+            mockforge_core::Error::internal("leave_group body_offset past buffer end")
+        })?;
+        let parsed = parse_leave_group(request.api_version, body_slice).map_err(|e| {
+            mockforge_core::Error::internal(format!(
+                "LeaveGroup v{} parse: {e}",
+                request.api_version
+            ))
+        })?;
+
+        {
+            let mut coord = self.group_coordinator.write().await;
+            for m in &parsed.members {
+                coord.leave_group(&parsed.group_id, &m.member_id);
+            }
+        }
+
+        let body = serialize_leave_group_response(
+            request.api_version,
+            request.correlation_id,
+            &parsed.members,
+        );
+        Ok(KafkaResponse::Preserialized(body))
+    }
+
+    /// Handle OffsetCommit v7 (non-flexible). Persists each committed
+    /// offset (and its opaque metadata blob) in the group coordinator so
+    /// a subsequent OffsetFetch — possibly from a different consumer in
+    /// the same group — resumes from the committed position.
     async fn handle_offset_commit(
         &self,
         message_buf: &[u8],
@@ -851,28 +898,41 @@ impl KafkaMockBroker {
         })?;
         let parsed = parse_offset_commit_v7(body_slice)
             .map_err(|e| mockforge_core::Error::internal(format!("OffsetCommit v7 parse: {e}")))?;
+
+        {
+            let mut coord = self.group_coordinator.write().await;
+            for topic in &parsed.topics {
+                for p in &topic.partitions {
+                    coord.commit_offset(
+                        &parsed.group_id,
+                        &topic.name,
+                        p.partition_index,
+                        p.committed_offset,
+                        p.committed_metadata.clone(),
+                    );
+                }
+            }
+        }
+
         let body = serialize_offset_commit_v7_response(request.correlation_id, &parsed.topics);
         Ok(KafkaResponse::Preserialized(body))
     }
 
-    /// Handle OffsetFetch v5 (non-flexible) — minimum stub: every
-    /// requested partition returns `offset = -1` (no committed offset),
-    /// which causes librdkafka to fall back to `auto.offset.reset`.
-    /// Persistence comes in the follow-up PR.
+    /// Handle OffsetFetch v5 (non-flexible). Looks up each requested
+    /// partition in the coordinator; partitions without a prior commit
+    /// return `offset = -1` so librdkafka falls back to
+    /// `auto.offset.reset`.
     async fn handle_offset_fetch(
         &self,
         message_buf: &[u8],
         request: &KafkaRequest,
     ) -> Result<KafkaResponse> {
         use crate::group_codec::{
-            parse_offset_fetch_v5, serialize_offset_fetch_v5_response, OffsetFetchRequestV5,
+            parse_offset_fetch_v5, serialize_offset_fetch_v5_response,
+            OffsetFetchPartitionResponse, OffsetFetchTopicResponse,
         };
         if request.api_version != 5 {
-            let empty = OffsetFetchRequestV5 {
-                group_id: String::new(),
-                topics: Vec::new(),
-            };
-            let body = serialize_offset_fetch_v5_response(request.correlation_id, &empty);
+            let body = serialize_offset_fetch_v5_response(request.correlation_id, &[]);
             tracing::warn!("rejecting OffsetFetch v{} (only v5 supported)", request.api_version);
             return Ok(KafkaResponse::Preserialized(body));
         }
@@ -881,7 +941,36 @@ impl KafkaMockBroker {
         })?;
         let parsed = parse_offset_fetch_v5(body_slice)
             .map_err(|e| mockforge_core::Error::internal(format!("OffsetFetch v5 parse: {e}")))?;
-        let body = serialize_offset_fetch_v5_response(request.correlation_id, &parsed);
+
+        let coord = self.group_coordinator.read().await;
+        let topic_responses: Vec<OffsetFetchTopicResponse> = parsed
+            .topics
+            .iter()
+            .map(|t| {
+                let partitions = t
+                    .partition_indexes
+                    .iter()
+                    .map(|&idx| match coord.fetch_offset(&parsed.group_id, &t.name, idx) {
+                        Some(committed) => OffsetFetchPartitionResponse {
+                            partition_index: idx,
+                            committed_offset: committed.offset,
+                            committed_metadata: committed.metadata,
+                        },
+                        None => OffsetFetchPartitionResponse {
+                            partition_index: idx,
+                            committed_offset: -1,
+                            committed_metadata: None,
+                        },
+                    })
+                    .collect();
+                OffsetFetchTopicResponse {
+                    name: t.name.clone(),
+                    partitions,
+                }
+            })
+            .collect();
+
+        let body = serialize_offset_fetch_v5_response(request.correlation_id, &topic_responses);
         Ok(KafkaResponse::Preserialized(body))
     }
 

--- a/crates/mockforge-kafka/src/group_codec.rs
+++ b/crates/mockforge-kafka/src/group_codec.rs
@@ -270,12 +270,87 @@ pub fn serialize_heartbeat_v3_response(correlation_id: i32, error_code: i16) -> 
 }
 
 // =========================================================================
-// OffsetCommit v7 (minimum stub — accept everything; no persistence yet)
+// LeaveGroup v0-v3 (non-flexible). Versions differ in:
+//   request : v0-v2 are single-member (group_id + member_id)
+//             v3+   are batch (group_id + [members])
+//   response: v0-v1: error_code
+//             v2+  : throttle_time_ms + error_code
+//             v3+  : adds per-member errors array
+// librdkafka 2.x picks v1 for our broker despite our ApiVersions saying
+// max=3; we accept any of v0..=v3 and respond appropriately.
+// =========================================================================
+
+/// Request fields we care about, after merging v0-v3 variants. Every
+/// version carries enough info to identify which member(s) to evict.
+#[derive(Debug, Clone)]
+pub struct LeaveGroupMember {
+    pub member_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct LeaveGroupRequest {
+    pub group_id: String,
+    pub members: Vec<LeaveGroupMember>,
+}
+
+/// Parse any non-flexible LeaveGroup request (v0..=v3).
+pub fn parse_leave_group(api_version: i16, body: &[u8]) -> Result<LeaveGroupRequest, String> {
+    let mut cur = body;
+    let group_id = read_string(&mut cur)?;
+    let members = if api_version >= 3 {
+        let count = read_i32(&mut cur)?;
+        if count < 0 {
+            return Err("leave_group members count is negative".into());
+        }
+        let mut out = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            let member_id = read_string(&mut cur)?;
+            let _group_instance_id = read_nullable_string(&mut cur)?;
+            out.push(LeaveGroupMember { member_id });
+        }
+        out
+    } else {
+        // v0-v2: single-member, no group_instance_id.
+        let member_id = read_string(&mut cur)?;
+        vec![LeaveGroupMember { member_id }]
+    };
+    Ok(LeaveGroupRequest { group_id, members })
+}
+
+/// Serialize a LeaveGroup response matching the request version.
+pub fn serialize_leave_group_response(
+    api_version: i16,
+    correlation_id: i32,
+    members: &[LeaveGroupMember],
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&correlation_id.to_be_bytes());
+    if api_version >= 2 {
+        out.extend_from_slice(&0i32.to_be_bytes()); // throttle_time_ms
+    }
+    out.extend_from_slice(&0i16.to_be_bytes()); // top-level error_code
+    if api_version >= 3 {
+        out.extend_from_slice(&(members.len() as i32).to_be_bytes());
+        for m in members {
+            push_string(&mut out, &m.member_id);
+            push_nullable_string(&mut out, None); // group_instance_id
+            out.extend_from_slice(&0i16.to_be_bytes()); // per-member error_code
+        }
+    }
+    out
+}
+
+// =========================================================================
+// OffsetCommit v7 — parsed fields include the actual committed offset so
+// the coordinator can persist it, and the metadata blob the client wants
+// to round-trip on the next OffsetFetch.
 // =========================================================================
 
 #[derive(Debug, Clone)]
 pub struct OffsetCommitPartition {
     pub partition_index: i32,
+    pub committed_offset: i64,
+    pub committed_metadata: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -286,12 +361,13 @@ pub struct OffsetCommitTopic {
 
 #[derive(Debug, Clone)]
 pub struct OffsetCommitRequestV7 {
+    pub group_id: String,
     pub topics: Vec<OffsetCommitTopic>,
 }
 
 pub fn parse_offset_commit_v7(body: &[u8]) -> Result<OffsetCommitRequestV7, String> {
     let mut cur = body;
-    let _group_id = read_string(&mut cur)?;
+    let group_id = read_string(&mut cur)?;
     let _generation_id = read_i32(&mut cur)?;
     let _member_id = read_string(&mut cur)?;
     let _group_instance_id = read_nullable_string(&mut cur)?;
@@ -309,14 +385,18 @@ pub fn parse_offset_commit_v7(body: &[u8]) -> Result<OffsetCommitRequestV7, Stri
         let mut partitions = Vec::with_capacity(parts_count as usize);
         for _ in 0..parts_count {
             let partition_index = read_i32(&mut cur)?;
-            let _committed_offset = read_i64(&mut cur)?;
+            let committed_offset = read_i64(&mut cur)?;
             let _committed_leader_epoch = read_i32(&mut cur)?;
-            let _committed_metadata = read_nullable_string(&mut cur)?;
-            partitions.push(OffsetCommitPartition { partition_index });
+            let committed_metadata = read_nullable_string(&mut cur)?;
+            partitions.push(OffsetCommitPartition {
+                partition_index,
+                committed_offset,
+                committed_metadata,
+            });
         }
         topics.push(OffsetCommitTopic { name, partitions });
     }
-    Ok(OffsetCommitRequestV7 { topics })
+    Ok(OffsetCommitRequestV7 { group_id, topics })
 }
 
 pub fn serialize_offset_commit_v7_response(
@@ -377,22 +457,38 @@ pub fn parse_offset_fetch_v5(body: &[u8]) -> Result<OffsetFetchRequestV5, String
     Ok(OffsetFetchRequestV5 { group_id, topics })
 }
 
+/// One partition's committed-offset lookup result for the OffsetFetch
+/// response. `offset == -1` means "no committed offset" (librdkafka
+/// then falls back to `auto.offset.reset`).
+#[derive(Debug, Clone)]
+pub struct OffsetFetchPartitionResponse {
+    pub partition_index: i32,
+    pub committed_offset: i64,
+    pub committed_metadata: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OffsetFetchTopicResponse {
+    pub name: String,
+    pub partitions: Vec<OffsetFetchPartitionResponse>,
+}
+
 pub fn serialize_offset_fetch_v5_response(
     correlation_id: i32,
-    req: &OffsetFetchRequestV5,
+    topics: &[OffsetFetchTopicResponse],
 ) -> Vec<u8> {
     let mut out = Vec::new();
     out.extend_from_slice(&correlation_id.to_be_bytes());
     out.extend_from_slice(&0i32.to_be_bytes()); // throttle_time_ms
-    out.extend_from_slice(&(req.topics.len() as i32).to_be_bytes());
-    for t in &req.topics {
+    out.extend_from_slice(&(topics.len() as i32).to_be_bytes());
+    for t in topics {
         push_string(&mut out, &t.name);
-        out.extend_from_slice(&(t.partition_indexes.len() as i32).to_be_bytes());
-        for &idx in &t.partition_indexes {
-            out.extend_from_slice(&idx.to_be_bytes());
-            out.extend_from_slice(&(-1i64).to_be_bytes()); // committed_offset = none
+        out.extend_from_slice(&(t.partitions.len() as i32).to_be_bytes());
+        for p in &t.partitions {
+            out.extend_from_slice(&p.partition_index.to_be_bytes());
+            out.extend_from_slice(&p.committed_offset.to_be_bytes());
             out.extend_from_slice(&(-1i32).to_be_bytes()); // committed_leader_epoch (v5+)
-            push_nullable_string(&mut out, None); // metadata
+            push_nullable_string(&mut out, p.committed_metadata.as_deref());
             out.extend_from_slice(&0i16.to_be_bytes()); // error_code
         }
     }
@@ -448,14 +544,15 @@ mod tests {
 
     #[test]
     fn offset_fetch_v5_response_says_no_committed() {
-        let req = OffsetFetchRequestV5 {
-            group_id: "g".into(),
-            topics: vec![OffsetFetchTopic {
-                name: "t".into(),
-                partition_indexes: vec![0],
+        let topics = vec![OffsetFetchTopicResponse {
+            name: "t".into(),
+            partitions: vec![OffsetFetchPartitionResponse {
+                partition_index: 0,
+                committed_offset: -1,
+                committed_metadata: None,
             }],
-        };
-        let resp = serialize_offset_fetch_v5_response(5, &req);
+        }];
+        let resp = serialize_offset_fetch_v5_response(5, &topics);
         // Layout: corr_id (4) + throttle_time_ms (4) + topics_len (4) + …
         assert_eq!(&resp[0..4], &5i32.to_be_bytes()); // correlation_id
         assert_eq!(&resp[4..8], &0i32.to_be_bytes()); // throttle_time_ms
@@ -470,5 +567,46 @@ mod tests {
         assert_eq!(&resp[23..31], &(-1i64).to_be_bytes());
         // committed_leader_epoch = -1 (v5+)
         assert_eq!(&resp[31..35], &(-1i32).to_be_bytes());
+    }
+
+    #[test]
+    fn offset_fetch_v5_response_carries_real_offset() {
+        let topics = vec![OffsetFetchTopicResponse {
+            name: "t".into(),
+            partitions: vec![OffsetFetchPartitionResponse {
+                partition_index: 2,
+                committed_offset: 42,
+                committed_metadata: Some("m".into()),
+            }],
+        }];
+        let resp = serialize_offset_fetch_v5_response(9, &topics);
+        // partition_index at byte 19, committed_offset at 23..31.
+        assert_eq!(&resp[0..4], &9i32.to_be_bytes());
+        assert_eq!(&resp[19..23], &2i32.to_be_bytes());
+        assert_eq!(&resp[23..31], &42i64.to_be_bytes());
+    }
+
+    #[test]
+    fn offset_commit_v7_parser_keeps_offset_and_metadata() {
+        let mut body = Vec::new();
+        push_string(&mut body, "g");
+        body.extend_from_slice(&7i32.to_be_bytes()); // generation_id
+        push_string(&mut body, "m"); // member_id
+        push_nullable_string(&mut body, None); // group_instance_id
+        body.extend_from_slice(&1i32.to_be_bytes()); // topics_count = 1
+        push_string(&mut body, "t");
+        body.extend_from_slice(&1i32.to_be_bytes()); // parts_count = 1
+        body.extend_from_slice(&3i32.to_be_bytes()); // partition_index
+        body.extend_from_slice(&42i64.to_be_bytes()); // committed_offset
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // leader_epoch
+        push_nullable_string(&mut body, Some("meta"));
+
+        let parsed = parse_offset_commit_v7(&body).unwrap();
+        assert_eq!(parsed.group_id, "g");
+        assert_eq!(parsed.topics.len(), 1);
+        let p = &parsed.topics[0].partitions[0];
+        assert_eq!(p.partition_index, 3);
+        assert_eq!(p.committed_offset, 42);
+        assert_eq!(p.committed_metadata.as_deref(), Some("meta"));
     }
 }

--- a/crates/mockforge-kafka/src/group_coordinator.rs
+++ b/crates/mockforge-kafka/src/group_coordinator.rs
@@ -8,15 +8,25 @@
 //! - SyncGroup records the leader-provided assignment and hands each
 //!   member back its slice.
 //! - Heartbeat just validates generation + member identity.
-//! - Offsets storage is provided here too so a follow-up PR can wire
-//!   OffsetCommit / OffsetFetch without another refactor.
+//! - Offset persistence: OffsetCommit stores per-(group, topic, partition)
+//!   offsets (+ metadata); OffsetFetch reads them back. A new consumer
+//!   joining a group with previously committed offsets resumes from the
+//!   committed position instead of `auto.offset.reset`.
 //!
 //! **Out of scope (tracked separately):** multi-member rebalance with
 //! generation bumps, instance IDs for static membership, coordinator
 //! failover, transactional producer-group coordination.
 
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 use uuid::Uuid;
+
+/// How long a member can go without heartbeating before a subsequent
+/// JoinGroup will evict them. librdkafka's default `session.timeout.ms`
+/// is 45s; we set this shorter because the mock only needs to survive
+/// ungraceful disconnects during tests, and a tighter window makes
+/// consumer-restart tests complete quickly.
+const STALE_MEMBER_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Per-member state inside a consumer group.
 #[derive(Debug, Clone)]
@@ -27,6 +37,10 @@ pub struct MemberInfo {
     pub metadata: Vec<u8>,
     /// Assignment blob filled in by SyncGroup once the leader has decided.
     pub assignment: Vec<u8>,
+    /// Last time we saw activity from this member (join, sync, heartbeat).
+    /// Used to evict members that disconnected without a LeaveGroup so a
+    /// new consumer with the same `group.id` can claim the partitions.
+    pub last_seen: Instant,
 }
 
 /// One consumer group's state.
@@ -52,12 +66,24 @@ pub struct JoinOutcome {
     pub members: Vec<MemberInfo>,
 }
 
+/// A committed offset plus the opaque metadata blob the client wrote
+/// alongside it. librdkafka uses metadata to round-trip caller state
+/// (often empty, sometimes a JSON blob); we just store what we're given.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommittedOffset {
+    pub offset: i64,
+    pub metadata: Option<String>,
+}
+
 /// In-memory coordinator shared across all broker connections for a
 /// particular process. Held behind `Arc<tokio::sync::RwLock<_>>` in the
 /// broker.
 #[derive(Debug, Default)]
 pub struct GroupCoordinator {
     groups: HashMap<String, GroupMembership>,
+    /// Committed offsets, keyed by `(group_id, topic, partition_index)`.
+    /// Survives member disconnects — that's the point of persistence.
+    offsets: HashMap<(String, String, i32), CommittedOffset>,
 }
 
 impl GroupCoordinator {
@@ -98,6 +124,18 @@ impl GroupCoordinator {
             members: HashMap::new(),
         });
 
+        // Evict members that haven't heartbeated recently. Without this,
+        // a previous consumer that exited ungracefully holds the leader
+        // slot forever, and the next consumer joins as a non-leader with
+        // no assignment — so it never fetches and never commits.
+        let now = Instant::now();
+        entry
+            .members
+            .retain(|_, m| now.duration_since(m.last_seen) < STALE_MEMBER_TIMEOUT);
+        if !entry.leader_id.is_empty() && !entry.members.contains_key(&entry.leader_id) {
+            entry.leader_id.clear();
+        }
+
         let member_id = if requested_member_id.is_empty() {
             // New member — generate an id, bump generation, (re)elect
             // leader if we don't have one.
@@ -109,6 +147,7 @@ impl GroupCoordinator {
                     member_id: new_id.clone(),
                     metadata: metadata.clone(),
                     assignment: Vec::new(),
+                    last_seen: now,
                 },
             );
             if entry.leader_id.is_empty() || !entry.members.contains_key(&entry.leader_id) {
@@ -122,11 +161,15 @@ impl GroupCoordinator {
             entry
                 .members
                 .entry(requested_member_id.to_string())
-                .and_modify(|m| m.metadata = metadata.clone())
+                .and_modify(|m| {
+                    m.metadata = metadata.clone();
+                    m.last_seen = now;
+                })
                 .or_insert_with(|| MemberInfo {
                     member_id: requested_member_id.to_string(),
                     metadata,
                     assignment: Vec::new(),
+                    last_seen: now,
                 });
             requested_member_id.to_string()
         };
@@ -149,19 +192,69 @@ impl GroupCoordinator {
         member_id: &str,
         assignments: Vec<(String, Vec<u8>)>,
     ) -> Option<Vec<u8>> {
+        let now = Instant::now();
         let group = self.groups.get_mut(group_id)?;
         for (target_member, assignment) in assignments {
             if let Some(m) = group.members.get_mut(&target_member) {
                 m.assignment = assignment;
             }
         }
+        if let Some(m) = group.members.get_mut(member_id) {
+            m.last_seen = now;
+        }
         group.members.get(member_id).map(|m| m.assignment.clone())
+    }
+
+    /// Remove a member from the group (LeaveGroup). If the member was
+    /// the leader, clears the leader slot so the next JoinGroup elects
+    /// a fresh leader. Committed offsets are kept — LeaveGroup doesn't
+    /// delete the group's committed state, that's `DeleteGroups`.
+    pub fn leave_group(&mut self, group_id: &str, member_id: &str) {
+        let Some(group) = self.groups.get_mut(group_id) else {
+            return;
+        };
+        group.members.remove(member_id);
+        if group.leader_id == member_id {
+            group.leader_id.clear();
+        }
+    }
+
+    /// Persist a committed offset for `(group_id, topic, partition)`.
+    /// Overwrites any previous commit — Kafka's protocol guarantees only
+    /// that the *latest* commit wins.
+    pub fn commit_offset(
+        &mut self,
+        group_id: &str,
+        topic: &str,
+        partition: i32,
+        offset: i64,
+        metadata: Option<String>,
+    ) {
+        self.offsets.insert(
+            (group_id.to_string(), topic.to_string(), partition),
+            CommittedOffset { offset, metadata },
+        );
+    }
+
+    /// Look up a previously committed offset. Returns `None` when the
+    /// group has never committed for that partition — the OffsetFetch
+    /// response serializer translates that into `offset = -1`, which
+    /// triggers `auto.offset.reset` on the client.
+    pub fn fetch_offset(
+        &self,
+        group_id: &str,
+        topic: &str,
+        partition: i32,
+    ) -> Option<CommittedOffset> {
+        self.offsets.get(&(group_id.to_string(), topic.to_string(), partition)).cloned()
     }
 
     /// Validate a heartbeat. Returns `Ok(())` on success, `Err(error_code)`
     /// on failure (e.g. UNKNOWN_MEMBER_ID 25 / ILLEGAL_GENERATION 22).
+    /// Also refreshes the member's `last_seen` on success so regularly
+    /// heartbeating members don't get evicted as stale.
     pub fn heartbeat(
-        &self,
+        &mut self,
         group_id: &str,
         generation_id: i32,
         member_id: &str,
@@ -169,13 +262,12 @@ impl GroupCoordinator {
         const ERR_ILLEGAL_GENERATION: i16 = 22;
         const ERR_UNKNOWN_MEMBER_ID: i16 = 25;
         const ERR_GROUP_ID_NOT_FOUND: i16 = 69;
-        let group = self.groups.get(group_id).ok_or(ERR_GROUP_ID_NOT_FOUND)?;
-        if !group.members.contains_key(member_id) {
-            return Err(ERR_UNKNOWN_MEMBER_ID);
-        }
+        let group = self.groups.get_mut(group_id).ok_or(ERR_GROUP_ID_NOT_FOUND)?;
         if group.generation_id != generation_id {
             return Err(ERR_ILLEGAL_GENERATION);
         }
+        let member = group.members.get_mut(member_id).ok_or(ERR_UNKNOWN_MEMBER_ID)?;
+        member.last_seen = Instant::now();
         Ok(())
     }
 }
@@ -221,5 +313,71 @@ mod tests {
         assert_eq!(coord.heartbeat("g", out.generation_id + 99, &out.member_id), Err(22));
         assert_eq!(coord.heartbeat("g", out.generation_id, "who?"), Err(25));
         assert_eq!(coord.heartbeat("no-such-group", 0, &out.member_id), Err(69));
+    }
+
+    #[test]
+    fn new_join_evicts_stale_leader_and_promotes_fresh_member() {
+        let mut coord = GroupCoordinator::new();
+        let first = coord.join_group("g", "", &[("range".into(), b"m".to_vec())]);
+        assert_eq!(first.leader_id, first.member_id);
+
+        // Backdate the first member's last_seen so the pruning kicks in.
+        let stale = Instant::now() - STALE_MEMBER_TIMEOUT - Duration::from_secs(1);
+        coord
+            .groups
+            .get_mut("g")
+            .unwrap()
+            .members
+            .get_mut(&first.member_id)
+            .unwrap()
+            .last_seen = stale;
+
+        let second = coord.join_group("g", "", &[("range".into(), b"m".to_vec())]);
+        assert_ne!(second.member_id, first.member_id);
+        assert_eq!(
+            second.leader_id, second.member_id,
+            "stale leader evicted, new member is leader"
+        );
+        // Only the fresh member remains in the group.
+        let group = coord.groups.get("g").unwrap();
+        assert_eq!(group.members.len(), 1);
+        assert!(group.members.contains_key(&second.member_id));
+    }
+
+    #[test]
+    fn commit_then_fetch_round_trips() {
+        let mut coord = GroupCoordinator::new();
+        coord.commit_offset("g", "t", 0, 42, Some("meta".into()));
+        let fetched = coord.fetch_offset("g", "t", 0).expect("committed offset");
+        assert_eq!(fetched.offset, 42);
+        assert_eq!(fetched.metadata.as_deref(), Some("meta"));
+    }
+
+    #[test]
+    fn fetch_returns_none_without_prior_commit() {
+        let coord = GroupCoordinator::new();
+        assert!(coord.fetch_offset("g", "t", 0).is_none());
+    }
+
+    #[test]
+    fn later_commit_overwrites_earlier_commit() {
+        let mut coord = GroupCoordinator::new();
+        coord.commit_offset("g", "t", 0, 10, None);
+        coord.commit_offset("g", "t", 0, 25, Some("fresh".into()));
+        let fetched = coord.fetch_offset("g", "t", 0).unwrap();
+        assert_eq!(fetched.offset, 25);
+        assert_eq!(fetched.metadata.as_deref(), Some("fresh"));
+    }
+
+    #[test]
+    fn offsets_are_scoped_per_group_topic_partition() {
+        let mut coord = GroupCoordinator::new();
+        coord.commit_offset("g1", "t", 0, 1, None);
+        coord.commit_offset("g2", "t", 0, 2, None);
+        coord.commit_offset("g1", "t", 1, 3, None);
+        assert_eq!(coord.fetch_offset("g1", "t", 0).unwrap().offset, 1);
+        assert_eq!(coord.fetch_offset("g2", "t", 0).unwrap().offset, 2);
+        assert_eq!(coord.fetch_offset("g1", "t", 1).unwrap().offset, 3);
+        assert!(coord.fetch_offset("g1", "other", 0).is_none());
     }
 }

--- a/crates/mockforge-kafka/src/partitions.rs
+++ b/crates/mockforge-kafka/src/partitions.rs
@@ -29,9 +29,13 @@ impl Partition {
         }
     }
 
-    /// Append a message to the partition
-    pub fn append(&mut self, message: KafkaMessage) -> i64 {
+    /// Append a message to the partition. The message's `offset` field
+    /// is overwritten with the assigned offset before it's stored, so
+    /// downstream Fetch path can compare `msg.offset` against
+    /// `fetch_offset` correctly.
+    pub fn append(&mut self, mut message: KafkaMessage) -> i64 {
         let offset = self.high_watermark;
+        message.offset = offset;
         self.messages.push_back(message);
         self.high_watermark += 1;
         offset
@@ -97,6 +101,19 @@ mod tests {
         assert_eq!(offset, 0);
         assert_eq!(partition.high_watermark, 1);
         assert_eq!(partition.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_append_stamps_assigned_offset_onto_message() {
+        let mut partition = Partition::new(0);
+        // Incoming message has offset=0, but this is the 3rd append so
+        // the assigned offset should be 2 — append must overwrite.
+        partition.append(create_test_message(0, b"m1"));
+        partition.append(create_test_message(0, b"m2"));
+        partition.append(create_test_message(0, b"m3"));
+
+        let offsets: Vec<i64> = partition.messages.iter().map(|m| m.offset).collect();
+        assert_eq!(offsets, vec![0, 1, 2]);
     }
 
     #[test]

--- a/crates/mockforge-kafka/src/protocol.rs
+++ b/crates/mockforge-kafka/src/protocol.rs
@@ -134,6 +134,13 @@ impl KafkaProtocolHandler {
             },
         ); // Heartbeat (v3 = last non-flexible)
         api_versions.insert(
+            13,
+            ApiVersion {
+                min_version: 0,
+                max_version: 3,
+            },
+        ); // LeaveGroup (v3 = last non-flexible; librdkafka 2.x sends v3 on close)
+        api_versions.insert(
             14,
             ApiVersion {
                 min_version: 0,
@@ -272,6 +279,7 @@ impl KafkaProtocolHandler {
             10 => KafkaRequestType::FindCoordinator,
             11 => KafkaRequestType::JoinGroup,
             12 => KafkaRequestType::Heartbeat,
+            13 => KafkaRequestType::LeaveGroup,
             14 => KafkaRequestType::SyncGroup,
             15 => KafkaRequestType::DescribeGroups,
             18 => KafkaRequestType::ApiVersions,
@@ -469,6 +477,7 @@ pub enum KafkaRequestType {
     JoinGroup,
     SyncGroup,
     Heartbeat,
+    LeaveGroup,
     ListGroups,
     DescribeGroups,
     ApiVersions,
@@ -531,6 +540,7 @@ fn is_flexible_request(api_key: i16, api_version: i16) -> bool {
         10 => 3, // FindCoordinator (flex at 3; we cap at 2)
         11 => 6, // JoinGroup    (flex at 6; we cap at 5)
         12 => 4, // Heartbeat    (flex at 4; we cap at 3)
+        13 => 4, // LeaveGroup   (flex at 4; we cap at 3)
         14 => 4, // SyncGroup    (flex at 4; we cap at 3)
         15 => 6, // DescribeGroups
         16 => 3, // ListGroups
@@ -736,6 +746,7 @@ mod tests {
                 KafkaRequestType::JoinGroup => "JoinGroup",
                 KafkaRequestType::SyncGroup => "SyncGroup",
                 KafkaRequestType::Heartbeat => "Heartbeat",
+                KafkaRequestType::LeaveGroup => "LeaveGroup",
                 KafkaRequestType::ListGroups => "ListGroups",
                 KafkaRequestType::DescribeGroups => "DescribeGroups",
                 KafkaRequestType::ApiVersions => "ApiVersions",
@@ -752,6 +763,7 @@ mod tests {
             (10, "FindCoordinator"),
             (11, "JoinGroup"),
             (12, "Heartbeat"),
+            (13, "LeaveGroup"),
             (14, "SyncGroup"),
             (8, "OffsetCommit"),
             (9, "OffsetFetch"),
@@ -1122,6 +1134,7 @@ mod tests {
             (10, 0, 2), // FindCoordinator (v2 = last non-flexible)
             (11, 0, 5), // JoinGroup (v5 = last non-flexible)
             (12, 0, 3), // Heartbeat (v3 = last non-flexible)
+            (13, 0, 3), // LeaveGroup (v3 = last non-flexible)
             (14, 0, 3), // SyncGroup (v3 = last non-flexible)
             (15, 0, 9), // DescribeGroups
             (16, 0, 5), // ListGroups (api_key 16 per Kafka spec)
@@ -1207,11 +1220,12 @@ mod tests {
         // entries (bumped from 11 when ListOffsets (key 2) was added);
         // varint(12 + 1) = 0x0D in a single byte.
         let n = handler.api_versions.len() as u32;
-        // 17 registered API keys after adding OffsetCommit (8) and
-        // OffsetFetch (9) and the corrected ListGroups slot at key 16.
-        // varint(17 + 1) = 0x12.
-        assert_eq!(n, 17);
-        assert_eq!(data[6], 0x12);
+        // 18 registered API keys after adding LeaveGroup (13) so
+        // librdkafka can send LeaveGroup on close and the coordinator
+        // evicts the member cleanly.
+        // varint(18 + 1) = 0x13.
+        assert_eq!(n, 18);
+        assert_eq!(data[6], 0x13);
 
         // Each entry: api_key(i16) + min(i16) + max(i16) + tag_buffer(0x00) = 7 bytes.
         let entries_start = 7;

--- a/crates/mockforge-kafka/tests/consumer_group_offsets.rs
+++ b/crates/mockforge-kafka/tests/consumer_group_offsets.rs
@@ -1,0 +1,143 @@
+//! End-to-end regression for OffsetCommit/OffsetFetch persistence.
+//!
+//! Before this PR the broker accepted OffsetCommit but threw the data
+//! away, and OffsetFetch hardcoded "no committed offset" for every
+//! partition. A new consumer joining a group with previously committed
+//! offsets would always restart from `auto.offset.reset` — meaning the
+//! mock couldn't model any real consumer's resume-from-committed flow.
+//!
+//! This test produces four records, has one consumer commit through
+//! offset 2, then spins up a fresh consumer in the same group and
+//! asserts it only sees records 3 onward. That exercises the full
+//! OffsetCommit v7 → coordinator → OffsetFetch v5 round trip.
+
+use mockforge_core::config::KafkaConfig;
+use mockforge_kafka::{KafkaMockBroker, Topic, TopicConfig};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::{Message, Offset, TopicPartitionList};
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn bind_free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+fn consumer_cfg(port: u16, group_id: &str) -> ClientConfig {
+    let mut cfg = ClientConfig::new();
+    cfg.set("bootstrap.servers", format!("127.0.0.1:{port}"));
+    cfg.set("group.id", group_id);
+    cfg.set("auto.offset.reset", "earliest");
+    cfg.set("enable.auto.commit", "false");
+    cfg.set("session.timeout.ms", "6000");
+    cfg.set("heartbeat.interval.ms", "1000");
+    cfg
+}
+
+async fn close_consumer(consumer: StreamConsumer) {
+    // StreamConsumer::drop is synchronous and routinely takes a couple
+    // of seconds for librdkafka to wind down its worker threads +
+    // round-trip LeaveGroup. Drop it on a blocking task with a bounded
+    // outer timeout so the test teardown can't hang.
+    let task = tokio::task::spawn_blocking(move || drop(consumer));
+    let _ = tokio::time::timeout(Duration::from_secs(10), task).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn committed_offsets_survive_consumer_restart() {
+    let port = bind_free_port().await;
+    let config = KafkaConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..KafkaConfig::default()
+    };
+    let broker = Arc::new(KafkaMockBroker::new(config.clone()).await.expect("broker"));
+
+    {
+        let mut topics = broker.topics.write().await;
+        topics.insert(
+            "offsets-topic".to_string(),
+            Topic::new(
+                "offsets-topic".to_string(),
+                TopicConfig {
+                    num_partitions: 1,
+                    replication_factor: 1,
+                    ..Default::default()
+                },
+            ),
+        );
+    }
+
+    let server = Arc::clone(&broker);
+    let server_handle = tokio::spawn(async move { server.start().await });
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    // Produce four records up-front. Offsets will be 0..=3.
+    let mut producer_cfg = ClientConfig::new();
+    producer_cfg.set("bootstrap.servers", format!("127.0.0.1:{port}"));
+    producer_cfg.set("message.timeout.ms", "5000");
+    producer_cfg.set("linger.ms", "0");
+    producer_cfg.set("acks", "1");
+    producer_cfg.set("enable.idempotence", "false");
+    let producer: FutureProducer = producer_cfg.create().expect("producer");
+    for i in 0..4u32 {
+        let payload = format!("rec-{i}");
+        producer
+            .send(
+                FutureRecord::<str, [u8]>::to("offsets-topic")
+                    .payload(payload.as_bytes())
+                    .key("k"),
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("produce");
+    }
+
+    // First consumer: read 3 records, commit offset 3 (= "next offset
+    // to read is 3"), then shut down. This is how librdkafka commits:
+    // the committed offset is the offset of the *next* record, not the
+    // last consumed one.
+    let first: StreamConsumer = consumer_cfg(port, "resume-group").create().expect("c1");
+    first.subscribe(&["offsets-topic"]).expect("subscribe");
+
+    for _ in 0..3 {
+        let msg = tokio::time::timeout(Duration::from_secs(15), first.recv())
+            .await
+            .expect("first consumer should receive within 15s")
+            .expect("no transport error");
+        // Drain headers/payload so librdkafka advances its position.
+        let _ = msg.payload();
+    }
+
+    let mut commit_positions = TopicPartitionList::new();
+    commit_positions
+        .add_partition_offset("offsets-topic", 0, Offset::Offset(3))
+        .expect("add partition offset");
+    first.commit(&commit_positions, CommitMode::Sync).expect("commit");
+    close_consumer(first).await;
+
+    // Second consumer, same group. OffsetFetch should return offset 3
+    // — the record at offset 3 is "rec-3", which is the only one we
+    // expect to see.
+    let second: StreamConsumer = consumer_cfg(port, "resume-group").create().expect("c2");
+    second.subscribe(&["offsets-topic"]).expect("subscribe");
+
+    let msg = tokio::time::timeout(Duration::from_secs(15), second.recv())
+        .await
+        .expect("second consumer should receive within 15s")
+        .expect("no transport error");
+
+    assert_eq!(msg.offset(), 3, "second consumer should resume at offset 3");
+    assert_eq!(
+        msg.payload().expect("payload present"),
+        b"rec-3",
+        "second consumer should see the 4th record (offset 3)"
+    );
+
+    close_consumer(second).await;
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary
Finishes the consumer-group work started in #186. Previously OffsetCommit discarded the data and OffsetFetch hardcoded \"no committed offset\", so a new consumer in an existing group always restarted from `auto.offset.reset` — the mock couldn't model a real consumer resume.

## Changes
- **`GroupCoordinator`**: HashMap<(group, topic, partition), CommittedOffset> with `commit_offset` / `fetch_offset` helpers. Committed offsets survive consumer restarts.
- **Broker handlers**: `handle_offset_commit` now persists, `handle_offset_fetch` looks up real data and only returns -1 when nothing's been committed (triggering `auto.offset.reset` as expected).
- **LeaveGroup v0-v3** codec + broker handler + ApiVersions entry. librdkafka 2.x picks v1 against our broker even though we advertise max=3, so the codec handles the full non-flexible range.
- **Stale-member eviction**: members not seen in 10s get evicted on the next JoinGroup, so an ungraceful disconnect doesn't hold the leader slot forever.
- **Pre-existing bug fix in `Partition::append`**: the stored message's `offset` field was never set, so every record had `offset=0`. Fetch's `msg.offset >= fetch_offset` filter happened to work from offset 0 but broke any resume-from-committed path.

## Test
New e2e regression `tests/consumer_group_offsets.rs`:
- Produce 4 records.
- Consumer A reads 3, calls `commit(offset=3, Sync)`, drops.
- Consumer B (same group.id) resumes and only sees the record at offset 3 (\"rec-3\").

## Test plan
- [x] \`cargo test -p mockforge-kafka\` — 282 tests pass (258 lib + integration + doc-tests)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-kafka --all-targets -- -D warnings\` clean
- [x] E2e test exercises the full OffsetCommit v7 → coordinator → OffsetFetch v5 round trip

## Closes
- Closes #163 — the consumer-group join path landed in #186; this PR is the persistence follow-up that was carved out there.

## Still scoped for later (tracked separately)
Multi-member rebalancing with real assignor-driven generation bumps, static membership via instance IDs, and coordinator failover.