### PR TITLE
fix(smtp): preserve 8BITMIME bodies byte-for-byte (#184)

### DIFF
--- a/crates/mockforge-smtp/src/server.rs
+++ b/crates/mockforge-smtp/src/server.rs
@@ -151,35 +151,43 @@ async fn handle_smtp_session(
     writer.write_all(greeting.as_bytes()).await?;
 
     let mut session_state = SessionState::new();
-    let mut line = String::new();
+    // Byte-level accumulator so 8BITMIME bodies (Latin-1, UTF-8 with
+    // explicit content-transfer-encoding, etc.) round-trip verbatim.
+    // `read_line` would fail on non-UTF-8 inputs.
+    let mut line: Vec<u8> = Vec::new();
 
-    while reader.read_line(&mut line).await? > 0 {
-        let command = line.trim();
-        debug!("SMTP command from {}: {}", peer_addr, command);
-
+    while reader.read_until(b'\n', &mut line).await? > 0 {
         // DATA mode bypasses command parsing entirely. Without this, the
         // first word of every body line would be matched against the SMTP
         // verb table — any body beginning with "Hello ..." / "Data ..." /
         // "Quit ..." / etc. was being re-interpreted as a command and
         // dropped on the floor. Inside DATA mode, only the bare "." ends
         // the message; everything else (headers, blank separator, body
-        // lines, verbatim) accumulates.
+        // lines, verbatim) accumulates *as bytes*.
         if session_state.in_data_mode {
-            if command == "." {
+            // Strip trailing \r\n / \n. If the line is exactly "." +
+            // newline, that terminates the DATA section per RFC 5321.
+            let trimmed = strip_line_terminator(&line);
+            if trimmed == b"." {
                 session_state.in_data_mode = false;
                 let response =
                     process_email(&session_state, &registry, &middleware, peer_addr).await?;
                 writer.write_all(response.as_bytes()).await?;
                 session_state.reset();
             } else {
-                // Preserve the raw line (minus trailing \r\n) so headers
-                // and body content survive byte-for-byte.
-                session_state.data.push_str(line.trim_end_matches(['\r', '\n']));
-                session_state.data.push('\n');
+                session_state.data.extend_from_slice(trimmed);
+                session_state.data.push(b'\n');
             }
             line.clear();
             continue;
         }
+
+        // Outside DATA mode, SMTP verbs are ASCII-only per spec. Decode
+        // lossily so a malformed UTF-8 byte doesn't crash the session,
+        // then parse the verb table as before.
+        let as_str = String::from_utf8_lossy(&line);
+        let command = as_str.trim();
+        debug!("SMTP command from {}: {}", peer_addr, command);
 
         // Skip blank lines outside DATA mode — otherwise idle keep-alive
         // newlines would reach the verb parser.
@@ -217,6 +225,20 @@ async fn handle_smtp_session(
     }
 
     Ok(())
+}
+
+/// Strip trailing `\r\n` or `\n` from an SMTP line read via
+/// `read_until(b'\n', ...)`. Keeps the rest of the bytes intact so
+/// a non-UTF-8 body round-trips verbatim.
+fn strip_line_terminator(line: &[u8]) -> &[u8] {
+    let mut end = line.len();
+    if end > 0 && line[end - 1] == b'\n' {
+        end -= 1;
+    }
+    if end > 0 && line[end - 1] == b'\r' {
+        end -= 1;
+    }
+    &line[..end]
 }
 
 /// Handle a single SMTP command
@@ -322,8 +344,13 @@ async fn handle_smtp_command<W: AsyncWriteExt + Unpin>(
                     writer.write_all(response.as_bytes()).await?;
                     state.reset();
                 } else {
-                    state.data.push_str(command);
-                    state.data.push('\n');
+                    // Command path: the caller already trimmed the line
+                    // into a `&str`. Non-ASCII bodies are accumulated
+                    // via the byte-level DATA-mode branch in
+                    // `handle_smtp_session`; this fallback just
+                    // preserves the UTF-8 subset.
+                    state.data.extend_from_slice(command.as_bytes());
+                    state.data.push(b'\n');
                 }
                 Ok(true)
             } else {
@@ -365,14 +392,17 @@ async fn process_email(
         from: from.clone(),
         to: state.rcpt_to.clone(),
         subject: subject.clone(),
-        body: state.data.clone(),
+        // `body` is `String`; decode lossy so callers that only want a
+        // preview of a UTF-8 message aren't forced to round-trip
+        // through `raw`. Byte-exact consumers use `raw`.
+        body: String::from_utf8_lossy(&state.data).into_owned(),
         headers: HashMap::from([
             ("from".to_string(), from.clone()),
             ("to".to_string(), to.clone()),
             ("subject".to_string(), subject.clone()),
         ]),
         received_at: chrono::Utc::now(),
-        raw: Some(state.data.as_bytes().to_vec()),
+        raw: Some(state.data.clone()),
     };
     if let Err(e) = registry.store_email(captured) {
         warn!("Failed to store email in mailbox: {}", e);
@@ -393,7 +423,7 @@ async fn process_email(
             ("to".to_string(), to.clone()),
             ("subject".to_string(), subject.clone()),
         ]),
-        body: Some(state.data.as_bytes().to_vec()),
+        body: Some(state.data.clone()),
         client_ip: Some(peer_addr.ip().to_string()),
     };
 
@@ -429,9 +459,17 @@ fn extract_email_address(param: &str) -> String {
     param.trim().to_string()
 }
 
-/// Extract subject from email data
-fn extract_subject(data: &str) -> String {
-    for line in data.lines() {
+/// Extract subject from email data. Takes bytes so non-UTF-8 bodies
+/// still succeed; the header zone (above the blank line) is ASCII per
+/// RFC 5322, so lossy decoding for the search is safe.
+fn extract_subject(data: &[u8]) -> String {
+    let header_text = String::from_utf8_lossy(data);
+    for line in header_text.lines() {
+        // Headers end at the first blank line; stop searching there so we
+        // don't accidentally match a "Subject:" that appears in the body.
+        if line.is_empty() {
+            break;
+        }
         if line.to_lowercase().starts_with("subject:") {
             return line[8..].trim().to_string();
         }
@@ -439,11 +477,17 @@ fn extract_subject(data: &str) -> String {
     String::new()
 }
 
-/// Session state for SMTP connection
+/// Session state for SMTP connection.
+///
+/// `data` is `Vec<u8>` (not `String`) so the DATA body survives
+/// byte-for-byte even when the sender negotiated 8BITMIME and
+/// included non-ASCII / non-UTF-8 content. The mailbox API still
+/// exposes a `String` body via lossy decoding; `raw` holds the
+/// byte-accurate version for consumers that need it.
 struct SessionState {
     mail_from: Option<String>,
     rcpt_to: Vec<String>,
-    data: String,
+    data: Vec<u8>,
     in_data_mode: bool,
 }
 
@@ -452,7 +496,7 @@ impl SessionState {
         Self {
             mail_from: None,
             rcpt_to: Vec::new(),
-            data: String::new(),
+            data: Vec::new(),
             in_data_mode: false,
         }
     }
@@ -495,25 +539,25 @@ mod tests {
     fn test_extract_subject() {
         let data =
             "From: sender@example.com\nSubject: Test Email\nTo: recipient@example.com\n\nBody text";
-        assert_eq!(extract_subject(data), "Test Email");
+        assert_eq!(extract_subject(data.as_bytes()), "Test Email");
     }
 
     #[test]
     fn test_extract_subject_not_found() {
         let data = "From: sender@example.com\nTo: recipient@example.com\n\nBody text";
-        assert_eq!(extract_subject(data), "");
+        assert_eq!(extract_subject(data.as_bytes()), "");
     }
 
     #[test]
     fn test_extract_subject_lowercase() {
         let data = "subject: lowercase subject\nFrom: sender@example.com";
-        assert_eq!(extract_subject(data), "lowercase subject");
+        assert_eq!(extract_subject(data.as_bytes()), "lowercase subject");
     }
 
     #[test]
     fn test_extract_subject_mixed_case() {
         let data = "SUBJECT: UPPERCASE SUBJECT\nFrom: sender@example.com";
-        assert_eq!(extract_subject(data), "UPPERCASE SUBJECT");
+        assert_eq!(extract_subject(data.as_bytes()), "UPPERCASE SUBJECT");
     }
 
     #[test]
@@ -545,7 +589,7 @@ mod tests {
         state.mail_from = Some("test@example.com".to_string());
         state.rcpt_to.push("recipient1@example.com".to_string());
         state.rcpt_to.push("recipient2@example.com".to_string());
-        state.data = "Email body content".to_string();
+        state.data = b"Email body content".to_vec();
         state.in_data_mode = true;
 
         state.reset();
@@ -568,10 +612,30 @@ mod tests {
     #[test]
     fn test_session_state_data_accumulation() {
         let mut state = SessionState::new();
-        state.data.push_str("Line 1\n");
-        state.data.push_str("Line 2\n");
-        state.data.push_str("Line 3\n");
-        assert_eq!(state.data, "Line 1\nLine 2\nLine 3\n");
+        state.data.extend_from_slice(b"Line 1\n");
+        state.data.extend_from_slice(b"Line 2\n");
+        state.data.extend_from_slice(b"Line 3\n");
+        assert_eq!(state.data, b"Line 1\nLine 2\nLine 3\n");
+    }
+
+    #[test]
+    fn test_strip_line_terminator() {
+        assert_eq!(strip_line_terminator(b"hello\r\n"), b"hello");
+        assert_eq!(strip_line_terminator(b"hello\n"), b"hello");
+        assert_eq!(strip_line_terminator(b"hello"), b"hello");
+        assert_eq!(strip_line_terminator(b""), b"");
+        // Non-UTF-8 bytes survive intact through the strip.
+        assert_eq!(strip_line_terminator(b"\xff\xfe\r\n"), b"\xff\xfe");
+    }
+
+    #[test]
+    fn test_extract_subject_from_bytes_with_non_utf8_body() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"From: a@example.test\r\n");
+        data.extend_from_slice(b"Subject: 8BITMIME body below\r\n");
+        data.extend_from_slice(b"\r\n");
+        data.extend_from_slice(&[0xff, 0xfe, 0xfd]); // garbage bytes
+        assert_eq!(extract_subject(&data), "8BITMIME body below");
     }
 
     #[tokio::test]

--- a/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
+++ b/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
@@ -14,6 +14,8 @@ use lettre::{AsyncSmtpTransport, AsyncTransport, Tokio1Executor};
 use mockforge_smtp::{SmtpConfig, SmtpServer, SmtpSpecRegistry};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
 
 async fn free_port() -> u16 {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -170,6 +172,122 @@ async fn smtp_real_client_multi_recipient_delivery_captures_all() {
             mail.to
         );
     }
+
+    server_handle.abort();
+}
+
+/// Drive the SMTP server directly over a raw `TcpStream` so we can
+/// include non-UTF-8 bytes in the body. lettre / `Message` insist on
+/// valid UTF-8 internally, so a lettre-based test can't exercise the
+/// 8BITMIME byte-preservation path end to end.
+async fn read_line_until_code(reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>) -> String {
+    let mut buf = String::new();
+    reader.read_line(&mut buf).await.expect("read SMTP reply line");
+    buf
+}
+
+/// 8BITMIME body preservation. The server advertises 8BITMIME in its
+/// EHLO response and must therefore preserve non-ASCII bytes in the
+/// DATA payload verbatim — specifically, `String::push_str`-based
+/// accumulation would drop or corrupt invalid UTF-8. This test drives
+/// a raw SMTP session and puts 0xFF/0xFE/0x80 in the body, then
+/// inspects `StoredEmail.raw` for a byte-exact match.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn smtp_raw_client_8bitmime_body_preserved_byte_for_byte() {
+    let port = free_port().await;
+    let config = SmtpConfig {
+        port,
+        host: "127.0.0.1".into(),
+        enable_starttls: false,
+        fixtures_dir: None,
+        ..SmtpConfig::default()
+    };
+    let spec_registry = Arc::new(SmtpSpecRegistry::new());
+    let server = SmtpServer::new(config, spec_registry.clone()).expect("server builds cleanly");
+    let server_handle = tokio::spawn(async move {
+        server.start().await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    let stream = TcpStream::connect(("127.0.0.1", port)).await.expect("connect");
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    // Greeting
+    let line = read_line_until_code(&mut reader).await;
+    assert!(line.starts_with("220"), "unexpected greeting: {line}");
+
+    // EHLO → 250 multiline response; drain until we see a code line
+    // without a '-' continuation.
+    write_half.write_all(b"EHLO test-client\r\n").await.unwrap();
+    loop {
+        let line = read_line_until_code(&mut reader).await;
+        if line.len() >= 4 && &line[3..4] == " " {
+            break;
+        }
+    }
+
+    // Use BODY=8BITMIME on MAIL FROM to match what a real 8BITMIME
+    // client would advertise. The server doesn't need to do anything
+    // special with it — it just shouldn't reject the verb form.
+    write_half
+        .write_all(b"MAIL FROM:<sender@example.test> BODY=8BITMIME\r\n")
+        .await
+        .unwrap();
+    let line = read_line_until_code(&mut reader).await;
+    assert!(line.starts_with("250"), "MAIL FROM reply: {line}");
+
+    write_half.write_all(b"RCPT TO:<receiver@example.test>\r\n").await.unwrap();
+    let line = read_line_until_code(&mut reader).await;
+    assert!(line.starts_with("250"), "RCPT TO reply: {line}");
+
+    write_half.write_all(b"DATA\r\n").await.unwrap();
+    let line = read_line_until_code(&mut reader).await;
+    assert!(line.starts_with("354"), "DATA reply: {line}");
+
+    // Headers (ASCII) + blank line + body (deliberately non-UTF-8).
+    let body_bytes: &[u8] = &[0xff, 0xfe, 0x80, b'h', b'i'];
+    let mut payload = Vec::new();
+    payload.extend_from_slice(b"Subject: 8BITMIME test\r\n");
+    payload.extend_from_slice(b"From: sender@example.test\r\n");
+    payload.extend_from_slice(b"To: receiver@example.test\r\n");
+    payload.extend_from_slice(b"\r\n");
+    payload.extend_from_slice(body_bytes);
+    payload.extend_from_slice(b"\r\n.\r\n");
+    write_half.write_all(&payload).await.unwrap();
+
+    let line = read_line_until_code(&mut reader).await;
+    assert!(line.starts_with("250"), "end-of-DATA reply: {line}");
+
+    write_half.write_all(b"QUIT\r\n").await.unwrap();
+    // Drain anything else the server sends.
+    let mut tail = Vec::new();
+    let _ = reader.read_to_end(&mut tail).await;
+
+    // Wait for the mailbox to register the delivery, then assert.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let captured = loop {
+        let emails = spec_registry.get_emails().expect("mailbox read");
+        if !emails.is_empty() {
+            break emails;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("8BITMIME message never made it into the mock mailbox");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    assert_eq!(captured.len(), 1);
+    let mail = &captured[0];
+    let raw = mail.raw.as_ref().expect("raw bytes must be captured");
+    // The body bytes must survive. We don't assert on the exact header
+    // formatting — different SMTP servers canonicalize headers — but
+    // the non-ASCII body bytes must be present intact.
+    assert!(
+        raw.windows(body_bytes.len()).any(|w| w == body_bytes),
+        "non-ASCII body bytes (0xFF 0xFE 0x80 'h' 'i') were lost from raw: {raw:?}"
+    );
+    assert_eq!(mail.subject, "8BITMIME test");
 
     server_handle.abort();
 }


### PR DESCRIPTION
## Summary
The server advertised 8BITMIME in EHLO, but the DATA accumulator was \`String\` and the read loop used \`read_line\`. Any body byte outside ASCII either aborted the session (invalid UTF-8 → \`read_line\` returns Err) or got silently corrupted on the way into storage. 8BITMIME clients that send Latin-1, raw binary, or ill-formed UTF-8 saw mail delivery fail silently.

## Changes
- \`SessionState.data\` is now \`Vec<u8>\`; the read loop uses \`read_until(b'\\n')\` and accumulates raw bytes in DATA mode. Outside DATA mode, lines are lossy-decoded for verb parsing (SMTP verbs are ASCII per RFC 5321, so no information is lost).
- \`extract_subject\` takes \`&[u8]\` and lossy-decodes the header zone only (stops at the first blank line).
- \`StoredEmail.body\` (String) is lossy-decoded at capture for ergonomics; \`StoredEmail.raw\` (Vec<u8>) holds the byte-exact copy.
- New helper \`strip_line_terminator(&[u8])\` trims \`\\r\\n\` / \`\\n\` without disturbing earlier bytes.

## Tests
- Two new unit tests: \`strip_line_terminator\` edge cases including non-UTF-8 bytes, and \`extract_subject\` on a message whose body contains invalid UTF-8.
- New e2e \`smtp_raw_client_8bitmime_body_preserved_byte_for_byte\` in \`smtp_deliver_e2e.rs\` drives the server directly over a \`TcpStream\` (lettre's \`Message\` insists on UTF-8 internally so can't exercise the byte-preservation path). Sends \`MAIL FROM BODY=8BITMIME\`, puts 0xFF 0xFE 0x80 in the DATA body, asserts \`StoredEmail.raw\` contains those exact bytes.

## Test plan
- [x] \`cargo test -p mockforge-smtp\` — 83 tests pass (63 lib + 16 integration + 3 e2e + 1 doc)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-smtp --all-targets -- -D warnings\` clean

## Closes
- Closes #184.