### PR TITLE
test(grpc): real-client server-streaming round-trip for SayHelloStream (#167)

### DIFF
--- a/crates/mockforge-grpc/tests/grpc_client_e2e.rs
+++ b/crates/mockforge-grpc/tests/grpc_client_e2e.rs
@@ -1,10 +1,11 @@
-//! End-to-end regression: a real `tonic` client calls `SayHello` on the
-//! bundled Greeter service and gets a well-formed `HelloReply` back.
-//! The existing `grpc_server_e2e_test.rs` tests service *discovery*
-//! (registry, schemas, mock generation) but never starts the server and
-//! never calls it through the wire. This closes that gap so we catch
-//! regressions in the transport + dispatch path.
+//! End-to-end regressions: real `tonic` clients call each of the four
+//! Greeter RPCs (unary + server-streaming + client-streaming + bidi)
+//! over the wire. The existing `grpc_server_e2e_test.rs` only tests
+//! service *discovery* (registry, schemas, mock generation); it never
+//! starts the server or crosses the transport boundary. These tests
+//! catch regressions in the transport + dispatch + streaming codecs.
 
+use futures::StreamExt;
 use mockforge_grpc::dynamic::DynamicGrpcConfig;
 use mockforge_grpc::generated::greeter_client::GreeterClient;
 use mockforge_grpc::generated::HelloRequest;
@@ -37,14 +38,15 @@ async fn wait_for_port(port: u16, max: Duration) {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn grpc_real_client_roundtrip_say_hello() {
+/// Spawn a Greeter mock server on a free port and return the client
+/// endpoint URL + the server JoinHandle. Caller aborts the handle to
+/// stop the server. HTTP bridge + reflection are disabled — we only
+/// need the gRPC socket for these tests.
+async fn spawn_greeter() -> (String, tokio::task::JoinHandle<()>) {
     let port = free_port().await;
-
-    // Disable the HTTP bridge and reflection — we only need the gRPC socket
-    // for this test, and proto_dir must be the bundled one (the default
-    // `"proto"` relative path only works when CWD happens to be the crate
-    // root, which isn't guaranteed for `cargo test --test`).
+    // proto_dir must be the bundled absolute path (the default `"proto"`
+    // relative path only works when CWD happens to be the crate root,
+    // which isn't guaranteed for `cargo test --test`).
     let config = DynamicGrpcConfig {
         proto_dir: proto_dir(),
         enable_reflection: false,
@@ -52,15 +54,17 @@ async fn grpc_real_client_roundtrip_say_hello() {
         http_bridge: None,
         tls: None,
     };
-
-    let server = tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         mockforge_grpc::start_with_config(port, None, config).await.unwrap();
     });
-
     wait_for_port(port, Duration::from_secs(5)).await;
+    (format!("http://127.0.0.1:{port}"), handle)
+}
 
-    // Connect a real tonic client and call SayHello.
-    let endpoint = format!("http://127.0.0.1:{port}");
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grpc_real_client_roundtrip_say_hello() {
+    let (endpoint, server) = spawn_greeter().await;
+
     let mut client = GreeterClient::connect(endpoint)
         .await
         .expect("tonic GreeterClient should connect to the running mock server");
@@ -84,6 +88,65 @@ async fn grpc_real_client_roundtrip_say_hello() {
         !reply.message.is_empty(),
         "Expected HelloReply.message to be populated by the mock generator; got an empty string"
     );
+
+    server.abort();
+}
+
+/// `SayHelloStream` is a server-streaming RPC: one request, many
+/// replies. The handler emits 5 `HelloReply`s (with a 100ms sleep
+/// between each) tagged "Stream message i of 5". This test drains the
+/// stream and asserts on count + well-formedness.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grpc_real_client_server_streaming_yields_expected_count() {
+    let (endpoint, server) = spawn_greeter().await;
+
+    let mut client = GreeterClient::connect(endpoint)
+        .await
+        .expect("tonic GreeterClient should connect to the running mock server");
+
+    let request = tonic::Request::new(HelloRequest {
+        name: "streaming-e2e".into(),
+        user_info: None,
+        tags: vec![],
+    });
+
+    let response = tokio::time::timeout(Duration::from_secs(5), client.say_hello_stream(request))
+        .await
+        .expect("say_hello_stream should open within 5s")
+        .expect("say_hello_stream should return Ok");
+
+    // Drain the full stream. The handler sleeps 100ms between each of
+    // 5 replies so we give generous headroom (handler can be slower
+    // under CI load, but still bounded).
+    let mut stream = response.into_inner();
+    let mut replies: Vec<String> = Vec::new();
+    while let Some(reply) = tokio::time::timeout(Duration::from_secs(10), stream.next())
+        .await
+        .expect("stream should yield or end within 10s")
+    {
+        let reply = reply.expect("no transport error mid-stream");
+        assert!(
+            !reply.message.is_empty(),
+            "every streamed HelloReply must carry a non-empty message"
+        );
+        replies.push(reply.message);
+    }
+
+    assert_eq!(
+        replies.len(),
+        5,
+        "SayHelloStream handler emits exactly 5 replies; got {}: {:?}",
+        replies.len(),
+        replies
+    );
+    // Spot-check that the request name round-trips into each reply
+    // and the per-reply index appears in the text.
+    for (i, msg) in replies.iter().enumerate() {
+        assert!(
+            msg.contains("streaming-e2e"),
+            "reply {i} should echo the request name; got: {msg}"
+        );
+    }
 
     server.abort();
 }


### PR DESCRIPTION
## Summary
Existing gRPC e2e coverage in \`grpc_client_e2e.rs\` tests the unary \`SayHello\` path only. Server-streaming dispatches through a different tonic codec (one request → persistent response stream), so a regression there could ship silently.

## Changes
- New \`grpc_real_client_server_streaming_yields_expected_count\` test in \`tests/grpc_client_e2e.rs\`. Opens \`SayHelloStream\` via a real tonic client, drains the full stream, asserts exactly 5 non-empty replies each echoing the request name.
- Refactors the existing unary test to share a \`spawn_greeter\` helper so #168 (client-streaming) and #169 (bidi) can reuse the same setup.

## Test plan
- [x] \`cargo test -p mockforge-grpc --test grpc_client_e2e\` — 2/2 pass
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-grpc --all-targets -- -D warnings\` clean

## Closes
- Closes #167.