### PR TITLE
feat(graphql): subscriptions over graphql-transport-ws WebSocket (#170)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8080,9 +8080,11 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-axum",
+ "async-stream",
  "async-trait",
  "axum 0.8.8",
  "base64 0.22.1",
+ "futures",
  "indexmap 2.13.0",
  "mockforge-core",
  "mockforge-data",
@@ -8103,8 +8105,10 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower 0.5.3",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/mockforge-graphql/Cargo.toml
+++ b/crates/mockforge-graphql/Cargo.toml
@@ -18,6 +18,9 @@ missing_docs = "deny"
 # GraphQL implementation - simplified for basic functionality
 async-graphql = { version = "7.0", features = ["apollo_tracing"] }
 async-graphql-axum = "7.0"
+# Streams for the Subscription root (`tick` emits a stream of ints).
+futures = { workspace = true }
+async-stream = "0.3"
 
 # Workspace dependencies
 tokio = { workspace = true }
@@ -57,3 +60,8 @@ tokio = { version = "1.49", features = ["macros", "rt-multi-thread"] }
 tower = { workspace = true }
 opentelemetry_sdk = "0.22"
 tempfile = "3.8"
+# Real GraphQL-over-WebSocket client for the subscriptions e2e test.
+tokio-tungstenite = "0.24"
+reqwest = { workspace = true, features = ["json"] }
+futures = { workspace = true }
+url = "2"

--- a/crates/mockforge-graphql/src/executor.rs
+++ b/crates/mockforge-graphql/src/executor.rs
@@ -1,7 +1,7 @@
 //! GraphQL execution engine
 
 use async_graphql::http::GraphQLPlaygroundConfig;
-use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
 use axum::{
     extract::State,
     response::{Html, IntoResponse},
@@ -62,11 +62,24 @@ pub async fn create_graphql_router(
 ) -> Result<Router, Box<dyn std::error::Error + Send + Sync>> {
     // Create a basic schema
     let schema = GraphQLSchema::generate_basic_schema();
+    // `async-graphql-axum`'s `GraphQLSubscription::new` wants the
+    // schema directly (not wrapped in our executor), so clone the
+    // inner async-graphql Schema for the /graphql/ws route before
+    // moving `schema` into the executor.
+    let schema_for_subscriptions = schema.schema().clone();
     let executor = GraphQLExecutor::new(schema);
 
     let mut app = Router::new()
         .route("/graphql", post(graphql_handler))
         .route("/graphql", get(graphql_playground))
+        // WebSocket endpoint for GraphQL subscriptions using the
+        // graphql-transport-ws protocol (the default in both
+        // async-graphql-axum and Apollo Sandbox). Clients that only
+        // support the older graphql-ws still work because the axum
+        // handler negotiates both subprotocols. `GraphQLSubscription`
+        // is a `tower::Service`, so we use `route_service` rather
+        // than `route` + a handler function.
+        .route_service("/graphql/ws", GraphQLSubscription::new(schema_for_subscriptions))
         .with_state(Arc::new(executor));
 
     // Add latency injection if configured
@@ -122,7 +135,7 @@ async fn graphql_playground() -> impl IntoResponse {
     Html(async_graphql::http::playground_source(
         GraphQLPlaygroundConfig::new("/graphql")
             .title("MockForge GraphQL Playground")
-            .subscription_endpoint("/graphql"),
+            .subscription_endpoint("/graphql/ws"),
     ))
 }
 

--- a/crates/mockforge-graphql/src/schema.rs
+++ b/crates/mockforge-graphql/src/schema.rs
@@ -1,6 +1,8 @@
 //! GraphQL schema parsing and generation
 
-use async_graphql::{EmptySubscription, Object, Schema};
+use async_graphql::{Object, Schema, Subscription};
+use futures::stream::Stream;
+use std::time::Duration;
 
 /// Simple User type for GraphQL
 #[derive(async_graphql::SimpleObject, Clone)]
@@ -97,20 +99,45 @@ impl MutationRoot {
     }
 }
 
+/// Root subscription type. A single `tick` subscription lets clients
+/// exercise the subscription dispatch path (WebSocket via
+/// `graphql-transport-ws` / `graphql-ws`, SSE, etc.) against the
+/// default schema without registering a custom SDL.
+///
+/// `tick` emits a monotonically increasing `i32` every 100ms, starting
+/// from 1, up to the requested `count`. Clients without a `count`
+/// argument get 5 ticks by default. The interval is short enough that
+/// multi-event tests complete in well under a second.
+pub struct SubscriptionRoot;
+
+#[Subscription]
+impl SubscriptionRoot {
+    /// Emit `count` ticks (default 5) at 100ms intervals.
+    async fn tick(&self, count: Option<i32>) -> impl Stream<Item = i32> {
+        let n = count.unwrap_or(5).max(1) as usize;
+        async_stream::stream! {
+            for i in 1..=n {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                yield i as i32;
+            }
+        }
+    }
+}
+
 /// GraphQL schema manager
 pub struct GraphQLSchema {
-    schema: Schema<QueryRoot, MutationRoot, EmptySubscription>,
+    schema: Schema<QueryRoot, MutationRoot, SubscriptionRoot>,
 }
 
 impl GraphQLSchema {
     /// Create a new basic schema
     pub fn new() -> Self {
-        let schema = Schema::build(QueryRoot, MutationRoot, EmptySubscription).finish();
+        let schema = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot).finish();
         Self { schema }
     }
 
     /// Get the underlying schema
-    pub fn schema(&self) -> &Schema<QueryRoot, MutationRoot, EmptySubscription> {
+    pub fn schema(&self) -> &Schema<QueryRoot, MutationRoot, SubscriptionRoot> {
         &self.schema
     }
 

--- a/crates/mockforge-graphql/tests/graphql_client_e2e.rs
+++ b/crates/mockforge-graphql/tests/graphql_client_e2e.rs
@@ -12,6 +12,14 @@ use serde_json::json;
 use std::time::Duration;
 
 async fn spawn_server() -> String {
+    let (http_url, _ws_url) = spawn_server_pair().await;
+    http_url
+}
+
+/// Spawn a GraphQL server and return both the HTTP `/graphql` URL
+/// and the WebSocket `/graphql/ws` URL. Used by the subscriptions
+/// test; the HTTP tests just discard the second element.
+async fn spawn_server_pair() -> (String, String) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let router = create_graphql_router(None).await.expect("router builds cleanly");
@@ -20,7 +28,7 @@ async fn spawn_server() -> String {
     });
     // Give axum a tick to start accepting.
     tokio::time::sleep(Duration::from_millis(50)).await;
-    format!("http://{addr}/graphql")
+    (format!("http://{addr}/graphql"), format!("ws://{addr}/graphql/ws"))
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -128,16 +136,18 @@ async fn graphql_real_client_introspection_query_returns_schema() {
         "queryType name should be QueryRoot"
     );
 
-    // Default schema exposes `MutationRoot` (with `createUser`) but
-    // still uses `EmptySubscription` — so subscriptionType stays null.
+    // Default schema now exposes both a mutation root (`createUser`)
+    // and a subscription root (`tick`) — introspection must report
+    // both.
     assert_eq!(
         schema.pointer("/mutationType/name").and_then(|v| v.as_str()),
         Some("MutationRoot"),
-        "default schema now has a mutation root named MutationRoot"
+        "default schema has a mutation root named MutationRoot"
     );
-    assert!(
-        schema.pointer("/subscriptionType").map(|v| v.is_null()).unwrap_or(false),
-        "default schema has no subscription root; subscriptionType should be null"
+    assert_eq!(
+        schema.pointer("/subscriptionType/name").and_then(|v| v.as_str()),
+        Some("SubscriptionRoot"),
+        "default schema has a subscription root named SubscriptionRoot"
     );
 
     let types = schema
@@ -204,4 +214,104 @@ async fn graphql_syntactically_invalid_query_surfaces_error_field() {
         errors.is_some_and(|e| !e.is_empty()),
         "expected non-empty errors array for invalid query, got: {value}"
     );
+}
+
+/// Real-client subscription via WebSocket. Uses the
+/// `graphql-transport-ws` subprotocol (the current spec; Apollo
+/// defaults to this, and async-graphql-axum's GraphQLSubscription
+/// service handles it). The default schema exposes a `tick`
+/// subscription that yields `count` monotonically increasing ints
+/// at 100ms intervals; we ask for 3 and assert we see exactly those
+/// three values in order.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_real_client_subscription_ticks_over_websocket() {
+    use futures::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::handshake::client::generate_key;
+    use tokio_tungstenite::tungstenite::http::Request;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let (_http_url, ws_url) = spawn_server_pair().await;
+
+    // Build the upgrade request by hand so we can advertise the
+    // `graphql-transport-ws` subprotocol, which the server requires.
+    let parsed = url::Url::parse(&ws_url).expect("valid ws url");
+    let host = parsed.host_str().expect("host");
+    let port = parsed.port().expect("port");
+    let req = Request::builder()
+        .uri(&ws_url)
+        .header("Host", format!("{host}:{port}"))
+        .header("Upgrade", "websocket")
+        .header("Connection", "Upgrade")
+        .header("Sec-WebSocket-Key", generate_key())
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Protocol", "graphql-transport-ws")
+        .body(())
+        .expect("request builds");
+
+    let (mut ws, _resp) =
+        tokio::time::timeout(Duration::from_secs(5), tokio_tungstenite::connect_async(req))
+            .await
+            .expect("ws connect should complete within 5s")
+            .expect("ws handshake ok");
+
+    // graphql-transport-ws handshake: client sends `connection_init`,
+    // server replies `connection_ack`.
+    ws.send(Message::Text(r#"{"type":"connection_init"}"#.into()))
+        .await
+        .expect("send connection_init");
+    let ack = tokio::time::timeout(Duration::from_secs(5), ws.next())
+        .await
+        .expect("ack arrives within 5s")
+        .expect("ack is present")
+        .expect("no transport error");
+    let ack_text = ack.to_text().expect("ack is text");
+    assert!(ack_text.contains("connection_ack"), "expected connection_ack, got: {ack_text}");
+
+    // Open the subscription. `id` is arbitrary; the server echoes it
+    // back on every `next` frame so we can demultiplex. We ask for 3
+    // ticks so the stream terminates quickly.
+    ws.send(Message::Text(
+        r#"{"type":"subscribe","id":"1","payload":{"query":"subscription { tick(count: 3) }"}}"#
+            .into(),
+    ))
+    .await
+    .expect("send subscribe");
+
+    // Drain `next` frames until we've collected 3 ticks or the stream
+    // ends. graphql-transport-ws emits:
+    //   {"type":"next","id":"1","payload":{"data":{"tick":N}}}
+    // followed by a final {"type":"complete","id":"1"}.
+    let mut ticks: Vec<i64> = Vec::new();
+    let mut saw_complete = false;
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("frame arrives within 5s")
+            .expect("frame present")
+            .expect("no transport error");
+        let text = match msg {
+            Message::Text(t) => t,
+            Message::Close(_) => break,
+            _ => continue, // ping/pong/binary — ignore.
+        };
+        let v: serde_json::Value = serde_json::from_str(&text).expect("valid json frame");
+        match v.pointer("/type").and_then(|t| t.as_str()) {
+            Some("next") => {
+                let n = v
+                    .pointer("/payload/data/tick")
+                    .and_then(|x| x.as_i64())
+                    .expect("tick value present in frame");
+                ticks.push(n);
+            }
+            Some("complete") => {
+                saw_complete = true;
+                break;
+            }
+            Some("error") => panic!("subscription error frame: {v}"),
+            _ => {}
+        }
+    }
+
+    assert!(saw_complete, "expected a terminal `complete` frame; got {} ticks", ticks.len());
+    assert_eq!(ticks, vec![1, 2, 3], "expected 3 monotonically increasing ticks");
 }


### PR DESCRIPTION
## Summary
The default schema used \`EmptySubscription\` and the router had no WebSocket endpoint — any client that tried \`subscription { ... }\` via Apollo, urql, or a raw graphql-transport-ws handshake got \"Subscription root type not defined\" and the upgrade was refused. The playground even advertised \`/graphql\` as the subscription endpoint, but that route only answered POST queries.

## Changes
- **New \`SubscriptionRoot\`** with one field: \`tick(count: Int) -> Int\`. Emits \`count\` (default 5) monotonically increasing ints at 100ms intervals via \`async_stream::stream!\`. Short enough that multi-event tests complete in under a second.
- \`GraphQLSchema\` parameterizes on \`SubscriptionRoot\` (not \`EmptySubscription\`).
- \`create_graphql_router\` mounts \`async_graphql_axum::GraphQLSubscription\` at \`/graphql/ws\` via \`route_service\` (it's a tower Service, not a handler fn). The playground's \`subscription_endpoint\` points at the new route.
- New deps: \`futures\` + \`async-stream\` (prod) and \`tokio-tungstenite\` + \`url\` (dev).
- The HTTP introspection test added in #188 now asserts \`subscriptionType.name == \"SubscriptionRoot\"\` instead of expecting null.

## Test
- \`graphql_real_client_subscription_ticks_over_websocket\`: raw tokio-tungstenite client opens a WebSocket with the \`graphql-transport-ws\` subprotocol, runs \`connection_init\` → \`connection_ack\`, sends a \`subscribe\` for \`tick(count: 3)\`, collects \`next\` frames until \`complete\`, asserts exactly \`[1, 2, 3]\` and a terminal \`complete\` frame.

## Test plan
- [x] \`cargo test -p mockforge-graphql\` — 187 tests pass (120 lib + integration + 6 e2e including the new subscription)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-graphql --all-targets -- -D warnings\` clean

## Closes
- Closes #170.