### PR TITLE
feat(amqp): message TTL honored — per-message + queue-level (#177)

### DIFF
--- a/crates/mockforge-amqp/src/connection.rs
+++ b/crates/mockforge-amqp/src/connection.rs
@@ -29,6 +29,97 @@ fn generate_id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
 }
 
+/// Minimal AMQP field-table parser that pulls a single integer-typed
+/// value out by key. Used for `x-message-ttl` on Queue.Declare and,
+/// later, other numeric x-args. Handles the tags AMQP clients
+/// actually use for TTL: `I` (i32), `i` (u32), `l` / `L` (i64 / u64),
+/// `B` (u8), `b` (i8), `u` (u16), `s` (i16). Returns `None` for
+/// anything else — malformed tables are silently ignored rather than
+/// faulting the channel, which keeps strict-mode clients usable
+/// against the mock.
+///
+/// Format: `u32 body_length` + body of (shortstr name, tagged value)
+/// pairs.
+fn extract_long_arg(table: &[u8], key: &str) -> Option<i64> {
+    if table.len() < 4 {
+        return None;
+    }
+    let body_len = u32::from_be_bytes([table[0], table[1], table[2], table[3]]) as usize;
+    let body = table.get(4..4 + body_len)?;
+
+    let mut i = 0usize;
+    while i < body.len() {
+        // name: shortstr (u8 len + bytes)
+        let name_len = *body.get(i)? as usize;
+        i += 1;
+        let name_bytes = body.get(i..i + name_len)?;
+        i += name_len;
+        // tag
+        let tag = *body.get(i)?;
+        i += 1;
+
+        let (value, consumed): (Option<i64>, usize) = match tag {
+            b'I' => {
+                let b = body.get(i..i + 4)?;
+                (Some(i32::from_be_bytes([b[0], b[1], b[2], b[3]]) as i64), 4)
+            }
+            b'i' => {
+                let b = body.get(i..i + 4)?;
+                (Some(u32::from_be_bytes([b[0], b[1], b[2], b[3]]) as i64), 4)
+            }
+            b'l' | b'L' => {
+                let b = body.get(i..i + 8)?;
+                (Some(i64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])), 8)
+            }
+            b's' => {
+                let b = body.get(i..i + 2)?;
+                (Some(i16::from_be_bytes([b[0], b[1]]) as i64), 2)
+            }
+            b'u' => {
+                let b = body.get(i..i + 2)?;
+                (Some(u16::from_be_bytes([b[0], b[1]]) as i64), 2)
+            }
+            b'b' => (Some(*body.get(i)? as i8 as i64), 1),
+            b'B' => (Some(*body.get(i)? as i64), 1),
+            // Known variable-width tags we need to skip past to keep
+            // scanning further key/value pairs.
+            b't' => (None, 1), // boolean
+            b'f' => (None, 4), // float
+            b'd' => (None, 8), // double
+            b'V' => (None, 0), // void
+            b'S' => {
+                // long string: u32 len + bytes
+                let b = body.get(i..i + 4)?;
+                let s_len = u32::from_be_bytes([b[0], b[1], b[2], b[3]]) as usize;
+                (None, 4 + s_len)
+            }
+            b'x' => {
+                // byte array: u32 len + bytes
+                let b = body.get(i..i + 4)?;
+                let x_len = u32::from_be_bytes([b[0], b[1], b[2], b[3]]) as usize;
+                (None, 4 + x_len)
+            }
+            b'F' => {
+                // nested field-table: u32 len + body
+                let b = body.get(i..i + 4)?;
+                let f_len = u32::from_be_bytes([b[0], b[1], b[2], b[3]]) as usize;
+                (None, 4 + f_len)
+            }
+            _ => {
+                // Unknown tag — we can't safely advance, bail out so
+                // we don't wrongly pair names with values downstream.
+                return None;
+            }
+        };
+        i += consumed;
+
+        if name_bytes == key.as_bytes() {
+            return value;
+        }
+    }
+    None
+}
+
 /// Connection state machine
 #[derive(Debug, Clone, PartialEq)]
 pub enum ConnectionState {
@@ -935,17 +1026,32 @@ impl AmqpConnection {
         let exclusive = flags & 0x04 != 0;
         let auto_delete = flags & 0x08 != 0;
         let no_wait = flags & 0x10 != 0;
+        offset += 1;
 
         // Generate queue name if empty
         if queue_name.is_empty() {
             queue_name = format!("amq.gen-{}", generate_id());
         }
 
-        tracing::debug!("Queue declare: {}", queue_name);
+        // Everything remaining in the Queue.Declare frame is the
+        // client-supplied argument field-table (`x-message-ttl`,
+        // `x-dead-letter-exchange`, etc.). We only pull out the keys
+        // we actually act on — unknown keys are ignored, matching the
+        // AMQP "broker chooses which extensions it supports" rule.
+        let message_ttl = extract_long_arg(&arguments[offset..], "x-message-ttl")
+            .map(|ms| std::time::Duration::from_millis(ms as u64));
+
+        tracing::debug!("Queue declare: {} (ttl={:?})", queue_name, message_ttl);
 
         // Declare the queue
         let mut queues = self.queues.write().await;
-        queues.declare_queue(queue_name.clone(), durable, exclusive, auto_delete);
+        queues.declare_queue_with_ttl(
+            queue_name.clone(),
+            durable,
+            exclusive,
+            auto_delete,
+            message_ttl,
+        );
         self.metrics.record_queue_declared();
         drop(queues);
 

--- a/crates/mockforge-amqp/src/queues.rs
+++ b/crates/mockforge-amqp/src/queues.rs
@@ -164,6 +164,25 @@ impl QueueManager {
             .or_insert_with(|| Queue::new(name, durable, exclusive, auto_delete));
     }
 
+    /// Variant of `declare_queue` that also applies `x-message-ttl`
+    /// from the queue's declare-time field-table. Applied only when
+    /// the queue is freshly created — redeclarations preserve the
+    /// existing properties to match AMQP spec idempotence.
+    pub fn declare_queue_with_ttl(
+        &mut self,
+        name: String,
+        durable: bool,
+        exclusive: bool,
+        auto_delete: bool,
+        message_ttl: Option<Duration>,
+    ) {
+        self.queues.entry(name.clone()).or_insert_with(|| {
+            let mut q = Queue::new(name, durable, exclusive, auto_delete);
+            q.properties.message_ttl = message_ttl;
+            q
+        });
+    }
+
     pub fn get_queue(&self, name: &str) -> Option<&Queue> {
         self.queues.get(name)
     }

--- a/crates/mockforge-amqp/tests/amqp_pubsub_e2e.rs
+++ b/crates/mockforge-amqp/tests/amqp_pubsub_e2e.rs
@@ -358,3 +358,169 @@ async fn amqp_publisher_confirms_ack_every_publish() {
     let _ = conn.close(0, "bye").await;
     server.abort();
 }
+
+/// Per-message TTL (AMQP `expiration` property). Messages with a
+/// per-message expiration MUST be silently dropped once the TTL
+/// elapses — the consumer MUST NOT see the expired payload. The
+/// expected flow:
+///   1. Publish two messages: one short-lived (`expiration=100ms`),
+///      one without expiration.
+///   2. Sleep 300ms, well past the TTL on the first message.
+///   3. Subscribe and drain. Only the second (unexpired) message
+///      should arrive.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn amqp_per_message_expiration_drops_stale_payload() {
+    let (port, server) = spawn_broker().await;
+    let uri = format!("amqp://127.0.0.1:{port}/%2f");
+
+    let conn = Connection::connect(&uri, ConnectionProperties::default())
+        .await
+        .expect("lapin connects");
+    let channel = conn.create_channel().await.expect("open channel");
+
+    let queue_name = "ttl-queue";
+    channel
+        .queue_declare(
+            queue_name,
+            QueueDeclareOptions {
+                durable: false,
+                exclusive: false,
+                auto_delete: false,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    // Short-lived message — AMQP `expiration` is a string of ms.
+    channel
+        .basic_publish(
+            "",
+            queue_name,
+            BasicPublishOptions::default(),
+            b"expires-fast",
+            BasicProperties::default().with_expiration("100".into()),
+        )
+        .await
+        .unwrap();
+    // Immortal message.
+    channel
+        .basic_publish(
+            "",
+            queue_name,
+            BasicPublishOptions::default(),
+            b"lives-forever",
+            BasicProperties::default(),
+        )
+        .await
+        .unwrap();
+
+    // Wait past the TTL before subscribing. The broker checks
+    // expiration at dequeue time (see `QueuedMessage::is_expired`),
+    // so subscribing AFTER the TTL is what drops the stale payload.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let mut consumer = channel
+        .basic_consume(
+            queue_name,
+            "ttl-consumer",
+            BasicConsumeOptions {
+                no_ack: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    // Drain. The first delivery must be the unexpired message.
+    let delivery = tokio::time::timeout(Duration::from_secs(5), consumer.next())
+        .await
+        .expect("consumer should receive the unexpired message within 5s")
+        .expect("stream produced")
+        .expect("delivery");
+    assert_eq!(
+        delivery.data, b"lives-forever",
+        "expired message must be silently dropped — consumer should only see the live one"
+    );
+
+    // Verify no further deliveries. A lingering expired message
+    // would surface here.
+    let extra = tokio::time::timeout(Duration::from_millis(500), consumer.next()).await;
+    assert!(
+        extra.is_err(),
+        "no further messages expected (expired one should be gone), got: {extra:?}"
+    );
+
+    let _ = conn.close(0, "bye").await;
+    server.abort();
+}
+
+/// Queue-level TTL via `x-message-ttl` queue argument. When the queue
+/// itself is declared with a TTL, every enqueued message inherits it
+/// even if the publisher doesn't set `expiration`. Same assertion as
+/// the per-message test: expired messages must not be delivered.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn amqp_queue_level_ttl_drops_stale_messages() {
+    let (port, server) = spawn_broker().await;
+    let uri = format!("amqp://127.0.0.1:{port}/%2f");
+
+    let conn = Connection::connect(&uri, ConnectionProperties::default()).await.unwrap();
+    let channel = conn.create_channel().await.unwrap();
+
+    let queue_name = "queue-ttl";
+    // x-message-ttl is an AMQP i64 ms argument on queue.declare.
+    let mut args = FieldTable::default();
+    args.insert("x-message-ttl".into(), lapin::types::AMQPValue::LongInt(100));
+
+    channel
+        .queue_declare(
+            queue_name,
+            QueueDeclareOptions {
+                durable: false,
+                exclusive: false,
+                auto_delete: false,
+                ..Default::default()
+            },
+            args,
+        )
+        .await
+        .expect("declare queue with x-message-ttl");
+
+    // Publish WITHOUT per-message expiration — the queue TTL applies.
+    channel
+        .basic_publish(
+            "",
+            queue_name,
+            BasicPublishOptions::default(),
+            b"should-expire",
+            BasicProperties::default(),
+        )
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let mut consumer = channel
+        .basic_consume(
+            queue_name,
+            "queue-ttl-consumer",
+            BasicConsumeOptions {
+                no_ack: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    let got = tokio::time::timeout(Duration::from_millis(500), consumer.next()).await;
+    assert!(
+        got.is_err(),
+        "queue with x-message-ttl=100ms must drop a 300ms-old payload; got: {got:?}"
+    );
+
+    let _ = conn.close(0, "bye").await;
+    server.abort();
+}


### PR DESCRIPTION
## Summary
Per-message \`expiration\` already worked (the queue's \`dequeue()\` silently drops expired heads). **Queue-level \`x-message-ttl\` did not** — the \`queue.declare\` handler parsed the flags but threw away the trailing argument field-table entirely. So a client declaring \`x-message-ttl\` saw its TTL silently ignored and messages persisted past their window.

## Changes
- **New \`extract_long_arg(&[u8], &str) -> Option<i64>\`** in \`connection.rs\`: minimal AMQP field-table parser that finds one integer-typed value by name. Handles the tags clients actually use (\`I\`/\`i\`/\`l\`/\`L\`/\`s\`/\`u\`/\`b\`/\`B\`), and skips past variable-width tags (\`S\`/\`F\`/\`x\`) so the scan doesn't desync on fields we don't care about. Unknown tags bail rather than wrongly pair names with values.
- **\`handle_queue_declare\` now parses the field-table** and passes \`x-message-ttl\` through to a new \`QueueManager::declare_queue_with_ttl\` variant. Preserves the redeclare-idempotence guarantee added in #176 (TTL is applied only on queue creation).

## Tests
- \`amqp_per_message_expiration_drops_stale_payload\`: publishes two messages (one with \`expiration=100\`, one without), sleeps past the TTL, subscribes — only the immortal message is delivered; short-timeout negative assertion confirms the expired one is gone.
- \`amqp_queue_level_ttl_drops_stale_messages\`: declares with \`x-message-ttl=100\`, publishes without per-message expiration, sleeps 300ms, asserts no delivery. Before the fix this failed because the TTL arg was ignored.

## Test plan
- [x] \`cargo test -p mockforge-amqp\` — 210 tests pass
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-amqp --all-targets -- -D warnings\` clean

## Closes
- Closes #177.