### PR TITLE
feat(graphql): add createUser mutation to default schema (#171)

### DIFF
--- a/crates/mockforge-graphql/src/schema.rs
+++ b/crates/mockforge-graphql/src/schema.rs
@@ -1,6 +1,6 @@
 //! GraphQL schema parsing and generation
 
-use async_graphql::{EmptyMutation, EmptySubscription, Object, Schema};
+use async_graphql::{EmptySubscription, Object, Schema};
 
 /// Simple User type for GraphQL
 #[derive(async_graphql::SimpleObject, Clone)]
@@ -70,20 +70,47 @@ impl QueryRoot {
     }
 }
 
+/// Root mutation type. A single `createUser` mutation lets clients
+/// exercise the mutation dispatch path against the default schema
+/// without registering a custom SDL. The mutation is stateless — the
+/// "created" user is fabricated from the inputs plus a deterministic
+/// id derived from (name, email), so callers can assert on the shape
+/// of the return value without mocking storage.
+pub struct MutationRoot;
+
+#[Object]
+impl MutationRoot {
+    /// Create a new user. Returns a freshly-shaped `User` with the
+    /// supplied `name` / `email` and an id derived from them so the
+    /// output is deterministic for tests (`user-{12 hex chars}`).
+    async fn create_user(&self, name: String, email: String) -> User {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        name.hash(&mut hasher);
+        email.hash(&mut hasher);
+        // Mask to 48 bits so the hex suffix is always exactly 12 chars
+        // (tests can then pin the exact id length without depending on
+        // how the hasher happens to fill the high bits).
+        let id = format!("user-{:012x}", hasher.finish() & 0xffff_ffff_ffff);
+        User { id, name, email }
+    }
+}
+
 /// GraphQL schema manager
 pub struct GraphQLSchema {
-    schema: Schema<QueryRoot, EmptyMutation, EmptySubscription>,
+    schema: Schema<QueryRoot, MutationRoot, EmptySubscription>,
 }
 
 impl GraphQLSchema {
     /// Create a new basic schema
     pub fn new() -> Self {
-        let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish();
+        let schema = Schema::build(QueryRoot, MutationRoot, EmptySubscription).finish();
         Self { schema }
     }
 
     /// Get the underlying schema
-    pub fn schema(&self) -> &Schema<QueryRoot, EmptyMutation, EmptySubscription> {
+    pub fn schema(&self) -> &Schema<QueryRoot, MutationRoot, EmptySubscription> {
         &self.schema
     }
 

--- a/crates/mockforge-graphql/tests/graphql_client_e2e.rs
+++ b/crates/mockforge-graphql/tests/graphql_client_e2e.rs
@@ -128,11 +128,12 @@ async fn graphql_real_client_introspection_query_returns_schema() {
         "queryType name should be QueryRoot"
     );
 
-    // Default schema has EmptyMutation/EmptySubscription, which async-graphql
-    // renders as a null type in introspection (not an empty type).
-    assert!(
-        schema.pointer("/mutationType").map(|v| v.is_null()).unwrap_or(false),
-        "default schema has no mutation root; mutationType should be null"
+    // Default schema exposes `MutationRoot` (with `createUser`) but
+    // still uses `EmptySubscription` — so subscriptionType stays null.
+    assert_eq!(
+        schema.pointer("/mutationType/name").and_then(|v| v.as_str()),
+        Some("MutationRoot"),
+        "default schema now has a mutation root named MutationRoot"
     );
     assert!(
         schema.pointer("/subscriptionType").map(|v| v.is_null()).unwrap_or(false),
@@ -153,6 +154,41 @@ async fn graphql_real_client_introspection_query_returns_schema() {
             "introspection types missing `{required}`; returned: {names:?}"
         );
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_real_client_create_user_mutation_returns_user() {
+    let url = spawn_server().await;
+    let client = reqwest::Client::new();
+    let body = json!({
+        "query": r#"
+            mutation CreateUser($name: String!, $email: String!) {
+              createUser(name: $name, email: $email) { id name email }
+            }
+        "#,
+        "variables": { "name": "Alice", "email": "alice@example.com" },
+    });
+    let response =
+        tokio::time::timeout(Duration::from_secs(5), client.post(&url).json(&body).send())
+            .await
+            .expect("request should complete within 5s")
+            .expect("reqwest transport ok");
+    assert!(response.status().is_success(), "HTTP {}", response.status());
+
+    let value: serde_json::Value = response.json().await.expect("response must be JSON");
+    if let Some(errs) = value.get("errors") {
+        assert!(
+            errs.as_array().map(|a| a.is_empty()).unwrap_or(false),
+            "expected no GraphQL errors, got: {errs}"
+        );
+    }
+
+    let user = value.pointer("/data/createUser").expect("data.createUser must be present");
+    assert_eq!(user.pointer("/name").and_then(|v| v.as_str()), Some("Alice"));
+    assert_eq!(user.pointer("/email").and_then(|v| v.as_str()), Some("alice@example.com"));
+    let id = user.pointer("/id").and_then(|v| v.as_str()).expect("id must be a string");
+    assert!(id.starts_with("user-"), "expected derived id `user-<hex>`, got {id}");
+    assert_eq!(id.len(), "user-".len() + 12, "expected 12-hex-char suffix, got {id}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/mockforge-graphql/tests/introspection_test.rs
+++ b/crates/mockforge-graphql/tests/introspection_test.rs
@@ -42,12 +42,10 @@ async fn test_schema_introspection_mutation_type() {
     let result = execute_query(router, "{ __schema { mutationType { name } } }").await;
 
     let data = result.get("data").expect("should have data");
-    // The default schema has EmptyMutation, so mutationType should be null
-    let mutation_type = &data["__schema"]["mutationType"];
-    assert!(
-        mutation_type.is_null(),
-        "default schema has no mutations, mutationType should be null"
-    );
+    // The default schema now exposes `MutationRoot` (with `createUser`)
+    // so `mutationType` must be non-null.
+    let name = &data["__schema"]["mutationType"]["name"];
+    assert_eq!(name, "MutationRoot");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
The default schema used \`EmptyMutation\`, so anyone testing mutation-shaped flows got \"mutation root not supported\" and had to register a custom SDL. Adding one useful mutation makes the mock usable for mutation-heavy clients out of the box.

## Changes
- **New \`MutationRoot\`** with \`createUser(name: String!, email: String!) -> User\`. Stateless — returns a freshly-shaped \`User\` with an id derived from (name, email) via \`DefaultHasher\` masked to 48 bits so tests pin an exact 12-hex-char suffix without depending on how the hasher fills high bits.
- \`GraphQLSchema\` now parameterizes on \`MutationRoot\` instead of \`EmptyMutation\`.
- Real-client regression in \`graphql_client_e2e.rs\`: posts the mutation via reqwest, asserts returned \`User\` shape + id format.
- Updated both existing assertions that expected \`mutationType == null\` (handler-level \`introspection_test.rs\` and the HTTP-level test added in #188) to expect \`mutationType.name == \"MutationRoot\"\`.

## Test plan
- [x] \`cargo test -p mockforge-graphql\` — 186 tests pass across lib + all test suites
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-graphql --all-targets -- -D warnings\` clean

## Closes
- Closes #171.