### PR TITLE
test(smtp): multi-recipient delivery real-client regression (#183)

### DIFF
--- a/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
+++ b/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
@@ -106,3 +106,70 @@ async fn smtp_real_client_delivers_and_message_is_captured() {
 
     server_handle.abort();
 }
+
+/// Multi-recipient delivery: a single SMTP transaction with `MAIL FROM`
+/// followed by several `RCPT TO` lines before `DATA` must capture every
+/// recipient in `StoredEmail.to`. The existing single-recipient test
+/// only exercises one `RCPT TO`, so a regression that drops all-but-one
+/// recipient would ship silently.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn smtp_real_client_multi_recipient_delivery_captures_all() {
+    let port = free_port().await;
+    let config = SmtpConfig {
+        port,
+        host: "127.0.0.1".into(),
+        enable_starttls: false,
+        fixtures_dir: None,
+        ..SmtpConfig::default()
+    };
+    let spec_registry = Arc::new(SmtpSpecRegistry::new());
+    let server = SmtpServer::new(config, spec_registry.clone()).expect("server builds cleanly");
+    let server_handle = tokio::spawn(async move {
+        server.start().await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    let transport: AsyncSmtpTransport<Tokio1Executor> =
+        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("127.0.0.1")
+            .port(port)
+            .build();
+
+    // lettre expands `.to()` into one RCPT TO per recipient in the same
+    // SMTP transaction, which is exactly what the issue asks us to
+    // cover.
+    let email = Message::builder()
+        .from("sender@example.test".parse::<Mailbox>().unwrap())
+        .to("one@example.test".parse::<Mailbox>().unwrap())
+        .to("two@example.test".parse::<Mailbox>().unwrap())
+        .to("three@example.test".parse::<Mailbox>().unwrap())
+        .subject("MockForge SMTP multi-RCPT")
+        .header(ContentType::TEXT_PLAIN)
+        .body("Hello to three addresses".to_string())
+        .unwrap();
+
+    transport.send(email).await.expect("lettre delivers via mock SMTP");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let captured = loop {
+        let emails = spec_registry.get_emails().expect("mailbox read");
+        if !emails.is_empty() {
+            break emails;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("message never made it into the mock mailbox");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    assert_eq!(captured.len(), 1, "multi-RCPT must still produce exactly one captured message");
+    let mail = &captured[0];
+    for expected in ["one@example.test", "two@example.test", "three@example.test"] {
+        assert!(
+            mail.to.iter().any(|r| r.contains(expected)),
+            "recipient `{expected}` missing from captured mail.to = {:?}",
+            mail.to
+        );
+    }
+
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary
The server already handles multi-\`RCPT TO\` correctly (appends each to \`state.rcpt_to\`, captures the full list in \`StoredEmail.to\`), but the existing e2e coverage from #159 only exercised a single recipient. A regression that dropped all-but-one recipient would have shipped silently — this test locks the behavior in.

## Changes
- New \`smtp_real_client_multi_recipient_delivery_captures_all\` in \`tests/smtp_deliver_e2e.rs\`. lettre sends one message to three recipients (lettre expands \`.to()\` into multiple RCPT TO lines in the same transaction), asserts exactly one captured message whose \`to\` list contains all three addresses.

## Test plan
- [x] \`cargo test -p mockforge-smtp --test smtp_deliver_e2e\` — 2/2 pass
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-smtp --all-targets -- -D warnings\` clean

## Closes
- Closes #183.