### PR TITLE
feat(amqp): durable queues survive client disconnect + drain on consume (#176)

### DIFF
--- a/crates/mockforge-amqp/src/connection.rs
+++ b/crates/mockforge-amqp/src/connection.rs
@@ -2042,28 +2042,36 @@ impl AmqpConnection {
             return Ok(());
         }
 
-        // For each consumer, try to deliver messages
+        // For each consumer, drain the queue up to the consumer's
+        // prefetch budget. Without the loop, only one message goes
+        // out per `deliver_to_consumers` call — so a durable queue
+        // with N messages where N > 1 only dribbles to a late
+        // subscriber as new publishes trigger new notifications.
         for (channel_id, consumer_tag, no_ack, prefetch_count) in deliveries {
-            // Check prefetch limit
-            let unacked_count =
-                self.channels.get(&channel_id).map(|ch| ch.unacked_messages.len()).unwrap_or(0);
+            loop {
+                // Check prefetch limit each iteration — an ack arriving
+                // mid-drain could free up budget.
+                let unacked_count =
+                    self.channels.get(&channel_id).map(|ch| ch.unacked_messages.len()).unwrap_or(0);
 
-            if prefetch_count > 0 && unacked_count >= prefetch_count as usize {
-                tracing::debug!(
-                    "Consumer {} on channel {} at prefetch limit",
-                    consumer_tag,
-                    channel_id
-                );
-                continue;
-            }
+                if prefetch_count > 0 && unacked_count >= prefetch_count as usize {
+                    tracing::debug!(
+                        "Consumer {} on channel {} at prefetch limit",
+                        consumer_tag,
+                        channel_id
+                    );
+                    break;
+                }
 
-            // Try to get a message from the queue
-            let message_opt = {
-                let mut queues = self.queues.write().await;
-                queues.get_queue_mut(queue_name).and_then(|q| q.dequeue())
-            };
+                // Try to get a message from the queue
+                let message_opt = {
+                    let mut queues = self.queues.write().await;
+                    queues.get_queue_mut(queue_name).and_then(|q| q.dequeue())
+                };
 
-            if let Some(queued_msg) = message_opt {
+                let Some(queued_msg) = message_opt else {
+                    break; // queue empty — done for this consumer
+                };
                 // Get delivery tag
                 let delivery_tag = self
                     .channels

--- a/crates/mockforge-amqp/src/queues.rs
+++ b/crates/mockforge-amqp/src/queues.rs
@@ -140,6 +140,18 @@ impl QueueManager {
         }
     }
 
+    /// Declare a queue. AMQP spec: declaring a queue that already
+    /// exists with the same flags is a no-op — it MUST NOT clear
+    /// the queue's state or drop pending messages. Previously this
+    /// method replaced the existing queue on every call, so a
+    /// durable queue's contents evaporated the moment a second
+    /// client redeclared it on reconnect.
+    ///
+    /// We use `entry(...).or_insert_with(...)` so the existing
+    /// queue (and its messages) survives. Callers that need strict
+    /// AMQP conformance around mismatched flags can layer a
+    /// channel-error response on top; for this PR's scope
+    /// (durability) we just preserve the existing queue.
     pub fn declare_queue(
         &mut self,
         name: String,
@@ -147,8 +159,9 @@ impl QueueManager {
         exclusive: bool,
         auto_delete: bool,
     ) {
-        let queue = Queue::new(name.clone(), durable, exclusive, auto_delete);
-        self.queues.insert(name, queue);
+        self.queues
+            .entry(name.clone())
+            .or_insert_with(|| Queue::new(name, durable, exclusive, auto_delete));
     }
 
     pub fn get_queue(&self, name: &str) -> Option<&Queue> {

--- a/crates/mockforge-amqp/tests/amqp_pubsub_e2e.rs
+++ b/crates/mockforge-amqp/tests/amqp_pubsub_e2e.rs
@@ -190,3 +190,102 @@ async fn amqp_topic_exchange_routes_wildcard_binding() {
     let _ = conn.close(0, "bye").await;
     server.abort();
 }
+
+/// Durable queues persist across a producer's disconnect. The AMQP
+/// broker must:
+///   1. Keep the queue declared by client A after A's connection
+///      closes (rather than replacing it when a subsequent redeclare
+///      arrives).
+///   2. Keep any pending messages that were routed into that queue.
+///   3. Deliver them to a fresh consumer C that reconnects later and
+///      redeclares the same queue name with the same flags.
+///
+/// Previously `declare_queue` unconditionally overwrote the existing
+/// queue on every call, so client B's redeclare dropped A's pending
+/// messages on the floor and the consumer got nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn amqp_durable_queue_retains_messages_across_producer_disconnect() {
+    let (port, server) = spawn_broker().await;
+    let uri = format!("amqp://127.0.0.1:{port}/%2f");
+
+    let queue_name = "durable-retains";
+    let durable_opts = QueueDeclareOptions {
+        durable: true,
+        exclusive: false,
+        auto_delete: false,
+        ..Default::default()
+    };
+
+    // --- Producer: declare durable queue + publish, then disconnect ---
+    {
+        let producer_conn = Connection::connect(&uri, ConnectionProperties::default())
+            .await
+            .expect("producer connects");
+        let producer_ch = producer_conn.create_channel().await.expect("producer channel");
+        producer_ch
+            .queue_declare(queue_name, durable_opts, FieldTable::default())
+            .await
+            .expect("producer declares durable queue");
+        for i in 0..3u32 {
+            producer_ch
+                .basic_publish(
+                    "",
+                    queue_name,
+                    BasicPublishOptions::default(),
+                    format!("persist-{i}").as_bytes(),
+                    BasicProperties::default(),
+                )
+                .await
+                .expect("publish");
+        }
+        // Give the broker a moment to route + persist.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let _ = producer_conn.close(0, "producer done").await;
+    }
+
+    // --- Consumer: fresh connection, redeclare same queue, drain ---
+    let consumer_conn = Connection::connect(&uri, ConnectionProperties::default())
+        .await
+        .expect("consumer reconnects after producer disconnect");
+    let consumer_ch = consumer_conn.create_channel().await.expect("consumer channel");
+    consumer_ch
+        .queue_declare(queue_name, durable_opts, FieldTable::default())
+        .await
+        .expect("consumer redeclares same durable queue — should be idempotent");
+
+    let mut consumer = consumer_ch
+        .basic_consume(
+            queue_name,
+            "durable-consumer",
+            BasicConsumeOptions {
+                no_ack: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .expect("basic_consume");
+
+    let mut received: Vec<Vec<u8>> = Vec::new();
+    for _ in 0..3 {
+        let delivery = tokio::time::timeout(Duration::from_secs(5), consumer.next())
+            .await
+            .expect("each persisted message should arrive within 5s")
+            .expect("stream produced")
+            .expect("delivery parses");
+        received.push(delivery.data);
+    }
+    received.sort();
+    assert_eq!(
+        received,
+        vec![
+            b"persist-0".to_vec(),
+            b"persist-1".to_vec(),
+            b"persist-2".to_vec(),
+        ],
+        "durable queue must deliver every persisted message to the new consumer"
+    );
+
+    let _ = consumer_conn.close(0, "consumer done").await;
+    server.abort();
+}


### PR DESCRIPTION
## Summary
Durable queues declared by a departing producer lost their buffered messages the moment a consumer reconnected. Two bugs conspired:

1. \`QueueManager::declare_queue\` unconditionally constructed a fresh \`Queue\` under the same name, replacing the existing queue and wiping its buffer.
2. \`deliver_to_consumers\` only drained **one** message per call. With no subsequent publishes to trigger more notifications, a newly-arrived consumer only saw the first message; the rest stayed buffered until the next publish.

## Fix
- \`declare_queue\` uses \`entry(name).or_insert_with(...)\` — existing queue (and messages) survives a redeclare. AMQP spec: redeclaring with matching flags is idempotent.
- \`deliver_to_consumers\` now loops per consumer, delivering until the queue is empty or the prefetch budget is hit. Works for both the notification-triggered path and the initial drain when a fresh consumer subscribes.

## Test
- New \`amqp_durable_queue_retains_messages_across_producer_disconnect\` in \`amqp_pubsub_e2e.rs\`: producer declares \`durable=true\`, publishes 3 messages, disconnects. Fresh consumer reconnects, redeclares the same queue, subscribes, asserts all 3 messages arrive. Before the fix this timed out.

## Test plan
- [x] \`cargo test -p mockforge-amqp\` — 207 tests pass (184 lib + integration + 3 e2e + 20 integration suite)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-amqp --all-targets -- -D warnings\` clean

## Closes
- Closes #176.