### PR TITLE
fix(mqtt): register outbound QoS 2 state so forwarded PUBRECs match (#173)

### DIFF
--- a/crates/mockforge-mqtt/src/server.rs
+++ b/crates/mockforge-mqtt/src/server.rs
@@ -617,10 +617,24 @@ where
                         return Ok(true);
                     }
                     Some(mut packet) => {
-                        // Assign packet ID for QoS > 0 publish packets
+                        // Assign packet ID for QoS > 0 publish packets.
+                        // For QoS 2 we also need to register outbound
+                        // state up-front so the subscriber's PUBREC
+                        // has a matching entry to match against — the
+                        // "atomic" helper assigns the id and inserts
+                        // into pending_qos2_out in the same lock scope.
                         if let Packet::Publish(ref mut publish) = packet {
-                            if publish.qos != QoS::AtMostOnce && publish.packet_id.is_none() {
-                                if let Some(id) = session_manager.assign_packet_id(client_id).await {
+                            if publish.packet_id.is_none() {
+                                let maybe_id = match publish.qos {
+                                    QoS::AtMostOnce => None,
+                                    QoS::AtLeastOnce => {
+                                        session_manager.assign_packet_id(client_id).await
+                                    }
+                                    QoS::ExactlyOnce => {
+                                        session_manager.assign_packet_id_qos2(client_id).await
+                                    }
+                                };
+                                if let Some(id) = maybe_id {
                                     publish.packet_id = Some(id);
                                 }
                             }
@@ -1016,10 +1030,24 @@ async fn handle_client_loop(
                         return Ok(true);
                     }
                     Some(mut packet) => {
-                        // Assign packet ID for QoS > 0 publish packets
+                        // Assign packet ID for QoS > 0 publish packets.
+                        // For QoS 2 we also need to register outbound
+                        // state up-front so the subscriber's PUBREC
+                        // has a matching entry to match against — the
+                        // "atomic" helper assigns the id and inserts
+                        // into pending_qos2_out in the same lock scope.
                         if let Packet::Publish(ref mut publish) = packet {
-                            if publish.qos != QoS::AtMostOnce && publish.packet_id.is_none() {
-                                if let Some(id) = session_manager.assign_packet_id(client_id).await {
+                            if publish.packet_id.is_none() {
+                                let maybe_id = match publish.qos {
+                                    QoS::AtMostOnce => None,
+                                    QoS::AtLeastOnce => {
+                                        session_manager.assign_packet_id(client_id).await
+                                    }
+                                    QoS::ExactlyOnce => {
+                                        session_manager.assign_packet_id_qos2(client_id).await
+                                    }
+                                };
+                                if let Some(id) = maybe_id {
                                     publish.packet_id = Some(id);
                                 }
                             }

--- a/crates/mockforge-mqtt/src/session.rs
+++ b/crates/mockforge-mqtt/src/session.rs
@@ -711,6 +711,19 @@ impl SessionManager {
         active.get_mut(client_id).map(|c| c.session.next_packet_id())
     }
 
+    /// Atomically assign a packet id *and* register the QoS 2 outbound
+    /// state so the subscriber's PUBREC lands in `handle_pubrec` with a
+    /// matching entry. If these two steps are separate, a racing PUBREC
+    /// from a very fast subscriber could arrive between them and get
+    /// silently dropped.
+    pub async fn assign_packet_id_qos2(&self, client_id: &str) -> Option<u16> {
+        let mut active = self.active_clients.write().await;
+        let client = active.get_mut(client_id)?;
+        let id = client.session.next_packet_id();
+        client.session.start_qos2_outbound(id);
+        Some(id)
+    }
+
     /// Get a client's subscriptions
     pub async fn get_client_subscriptions(&self, client_id: &str) -> Vec<(String, QoS)> {
         let active = self.active_clients.read().await;

--- a/crates/mockforge-mqtt/tests/mqtt_pubsub_e2e.rs
+++ b/crates/mockforge-mqtt/tests/mqtt_pubsub_e2e.rs
@@ -325,6 +325,69 @@ async fn mqtt_last_will_suppressed_on_graceful_disconnect() {
     server.abort();
 }
 
+/// QoS 2 (exactly-once) round-trip. The broker runs two separate
+/// four-step handshakes per message:
+///   inbound:  publisher → PUBLISH; broker → PUBREC; publisher → PUBREL;
+///             broker → PUBCOMP
+///   outbound: broker → PUBLISH; subscriber → PUBREC; broker → PUBREL;
+///             subscriber → PUBCOMP
+/// rumqttc's event loop drives both sides transparently — we just set
+/// `QoS::ExactlyOnce` and assert the payload arrives exactly once. The
+/// real check is "does the outbound PUBREL ever go out". Before this
+/// fix the broker assigned an outbound packet id but never registered
+/// it in `pending_qos2_out`, so the subscriber's PUBREC had no matching
+/// entry and the flow stalled.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mqtt_qos2_exactly_once_round_trip() {
+    let port = free_port().await;
+    let config = MqttConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..MqttConfig::default()
+    };
+    let server = tokio::spawn(async move {
+        start_mqtt_server(config).await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    let mut sub_opts = MqttOptions::new("qos2-sub", "127.0.0.1", port);
+    sub_opts.set_keep_alive(Duration::from_secs(30));
+    let (sub_client, sub_eventloop) = AsyncClient::new(sub_opts, 16);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sub_pump = drain_until_publish(sub_eventloop, tx);
+
+    sub_client.subscribe("qos2/topic", QoS::ExactlyOnce).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let mut pub_opts = MqttOptions::new("qos2-pub", "127.0.0.1", port);
+    pub_opts.set_keep_alive(Duration::from_secs(30));
+    let (pub_client, pub_eventloop) = AsyncClient::new(pub_opts, 16);
+    let pub_pump = pump(pub_eventloop);
+
+    pub_client
+        .publish("qos2/topic", QoS::ExactlyOnce, false, b"exactly-once-payload".to_vec())
+        .await
+        .unwrap();
+
+    let payload = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("qos2 subscriber should receive payload within 5s")
+        .expect("eventloop forwarded payload");
+    assert_eq!(payload, b"exactly-once-payload");
+
+    // Exactly-once: no *additional* payload should arrive on the same
+    // topic. Poll for a short window and assert silence — catches any
+    // duplicate-delivery bug.
+    let extra = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+    assert!(extra.is_err(), "QoS 2 must deliver exactly once; got a duplicate: {extra:?}");
+
+    sub_client.disconnect().await.ok();
+    pub_client.disconnect().await.ok();
+    sub_pump.abort();
+    pub_pump.abort();
+    server.abort();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mqtt_wildcard_subscription_matches_published_topic() {
     // A `+` wildcard subscription must receive messages from any single-


### PR DESCRIPTION
## Summary
The broker's *inbound* QoS 2 handshake (publisher-side: PUBLISH → PUBREC → PUBREL → PUBCOMP) was already complete. But the *outbound* side — broker forwarding a QoS 2 PUBLISH to a subscriber — only assigned a packet id and never inserted it into \`pending_qos2_out\`. When the subscriber replied with PUBREC, \`ClientSession::handle_pubrec\` found no matching entry, returned \`false\`, and the broker never sent PUBREL. Subscribers hung; the flow never completed.

## Fix
- New \`SessionManager::assign_packet_id_qos2\`: assigns a packet id *and* inserts \`pending_qos2_out[id] = WaitingPubrec\` atomically under the same session lock. A racing PUBREC from a fast subscriber can't arrive between \"assign\" and \"register\" anymore.
- Writer paths (plain + TLS) dispatch on \`publish.qos\` and call \`assign_packet_id_qos2\` for ExactlyOnce forwards; the old \`assign_packet_id\` stays for QoS 1.

## Test
- New \`mqtt_qos2_exactly_once_round_trip\` real-client e2e: rumqttc publisher + subscriber exchange a QoS 2 payload, asserts arrival once and no duplicate follows (short-timeout negative assertion). Before the fix this test hung on the subscriber side.

## Test plan
- [x] \`cargo test -p mockforge-mqtt\` — 230 tests pass
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-mqtt --all-targets -- -D warnings\` clean

## Closes
- Closes #173.