### PR TITLE
feat(amqp): dead-letter exchange routing on reject + nack (#178)

### DIFF
--- a/crates/mockforge-amqp/src/connection.rs
+++ b/crates/mockforge-amqp/src/connection.rs
@@ -120,6 +120,62 @@ fn extract_long_arg(table: &[u8], key: &str) -> Option<i64> {
     None
 }
 
+/// Pull a single string-typed value out of an AMQP field-table by
+/// key. Handles both shortstr (`S` is used by lapin for strings,
+/// though the AMQP wire tag is technically `S`/longstr) and
+/// shortstr-in-table encoding. Used for `x-dead-letter-exchange`
+/// / `x-dead-letter-routing-key` on Queue.Declare.
+fn extract_string_arg(table: &[u8], key: &str) -> Option<String> {
+    if table.len() < 4 {
+        return None;
+    }
+    let body_len = u32::from_be_bytes([table[0], table[1], table[2], table[3]]) as usize;
+    let body = table.get(4..4 + body_len)?;
+
+    let mut i = 0usize;
+    while i < body.len() {
+        let name_len = *body.get(i)? as usize;
+        i += 1;
+        let name_bytes = body.get(i..i + name_len)?;
+        i += name_len;
+        let tag = *body.get(i)?;
+        i += 1;
+
+        let (value, consumed): (Option<String>, usize) = match tag {
+            b'S' => {
+                let b = body.get(i..i + 4)?;
+                let s_len = u32::from_be_bytes([b[0], b[1], b[2], b[3]]) as usize;
+                let bytes = body.get(i + 4..i + 4 + s_len)?;
+                (Some(String::from_utf8_lossy(bytes).into_owned()), 4 + s_len)
+            }
+            b's' => {
+                let b = body.get(i..i + 2)?;
+                let slen = i16::from_be_bytes([b[0], b[1]]).max(0) as usize;
+                let bytes = body.get(i + 2..i + 2 + slen)?;
+                (Some(String::from_utf8_lossy(bytes).into_owned()), 2 + slen)
+            }
+            // Fixed-width numeric tags — skip past the value.
+            b't' | b'b' | b'B' => (None, 1),
+            b'u' => (None, 2),
+            b'I' | b'i' | b'f' => (None, 4),
+            b'l' | b'L' | b'd' => (None, 8),
+            b'V' => (None, 0),
+            b'x' | b'F' | b'A' => {
+                let b = body.get(i..i + 4)?;
+                let v_len = u32::from_be_bytes([b[0], b[1], b[2], b[3]]) as usize;
+                (None, 4 + v_len)
+            }
+            _ => return None,
+        };
+        i += consumed;
+
+        if name_bytes == key.as_bytes() {
+            return value;
+        }
+    }
+    None
+}
+
 /// Connection state machine
 #[derive(Debug, Clone, PartialEq)]
 pub enum ConnectionState {
@@ -1035,22 +1091,34 @@ impl AmqpConnection {
 
         // Everything remaining in the Queue.Declare frame is the
         // client-supplied argument field-table (`x-message-ttl`,
-        // `x-dead-letter-exchange`, etc.). We only pull out the keys
-        // we actually act on — unknown keys are ignored, matching the
-        // AMQP "broker chooses which extensions it supports" rule.
-        let message_ttl = extract_long_arg(&arguments[offset..], "x-message-ttl")
+        // `x-dead-letter-exchange`, `x-dead-letter-routing-key`,
+        // etc.). We only pull out the keys we actually act on —
+        // unknown keys are ignored, matching the AMQP "broker chooses
+        // which extensions it supports" rule.
+        let tail = &arguments[offset..];
+        let message_ttl = extract_long_arg(tail, "x-message-ttl")
             .map(|ms| std::time::Duration::from_millis(ms as u64));
+        let dlx = extract_string_arg(tail, "x-dead-letter-exchange");
+        let dlrk = extract_string_arg(tail, "x-dead-letter-routing-key");
 
-        tracing::debug!("Queue declare: {} (ttl={:?})", queue_name, message_ttl);
+        tracing::debug!(
+            "Queue declare: {} (ttl={:?} dlx={:?} dlrk={:?})",
+            queue_name,
+            message_ttl,
+            dlx,
+            dlrk
+        );
 
         // Declare the queue
         let mut queues = self.queues.write().await;
-        queues.declare_queue_with_ttl(
+        queues.declare_queue_with_args(
             queue_name.clone(),
             durable,
             exclusive,
             auto_delete,
             message_ttl,
+            dlx,
+            dlrk,
         );
         self.metrics.record_queue_declared();
         drop(queues);
@@ -1644,12 +1712,44 @@ impl AmqpConnection {
                     }
                 }
             }
-        } else if let Some(ch) = self.channels.get_mut(&channel) {
-            ch.unacked_messages.remove(&delivery_tag);
+        } else {
+            // requeue=false: pop the unacked message and, if the
+            // queue is configured with `x-dead-letter-exchange`,
+            // republish to that exchange so retry / audit flows see
+            // the rejected payload.
+            let popped = self
+                .channels
+                .get_mut(&channel)
+                .and_then(|ch| ch.unacked_messages.remove(&delivery_tag));
+            if let Some(unacked) = popped {
+                self.dead_letter(&unacked.queue_name, unacked.message).await;
+            }
         }
 
         self.metrics.record_reject();
         Ok(true)
+    }
+
+    /// If `queue_name` is configured with an `x-dead-letter-exchange`,
+    /// republish `message` to that exchange using the configured
+    /// dead-letter routing key (or the message's original routing key
+    /// if none was set). No-op when the queue has no DLX or doesn't
+    /// exist anymore.
+    async fn dead_letter(&mut self, queue_name: &str, message: Message) {
+        let (dlx, dlrk) = {
+            let queues = self.queues.read().await;
+            let Some(q) = queues.get_queue(queue_name) else {
+                return;
+            };
+            (
+                q.properties.dead_letter_exchange.clone(),
+                q.properties.dead_letter_routing_key.clone(),
+            )
+        };
+        let Some(dlx) = dlx else { return };
+        let routing_key = dlrk.unwrap_or_else(|| message.routing_key.clone());
+        tracing::debug!("Dead-lettering message from {queue_name} -> {dlx}/{routing_key}");
+        self.route_message(&dlx, &routing_key, message).await;
     }
 
     async fn handle_basic_nack(&mut self, channel: u16, arguments: &[u8]) -> io::Result<bool> {
@@ -1679,9 +1779,14 @@ impl AmqpConnection {
             requeue
         );
 
-        // Similar to reject but can be multiple
-        if let Some(ch) = self.channels.get_mut(&channel) {
-            let tags_to_nack: Vec<u64> = if multiple {
+        // Collect tags + unacked messages up front so we can drop
+        // the `self.channels` borrow before doing DLX routing
+        // (which needs `&mut self`).
+        let popped: Vec<UnackedMessage> = {
+            let Some(ch) = self.channels.get_mut(&channel) else {
+                return Ok(true);
+            };
+            let tags: Vec<u64> = if multiple {
                 ch.unacked_messages
                     .keys()
                     .filter(|&&tag| tag <= delivery_tag)
@@ -1690,18 +1795,20 @@ impl AmqpConnection {
             } else {
                 vec![delivery_tag]
             };
+            tags.into_iter().filter_map(|t| ch.unacked_messages.remove(&t)).collect()
+        };
 
-            for tag in tags_to_nack {
-                if let Some(unacked) = ch.unacked_messages.remove(&tag) {
-                    if requeue {
-                        let mut queues = self.queues.write().await;
-                        if let Some(queue) = queues.get_queue_mut(&unacked.queue_name) {
-                            queue.messages.push_front(QueuedMessage::new(unacked.message));
-                        }
-                    }
+        for unacked in popped {
+            if requeue {
+                let mut queues = self.queues.write().await;
+                if let Some(queue) = queues.get_queue_mut(&unacked.queue_name) {
+                    queue.messages.push_front(QueuedMessage::new(unacked.message));
                 }
-                self.metrics.record_reject();
+            } else {
+                // requeue=false + DLX configured → republish there.
+                self.dead_letter(&unacked.queue_name, unacked.message).await;
             }
+            self.metrics.record_reject();
         }
 
         Ok(true)

--- a/crates/mockforge-amqp/src/queues.rs
+++ b/crates/mockforge-amqp/src/queues.rs
@@ -164,21 +164,28 @@ impl QueueManager {
             .or_insert_with(|| Queue::new(name, durable, exclusive, auto_delete));
     }
 
-    /// Variant of `declare_queue` that also applies `x-message-ttl`
-    /// from the queue's declare-time field-table. Applied only when
-    /// the queue is freshly created — redeclarations preserve the
-    /// existing properties to match AMQP spec idempotence.
-    pub fn declare_queue_with_ttl(
+    /// Variant of `declare_queue` that also applies `x-message-ttl`,
+    /// `x-dead-letter-exchange`, and `x-dead-letter-routing-key`
+    /// derived from the queue's declare-time field-table. Applied
+    /// only when the queue is freshly created — redeclarations
+    /// preserve the existing properties to match AMQP spec
+    /// idempotence.
+    #[allow(clippy::too_many_arguments)]
+    pub fn declare_queue_with_args(
         &mut self,
         name: String,
         durable: bool,
         exclusive: bool,
         auto_delete: bool,
         message_ttl: Option<Duration>,
+        dead_letter_exchange: Option<String>,
+        dead_letter_routing_key: Option<String>,
     ) {
         self.queues.entry(name.clone()).or_insert_with(|| {
             let mut q = Queue::new(name, durable, exclusive, auto_delete);
             q.properties.message_ttl = message_ttl;
+            q.properties.dead_letter_exchange = dead_letter_exchange;
+            q.properties.dead_letter_routing_key = dead_letter_routing_key;
             q
         });
     }

--- a/crates/mockforge-amqp/tests/amqp_pubsub_e2e.rs
+++ b/crates/mockforge-amqp/tests/amqp_pubsub_e2e.rs
@@ -8,11 +8,11 @@
 //! locks in the end-to-end pub/sub contract.
 
 use lapin::options::{
-    BasicConsumeOptions, BasicPublishOptions, ConfirmSelectOptions, QueueBindOptions,
-    QueueDeclareOptions,
+    BasicConsumeOptions, BasicNackOptions, BasicPublishOptions, ConfirmSelectOptions,
+    ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions,
 };
 use lapin::types::FieldTable;
-use lapin::{BasicProperties, Connection, ConnectionProperties};
+use lapin::{BasicProperties, Connection, ConnectionProperties, ExchangeKind};
 use mockforge_amqp::broker::AmqpBroker;
 use mockforge_amqp::spec_registry::AmqpSpecRegistry;
 use mockforge_core::config::AmqpConfig;
@@ -519,6 +519,150 @@ async fn amqp_queue_level_ttl_drops_stale_messages() {
     assert!(
         got.is_err(),
         "queue with x-message-ttl=100ms must drop a 300ms-old payload; got: {got:?}"
+    );
+
+    let _ = conn.close(0, "bye").await;
+    server.abort();
+}
+
+/// Dead-letter-exchange routing. When a queue is declared with
+/// `x-dead-letter-exchange` and a consumer rejects a delivery with
+/// `requeue=false`, the rejected message MUST be re-routed to the
+/// DLX (and the optional `x-dead-letter-routing-key`). A DLX-bound
+/// queue then picks it up for retry / audit flows.
+///
+/// Topology:
+///   producer → work-queue (with x-dead-letter-exchange=dlx,
+///                          x-dead-letter-routing-key=dead)
+///   dlx (direct) → dlq bound on routing_key=dead
+///   consumer on work-queue nacks → broker republishes to dlx →
+///   dlq consumer receives the dead-lettered payload.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn amqp_dead_letter_exchange_receives_rejected_messages() {
+    let (port, server) = spawn_broker().await;
+    let uri = format!("amqp://127.0.0.1:{port}/%2f");
+
+    let conn = Connection::connect(&uri, ConnectionProperties::default()).await.unwrap();
+    let channel = conn.create_channel().await.unwrap();
+
+    // Declare the DLX + DLQ first. The DLX is a plain direct
+    // exchange; the DLQ is a normal durable queue bound on
+    // `routing_key=dead`.
+    channel
+        .exchange_declare(
+            "dlx",
+            ExchangeKind::Direct,
+            ExchangeDeclareOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .expect("declare dlx");
+    channel
+        .queue_declare(
+            "dlq",
+            QueueDeclareOptions {
+                durable: true,
+                exclusive: false,
+                auto_delete: false,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .expect("declare dlq");
+    channel
+        .queue_bind("dlq", "dlx", "dead", QueueBindOptions::default(), FieldTable::default())
+        .await
+        .expect("bind dlq");
+
+    // Declare the work queue with DLX routing configured.
+    let mut args = FieldTable::default();
+    args.insert(
+        "x-dead-letter-exchange".into(),
+        lapin::types::AMQPValue::LongString("dlx".into()),
+    );
+    args.insert(
+        "x-dead-letter-routing-key".into(),
+        lapin::types::AMQPValue::LongString("dead".into()),
+    );
+    channel
+        .queue_declare(
+            "work-queue",
+            QueueDeclareOptions {
+                durable: false,
+                exclusive: false,
+                auto_delete: false,
+                ..Default::default()
+            },
+            args,
+        )
+        .await
+        .expect("declare work-queue with DLX args");
+
+    // Publish one message to the work queue.
+    channel
+        .basic_publish(
+            "",
+            "work-queue",
+            BasicPublishOptions::default(),
+            b"doomed",
+            BasicProperties::default(),
+        )
+        .await
+        .unwrap();
+
+    // Consume and nack with requeue=false — this is what triggers
+    // the dead-letter.
+    let mut work_consumer = channel
+        .basic_consume(
+            "work-queue",
+            "work-consumer",
+            BasicConsumeOptions {
+                no_ack: false, // must ack/nack explicitly for DLX to fire
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    let delivery = tokio::time::timeout(Duration::from_secs(5), work_consumer.next())
+        .await
+        .expect("work consumer receives within 5s")
+        .expect("stream produced")
+        .expect("delivery");
+    assert_eq!(delivery.data, b"doomed");
+    // Nack with requeue=false → broker should reroute to dlx.
+    delivery
+        .nack(BasicNackOptions {
+            requeue: false,
+            multiple: false,
+        })
+        .await
+        .expect("nack");
+
+    // Now subscribe to the DLQ and expect the dead-lettered payload.
+    let mut dlq_consumer = channel
+        .basic_consume(
+            "dlq",
+            "dlq-consumer",
+            BasicConsumeOptions {
+                no_ack: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    let dead = tokio::time::timeout(Duration::from_secs(5), dlq_consumer.next())
+        .await
+        .expect("DLQ consumer should see the rejected payload within 5s")
+        .expect("stream produced")
+        .expect("delivery");
+    assert_eq!(
+        dead.data, b"doomed",
+        "DLQ should receive the exact rejected payload byte-for-byte"
     );
 
     let _ = conn.close(0, "bye").await;


### PR DESCRIPTION
## Summary
Rejected / nack'd messages with \`requeue=false\` were silently dropped even when the queue had \`x-dead-letter-exchange\` set. No DLX routing meant retry + audit flows had nothing to pick up — the \"dead letter\" was just gone.

## Changes
- \`handle_queue_declare\` extracts \`x-dead-letter-exchange\` and \`x-dead-letter-routing-key\` from the declare field-table (new \`extract_string_arg\` helper, same shape as \`extract_long_arg\` from #177).
- \`QueueManager::declare_queue_with_ttl\` renamed to \`declare_queue_with_args\` and now carries DLX + DL-routing-key through to the Queue's properties on first creation.
- New \`Connection::dead_letter(queue_name, message)\` looks up the queue's DLX settings and re-routes via \`route_message\`. If the queue has no DLX, it's a no-op (matching RabbitMQ behavior).
- \`handle_basic_reject\` + \`handle_basic_nack\` now call \`dead_letter(...)\` on the \`requeue=false\` branch. \`handle_basic_nack\` was restructured to collect popped messages into \`Vec<UnackedMessage>\` before processing so the \`self.channels\` mutable borrow is dropped before the DLX routing (which needs \`&mut self\`).

## Test
- New \`amqp_dead_letter_exchange_receives_rejected_messages\`: sets up \`dlx\` direct exchange + \`dlq\` bound on \`routing_key=dead\`, declares \`work-queue\` with both \`x-dead-letter-exchange\` and \`x-dead-letter-routing-key\`, publishes one message, consumes + nacks with \`requeue=false\`, then subscribes to \`dlq\` and asserts the exact payload arrives there.

## Test plan
- [x] \`cargo test -p mockforge-amqp\` — 211 tests pass (184 lib + integration + 7 e2e + 20 integration suite)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-amqp --all-targets -- -D warnings\` clean

## Closes
- Closes #178.