### PR TITLE
feat(smtp): STARTTLS actually upgrades the socket to TLS (#181)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7073,10 +7073,13 @@ dependencies = [
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
+ "rustls 0.23.37",
  "socket2 0.6.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "url",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -8929,6 +8932,7 @@ dependencies = [
  "lettre",
  "mail-parser",
  "mockforge-core",
+ "rcgen",
  "regex",
  "rustls 0.23.37",
  "rustls-pemfile 1.0.4",

--- a/crates/mockforge-smtp/Cargo.toml
+++ b/crates/mockforge-smtp/Cargo.toml
@@ -42,7 +42,12 @@ tempfile = "3.0"
 criterion = { workspace = true }
 # Real SMTP client for the end-to-end regression test — sends a message
 # via the mock server and we then inspect the captured mailbox.
-lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "builder", "tokio1"] }
+# `rustls-tls` enables lettre's TLS support against the STARTTLS-upgraded
+# mock; `dangerous-tls` (via rustls crate below) lets tests accept the
+# self-signed cert we generate with `rcgen` at test setup.
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "builder", "tokio1", "tokio1-rustls-tls", "pool"] }
+# Generate a self-signed cert/key for the STARTTLS test.
+rcgen = "0.13"
 
 [[bench]]
 name = "smtp_benchmarks"

--- a/crates/mockforge-smtp/src/server.rs
+++ b/crates/mockforge-smtp/src/server.rs
@@ -7,11 +7,67 @@ use mockforge_core::protocol_abstraction::{
 use mockforge_core::Result;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use std::task::{Context, Poll};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
-use tokio_rustls::{rustls, TlsAcceptor};
+use tokio_rustls::{rustls, server::TlsStream, TlsAcceptor};
 use tracing::{debug, error, info, warn};
+
+/// Stream wrapper that can be either plaintext TCP or TLS-upgraded.
+/// The session handler starts each connection as `Plain` and swaps to
+/// `Tls` mid-stream when the client sends STARTTLS (RFC 3207). The
+/// enum-plus-manual-AsyncRead/Write-impl pattern is what lets us put
+/// the upgraded stream back into the existing `BufReader` without
+/// rewriting the whole session loop.
+pub enum SmtpStream {
+    /// Plaintext TCP before STARTTLS (or when STARTTLS is disabled).
+    Plain(TcpStream),
+    /// TLS-encrypted after STARTTLS completes. Boxed to keep the
+    /// enum size manageable — `TlsStream` is large.
+    Tls(Box<TlsStream<TcpStream>>),
+}
+
+impl AsyncRead for SmtpStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            SmtpStream::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            SmtpStream::Tls(s) => Pin::new(s.as_mut()).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for SmtpStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            SmtpStream::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            SmtpStream::Tls(s) => Pin::new(s.as_mut()).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            SmtpStream::Plain(s) => Pin::new(s).poll_flush(cx),
+            SmtpStream::Tls(s) => Pin::new(s.as_mut()).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            SmtpStream::Plain(s) => Pin::new(s).poll_shutdown(cx),
+            SmtpStream::Tls(s) => Pin::new(s.as_mut()).poll_shutdown(cx),
+        }
+    }
+}
 
 /// SMTP server
 pub struct SmtpServer {
@@ -117,11 +173,18 @@ impl SmtpServer {
                     let registry = self.spec_registry.clone();
                     let middleware = self.middleware_chain.clone();
                     let hostname = self.config.hostname.clone();
+                    let tls_acceptor = self.tls_acceptor.clone();
 
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            handle_smtp_session(stream, peer_addr, registry, middleware, hostname)
-                                .await
+                        if let Err(e) = handle_smtp_session(
+                            SmtpStream::Plain(stream),
+                            peer_addr,
+                            registry,
+                            middleware,
+                            hostname,
+                            tls_acceptor,
+                        )
+                        .await
                         {
                             error!("SMTP session error from {}: {}", peer_addr, e);
                         }
@@ -135,20 +198,25 @@ impl SmtpServer {
     }
 }
 
-/// Handle a single SMTP session
+/// Handle a single SMTP session. Accepts an `SmtpStream` (plaintext
+/// or TLS) so a STARTTLS mid-session upgrade can swap the underlying
+/// transport without tearing down the connection.
 async fn handle_smtp_session(
-    stream: TcpStream,
+    stream: SmtpStream,
     peer_addr: SocketAddr,
     registry: Arc<SmtpSpecRegistry>,
     middleware: Arc<MiddlewareChain>,
     hostname: String,
+    tls_acceptor: Option<TlsAcceptor>,
 ) -> Result<()> {
-    let (reader, mut writer) = stream.into_split();
-    let mut reader = BufReader::new(reader);
+    // Keep read + write on the same `SmtpStream` so STARTTLS can
+    // upgrade both halves atomically. Writes go through
+    // `reader.get_mut()` to avoid an extra split.
+    let mut reader = BufReader::new(stream);
 
     // Send greeting
     let greeting = format!("220 {} ESMTP MockForge SMTP Server\r\n", hostname);
-    writer.write_all(greeting.as_bytes()).await?;
+    reader.get_mut().write_all(greeting.as_bytes()).await?;
 
     let mut session_state = SessionState::new();
     // Byte-level accumulator so 8BITMIME bodies (Latin-1, UTF-8 with
@@ -172,7 +240,7 @@ async fn handle_smtp_session(
                 session_state.in_data_mode = false;
                 let response =
                     process_email(&session_state, &registry, &middleware, peer_addr).await?;
-                writer.write_all(response.as_bytes()).await?;
+                reader.get_mut().write_all(response.as_bytes()).await?;
                 session_state.reset();
             } else {
                 session_state.data.extend_from_slice(trimmed);
@@ -194,7 +262,7 @@ async fn handle_smtp_session(
         // SMTP verb. Handle it here before the verb table would send
         // back "502 Command not implemented".
         if let Some(stage) = session_state.pending_auth.clone() {
-            handle_auth_continuation(stage, command, &mut session_state, &mut writer).await?;
+            handle_auth_continuation(stage, command, &mut session_state, reader.get_mut()).await?;
             line.clear();
             continue;
         }
@@ -206,11 +274,48 @@ async fn handle_smtp_session(
             continue;
         }
 
+        // STARTTLS is handled at this outer level (not in the verb
+        // table) because we need to swap out the BufReader's owned
+        // stream. Only fires when (a) client asked for STARTTLS,
+        // (b) we're still plaintext, and (c) a TLS acceptor is
+        // configured. Per RFC 3207, the upgraded session starts
+        // completely fresh — the client MUST re-EHLO.
+        if command.eq_ignore_ascii_case("STARTTLS") {
+            if !matches!(reader.get_ref(), SmtpStream::Plain(_)) {
+                // Already TLS — refuse per spec.
+                reader.get_mut().write_all(b"503 Command not allowed\r\n").await?;
+            } else if let Some(acceptor) = tls_acceptor.clone() {
+                reader.get_mut().write_all(b"220 Ready to start TLS\r\n").await?;
+                reader.get_mut().flush().await?;
+
+                let inner = reader.into_inner();
+                let tcp = match inner {
+                    SmtpStream::Plain(t) => t,
+                    SmtpStream::Tls(_) => unreachable!("checked is Plain above"),
+                };
+                let tls_stream = acceptor.accept(tcp).await.map_err(|e| {
+                    mockforge_core::Error::internal(format!("TLS accept failed: {e}"))
+                })?;
+                reader = BufReader::new(SmtpStream::Tls(Box::new(tls_stream)));
+                session_state = SessionState::new();
+                line.clear();
+                continue;
+            } else {
+                // STARTTLS requested but no cert configured.
+                reader
+                    .get_mut()
+                    .write_all(b"454 TLS not available due to temporary reason\r\n")
+                    .await?;
+            }
+            line.clear();
+            continue;
+        }
+
         // Parse and handle SMTP command
         match handle_smtp_command(
             command,
             &mut session_state,
-            &mut writer,
+            reader.get_mut(),
             &hostname,
             &registry,
             &middleware,
@@ -227,7 +332,7 @@ async fn handle_smtp_session(
             Err(e) => {
                 error!("Error handling SMTP command: {}", e);
                 let error_response = "500 Internal server error\r\n";
-                writer.write_all(error_response.as_bytes()).await?;
+                reader.get_mut().write_all(error_response.as_bytes()).await?;
             }
         }
 

--- a/crates/mockforge-smtp/tests/integration.rs
+++ b/crates/mockforge-smtp/tests/integration.rs
@@ -868,7 +868,13 @@ async fn test_smtp_load_concurrent_connections() {
 }
 
 #[tokio::test]
-async fn test_smtp_starttls_command() {
+async fn test_smtp_starttls_without_cert_returns_454() {
+    // With `enable_starttls=false` (the default) we advertise
+    // STARTTLS in EHLO but reject the actual upgrade with 454 per
+    // RFC 3207. Previously we replied 220 Ready and kept the socket
+    // plaintext, which silently corrupted any real TLS client —
+    // `feat/smtp-starttls-upgrade` fixes that: when no cert is
+    // configured, we refuse the upgrade politely instead.
     let (server, port) = start_test_server().await;
 
     tokio::spawn(async move {
@@ -880,10 +886,12 @@ async fn test_smtp_starttls_command() {
     let (mut reader, mut writer, _greeting) = connect_and_read_greeting(port).await;
     let mut response = String::new();
 
-    // Test STARTTLS command
     writer.write_all(b"STARTTLS\r\n").await.expect("Failed to write STARTTLS");
     reader.read_line(&mut response).await.expect("Failed to read STARTTLS response");
-    assert!(response.contains("220"), "STARTTLS should return 220 Ready to start TLS");
+    assert!(
+        response.starts_with("454"),
+        "STARTTLS without a configured cert must return 454 TLS not available; got: {response:?}"
+    );
 
     // QUIT
     writer.write_all(b"QUIT\r\n").await.ok();

--- a/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
+++ b/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
@@ -431,3 +431,165 @@ async fn smtp_raw_client_auth_login_two_step_challenge() {
 
     server_handle.abort();
 }
+
+/// Generate a short-lived self-signed cert + key on disk. Returns
+/// (cert_path, key_path) — the caller is responsible for deleting
+/// them (we lean on `tempfile::TempDir` for that via the caller's
+/// drop).
+fn write_self_signed_cert(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    use rcgen::{generate_simple_self_signed, CertifiedKey};
+    let CertifiedKey { cert, key_pair } =
+        generate_simple_self_signed(vec!["127.0.0.1".into(), "localhost".into()]).expect("rcgen");
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+    std::fs::write(&cert_path, cert.pem()).expect("write cert");
+    std::fs::write(&key_path, key_pair.serialize_pem()).expect("write key");
+    (cert_path, key_path)
+}
+
+/// STARTTLS: client opens a plaintext connection, issues EHLO,
+/// upgrades the socket via STARTTLS, then repeats EHLO over TLS
+/// before sending any mail command. Before this fix the broker
+/// replied `220 Ready to start TLS` and kept the socket plaintext —
+/// which makes any TLS client's handshake fail with "garbage" bytes.
+///
+/// The test drives a raw TcpStream through the plaintext + TLS halves
+/// of the session using `tokio_rustls` as a dangerous-trust client,
+/// since lettre's STARTTLS transport would refuse the self-signed
+/// cert without extra plumbing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn smtp_raw_client_starttls_actually_upgrades_socket() {
+    use tokio_rustls::rustls::{Certificate, ClientConfig, RootCertStore, ServerName};
+    use tokio_rustls::TlsConnector;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (cert_path, key_path) = write_self_signed_cert(tmp.path());
+
+    let port = free_port().await;
+    let config = SmtpConfig {
+        port,
+        host: "127.0.0.1".into(),
+        enable_starttls: true,
+        tls_cert_path: Some(cert_path.clone()),
+        tls_key_path: Some(key_path),
+        fixtures_dir: None,
+        ..SmtpConfig::default()
+    };
+    let spec_registry = Arc::new(SmtpSpecRegistry::new());
+    let server = SmtpServer::new(config, spec_registry.clone()).expect("server builds");
+    let server_handle = tokio::spawn(async move {
+        server.start().await.unwrap();
+    });
+    wait_for_port(port, Duration::from_secs(5)).await;
+
+    // --- Plaintext phase: greeting → EHLO → STARTTLS → 220 Ready ----
+    let plain = TcpStream::connect(("127.0.0.1", port)).await.expect("tcp connect");
+    let (pread, mut pwrite) = plain.into_split();
+    let mut preader = BufReader::new(pread);
+
+    let line = {
+        let mut s = String::new();
+        preader.read_line(&mut s).await.unwrap();
+        s
+    };
+    assert!(line.starts_with("220"), "unexpected greeting: {line:?}");
+
+    pwrite.write_all(b"EHLO test-client\r\n").await.unwrap();
+    // Drain EHLO multiline response until we see a " " after the code.
+    let mut saw_starttls = false;
+    loop {
+        let mut s = String::new();
+        preader.read_line(&mut s).await.unwrap();
+        if s.to_ascii_uppercase().contains("STARTTLS") {
+            saw_starttls = true;
+        }
+        if s.len() >= 4 && &s[3..4] == " " {
+            break;
+        }
+    }
+    assert!(saw_starttls, "server must advertise STARTTLS when enable_starttls=true");
+
+    pwrite.write_all(b"STARTTLS\r\n").await.unwrap();
+    let mut tls_ready = String::new();
+    preader.read_line(&mut tls_ready).await.unwrap();
+    assert!(
+        tls_ready.starts_with("220"),
+        "STARTTLS must be accepted with 220 Ready, got: {tls_ready:?}"
+    );
+
+    // --- Reassemble and negotiate TLS -------------------------------
+    let tcp = preader.into_inner().reunite(pwrite).expect("reunite");
+
+    // Trust the server's self-signed cert for this test only. In
+    // production lettre/others would verify against the system root
+    // store; here we add the test cert directly so the handshake
+    // succeeds. rustls 0.21 API (via tokio-rustls 0.24) takes raw
+    // `Certificate(Vec<u8>)` rather than the newer `CertificateDer`.
+    let cert_bytes = std::fs::read(&cert_path).unwrap();
+    let der_certs = rustls_pemfile::certs(&mut cert_bytes.as_slice()).expect("parse PEM");
+    let mut root_store = RootCertStore::empty();
+    for der in der_certs {
+        root_store.add(&Certificate(der)).expect("add cert");
+    }
+    let client_cfg = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(client_cfg));
+    let server_name = ServerName::try_from("localhost").unwrap();
+    let mut tls = tokio::time::timeout(Duration::from_secs(5), connector.connect(server_name, tcp))
+        .await
+        .expect("TLS handshake completes within 5s")
+        .expect("TLS handshake succeeds");
+
+    // --- Over TLS: full mail transaction ---------------------------
+    // Per RFC 3207 the client MUST re-EHLO after a successful upgrade.
+    tls.write_all(b"EHLO test-client\r\n").await.unwrap();
+    // Drain EHLO again.
+    let mut buf = [0u8; 1024];
+    loop {
+        let n = tls.read(&mut buf).await.unwrap();
+        let chunk = std::str::from_utf8(&buf[..n]).unwrap_or("");
+        if chunk.contains("250 ") {
+            break;
+        }
+    }
+
+    tls.write_all(b"MAIL FROM:<sender@example.test>\r\n").await.unwrap();
+    let mut r = [0u8; 64];
+    let n = tls.read(&mut r).await.unwrap();
+    assert!(std::str::from_utf8(&r[..n]).unwrap().starts_with("250"));
+
+    tls.write_all(b"RCPT TO:<receiver@example.test>\r\n").await.unwrap();
+    let n = tls.read(&mut r).await.unwrap();
+    assert!(std::str::from_utf8(&r[..n]).unwrap().starts_with("250"));
+
+    tls.write_all(b"DATA\r\n").await.unwrap();
+    let n = tls.read(&mut r).await.unwrap();
+    assert!(std::str::from_utf8(&r[..n]).unwrap().starts_with("354"));
+
+    tls.write_all(b"Subject: TLS only\r\n\r\nTLS body\r\n.\r\n").await.unwrap();
+    let n = tls.read(&mut r).await.unwrap();
+    assert!(std::str::from_utf8(&r[..n]).unwrap().starts_with("250"));
+
+    tls.write_all(b"QUIT\r\n").await.unwrap();
+
+    // Mailbox check — message must have been captured over the TLS
+    // leg, proving the upgrade was real.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let captured = loop {
+        let emails = spec_registry.get_emails().expect("mailbox read");
+        if !emails.is_empty() {
+            break emails;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("STARTTLS-delivered message never made it into the mailbox");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].subject, "TLS only");
+    assert!(captured[0].body.contains("TLS body"));
+
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary
Before this PR the broker replied \`220 Ready to start TLS\` to every STARTTLS command and kept the socket plaintext. Any real TLS client that followed up with a ClientHello saw the next few bytes parsed as SMTP text and dropped the connection.

## Changes
- **New \`SmtpStream\` enum** wrapping either \`TcpStream\` or \`Box<TlsStream<TcpStream>>\`. Implements \`AsyncRead + AsyncWrite\` by delegating to the inner variant, so the session's \`BufReader<SmtpStream>\` keeps working unchanged when we swap streams mid-session.
- \`handle_smtp_session\` now takes \`SmtpStream\` + the server's \`TlsAcceptor\`. STARTTLS is intercepted at the outer loop (before the verb table) so we can tear down the \`BufReader\`, call \`acceptor.accept(tcp).await\`, and rebuild the \`BufReader\` around the new TLS stream.
- TLS-upgraded session resets \`SessionState\` per RFC 3207 (client MUST re-EHLO; prior MAIL/RCPT state discarded).
- When STARTTLS is disabled (no cert), we now reply \`454 TLS not available\` instead of the old stub \`220\`. Existing integration test updated: \`test_smtp_starttls_without_cert_returns_454\`.
- Session writes go through \`reader.get_mut()\` — required so the stream stays owned by a single \`BufReader\` across the swap.
- Deps: dev-deps get \`lettre\`'s \`tokio1-rustls-tls\` + \`pool\`, plus \`rcgen = \"0.13\"\` for cert generation.

## Test
- \`smtp_raw_client_starttls_actually_upgrades_socket\`: generates a self-signed cert via rcgen, starts the server with \`enable_starttls=true\`, then drives a raw TcpStream through the full flow: greeting → EHLO (verifies STARTTLS is advertised) → STARTTLS → 220 → TLS handshake via tokio_rustls (trusting the generated cert) → re-EHLO → MAIL/RCPT/DATA over TLS → asserts the mailbox captured the delivery on the encrypted leg.

## Test plan
- [x] \`cargo test -p mockforge-smtp\` — 86 tests pass (63 lib + 16 integration including the updated STARTTLS test + 6 e2e + 1 doc)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-smtp --all-targets -- -D warnings\` clean

## Closes
- Closes #181.