### PR TITLE
feat(mqtt): publish Last-Will-and-Testament on abrupt disconnect (#175)

### DIFF
--- a/crates/mockforge-mqtt/src/server.rs
+++ b/crates/mockforge-mqtt/src/server.rs
@@ -465,9 +465,16 @@ async fn handle_tls_connection(
     // Create channel for sending packets to this client
     let (tx, mut rx) = mpsc::channel(CLIENT_CHANNEL_CAPACITY);
 
-    // Register with session manager
+    // Register with session manager (also hands over the Last Will,
+    // which the broker fires on abrupt disconnect).
     let connect_result = session_manager
-        .connect(cid.clone(), connect_packet.clean_session, connect_packet.keep_alive, tx)
+        .connect(
+            cid.clone(),
+            connect_packet.clean_session,
+            connect_packet.keep_alive,
+            tx,
+            connect_packet.will.clone(),
+        )
         .await;
 
     let session_present = match connect_result {
@@ -525,15 +532,20 @@ async fn handle_tls_connection(
     )
     .await;
 
-    // Clean up on disconnect
-    session_manager.disconnect(&cid).await;
+    // `Ok(true)`  = graceful DISCONNECT; `Ok(false)` = TCP EOF;
+    // `Err(_)`    = transport error. Will fires unless graceful.
+    let graceful = matches!(result, Ok(true));
+    session_manager.disconnect(&cid, graceful).await;
     info!("TLS client {} disconnected", cid);
 
-    result
+    result.map(|_| ())
 }
 
 /// Handle the main TLS client message loop
 #[allow(clippy::too_many_arguments)]
+/// TLS counterpart of `handle_client_loop`. Returns `Ok(true)` for a
+/// graceful DISCONNECT packet, `Ok(false)` for TCP EOF — only the
+/// `true` case suppresses the Last Will.
 async fn handle_tls_client_loop<R, W>(
     reader: &mut tokio::io::BufReader<R>,
     writer: &mut W,
@@ -544,7 +556,7 @@ async fn handle_tls_client_loop<R, W>(
     buffer: &mut [u8],
     buf_len: &mut usize,
     max_packet_size: usize,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
@@ -555,8 +567,8 @@ where
             read_result = reader.read(&mut buffer[*buf_len..]) => {
                 match read_result {
                     Ok(0) => {
-                        debug!("TLS client {} closed connection", client_id);
-                        return Ok(());
+                        debug!("TLS client {} closed connection (EOF)", client_id);
+                        return Ok(false);
                     }
                     Ok(n) => {
                         *buf_len += n;
@@ -583,7 +595,7 @@ where
                                 metrics,
                             ).await {
                                 Ok(true) => continue,
-                                Ok(false) => return Ok(()), // Disconnect requested
+                                Ok(false) => return Ok(true), // DISCONNECT packet
                                 Err(e) => {
                                     warn!("Error handling packet from TLS client {}: {}", client_id, e);
                                     metrics.record_error(&e.to_string());
@@ -602,7 +614,7 @@ where
                 match packet {
                     Some(Packet::Disconnect) => {
                         debug!("Sending disconnect to TLS client {}", client_id);
-                        return Ok(());
+                        return Ok(true);
                     }
                     Some(mut packet) => {
                         // Assign packet ID for QoS > 0 publish packets
@@ -619,7 +631,7 @@ where
                     }
                     None => {
                         debug!("Channel closed for TLS client {}", client_id);
-                        return Ok(());
+                        return Ok(true);
                     }
                 }
             }
@@ -844,9 +856,16 @@ async fn handle_connection(
     // Create channel for sending packets to this client
     let (tx, mut rx) = mpsc::channel(CLIENT_CHANNEL_CAPACITY);
 
-    // Register with session manager
+    // Register with session manager (also hands over the Last Will,
+    // which the broker fires on abrupt disconnect).
     let connect_result = session_manager
-        .connect(cid.clone(), connect_packet.clean_session, connect_packet.keep_alive, tx)
+        .connect(
+            cid.clone(),
+            connect_packet.clean_session,
+            connect_packet.keep_alive,
+            tx,
+            connect_packet.will.clone(),
+        )
         .await;
 
     let session_present = match connect_result {
@@ -906,14 +925,23 @@ async fn handle_connection(
     )
     .await;
 
-    // Clean up on disconnect
-    session_manager.disconnect(&cid).await;
+    // `Ok(true)`  = graceful DISCONNECT packet received.
+    // `Ok(false)` = TCP EOF without a DISCONNECT (ungraceful).
+    // `Err(_)`    = transport error (also ungraceful).
+    // The Last Will fires in the ungraceful cases per MQTT §3.1.2.5.
+    let graceful = matches!(result, Ok(true));
+    session_manager.disconnect(&cid, graceful).await;
     info!("Client {} disconnected", cid);
 
-    result
+    result.map(|_| ())
 }
 
-/// Handle the main client message loop
+/// Handle the main client message loop.
+///
+/// Returns `Ok(true)` when the client sent a graceful DISCONNECT
+/// packet, `Ok(false)` when the TCP stream was closed without one
+/// (EOF). Both are "normal" exits from the broker's perspective; only
+/// the `Ok(true)` variant should suppress the Last Will.
 #[allow(clippy::too_many_arguments)]
 async fn handle_client_loop(
     reader: &mut tokio::io::BufReader<tokio::net::tcp::OwnedReadHalf>,
@@ -925,15 +953,17 @@ async fn handle_client_loop(
     buffer: &mut [u8],
     buf_len: &mut usize,
     max_packet_size: usize,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
     loop {
         tokio::select! {
             // Handle incoming packets from client
             read_result = reader.read(&mut buffer[*buf_len..]) => {
                 match read_result {
                     Ok(0) => {
-                        debug!("Client {} closed connection", client_id);
-                        return Ok(());
+                        debug!("Client {} closed connection (EOF)", client_id);
+                        // EOF without a DISCONNECT packet is ungraceful
+                        // — publish the Last Will.
+                        return Ok(false);
                     }
                     Ok(n) => {
                         *buf_len += n;
@@ -960,7 +990,7 @@ async fn handle_client_loop(
                                 metrics,
                             ).await {
                                 Ok(true) => continue,
-                                Ok(false) => return Ok(()), // Disconnect requested
+                                Ok(false) => return Ok(true), // DISCONNECT packet = graceful
                                 Err(e) => {
                                     warn!("Error handling packet from {}: {}", client_id, e);
                                     metrics.record_error(&e.to_string());
@@ -978,8 +1008,12 @@ async fn handle_client_loop(
             packet = packet_rx.recv() => {
                 match packet {
                     Some(Packet::Disconnect) => {
+                        // Server-initiated disconnect (takeover from a
+                        // newer connection with the same client_id).
+                        // Treat as graceful so we don't fire the will
+                        // against a client that didn't actually crash.
                         debug!("Sending disconnect to {}", client_id);
-                        return Ok(());
+                        return Ok(true);
                     }
                     Some(mut packet) => {
                         // Assign packet ID for QoS > 0 publish packets
@@ -995,8 +1029,10 @@ async fn handle_client_loop(
                         writer.write_all(&bytes).await?;
                     }
                     None => {
+                        // Sender dropped — broker shutting down. Don't
+                        // fire the will in that case either.
                         debug!("Channel closed for {}", client_id);
-                        return Ok(());
+                        return Ok(true);
                     }
                 }
             }
@@ -1296,8 +1332,10 @@ mod tests {
         let server = MqttServer::new(&config, metrics);
 
         let (tx, _rx) = mpsc::channel(10);
-        let result =
-            server.session_manager().connect("test-client".to_string(), true, 60, tx).await;
+        let result = server
+            .session_manager()
+            .connect("test-client".to_string(), true, 60, tx, None)
+            .await;
 
         assert!(result.is_ok());
         assert_eq!(server.session_manager().connection_count().await, 1);

--- a/crates/mockforge-mqtt/src/session.rs
+++ b/crates/mockforge-mqtt/src/session.rs
@@ -214,6 +214,12 @@ pub struct ActiveClient {
     pub session: ClientSession,
     /// Channel to send packets to the client
     pub sender: ClientSender,
+    /// Last-will-and-testament declared on CONNECT. The broker stores it
+    /// here until the client either disconnects gracefully (in which
+    /// case the will is dropped) or the TCP connection goes away without
+    /// a DISCONNECT packet (in which case the will is published per
+    /// MQTT spec §3.1.2.5).
+    pub will: Option<crate::protocol::Will>,
 }
 
 /// Session manager for tracking all client sessions
@@ -249,6 +255,7 @@ impl SessionManager {
         clean_session: bool,
         keep_alive: u16,
         sender: ClientSender,
+        will: Option<crate::protocol::Will>,
     ) -> Result<(bool, ConnackCode), ConnackCode> {
         let active = self.active_clients.read().await;
         if active.len() >= self.max_connections {
@@ -290,7 +297,14 @@ impl SessionManager {
             (ClientSession::new(client_id.clone(), false, keep_alive), false)
         };
 
-        active.insert(client_id.clone(), ActiveClient { session, sender });
+        active.insert(
+            client_id.clone(),
+            ActiveClient {
+                session,
+                sender,
+                will,
+            },
+        );
 
         if let Some(metrics) = &self.metrics {
             metrics.record_connection();
@@ -304,30 +318,99 @@ impl SessionManager {
         Ok((session_present, ConnackCode::Accepted))
     }
 
-    /// Handle client disconnect
-    pub async fn disconnect(&self, client_id: &str) {
+    /// Handle client disconnect.
+    ///
+    /// `graceful = true` means a DISCONNECT packet was received: the
+    /// client is leaving cleanly and the Last Will is discarded per
+    /// MQTT spec. `graceful = false` means the TCP connection closed
+    /// without a DISCONNECT (process crash, network drop, etc.) — in
+    /// that case, if the client declared a will on CONNECT, the broker
+    /// publishes it on behalf of the departed client.
+    pub async fn disconnect(&self, client_id: &str, graceful: bool) {
         let mut active = self.active_clients.write().await;
-        if let Some(client) = active.remove(client_id) {
-            if !client.session.clean_session {
-                // Persist session for later reconnection
-                let mut persistent = self.persistent_sessions.write().await;
-                persistent.insert(client_id.to_string(), client.session);
-                info!("Persisted session for client {}", client_id);
-            } else {
-                // Clean session - remove subscriptions
-                let mut topics = self.topics.write().await;
-                for filter in client.session.subscriptions.keys() {
-                    topics.unsubscribe(filter, client_id);
+        let client = match active.remove(client_id) {
+            Some(c) => c,
+            None => return,
+        };
 
+        // Capture the will before we decide whether to persist the
+        // session. If the disconnect was ungraceful and a will is set,
+        // we publish it after releasing `active` to avoid recursive
+        // lock acquisition via `handle_publish`.
+        let will_to_fire = if graceful { None } else { client.will.clone() };
+
+        if !client.session.clean_session {
+            // Persist session for later reconnection
+            let mut persistent = self.persistent_sessions.write().await;
+            persistent.insert(client_id.to_string(), client.session);
+            info!("Persisted session for client {}", client_id);
+        } else {
+            // Clean session - remove subscriptions
+            let mut topics = self.topics.write().await;
+            for filter in client.session.subscriptions.keys() {
+                topics.unsubscribe(filter, client_id);
+
+                if let Some(metrics) = &self.metrics {
+                    metrics.record_unsubscription();
+                }
+            }
+            info!("Cleaned up session for client {}", client_id);
+        }
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_connection_closed();
+        }
+
+        drop(active);
+
+        if let Some(will) = will_to_fire {
+            info!(
+                "Publishing Last Will for disconnected client {} on topic {}",
+                client_id, will.topic
+            );
+            self.publish_will(client_id, will).await;
+        }
+    }
+
+    /// Publish a Last Will. Delivered to current subscribers of the
+    /// topic and — if the will's `retain` flag is set — stored as the
+    /// topic's retained message so future subscribers see it too.
+    async fn publish_will(&self, client_id: &str, will: crate::protocol::Will) {
+        // Persist retained first, so a subscribe that races with the
+        // will publish still sees it through the retained-delivery path.
+        if will.retain {
+            let mut topics = self.topics.write().await;
+            topics.retain_message(&will.topic, will.message.clone(), will.qos as u8);
+            if let Some(metrics) = &self.metrics {
+                metrics.record_retained_message();
+            }
+        }
+
+        // Forward to every current subscriber, matching the regular
+        // PUBLISH path's QoS rules.
+        let topics = self.topics.read().await;
+        let subscribers = topics.match_topic(&will.topic);
+        let active = self.active_clients.read().await;
+        for sub in subscribers {
+            if sub.client_id == client_id {
+                continue; // Don't send back to the dead client
+            }
+            if let Some(c) = active.get(&sub.client_id) {
+                let delivery_qos = std::cmp::min(will.qos as u8, sub.qos);
+                let delivery_qos = QoS::try_from(delivery_qos).unwrap_or(QoS::AtMostOnce);
+                let packet = Packet::Publish(PublishPacket {
+                    dup: false,
+                    qos: delivery_qos,
+                    retain: false, // not a retained delivery — live forwarding
+                    topic: will.topic.clone(),
+                    packet_id: None,
+                    payload: will.message.clone(),
+                });
+                if c.sender.send(packet).await.is_ok() {
                     if let Some(metrics) = &self.metrics {
-                        metrics.record_unsubscription();
+                        metrics.record_delivery();
                     }
                 }
-                info!("Cleaned up session for client {}", client_id);
-            }
-
-            if let Some(metrics) = &self.metrics {
-                metrics.record_connection_closed();
             }
         }
     }
@@ -613,7 +696,10 @@ impl SessionManager {
 
         for client_id in &expired {
             warn!("Disconnecting expired session: {}", client_id);
-            self.disconnect(client_id).await;
+            // Keep-alive timeout is an ungraceful disconnect per MQTT
+            // spec — the client didn't send a DISCONNECT, so fire its
+            // Last Will if one was declared.
+            self.disconnect(client_id, /* graceful */ false).await;
         }
 
         expired
@@ -831,7 +917,7 @@ mod tests {
         let manager = SessionManager::new(100, None);
         let (tx, _rx) = mpsc::channel(10);
 
-        let result = manager.connect("client-1".to_string(), true, 60, tx).await;
+        let result = manager.connect("client-1".to_string(), true, 60, tx, None).await;
         assert!(result.is_ok());
         let (session_present, code) = result.unwrap();
         assert!(!session_present);
@@ -845,8 +931,8 @@ mod tests {
         let manager = SessionManager::new(100, None);
         let (tx, _rx) = mpsc::channel(10);
 
-        manager.connect("client-1".to_string(), true, 60, tx).await.unwrap();
-        manager.disconnect("client-1").await;
+        manager.connect("client-1".to_string(), true, 60, tx, None).await.unwrap();
+        manager.disconnect("client-1", true).await;
 
         assert_eq!(manager.connection_count().await, 0);
     }
@@ -857,7 +943,7 @@ mod tests {
 
         // First connection with clean_session=false
         let (tx1, _rx1) = mpsc::channel(10);
-        manager.connect("client-1".to_string(), false, 60, tx1).await.unwrap();
+        manager.connect("client-1".to_string(), false, 60, tx1, None).await.unwrap();
 
         // Subscribe
         manager
@@ -865,11 +951,11 @@ mod tests {
             .await;
 
         // Disconnect
-        manager.disconnect("client-1").await;
+        manager.disconnect("client-1", true).await;
 
         // Reconnect - should have session
         let (tx2, _rx2) = mpsc::channel(10);
-        let result = manager.connect("client-1".to_string(), false, 60, tx2).await;
+        let result = manager.connect("client-1".to_string(), false, 60, tx2, None).await;
         let (session_present, _) = result.unwrap();
         assert!(session_present);
     }
@@ -879,7 +965,7 @@ mod tests {
         let manager = SessionManager::new(100, None);
         let (tx, _rx) = mpsc::channel(10);
 
-        manager.connect("client-1".to_string(), true, 60, tx).await.unwrap();
+        manager.connect("client-1".to_string(), true, 60, tx, None).await.unwrap();
 
         let result = manager
             .subscribe(
@@ -903,7 +989,7 @@ mod tests {
         let manager = SessionManager::new(100, None);
         let (tx, _rx) = mpsc::channel(10);
 
-        manager.connect("client-1".to_string(), true, 60, tx).await.unwrap();
+        manager.connect("client-1".to_string(), true, 60, tx, None).await.unwrap();
 
         manager
             .subscribe("client-1", vec![("topic/a".to_string(), QoS::AtMostOnce)])
@@ -921,10 +1007,10 @@ mod tests {
         let (tx2, _rx2) = mpsc::channel(10);
         let (tx3, _rx3) = mpsc::channel(10);
 
-        manager.connect("client-1".to_string(), true, 60, tx1).await.unwrap();
-        manager.connect("client-2".to_string(), true, 60, tx2).await.unwrap();
+        manager.connect("client-1".to_string(), true, 60, tx1, None).await.unwrap();
+        manager.connect("client-2".to_string(), true, 60, tx2, None).await.unwrap();
 
-        let result = manager.connect("client-3".to_string(), true, 60, tx3).await;
+        let result = manager.connect("client-3".to_string(), true, 60, tx3, None).await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), ConnackCode::ServerUnavailable);
     }

--- a/crates/mockforge-mqtt/tests/mqtt_pubsub_e2e.rs
+++ b/crates/mockforge-mqtt/tests/mqtt_pubsub_e2e.rs
@@ -9,7 +9,7 @@
 
 use mockforge_mqtt::broker::MqttConfig;
 use mockforge_mqtt::start_mqtt_server;
-use rumqttc::{AsyncClient, Event, EventLoop, Incoming, MqttOptions, QoS};
+use rumqttc::{AsyncClient, Event, EventLoop, Incoming, LastWill, MqttOptions, QoS};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -190,6 +190,135 @@ async fn mqtt_retained_message_delivered_to_new_subscriber() {
         retain_flag,
         "retained messages MUST be delivered with retain=true per MQTT spec"
     );
+
+    sub_client.disconnect().await.ok();
+    sub_pump.abort();
+    server.abort();
+}
+
+/// Last-Will-and-Testament delivery on *abrupt* disconnect. The MQTT
+/// spec (§3.1.2.5): a client that declares a will on CONNECT and then
+/// goes away without sending a DISCONNECT packet causes the broker to
+/// publish that will to its declared topic on behalf of the departed
+/// client. A graceful DISCONNECT, by contrast, silently discards the
+/// will. This test covers the abrupt case end-to-end:
+///   1. Subscriber attaches to "device/will-topic".
+///   2. Second client connects with a Last Will pointing at that topic.
+///   3. Second client's event loop is dropped without `disconnect()` —
+///      simulating a crash / network drop.
+///   4. Subscriber must receive the will payload.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mqtt_last_will_delivered_on_abrupt_disconnect() {
+    let port = free_port().await;
+    let config = MqttConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..MqttConfig::default()
+    };
+    let server = tokio::spawn(async move {
+        start_mqtt_server(config).await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    // --- Subscriber waits on the will topic -----------------------------
+    let mut sub_opts = MqttOptions::new("will-watcher", "127.0.0.1", port);
+    sub_opts.set_keep_alive(Duration::from_secs(30));
+    let (sub_client, sub_eventloop) = AsyncClient::new(sub_opts, 16);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sub_pump = drain_until_publish(sub_eventloop, tx);
+
+    sub_client.subscribe("device/will-topic", QoS::AtLeastOnce).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // --- Client with a Last Will; CONNECT, then go away ungracefully ---
+    let mut will_opts = MqttOptions::new("will-maker", "127.0.0.1", port);
+    will_opts.set_keep_alive(Duration::from_secs(30));
+    will_opts.set_last_will(LastWill::new(
+        "device/will-topic",
+        b"will-maker went offline".to_vec(),
+        QoS::AtLeastOnce,
+        /*retain=*/ false,
+    ));
+    let (will_client, will_eventloop) = AsyncClient::new(will_opts, 16);
+
+    // Pump the event loop just long enough to finish CONNECT/CONNACK,
+    // then drop both halves. Dropping the event loop closes the TCP
+    // socket without a DISCONNECT packet — the broker treats this as an
+    // abrupt disconnect and publishes the will.
+    let will_handle = tokio::spawn(async move {
+        let mut ev = will_eventloop;
+        // Poll once so the CONNECT/CONNACK handshake completes. If we
+        // return before that, the broker never saw the will.
+        for _ in 0..20 {
+            if ev.poll().await.is_err() {
+                return;
+            }
+        }
+    });
+    // Let the connect handshake land.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    drop(will_client);
+    will_handle.abort();
+
+    // --- Subscriber should see the will --------------------------------
+    let payload = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("subscriber should receive will within 5s")
+        .expect("eventloop forwarded payload");
+    assert_eq!(payload, b"will-maker went offline");
+
+    sub_client.disconnect().await.ok();
+    sub_pump.abort();
+    server.abort();
+}
+
+/// Counterpart: a graceful DISCONNECT must *not* trigger the will.
+/// Without this, the broker would wrongly publish wills on every clean exit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mqtt_last_will_suppressed_on_graceful_disconnect() {
+    let port = free_port().await;
+    let config = MqttConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..MqttConfig::default()
+    };
+    let server = tokio::spawn(async move {
+        start_mqtt_server(config).await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    let mut sub_opts = MqttOptions::new("will-watcher-graceful", "127.0.0.1", port);
+    sub_opts.set_keep_alive(Duration::from_secs(30));
+    let (sub_client, sub_eventloop) = AsyncClient::new(sub_opts, 16);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sub_pump = drain_until_publish(sub_eventloop, tx);
+
+    sub_client.subscribe("device/graceful-will", QoS::AtLeastOnce).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let mut will_opts = MqttOptions::new("graceful-will-maker", "127.0.0.1", port);
+    will_opts.set_keep_alive(Duration::from_secs(30));
+    will_opts.set_last_will(LastWill::new(
+        "device/graceful-will",
+        b"should NOT be delivered".to_vec(),
+        QoS::AtLeastOnce,
+        false,
+    ));
+    let (will_client, will_eventloop) = AsyncClient::new(will_opts, 16);
+    let will_pump = pump(will_eventloop);
+
+    // Give the handshake a beat, then disconnect gracefully.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    will_client.disconnect().await.ok();
+    // Allow the broker to process the DISCONNECT + the client's close.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    will_pump.abort();
+
+    // The subscriber should *not* see anything. Using a short timeout
+    // here is the whole assertion — if the will fires, rx.recv() hands
+    // us the payload.
+    let got = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+    assert!(got.is_err(), "graceful disconnect must NOT publish the will; received: {got:?}");
 
     sub_client.disconnect().await.ok();
     sub_pump.abort();


### PR DESCRIPTION
## Summary
MQTT spec §3.1.2.5: a client that declares a Will on CONNECT and then goes away without a DISCONNECT packet causes the broker to publish the will on its behalf. A graceful DISCONNECT silently discards it. The previous broker parsed the Will field off the wire but never stored or fired it, so every abrupt disconnect was indistinguishable from a clean exit to downstream subscribers.

## Changes
- \`ActiveClient\` gains \`will: Option<Will>\`; \`SessionManager::connect\` accepts and stores it.
- \`SessionManager::disconnect\` grows a \`graceful: bool\` parameter. When ungraceful and a will is set, the coordinator publishes it (persisting as retained if \`will.retain\` is true) after dropping session locks to avoid re-entry through the publish path.
- \`handle_client_loop\` / \`handle_tls_client_loop\` now return \`Result<bool, Error>\` where \`Ok(true)\` means graceful DISCONNECT packet received and \`Ok(false)\` means TCP EOF without one. Both used to collapse to \`Ok(())\`, which wrongly classified EOF as graceful and silenced the will. Keep-alive expiry also counts as ungraceful.
- Two new real-client e2e tests in \`mqtt_pubsub_e2e.rs\`:
  - Abrupt disconnect delivers the will to a waiting subscriber.
  - Graceful DISCONNECT suppresses it (short-timeout negative assertion).

## Test plan
- [x] \`cargo test -p mockforge-mqtt\` — 229 tests pass (213 lib + integration + e2e + doc)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-mqtt --all-targets -- -D warnings\` clean

## Closes
- Closes #175.