### PR TITLE
feat(mqtt): deliver retained messages to new subscribers (#174)

### DIFF
--- a/crates/mockforge-mqtt/src/session.rs
+++ b/crates/mockforge-mqtt/src/session.rs
@@ -340,9 +340,16 @@ impl SessionManager {
     ) -> Option<Vec<SubackReturnCode>> {
         let mut active = self.active_clients.write().await;
         let client = active.get_mut(client_id)?;
+        let sender = client.sender.clone();
 
         let mut topics = self.topics.write().await;
         let mut return_codes = Vec::new();
+        // Snapshot every retained PUBLISH that matches one of the new
+        // subscriptions so we can deliver after releasing the `topics`
+        // write lock. MQTT spec: retained messages MUST be delivered
+        // with the retain flag set, and the delivery QoS is the minimum
+        // of the retained QoS and the subscription QoS.
+        let mut retained_to_deliver: Vec<(String, Vec<u8>, u8, QoS)> = Vec::new();
 
         for (filter, requested_qos) in subscriptions {
             // Add to topic tree
@@ -358,7 +365,46 @@ impl SessionManager {
                 metrics.record_subscription();
             }
 
+            // Collect any retained PUBLISH matching this filter.
+            for (topic, retained) in topics.get_retained_for_filter(&filter) {
+                retained_to_deliver.push((
+                    topic.to_string(),
+                    retained.payload.clone(),
+                    retained.qos,
+                    requested_qos,
+                ));
+            }
+
             debug!("Client {} subscribed to {} with QoS {:?}", client_id, filter, requested_qos);
+        }
+
+        drop(topics);
+        drop(active);
+
+        // Deliver retained messages. Done *after* the locks are released
+        // so a backpressured `sender.send` can't deadlock against another
+        // handler that takes these same locks.
+        for (topic, payload, retained_qos, sub_qos) in retained_to_deliver {
+            let delivery_qos = std::cmp::min(retained_qos, sub_qos as u8);
+            let delivery_qos = QoS::try_from(delivery_qos).unwrap_or(QoS::AtMostOnce);
+            let packet = Packet::Publish(PublishPacket {
+                dup: false,
+                qos: delivery_qos,
+                retain: true, // spec: set on delivery to a new subscriber
+                topic: topic.clone(),
+                // Leave packet_id = None for QoS > 0; the writer task
+                // assigns it from the subscriber's session to avoid the
+                // packet_id=0 wire error (same invariant as regular
+                // publishes, see handle_publish).
+                packet_id: None,
+                payload,
+            });
+            if sender.send(packet).await.is_ok() {
+                if let Some(metrics) = &self.metrics {
+                    metrics.record_delivery();
+                }
+                debug!("Delivered retained message to {} on topic {}", client_id, topic);
+            }
         }
 
         Some(return_codes)

--- a/crates/mockforge-mqtt/tests/mqtt_pubsub_e2e.rs
+++ b/crates/mockforge-mqtt/tests/mqtt_pubsub_e2e.rs
@@ -114,6 +114,88 @@ async fn mqtt_publish_subscribe_round_trip() {
     server.abort();
 }
 
+/// Variant of `drain_until_publish` that also forwards the `retain`
+/// flag — the retained-messages test needs to distinguish "delivered
+/// as retained snapshot" from "delivered as live publish".
+fn drain_with_retain(
+    mut eventloop: EventLoop,
+    tx: mpsc::UnboundedSender<(Vec<u8>, bool)>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match eventloop.poll().await {
+                Ok(Event::Incoming(Incoming::Publish(p))) => {
+                    let _ = tx.send((p.payload.to_vec(), p.retain));
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("rumqttc eventloop terminated: {e}");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Retained-message delivery for late subscribers. The MQTT spec:
+/// when a PUBLISH arrives with `retain=true`, the broker stores it
+/// per-topic and delivers it immediately to any future subscriber —
+/// with the `retain` flag set on that delivery. This test:
+///   1. Publisher sets retain=true on "home/temperature".
+///   2. Publisher disconnects (broker keeps the retained value).
+///   3. A fresh subscriber subscribes — expects the retained PUBLISH
+///      immediately, with retain=true.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mqtt_retained_message_delivered_to_new_subscriber() {
+    let port = free_port().await;
+    let config = MqttConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..MqttConfig::default()
+    };
+    let server = tokio::spawn(async move {
+        start_mqtt_server(config).await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    // --- Publish a retained message, then disconnect --------------------
+    let mut pub_opts = MqttOptions::new("retain-pub", "127.0.0.1", port);
+    pub_opts.set_keep_alive(Duration::from_secs(30));
+    let (pub_client, pub_eventloop) = AsyncClient::new(pub_opts, 16);
+    let pub_pump = pump(pub_eventloop);
+    pub_client
+        .publish("home/temperature", QoS::AtLeastOnce, /*retain=*/ true, b"21.8C".to_vec())
+        .await
+        .unwrap();
+    // Give the broker a beat to process the PUBLISH + persist the retain.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    pub_client.disconnect().await.ok();
+    pub_pump.abort();
+
+    // --- Fresh subscriber joins after the publisher is gone -------------
+    let mut sub_opts = MqttOptions::new("retain-sub", "127.0.0.1", port);
+    sub_opts.set_keep_alive(Duration::from_secs(30));
+    let (sub_client, sub_eventloop) = AsyncClient::new(sub_opts, 16);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sub_pump = drain_with_retain(sub_eventloop, tx);
+
+    sub_client.subscribe("home/temperature", QoS::AtLeastOnce).await.unwrap();
+
+    let (payload, retain_flag) = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("subscriber should receive retained message within 5s")
+        .expect("eventloop forwarded payload");
+    assert_eq!(payload, b"21.8C", "retained payload must round-trip byte-for-byte");
+    assert!(
+        retain_flag,
+        "retained messages MUST be delivered with retain=true per MQTT spec"
+    );
+
+    sub_client.disconnect().await.ok();
+    sub_pump.abort();
+    server.abort();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mqtt_wildcard_subscription_matches_published_topic() {
     // A `+` wildcard subscription must receive messages from any single-


### PR DESCRIPTION
## Summary
MQTT spec: when a PUBLISH arrives with \`retain=true\`, the broker stores it per-topic and delivers it immediately to every future subscriber that matches — with the \`retain\` flag set on that delivery. The existing broker persisted retained PUBLISHes via \`topics.retain_message\` but never replayed them on SUBSCRIBE, so a late subscriber sat silent until a live publisher showed up.

## Changes
- \`SessionManager::subscribe\` now queries \`topics.get_retained_for_filter\` for each new subscription and (after dropping the \`topics\` and \`active_clients\` locks to avoid deadlock against the publish path) forwards each matching retained PUBLISH to the new subscriber. \`retain\` is set to true on delivery per spec; delivery QoS is \`min(retained.qos, sub.qos)\`.
- Real-client regression test in \`mqtt_pubsub_e2e.rs\`: retained publisher publishes + disconnects; fresh subscriber subscribes and asserts it receives the payload with \`retain=true\`.

## Test plan
- [x] \`cargo test -p mockforge-mqtt\` — 227 tests pass (213 lib + integration + e2e)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-mqtt --all-targets -- -D warnings\` clean

## Closes
- Closes #174.