### PR TITLE
feat(kafka): non-flexible Produce v3-v8 / Fetch v4-v11 codecs so older clients work (#165)

### DIFF
--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -341,14 +341,13 @@ impl KafkaMockBroker {
         Ok(KafkaResponse::Metadata)
     }
 
-    /// Handle a Produce v9 request: parse the flexible body, decode each
-    /// RecordBatch v2, write decoded records into the corresponding topic
-    /// partition, and serialize a v9 response with real base_offsets.
+    /// Handle a Produce request: parse the body (flexible v9 or non-flexible
+    /// v3..=v8), decode each RecordBatch v2, write decoded records into the
+    /// corresponding topic partition, and serialize a version-matched
+    /// response with real base_offsets.
     ///
-    /// Currently only v9 is supported. Older Produce versions advertise
-    /// max=9 in ApiVersions, so auto-negotiating clients land here; if a
-    /// v8-or-older request does arrive it gets an error code per partition
-    /// rather than a crash.
+    /// librdkafka 1.8.x (e.g. kcat 1.7.1) caps at v7 — a non-flexible version.
+    /// Modern clients auto-negotiate to v9.
     async fn handle_produce(
         &self,
         message_buf: &[u8],
@@ -358,24 +357,22 @@ impl KafkaMockBroker {
             parse_produce_v9, serialize_produce_v9_response, PartitionProduceResult,
             TopicProduceResult,
         };
+        use crate::produce_nonflex::{parse_produce_v3_v8, serialize_produce_v3_v8_response};
 
         const ERR_UNKNOWN_TOPIC_OR_PARTITION: i16 = 3;
         const ERR_UNSUPPORTED_COMPRESSION_TYPE: i16 = 74;
-        const ERR_UNSUPPORTED_VERSION: i16 = 35;
 
-        if request.api_version != 9 {
-            // Only v9 is implemented. Respond with per-topic UNSUPPORTED_VERSION
-            // so clients get a real error instead of a hang. Shape-wise the
-            // response still has to match v9 flexible since that's the version
-            // we advertised.
+        let version = request.api_version;
+        let is_flexible = version == 9;
+        let is_nonflex = (3..=8).contains(&version);
+        if !is_flexible && !is_nonflex {
+            // Outside the advertised range. Reply with an empty response in
+            // the shape of the most-compatible version we can. v9 flexible
+            // is what we advertise as max; use it so auto-negotiating
+            // clients fall back to a supported version on their next
+            // ApiVersions check.
             let body = serialize_produce_v9_response(request.correlation_id, &[]);
-            tracing::warn!("rejecting Produce v{} (only v9 supported)", request.api_version);
-            // Client will see zero topic results and a non-error response;
-            // better than nothing. (A full implementation returns
-            // UNSUPPORTED_VERSION at the partition level once we decode the
-            // request, but the body format differs per version so we can't
-            // parse a non-v9 request.)
-            let _ = ERR_UNSUPPORTED_VERSION;
+            tracing::warn!("rejecting Produce v{version} (supported: 3..=9)");
             return Ok(KafkaResponse::Preserialized(body));
         }
 
@@ -383,9 +380,15 @@ impl KafkaMockBroker {
             mockforge_core::Error::internal("produce request body_offset past end of buffer")
         })?;
 
-        let parsed = parse_produce_v9(body_slice).map_err(|e| {
-            mockforge_core::Error::internal(format!("failed to parse Produce v9: {e}"))
-        })?;
+        let parsed = if is_flexible {
+            parse_produce_v9(body_slice).map_err(|e| {
+                mockforge_core::Error::internal(format!("failed to parse Produce v9: {e}"))
+            })?
+        } else {
+            parse_produce_v3_v8(body_slice).map_err(|e| {
+                mockforge_core::Error::internal(format!("failed to parse Produce v{version}: {e}"))
+            })?
+        };
 
         let append_time_ms = chrono::Utc::now().timestamp_millis();
         let mut topic_results = Vec::with_capacity(parsed.topics.len());
@@ -466,14 +469,21 @@ impl KafkaMockBroker {
             });
         }
 
-        let body = serialize_produce_v9_response(request.correlation_id, &topic_results);
+        let body = if is_flexible {
+            serialize_produce_v9_response(request.correlation_id, &topic_results)
+        } else {
+            serialize_produce_v3_v8_response(request.correlation_id, version, &topic_results)
+        };
         Ok(KafkaResponse::Preserialized(body))
     }
 
-    /// Handle a Fetch v12 request: parse the flexible body, pull records
-    /// from topic/partition storage starting at each requested fetch_offset,
-    /// and serialize a v12 response with real RecordBatch v2 blobs
-    /// (CRC32C-validated so consumers accept them).
+    /// Handle a Fetch request: parse the body (flexible v12 or non-flexible
+    /// v4..=v11), pull records from topic/partition storage starting at each
+    /// requested fetch_offset, and serialize a version-matched response with
+    /// real RecordBatch v2 blobs (CRC32C-validated so consumers accept them).
+    ///
+    /// librdkafka 1.8.x / kcat 1.7.1 sends v11 (non-flexible); modern
+    /// clients auto-negotiate to v12.
     async fn handle_fetch(
         &self,
         message_buf: &[u8],
@@ -483,13 +493,17 @@ impl KafkaMockBroker {
             parse_fetch_v12, serialize_fetch_v12_response, serialize_record_batch_v2,
             FetchPartitionResponse, FetchTopicResponse,
         };
+        use crate::fetch_nonflex::{parse_fetch_v4_v11, serialize_fetch_v4_v11_response};
 
         const ERR_UNKNOWN_TOPIC_OR_PARTITION: i16 = 3;
         const ERR_OFFSET_OUT_OF_RANGE: i16 = 1;
 
-        if request.api_version != 12 {
+        let version = request.api_version;
+        let is_flexible = version == 12;
+        let is_nonflex = (4..=11).contains(&version);
+        if !is_flexible && !is_nonflex {
             let body = serialize_fetch_v12_response(request.correlation_id, 0, &[]);
-            tracing::warn!("rejecting Fetch v{} (only v12 supported)", request.api_version);
+            tracing::warn!("rejecting Fetch v{version} (supported: 4..=12)");
             return Ok(KafkaResponse::Preserialized(body));
         }
 
@@ -497,9 +511,15 @@ impl KafkaMockBroker {
             mockforge_core::Error::internal("fetch request body_offset past end of buffer")
         })?;
 
-        let parsed = parse_fetch_v12(body_slice).map_err(|e| {
-            mockforge_core::Error::internal(format!("failed to parse Fetch v12: {e}"))
-        })?;
+        let parsed = if is_flexible {
+            parse_fetch_v12(body_slice).map_err(|e| {
+                mockforge_core::Error::internal(format!("failed to parse Fetch v12: {e}"))
+            })?
+        } else {
+            parse_fetch_v4_v11(version, body_slice).map_err(|e| {
+                mockforge_core::Error::internal(format!("failed to parse Fetch v{version}: {e}"))
+            })?
+        };
 
         let topics_guard = self.topics.read().await;
         let mut topic_responses = Vec::with_capacity(parsed.topics.len());
@@ -589,11 +609,20 @@ impl KafkaMockBroker {
             });
         }
 
-        let body = serialize_fetch_v12_response(
-            request.correlation_id,
-            parsed.session_id,
-            &topic_responses,
-        );
+        let body = if is_flexible {
+            serialize_fetch_v12_response(
+                request.correlation_id,
+                parsed.session_id,
+                &topic_responses,
+            )
+        } else {
+            serialize_fetch_v4_v11_response(
+                request.correlation_id,
+                version,
+                parsed.session_id,
+                &topic_responses,
+            )
+        };
         Ok(KafkaResponse::Preserialized(body))
     }
 

--- a/crates/mockforge-kafka/src/fetch_nonflex.rs
+++ b/crates/mockforge-kafka/src/fetch_nonflex.rs
@@ -1,0 +1,450 @@
+//! Non-flexible Fetch codec for v4–v11.
+//!
+//! Modern clients auto-negotiate to Fetch v12 (flexible), which
+//! `fetch_codec` already handles. Older clients stuck on librdkafka 1.8.x —
+//! notably `edenhill/kcat:1.7.1` — send Fetch v11, which is non-flexible.
+//!
+//! v4 is the floor:
+//!   - v3 added `max_bytes` at the top of the request.
+//!   - v4 added `isolation_level`; every response from v4 onward carries
+//!     `last_stable_offset` + `aborted_transactions` per partition, which
+//!     clients parse unconditionally at v4+.
+//!
+//! Supporting v0–v3 would mean a second per-partition response shape
+//! (without `last_stable_offset` / `aborted_transactions`) to satisfy a
+//! client class that essentially no longer exists in the wild, so we skip
+//! it. v4 is the minimum version any client released in the last ~7 years
+//! sends.
+//!
+//! Request body shape differs across the v4–v11 range:
+//!   v4:      replica_id, max_wait_ms, min_bytes, max_bytes, isolation_level,
+//!            topics[name, partitions[partition_index, fetch_offset,
+//!                                    partition_max_bytes]]
+//!   v5–v6:   +per-partition log_start_offset (between fetch_offset and
+//!            partition_max_bytes)
+//!   v7–v8:   +session_id, session_epoch at top;
+//!            +forgotten_topics_data array at end (before rack_id in v11)
+//!   v9–v10:  +per-partition current_leader_epoch (between partition_index
+//!            and fetch_offset)
+//!   v11:     +rack_id (non-compact STRING at end)
+//!
+//! Response body shape:
+//!   v4:      throttle_time_ms at top; per-partition has partition_index,
+//!            error_code, high_watermark, last_stable_offset,
+//!            aborted_transactions array, records.
+//!   v5–v10:  per-partition adds log_start_offset (between
+//!            last_stable_offset and aborted_transactions).
+//!   v7+:     top gains error_code + session_id (after throttle_time_ms).
+//!   v11:     per-partition adds preferred_read_replica (between
+//!            aborted_transactions and records).
+//!
+//! Response header is v0 for every non-flexible version: just
+//! correlation_id, no tag buffer.
+
+use crate::fetch_codec::{
+    FetchPartitionRequest, FetchRequestV12, FetchTopicRequest, FetchTopicResponse,
+};
+
+// =========================================================================
+// Non-flexible wire primitives
+// =========================================================================
+
+fn take<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], String> {
+    if buf.len() < n {
+        return Err(format!("short read: wanted {n}, have {}", buf.len()));
+    }
+    let (head, tail) = buf.split_at(n);
+    *buf = tail;
+    Ok(head)
+}
+
+fn read_i8(buf: &mut &[u8]) -> Result<i8, String> {
+    Ok(take(buf, 1)?[0] as i8)
+}
+
+fn read_i16(buf: &mut &[u8]) -> Result<i16, String> {
+    let b = take(buf, 2)?;
+    Ok(i16::from_be_bytes([b[0], b[1]]))
+}
+
+fn read_i32(buf: &mut &[u8]) -> Result<i32, String> {
+    let b = take(buf, 4)?;
+    Ok(i32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+fn read_i64(buf: &mut &[u8]) -> Result<i64, String> {
+    let b = take(buf, 8)?;
+    Ok(i64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
+}
+
+fn read_string(buf: &mut &[u8]) -> Result<String, String> {
+    let len = read_i16(buf)?;
+    if len < 0 {
+        return Err("expected non-null STRING, got null".into());
+    }
+    let bytes = take(buf, len as usize)?;
+    String::from_utf8(bytes.to_vec()).map_err(|e| format!("invalid utf8: {e}"))
+}
+
+fn push_string(out: &mut Vec<u8>, s: &str) {
+    out.extend_from_slice(&(s.len() as i16).to_be_bytes());
+    out.extend_from_slice(s.as_bytes());
+}
+
+/// Version at which each feature first appears in a non-flexible Fetch.
+fn has_log_start_offset_in_request(v: i16) -> bool {
+    v >= 5
+}
+fn has_session_fields(v: i16) -> bool {
+    v >= 7
+}
+fn has_current_leader_epoch(v: i16) -> bool {
+    v >= 9
+}
+fn has_rack_id(v: i16) -> bool {
+    v >= 11
+}
+fn has_log_start_offset_in_response(v: i16) -> bool {
+    v >= 5
+}
+fn has_response_session_fields(v: i16) -> bool {
+    v >= 7
+}
+fn has_preferred_read_replica(v: i16) -> bool {
+    v >= 11
+}
+
+// =========================================================================
+// Fetch v4–v11 request parser
+// =========================================================================
+
+/// Parse a non-flexible Fetch request body for any version in `4..=11`.
+/// Returns the same `FetchRequestV12` shape the broker already consumes;
+/// fields that don't exist in older versions (e.g. `session_id` pre-v7) are
+/// populated with the spec-defined default (0 for session_id).
+pub fn parse_fetch_v4_v11(api_version: i16, body: &[u8]) -> Result<FetchRequestV12, String> {
+    if !(4..=11).contains(&api_version) {
+        return Err(format!("parse_fetch_v4_v11 called with unsupported version {api_version}"));
+    }
+    let mut cur = body;
+
+    let _replica_id = read_i32(&mut cur)?;
+    let max_wait_ms = read_i32(&mut cur)?;
+    let min_bytes = read_i32(&mut cur)?;
+    // max_bytes added in v3, always present at v4+.
+    let max_bytes = read_i32(&mut cur)?;
+    // isolation_level added in v4.
+    let _isolation_level = read_i8(&mut cur)?;
+
+    // session fields introduced in v7.
+    let session_id = if has_session_fields(api_version) {
+        let id = read_i32(&mut cur)?;
+        let _session_epoch = read_i32(&mut cur)?;
+        id
+    } else {
+        0
+    };
+
+    let topics_count = read_i32(&mut cur)?;
+    if topics_count < 0 {
+        return Err(format!("fetch topics count is negative: {topics_count}"));
+    }
+    let mut topics = Vec::with_capacity(topics_count as usize);
+
+    for _ in 0..topics_count {
+        let topic = read_string(&mut cur)?;
+        let parts_count = read_i32(&mut cur)?;
+        if parts_count < 0 {
+            return Err(format!("fetch partitions count for {topic} is negative"));
+        }
+        let mut partitions = Vec::with_capacity(parts_count as usize);
+        for _ in 0..parts_count {
+            let partition_index = read_i32(&mut cur)?;
+            if has_current_leader_epoch(api_version) {
+                let _current_leader_epoch = read_i32(&mut cur)?;
+            }
+            let fetch_offset = read_i64(&mut cur)?;
+            if has_log_start_offset_in_request(api_version) {
+                let _log_start_offset = read_i64(&mut cur)?;
+            }
+            let partition_max_bytes = read_i32(&mut cur)?;
+            partitions.push(FetchPartitionRequest {
+                partition_index,
+                fetch_offset,
+                partition_max_bytes,
+            });
+        }
+        topics.push(FetchTopicRequest { topic, partitions });
+    }
+
+    // forgotten_topics_data added in v7. Parse and discard.
+    if has_session_fields(api_version) {
+        let forgotten_count = read_i32(&mut cur)?;
+        if forgotten_count > 0 {
+            for _ in 0..forgotten_count {
+                let _forgotten_topic = read_string(&mut cur)?;
+                let plen = read_i32(&mut cur)?;
+                for _ in 0..plen.max(0) {
+                    let _ = read_i32(&mut cur)?;
+                }
+            }
+        }
+    }
+
+    // rack_id added in v11.
+    if has_rack_id(api_version) {
+        let _rack_id = read_string(&mut cur)?;
+    }
+
+    Ok(FetchRequestV12 {
+        max_wait_ms,
+        min_bytes,
+        max_bytes,
+        session_id,
+        topics,
+    })
+}
+
+// =========================================================================
+// Fetch v4–v11 response serializer
+// =========================================================================
+
+/// Serialize a full non-flexible Fetch response. Writes response header v0
+/// (correlation_id only) followed by a body whose shape depends on
+/// `api_version` (4..=11).
+pub fn serialize_fetch_v4_v11_response(
+    correlation_id: i32,
+    api_version: i16,
+    session_id: i32,
+    topics: &[FetchTopicResponse],
+) -> Vec<u8> {
+    debug_assert!(
+        (4..=11).contains(&api_version),
+        "serialize_fetch_v4_v11_response called with api_version {api_version}"
+    );
+
+    let mut out = Vec::new();
+    // Response header v0.
+    out.extend_from_slice(&correlation_id.to_be_bytes());
+
+    // throttle_time_ms (v1+, always present at v4+).
+    out.extend_from_slice(&0i32.to_be_bytes());
+
+    // error_code + session_id at top-level in v7+.
+    if has_response_session_fields(api_version) {
+        out.extend_from_slice(&0i16.to_be_bytes()); // top-level error_code
+        out.extend_from_slice(&session_id.to_be_bytes());
+    }
+
+    // responses (topic array, int32 length).
+    out.extend_from_slice(&(topics.len() as i32).to_be_bytes());
+    for topic in topics {
+        push_string(&mut out, &topic.topic);
+        out.extend_from_slice(&(topic.partitions.len() as i32).to_be_bytes());
+        for p in &topic.partitions {
+            out.extend_from_slice(&p.partition_index.to_be_bytes());
+            out.extend_from_slice(&p.error_code.to_be_bytes());
+            out.extend_from_slice(&p.high_watermark.to_be_bytes());
+            // last_stable_offset: v4+ always present. We don't track
+            // transactional state, so advertise high_watermark.
+            out.extend_from_slice(&p.high_watermark.to_be_bytes());
+            if has_log_start_offset_in_response(api_version) {
+                out.extend_from_slice(&p.log_start_offset.to_be_bytes());
+            }
+            // aborted_transactions: empty array (int32 = 0) at v4+.
+            out.extend_from_slice(&0i32.to_be_bytes());
+            if has_preferred_read_replica(api_version) {
+                // preferred_read_replica = -1 (no preference)
+                out.extend_from_slice(&(-1i32).to_be_bytes());
+            }
+            // records: non-null bytes (int32 length + bytes). Empty fetch
+            // sends length = 0, which clients accept without triggering a
+            // "MessageSetSize = -1" back-off.
+            out.extend_from_slice(&(p.records.len() as i32).to_be_bytes());
+            out.extend_from_slice(&p.records);
+        }
+    }
+    out
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fetch_codec::{serialize_record_batch_v2, FetchPartitionResponse};
+    use crate::partitions::KafkaMessage;
+
+    /// Build a minimal v11 request body: one topic, one partition,
+    /// all optional fields present.
+    fn build_v11_request(topic: &str, partition: i32, fetch_offset: i64) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // replica_id
+        body.extend_from_slice(&500i32.to_be_bytes()); // max_wait_ms
+        body.extend_from_slice(&1i32.to_be_bytes()); // min_bytes
+        body.extend_from_slice(&1_048_576i32.to_be_bytes()); // max_bytes
+        body.push(0); // isolation_level
+        body.extend_from_slice(&0i32.to_be_bytes()); // session_id
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // session_epoch
+
+        body.extend_from_slice(&1i32.to_be_bytes()); // topics count = 1
+        push_string(&mut body, topic);
+        body.extend_from_slice(&1i32.to_be_bytes()); // partitions count = 1
+        body.extend_from_slice(&partition.to_be_bytes()); // partition_index
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // current_leader_epoch (v9+)
+        body.extend_from_slice(&fetch_offset.to_be_bytes());
+        body.extend_from_slice(&(-1i64).to_be_bytes()); // log_start_offset (v5+)
+        body.extend_from_slice(&65_536i32.to_be_bytes()); // partition_max_bytes
+
+        body.extend_from_slice(&0i32.to_be_bytes()); // forgotten_topics_data count = 0
+        push_string(&mut body, ""); // rack_id empty
+        body
+    }
+
+    #[test]
+    fn parses_v11_request() {
+        let body = build_v11_request("orders", 3, 42);
+        let parsed = parse_fetch_v4_v11(11, &body).unwrap();
+        assert_eq!(parsed.max_wait_ms, 500);
+        assert_eq!(parsed.max_bytes, 1_048_576);
+        assert_eq!(parsed.session_id, 0);
+        assert_eq!(parsed.topics.len(), 1);
+        assert_eq!(parsed.topics[0].topic, "orders");
+        assert_eq!(parsed.topics[0].partitions[0].partition_index, 3);
+        assert_eq!(parsed.topics[0].partitions[0].fetch_offset, 42);
+        assert_eq!(parsed.topics[0].partitions[0].partition_max_bytes, 65_536);
+    }
+
+    #[test]
+    fn parses_v4_request_minimal() {
+        // v4: no session fields, no current_leader_epoch, no log_start_offset,
+        // no forgotten_topics, no rack_id.
+        let mut body = Vec::new();
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // replica_id
+        body.extend_from_slice(&100i32.to_be_bytes()); // max_wait_ms
+        body.extend_from_slice(&1i32.to_be_bytes()); // min_bytes
+        body.extend_from_slice(&524_288i32.to_be_bytes()); // max_bytes
+        body.push(0); // isolation_level
+
+        body.extend_from_slice(&1i32.to_be_bytes()); // topics count
+        push_string(&mut body, "t");
+        body.extend_from_slice(&1i32.to_be_bytes()); // partitions count
+        body.extend_from_slice(&0i32.to_be_bytes()); // partition_index
+        body.extend_from_slice(&7i64.to_be_bytes()); // fetch_offset
+        body.extend_from_slice(&32_768i32.to_be_bytes()); // partition_max_bytes
+
+        let parsed = parse_fetch_v4_v11(4, &body).unwrap();
+        assert_eq!(parsed.max_wait_ms, 100);
+        assert_eq!(parsed.topics[0].partitions[0].fetch_offset, 7);
+        assert_eq!(parsed.topics[0].partitions[0].partition_max_bytes, 32_768);
+    }
+
+    #[test]
+    fn rejects_unsupported_versions() {
+        assert!(parse_fetch_v4_v11(3, &[]).is_err());
+        assert!(parse_fetch_v4_v11(12, &[]).is_err());
+    }
+
+    fn msg(offset: i64, value: &[u8]) -> KafkaMessage {
+        KafkaMessage {
+            offset,
+            timestamp: 1_000,
+            key: None,
+            value: value.to_vec(),
+            headers: vec![],
+        }
+    }
+
+    fn one_response(records: Vec<u8>) -> Vec<FetchTopicResponse> {
+        vec![FetchTopicResponse {
+            topic: "t".to_string(),
+            partitions: vec![FetchPartitionResponse {
+                partition_index: 0,
+                error_code: 0,
+                high_watermark: 5,
+                log_start_offset: 0,
+                records,
+            }],
+        }]
+    }
+
+    #[test]
+    fn response_v4_shape() {
+        // v4 per-partition: partition_index(4) + error_code(2) +
+        //   high_watermark(8) + last_stable_offset(8) +
+        //   aborted_transactions(4=0 entries) + records(len+bytes)
+        let data = serialize_fetch_v4_v11_response(7, 4, 0, &one_response(vec![]));
+
+        // correlation_id
+        assert_eq!(&data[0..4], &7i32.to_be_bytes());
+        // throttle_time_ms
+        assert_eq!(&data[4..8], &0i32.to_be_bytes());
+        // topics count (v4 has no session fields)
+        assert_eq!(&data[8..12], &1i32.to_be_bytes());
+        // topic name "t"
+        assert_eq!(&data[12..14], &1i16.to_be_bytes());
+        assert_eq!(&data[14..15], b"t");
+        // partitions count
+        assert_eq!(&data[15..19], &1i32.to_be_bytes());
+        // partition layout
+        assert_eq!(&data[19..23], &0i32.to_be_bytes()); // partition_index
+        assert_eq!(&data[23..25], &0i16.to_be_bytes()); // error_code
+        assert_eq!(&data[25..33], &5i64.to_be_bytes()); // high_watermark
+        assert_eq!(&data[33..41], &5i64.to_be_bytes()); // last_stable_offset
+        assert_eq!(&data[41..45], &0i32.to_be_bytes()); // aborted_transactions count
+        assert_eq!(&data[45..49], &0i32.to_be_bytes()); // records length = 0
+        assert_eq!(data.len(), 49);
+    }
+
+    #[test]
+    fn response_v11_adds_session_and_preferred_replica() {
+        // v11 extras vs v4:
+        //   top: +error_code(2) + session_id(4)
+        //   partition: +log_start_offset(8) + preferred_read_replica(4)
+        let data = serialize_fetch_v4_v11_response(7, 11, 42, &one_response(vec![]));
+
+        // header(4) + throttle(4) + error(2) + session(4) = 14 before topics
+        assert_eq!(&data[8..10], &0i16.to_be_bytes()); // top-level error_code
+        assert_eq!(&data[10..14], &42i32.to_be_bytes()); // session_id
+        assert_eq!(&data[14..18], &1i32.to_be_bytes()); // topics count
+                                                        // topic name "t"
+        assert_eq!(&data[18..20], &1i16.to_be_bytes());
+        assert_eq!(&data[20..21], b"t");
+        // partitions count
+        assert_eq!(&data[21..25], &1i32.to_be_bytes());
+        // partition layout
+        assert_eq!(&data[25..29], &0i32.to_be_bytes()); // partition_index
+        assert_eq!(&data[29..31], &0i16.to_be_bytes()); // error_code
+        assert_eq!(&data[31..39], &5i64.to_be_bytes()); // high_watermark
+        assert_eq!(&data[39..47], &5i64.to_be_bytes()); // last_stable_offset
+        assert_eq!(&data[47..55], &0i64.to_be_bytes()); // log_start_offset
+        assert_eq!(&data[55..59], &0i32.to_be_bytes()); // aborted_transactions
+        assert_eq!(&data[59..63], &(-1i32).to_be_bytes()); // preferred_read_replica
+        assert_eq!(&data[63..67], &0i32.to_be_bytes()); // records length = 0
+        assert_eq!(data.len(), 67);
+    }
+
+    #[test]
+    fn response_v11_embeds_records_blob() {
+        // The records field carries a complete RecordBatch v2 blob.
+        let stored = [msg(10, b"hi")];
+        let refs: Vec<&KafkaMessage> = stored.iter().collect();
+        let batch = serialize_record_batch_v2(&refs);
+        let batch_len = batch.len();
+        let topics = one_response(batch.clone());
+
+        let data = serialize_fetch_v4_v11_response(1, 11, 0, &topics);
+        // Records sit at the very end; the preceding i32 is their length.
+        let len_offset = data.len() - batch_len - 4;
+        let got_len = i32::from_be_bytes([
+            data[len_offset],
+            data[len_offset + 1],
+            data[len_offset + 2],
+            data[len_offset + 3],
+        ]);
+        assert_eq!(got_len as usize, batch_len);
+        assert_eq!(&data[len_offset + 4..], batch.as_slice());
+    }
+}

--- a/crates/mockforge-kafka/src/lib.rs
+++ b/crates/mockforge-kafka/src/lib.rs
@@ -127,6 +127,7 @@
 pub mod broker;
 pub mod consumer_groups;
 pub mod fetch_codec;
+pub mod fetch_nonflex;
 pub mod fixture_file;
 pub mod fixtures;
 pub mod group_codec;
@@ -135,6 +136,7 @@ pub mod listoffsets_codec;
 pub mod metrics;
 pub mod partitions;
 pub mod produce_codec;
+pub mod produce_nonflex;
 pub mod protocol;
 /// Unified protocol server lifecycle implementation (KafkaMockServer)
 pub mod server;

--- a/crates/mockforge-kafka/src/produce_nonflex.rs
+++ b/crates/mockforge-kafka/src/produce_nonflex.rs
@@ -1,0 +1,363 @@
+//! Non-flexible Produce codec for v3–v8.
+//!
+//! Modern clients (librdkafka 2.x, confluent-kafka-python 2.x, Java 2.0+)
+//! auto-negotiate to Produce v9, which is flexible (compact arrays + tag
+//! buffers) and handled by `produce_codec`. Older clients stuck on
+//! librdkafka 1.8.x — notably `edenhill/kcat:1.7.1` — top out at Produce v7,
+//! which is *non-flexible* (classic int16-prefixed strings, int32 array
+//! lengths, no tag buffers).
+//!
+//! This module adds the non-flexible parser/serializer so those clients can
+//! produce against the mock broker. v3 is the floor because it's the first
+//! version whose record set is always RecordBatch v2 (`magic == 2`), which
+//! is what our decoder understands.
+//!
+//! Request body shape (v3–v8, all identical):
+//!   transactional_id NULLABLE_STRING
+//!   acks             INT16
+//!   timeout_ms       INT32
+//!   topics           ARRAY of {
+//!       name         STRING
+//!       partitions   ARRAY of {
+//!           partition_index INT32
+//!           records         NULLABLE_BYTES   // RecordBatch v2 blob
+//!       }
+//!   }
+//!
+//! Response body shape (version-dependent):
+//!   v3–v4:  throttle_time_ms at top; per-partition has partition_index,
+//!           error_code, base_offset, log_append_time_ms.
+//!   v5–v7:  per-partition adds log_start_offset.
+//!   v8:     per-partition adds record_errors (always empty) + error_message
+//!           (always null).
+//!
+//! Response header for every non-flexible version is v0: just correlation_id
+//! (no tag buffer). `produce_codec` handles v9 with the flexible v1 header.
+
+use crate::produce_codec::{
+    parse_record_batch, PartitionProduceData, ProduceRequestV9, TopicProduceData,
+    TopicProduceResult,
+};
+
+// =========================================================================
+// Non-flexible wire primitives
+// =========================================================================
+
+fn take<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], String> {
+    if buf.len() < n {
+        return Err(format!("short read: wanted {n}, have {}", buf.len()));
+    }
+    let (head, tail) = buf.split_at(n);
+    *buf = tail;
+    Ok(head)
+}
+
+fn read_i16(buf: &mut &[u8]) -> Result<i16, String> {
+    let b = take(buf, 2)?;
+    Ok(i16::from_be_bytes([b[0], b[1]]))
+}
+
+fn read_i32(buf: &mut &[u8]) -> Result<i32, String> {
+    let b = take(buf, 4)?;
+    Ok(i32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+fn read_nullable_string(buf: &mut &[u8]) -> Result<Option<String>, String> {
+    let len = read_i16(buf)?;
+    if len < 0 {
+        return Ok(None);
+    }
+    let bytes = take(buf, len as usize)?;
+    String::from_utf8(bytes.to_vec())
+        .map(Some)
+        .map_err(|e| format!("invalid utf8: {e}"))
+}
+
+fn read_string(buf: &mut &[u8]) -> Result<String, String> {
+    read_nullable_string(buf)?.ok_or_else(|| "expected non-null STRING, got null".into())
+}
+
+fn read_nullable_bytes<'a>(buf: &mut &'a [u8]) -> Result<Option<&'a [u8]>, String> {
+    let len = read_i32(buf)?;
+    if len < 0 {
+        return Ok(None);
+    }
+    Ok(Some(take(buf, len as usize)?))
+}
+
+fn push_string(out: &mut Vec<u8>, s: &str) {
+    out.extend_from_slice(&(s.len() as i16).to_be_bytes());
+    out.extend_from_slice(s.as_bytes());
+}
+
+// =========================================================================
+// Produce v3–v8 request parser
+// =========================================================================
+
+/// Parse a non-flexible Produce request body (v3–v8). The request bodies
+/// are byte-identical across this range; the version only matters for the
+/// response serializer. Returns the same `ProduceRequestV9` shape the
+/// broker already consumes so the handler can stay version-agnostic.
+pub fn parse_produce_v3_v8(body: &[u8]) -> Result<ProduceRequestV9, String> {
+    let mut cur = body;
+
+    let transactional_id = read_nullable_string(&mut cur)?;
+    let acks = read_i16(&mut cur)?;
+    let timeout_ms = read_i32(&mut cur)?;
+
+    let topics_count = read_i32(&mut cur)?;
+    if topics_count < 0 {
+        return Err(format!("produce topics count is negative: {topics_count}"));
+    }
+    let mut topics = Vec::with_capacity(topics_count as usize);
+    for _ in 0..topics_count {
+        let name = read_string(&mut cur)?;
+        let parts_count = read_i32(&mut cur)?;
+        if parts_count < 0 {
+            return Err(format!("produce partitions count for {name} is negative"));
+        }
+        let mut parts = Vec::with_capacity(parts_count as usize);
+        for _ in 0..parts_count {
+            let partition_index = read_i32(&mut cur)?;
+            let records_bytes = read_nullable_bytes(&mut cur)?;
+            let (records, attributes) = match records_bytes {
+                None => (Vec::new(), 0i16),
+                Some(bytes) => parse_record_batch(bytes)?,
+            };
+            parts.push(PartitionProduceData {
+                partition_index,
+                records,
+                compression_codec: (attributes & 0x7) as i8,
+            });
+        }
+        topics.push(TopicProduceData {
+            name,
+            partitions: parts,
+        });
+    }
+
+    Ok(ProduceRequestV9 {
+        transactional_id,
+        acks,
+        timeout_ms,
+        topics,
+    })
+}
+
+// =========================================================================
+// Produce v3–v8 response serializer
+// =========================================================================
+
+/// Serialize a full Produce response with non-flexible framing for the
+/// given `api_version`. Writes the response header v0 (correlation_id
+/// only) followed by a body whose shape is version-branched.
+///
+/// Supported versions: 3, 4, 5, 6, 7, 8.
+pub fn serialize_produce_v3_v8_response(
+    correlation_id: i32,
+    api_version: i16,
+    results: &[TopicProduceResult],
+) -> Vec<u8> {
+    debug_assert!(
+        (3..=8).contains(&api_version),
+        "serialize_produce_v3_v8_response called with api_version {api_version}"
+    );
+
+    let has_log_start_offset = api_version >= 5;
+    let has_record_errors = api_version >= 8;
+
+    let mut out = Vec::new();
+    // Response header v0: correlation_id only, no tag buffer.
+    out.extend_from_slice(&correlation_id.to_be_bytes());
+
+    // topics array (int32 length)
+    out.extend_from_slice(&(results.len() as i32).to_be_bytes());
+    for topic in results {
+        push_string(&mut out, &topic.name);
+        out.extend_from_slice(&(topic.partitions.len() as i32).to_be_bytes());
+        for p in &topic.partitions {
+            out.extend_from_slice(&p.partition_index.to_be_bytes());
+            out.extend_from_slice(&p.error_code.to_be_bytes());
+            out.extend_from_slice(&p.base_offset.to_be_bytes());
+            // v2+ has log_append_time_ms; we only target v3+ so it's always present.
+            out.extend_from_slice(&p.log_append_time_ms.to_be_bytes());
+            if has_log_start_offset {
+                out.extend_from_slice(&p.log_start_offset.to_be_bytes());
+            }
+            if has_record_errors {
+                // record_errors: empty array (int32 = 0)
+                out.extend_from_slice(&0i32.to_be_bytes());
+                // error_message: null nullable-string (int16 = -1)
+                out.extend_from_slice(&(-1i16).to_be_bytes());
+            }
+        }
+    }
+
+    // throttle_time_ms at the end (v1+).
+    out.extend_from_slice(&0i32.to_be_bytes());
+    out
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::produce_codec::{one_record_batch_for_testing, PartitionProduceResult};
+
+    fn build_request_body(topic: &str, partition: i32, batch: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        // transactional_id = null
+        body.extend_from_slice(&(-1i16).to_be_bytes());
+        // acks = -1
+        body.extend_from_slice(&(-1i16).to_be_bytes());
+        // timeout_ms = 30_000
+        body.extend_from_slice(&30_000i32.to_be_bytes());
+        // topics count = 1
+        body.extend_from_slice(&1i32.to_be_bytes());
+        push_string(&mut body, topic);
+        // partitions count = 1
+        body.extend_from_slice(&1i32.to_be_bytes());
+        body.extend_from_slice(&partition.to_be_bytes());
+        // records NULLABLE_BYTES: length-prefixed with int32
+        body.extend_from_slice(&(batch.len() as i32).to_be_bytes());
+        body.extend_from_slice(batch);
+        body
+    }
+
+    #[test]
+    fn parses_minimal_produce_v7_request() {
+        let batch = one_record_batch_for_testing(Some(b"k"), b"hello");
+        let body = build_request_body("orders", 2, &batch);
+
+        let parsed = parse_produce_v3_v8(&body).unwrap();
+        assert_eq!(parsed.transactional_id, None);
+        assert_eq!(parsed.acks, -1);
+        assert_eq!(parsed.timeout_ms, 30_000);
+        assert_eq!(parsed.topics.len(), 1);
+        assert_eq!(parsed.topics[0].name, "orders");
+        assert_eq!(parsed.topics[0].partitions.len(), 1);
+        assert_eq!(parsed.topics[0].partitions[0].partition_index, 2);
+        assert_eq!(parsed.topics[0].partitions[0].records.len(), 1);
+        assert_eq!(parsed.topics[0].partitions[0].records[0].value, b"hello");
+        assert_eq!(parsed.topics[0].partitions[0].compression_codec, 0);
+    }
+
+    #[test]
+    fn parses_produce_v3_v8_with_null_records() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&(-1i16).to_be_bytes()); // transactional_id null
+        body.extend_from_slice(&1i16.to_be_bytes()); // acks = 1
+        body.extend_from_slice(&5_000i32.to_be_bytes()); // timeout_ms
+        body.extend_from_slice(&1i32.to_be_bytes()); // topics = 1
+        push_string(&mut body, "t");
+        body.extend_from_slice(&1i32.to_be_bytes()); // partitions = 1
+        body.extend_from_slice(&0i32.to_be_bytes()); // partition_index
+        body.extend_from_slice(&(-1i32).to_be_bytes()); // records length -1 = null
+
+        let parsed = parse_produce_v3_v8(&body).unwrap();
+        assert_eq!(parsed.acks, 1);
+        assert!(parsed.topics[0].partitions[0].records.is_empty());
+    }
+
+    #[test]
+    fn detects_compressed_batch_in_v7_request() {
+        let mut batch = one_record_batch_for_testing(None, b"x");
+        // Attributes i16 is at offset 21: flip compression to gzip (bit 0).
+        batch[21] = 0;
+        batch[22] = 1;
+        let body = build_request_body("t", 0, &batch);
+
+        let parsed = parse_produce_v3_v8(&body).unwrap();
+        assert_eq!(parsed.topics[0].partitions[0].compression_codec, 1);
+        assert!(parsed.topics[0].partitions[0].records.is_empty());
+    }
+
+    fn one_result(log_start_offset: i64) -> Vec<TopicProduceResult> {
+        vec![TopicProduceResult {
+            name: "orders".to_string(),
+            partitions: vec![PartitionProduceResult {
+                partition_index: 2,
+                error_code: 0,
+                base_offset: 41,
+                log_append_time_ms: -1,
+                log_start_offset,
+            }],
+        }]
+    }
+
+    #[test]
+    fn response_v3_shape() {
+        let data = serialize_produce_v3_v8_response(99, 3, &one_result(0));
+
+        // correlation_id
+        assert_eq!(&data[0..4], &99i32.to_be_bytes());
+        // topics count = 1
+        assert_eq!(&data[4..8], &1i32.to_be_bytes());
+        // topic name "orders" length=6 then bytes
+        assert_eq!(&data[8..10], &6i16.to_be_bytes());
+        assert_eq!(&data[10..16], b"orders");
+        // partitions count = 1
+        assert_eq!(&data[16..20], &1i32.to_be_bytes());
+        // partition_index, error_code, base_offset, log_append_time_ms
+        assert_eq!(&data[20..24], &2i32.to_be_bytes());
+        assert_eq!(&data[24..26], &0i16.to_be_bytes());
+        assert_eq!(&data[26..34], &41i64.to_be_bytes());
+        assert_eq!(&data[34..42], &(-1i64).to_be_bytes());
+        // throttle_time_ms at end
+        assert_eq!(&data[42..46], &0i32.to_be_bytes());
+        assert_eq!(data.len(), 46);
+    }
+
+    #[test]
+    fn response_v7_adds_log_start_offset() {
+        let data = serialize_produce_v3_v8_response(7, 7, &one_result(0));
+        // Expected layout length for v7: header(4) + topics_len(4) +
+        // string_len(2) + "orders"(6) + parts_len(4) + partition_index(4) +
+        // error_code(2) + base_offset(8) + log_append_time_ms(8) +
+        // log_start_offset(8) + throttle_time_ms(4) = 54
+        assert_eq!(data.len(), 54);
+        // Double-check log_start_offset lands at the right offset.
+        assert_eq!(&data[42..50], &0i64.to_be_bytes());
+    }
+
+    #[test]
+    fn response_v8_adds_record_errors_and_error_message() {
+        let data = serialize_produce_v3_v8_response(123, 8, &one_result(0));
+        // v8 layout: v7 (54 bytes minus trailing throttle) + record_errors(4)
+        // + error_message(2) + throttle(4)
+        //   header(4) + topics(4) + name(8) + parts_count(4) + partition(4)
+        //   + error_code(2) + base_offset(8) + log_append_time(8) +
+        //   log_start_offset(8) + record_errors(4) + error_message(2) +
+        //   throttle(4) = 60
+        assert_eq!(data.len(), 60);
+        // record_errors array length = 0
+        assert_eq!(&data[50..54], &0i32.to_be_bytes());
+        // error_message = null (-1)
+        assert_eq!(&data[54..56], &(-1i16).to_be_bytes());
+    }
+
+    #[test]
+    fn request_parser_roundtrips_through_serializer() {
+        let batch = one_record_batch_for_testing(None, b"v");
+        let body = build_request_body("t", 0, &batch);
+
+        let parsed = parse_produce_v3_v8(&body).unwrap();
+
+        // Build a plausible response using a v7 shape.
+        let results = vec![TopicProduceResult {
+            name: parsed.topics[0].name.clone(),
+            partitions: vec![PartitionProduceResult {
+                partition_index: parsed.topics[0].partitions[0].partition_index,
+                error_code: 0,
+                base_offset: 0,
+                log_append_time_ms: 1_700_000_000_000,
+                log_start_offset: 0,
+            }],
+        }];
+        let resp = serialize_produce_v3_v8_response(42, 7, &results);
+        assert_eq!(&resp[0..4], &42i32.to_be_bytes());
+    }
+}

--- a/crates/mockforge-kafka/src/protocol.rs
+++ b/crates/mockforge-kafka/src/protocol.rs
@@ -48,22 +48,26 @@ impl KafkaProtocolHandler {
     /// broker (node 1) as leader + sole replica + in-sync replica.
     pub fn with_topology(host: impl Into<String>, port: i32, topics: Vec<TopicMetadata>) -> Self {
         let mut api_versions = HashMap::new();
-        // Add supported API versions. Produce is capped at v9 because that's
-        // the newest flexible version our codec serializes; auto-negotiating
-        // clients will land on v9.
+        // Produce: non-flexible codec covers v3..=v8 (first RecordBatch-v2
+        // version through the last non-flexible one); flexible codec covers
+        // v9. Clients stuck on librdkafka 1.8.x (e.g. kcat 1.7.1) cap at
+        // v7 and land on the non-flexible codec; modern clients auto-
+        // negotiate to v9.
         api_versions.insert(
             0,
             ApiVersion {
-                min_version: 0,
+                min_version: 3,
                 max_version: 9,
             },
         ); // Produce
-           // Fetch capped at v12 — the first flexible version, which is the one
-           // our codec emits. Auto-negotiating clients land on v12.
+           // Fetch: non-flexible codec covers v4..=v11 (v4 is where
+           // isolation_level + last_stable_offset first appear); flexible
+           // codec covers v12. librdkafka 1.8.x sends v11, rdkafka 2.x
+           // sends v12.
         api_versions.insert(
             1,
             ApiVersion {
-                min_version: 0,
+                min_version: 4,
                 max_version: 12,
             },
         ); // Fetch
@@ -618,9 +622,12 @@ mod tests {
     #[test]
     fn test_is_api_version_supported_produce() {
         let handler = KafkaProtocolHandler::new();
-        // Produce API (key 0) supports versions 0-12
-        // Produce capped at v9 (first flexible version — see serialize path).
-        assert!(handler.is_api_version_supported(0, 0));
+        // Produce: non-flexible v3..=v8 + flexible v9. Versions below v3
+        // are rejected because those predate RecordBatch v2.
+        assert!(!handler.is_api_version_supported(0, 0));
+        assert!(!handler.is_api_version_supported(0, 2));
+        assert!(handler.is_api_version_supported(0, 3));
+        assert!(handler.is_api_version_supported(0, 7));
         assert!(handler.is_api_version_supported(0, 9));
         assert!(!handler.is_api_version_supported(0, 10));
         assert!(!handler.is_api_version_supported(0, -1));
@@ -629,9 +636,13 @@ mod tests {
     #[test]
     fn test_is_api_version_supported_fetch() {
         let handler = KafkaProtocolHandler::new();
-        // Fetch API (key 1) supports versions 0-16
-        // Fetch capped at v12 (first flexible version — what our codec emits).
-        assert!(handler.is_api_version_supported(1, 0));
+        // Fetch: non-flexible v4..=v11 + flexible v12. Versions below v4
+        // are rejected because those predate `isolation_level` +
+        // `last_stable_offset` (which v4+ responses always carry).
+        assert!(!handler.is_api_version_supported(1, 0));
+        assert!(!handler.is_api_version_supported(1, 3));
+        assert!(handler.is_api_version_supported(1, 4));
+        assert!(handler.is_api_version_supported(1, 11));
         assert!(handler.is_api_version_supported(1, 12));
         assert!(!handler.is_api_version_supported(1, 13));
     }
@@ -1125,8 +1136,8 @@ mod tests {
 
         // Test all configured API versions
         let api_configs = vec![
-            (0, 0, 9),  // Produce (capped at v9 — see serialize_response)
-            (1, 0, 12), // Fetch (capped at v12 — see serialize_response)
+            (0, 3, 9),  // Produce: non-flexible v3..=v8 + flexible v9
+            (1, 4, 12), // Fetch: non-flexible v4..=v11 + flexible v12
             (2, 0, 7),  // ListOffsets
             (3, 0, 4),  // Metadata (capped at v4 — see serialize_response)
             (8, 0, 7),  // OffsetCommit (v7 = last non-flexible)

--- a/crates/mockforge-kafka/tests/nonflex_e2e.rs
+++ b/crates/mockforge-kafka/tests/nonflex_e2e.rs
@@ -1,0 +1,367 @@
+//! End-to-end regression for the non-flexible Produce v7 + Fetch v11 path
+//! that older clients (librdkafka 1.8.x, kcat 1.7.1) depend on.
+//!
+//! rdkafka 0.38 auto-negotiates to Produce v9 / Fetch v12, so the existing
+//! librdkafka-based tests only cover the flexible side. This file drives
+//! the broker over raw TCP with bytes that match the older non-flexible
+//! wire layouts — if the dispatch or codecs break, produce+fetch against
+//! those older clients will silently stop working and the flexible tests
+//! won't notice.
+
+use mockforge_core::config::KafkaConfig;
+use mockforge_kafka::fetch_codec::serialize_record_batch_v2;
+use mockforge_kafka::partitions::KafkaMessage;
+use mockforge_kafka::{KafkaMockBroker, Topic, TopicConfig};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+async fn bind_free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+fn push_string(out: &mut Vec<u8>, s: &str) {
+    out.extend_from_slice(&(s.len() as i16).to_be_bytes());
+    out.extend_from_slice(s.as_bytes());
+}
+
+/// Build a request header v1: api_key, api_version, correlation_id,
+/// client_id (non-null STRING). Non-flexible requests stop here — no
+/// trailing tag buffer.
+fn header_v1(api_key: i16, api_version: i16, correlation_id: i32) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&api_key.to_be_bytes());
+    out.extend_from_slice(&api_version.to_be_bytes());
+    out.extend_from_slice(&correlation_id.to_be_bytes());
+    push_string(&mut out, "nonflex-e2e");
+    out
+}
+
+/// Frame a Kafka request: 4-byte big-endian length + header + body.
+fn frame(header: Vec<u8>, body: Vec<u8>) -> Vec<u8> {
+    let mut packet = Vec::with_capacity(4 + header.len() + body.len());
+    let total = (header.len() + body.len()) as i32;
+    packet.extend_from_slice(&total.to_be_bytes());
+    packet.extend_from_slice(&header);
+    packet.extend_from_slice(&body);
+    packet
+}
+
+async fn send_request(stream: &mut TcpStream, packet: &[u8]) -> Vec<u8> {
+    stream.write_all(packet).await.expect("write request");
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await.expect("read response length");
+    let len = i32::from_be_bytes(len_buf) as usize;
+    let mut body = vec![0u8; len];
+    stream.read_exact(&mut body).await.expect("read response body");
+    body
+}
+
+/// Build a Produce v7 request body with a single RecordBatch v2 payload
+/// carrying `key`/`value`.
+fn produce_v7_body(topic: &str, partition: i32, key: Option<&[u8]>, value: &[u8]) -> Vec<u8> {
+    // RecordBatch v2 assembled using the fetch serializer (same logic —
+    // keeps the test focused on the wire framing).
+    let stored = KafkaMessage {
+        offset: 0,
+        timestamp: 1_700_000_000_000,
+        key: key.map(|k| k.to_vec()),
+        value: value.to_vec(),
+        headers: vec![],
+    };
+    let batch = serialize_record_batch_v2(&[&stored]);
+
+    let mut body = Vec::new();
+    // transactional_id = null
+    body.extend_from_slice(&(-1i16).to_be_bytes());
+    // acks = -1 (all)
+    body.extend_from_slice(&(-1i16).to_be_bytes());
+    // timeout_ms = 30_000
+    body.extend_from_slice(&30_000i32.to_be_bytes());
+    // topics count = 1
+    body.extend_from_slice(&1i32.to_be_bytes());
+    push_string(&mut body, topic);
+    // partitions count = 1
+    body.extend_from_slice(&1i32.to_be_bytes());
+    body.extend_from_slice(&partition.to_be_bytes());
+    // records NULLABLE_BYTES: length + blob
+    body.extend_from_slice(&(batch.len() as i32).to_be_bytes());
+    body.extend_from_slice(&batch);
+    body
+}
+
+fn parse_produce_v7_response(data: &[u8], expected_correlation_id: i32) -> (String, i32, i16, i64) {
+    // correlation_id i32
+    let corr = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+    assert_eq!(corr, expected_correlation_id);
+    let mut i = 4;
+    // topics count i32
+    let topics_count = i32::from_be_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+    assert_eq!(topics_count, 1, "expected exactly one topic in response");
+    i += 4;
+    // name STRING
+    let name_len = i16::from_be_bytes([data[i], data[i + 1]]) as usize;
+    i += 2;
+    let name = std::str::from_utf8(&data[i..i + name_len]).unwrap().to_string();
+    i += name_len;
+    // partitions count i32
+    let partitions_count = i32::from_be_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+    assert_eq!(partitions_count, 1);
+    i += 4;
+    let partition_index = i32::from_be_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+    i += 4;
+    let error_code = i16::from_be_bytes([data[i], data[i + 1]]);
+    i += 2;
+    let base_offset = i64::from_be_bytes([
+        data[i],
+        data[i + 1],
+        data[i + 2],
+        data[i + 3],
+        data[i + 4],
+        data[i + 5],
+        data[i + 6],
+        data[i + 7],
+    ]);
+    (name, partition_index, error_code, base_offset)
+}
+
+/// Build a Fetch v11 request body for a single topic/partition.
+fn fetch_v11_body(topic: &str, partition: i32, fetch_offset: i64) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&(-1i32).to_be_bytes()); // replica_id
+    body.extend_from_slice(&200i32.to_be_bytes()); // max_wait_ms
+    body.extend_from_slice(&1i32.to_be_bytes()); // min_bytes
+    body.extend_from_slice(&1_048_576i32.to_be_bytes()); // max_bytes
+    body.push(0); // isolation_level
+    body.extend_from_slice(&0i32.to_be_bytes()); // session_id
+    body.extend_from_slice(&(-1i32).to_be_bytes()); // session_epoch
+
+    body.extend_from_slice(&1i32.to_be_bytes()); // topics count = 1
+    push_string(&mut body, topic);
+    body.extend_from_slice(&1i32.to_be_bytes()); // partitions count = 1
+    body.extend_from_slice(&partition.to_be_bytes()); // partition_index
+    body.extend_from_slice(&(-1i32).to_be_bytes()); // current_leader_epoch (v9+)
+    body.extend_from_slice(&fetch_offset.to_be_bytes());
+    body.extend_from_slice(&(-1i64).to_be_bytes()); // log_start_offset (v5+)
+    body.extend_from_slice(&65_536i32.to_be_bytes()); // partition_max_bytes
+
+    body.extend_from_slice(&0i32.to_be_bytes()); // forgotten_topics_data count = 0
+    push_string(&mut body, ""); // rack_id empty
+    body
+}
+
+fn parse_fetch_v11_records(data: &[u8], expected_correlation_id: i32) -> Vec<u8> {
+    // Response header v0: correlation_id only.
+    let corr = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+    assert_eq!(corr, expected_correlation_id);
+    let mut i = 4;
+    // throttle_time_ms
+    i += 4;
+    // top-level error_code (v7+)
+    let top_err = i16::from_be_bytes([data[i], data[i + 1]]);
+    assert_eq!(top_err, 0, "unexpected top-level fetch error");
+    i += 2;
+    // session_id (v7+)
+    i += 4;
+    // topics count
+    let topics_count = i32::from_be_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+    assert_eq!(topics_count, 1);
+    i += 4;
+    // topic name
+    let name_len = i16::from_be_bytes([data[i], data[i + 1]]) as usize;
+    i += 2 + name_len;
+    // partitions count
+    let partitions_count = i32::from_be_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+    assert_eq!(partitions_count, 1);
+    i += 4;
+    // partition_index, error_code, high_watermark, last_stable_offset,
+    // log_start_offset, aborted_transactions, preferred_read_replica (v11)
+    i += 4; // partition_index
+    let err = i16::from_be_bytes([data[i], data[i + 1]]);
+    assert_eq!(err, 0, "partition-level fetch error");
+    i += 2;
+    i += 8; // high_watermark
+    i += 8; // last_stable_offset
+    i += 8; // log_start_offset
+            // aborted_transactions: i32 count = 0
+    let aborted = i32::from_be_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+    assert_eq!(aborted, 0);
+    i += 4;
+    i += 4; // preferred_read_replica (v11+)
+            // records bytes: i32 length + body
+    let records_len = i32::from_be_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+    i += 4;
+    assert!(records_len >= 0, "records_len negative: {records_len}");
+    data[i..i + records_len as usize].to_vec()
+}
+
+/// Dig the record value out of a RecordBatch v2 blob.
+///
+/// We assume a single-record batch with no compression — which is what the
+/// broker produces for our single Produce-sent record. We only need to
+/// pull the value bytes out to assert they roundtripped correctly.
+fn extract_single_record_value(batch: &[u8]) -> Vec<u8> {
+    use mockforge_kafka::produce_codec::parse_record_batch;
+    let (records, attrs) = parse_record_batch(batch).expect("parse record batch");
+    assert_eq!(attrs & 0x7, 0, "unexpected compression in roundtrip batch");
+    assert_eq!(records.len(), 1, "expected single record in roundtrip batch");
+    records.into_iter().next().unwrap().value
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_flexible_produce_v7_fetch_v11_round_trip() {
+    let port = bind_free_port().await;
+    let config = KafkaConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..KafkaConfig::default()
+    };
+
+    let broker = Arc::new(KafkaMockBroker::new(config.clone()).await.expect("broker init"));
+    {
+        let mut topics = broker.topics.write().await;
+        topics.insert(
+            "nonflex-topic".to_string(),
+            Topic::new(
+                "nonflex-topic".to_string(),
+                TopicConfig {
+                    num_partitions: 1,
+                    replication_factor: 1,
+                    ..Default::default()
+                },
+            ),
+        );
+    }
+
+    let server = Arc::clone(&broker);
+    let server_handle = tokio::spawn(async move { server.start().await });
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).await.expect("connect");
+
+    // --- Produce v7 -----------------------------------------------------
+    let produce_body = produce_v7_body("nonflex-topic", 0, Some(b"k1"), b"hello-v7");
+    let produce_packet = frame(header_v1(0, 7, 101), produce_body);
+    let produce_resp = send_request(&mut stream, &produce_packet).await;
+
+    let (topic_name, partition_index, error_code, base_offset) =
+        parse_produce_v7_response(&produce_resp, 101);
+    assert_eq!(topic_name, "nonflex-topic");
+    assert_eq!(partition_index, 0);
+    assert_eq!(error_code, 0, "Produce v7 returned error code {error_code}");
+    assert_eq!(base_offset, 0);
+
+    // --- Fetch v11 ------------------------------------------------------
+    let fetch_body = fetch_v11_body("nonflex-topic", 0, 0);
+    let fetch_packet = frame(header_v1(1, 11, 202), fetch_body);
+    let fetch_resp = send_request(&mut stream, &fetch_packet).await;
+
+    let records_blob = parse_fetch_v11_records(&fetch_resp, 202);
+    assert!(!records_blob.is_empty(), "fetch returned empty records blob");
+
+    let value = extract_single_record_value(&records_blob);
+    assert_eq!(value, b"hello-v7", "fetched value didn't match what we produced");
+
+    // Broker's in-memory storage must also hold the record.
+    let topics = broker.topics.read().await;
+    let topic = topics.get("nonflex-topic").expect("topic present");
+    let stored: Vec<_> = topic.partitions.iter().flat_map(|p| p.messages.iter()).collect();
+    assert_eq!(stored.len(), 1, "broker stored the wrong number of records");
+    assert_eq!(stored[0].value, b"hello-v7");
+    assert_eq!(stored[0].key.as_deref(), Some(b"k1".as_ref()));
+
+    server_handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn api_versions_advertises_non_flexible_floor() {
+    // ApiVersions v3 (what librdkafka/kcat probe with) must now report
+    // Produce min=3 and Fetch min=4 so older clients see they can use
+    // their default versions.
+    let port = bind_free_port().await;
+    let config = KafkaConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..KafkaConfig::default()
+    };
+
+    let broker = Arc::new(KafkaMockBroker::new(config.clone()).await.expect("broker init"));
+    let server = Arc::clone(&broker);
+    let server_handle = tokio::spawn(async move { server.start().await });
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).await.expect("connect");
+
+    // ApiVersions request header (v3 is flexible: trailing tag buffer).
+    let mut header = Vec::new();
+    header.extend_from_slice(&18i16.to_be_bytes()); // api_key
+    header.extend_from_slice(&3i16.to_be_bytes()); // api_version = 3
+    header.extend_from_slice(&7i32.to_be_bytes()); // correlation_id
+    push_string(&mut header, "probe");
+    header.push(0); // empty tag buffer (flexible header)
+                    // ApiVersions v3 request body: client_software_name (compact string,
+                    // empty = varint 1), client_software_version (compact string, empty =
+                    // varint 1), trailing tag buffer.
+    let body = vec![1, 1, 0];
+
+    let packet = frame(header, body);
+    let resp = send_request(&mut stream, &packet).await;
+
+    // Response header v0: correlation_id only. Body is flexible (v3+).
+    let corr = i32::from_be_bytes([resp[0], resp[1], resp[2], resp[3]]);
+    assert_eq!(corr, 7);
+
+    // Scan the flexible body for Produce / Fetch entries.
+    // Body layout: error_code(2) + compact_array(api_entries) + ...
+    // Each entry: api_key(i16), min(i16), max(i16), tag_buffer(u8).
+    let body_bytes = &resp[4..];
+    let err = i16::from_be_bytes([body_bytes[0], body_bytes[1]]);
+    assert_eq!(err, 0);
+
+    // Compact array length is unsigned-varint(len+1).
+    let (mut cur, count) = {
+        let mut buf = &body_bytes[2..];
+        let raw = read_uvarint(&mut buf);
+        (buf, raw - 1)
+    };
+
+    let mut saw_produce = false;
+    let mut saw_fetch = false;
+    for _ in 0..count {
+        let api_key = i16::from_be_bytes([cur[0], cur[1]]);
+        let min_v = i16::from_be_bytes([cur[2], cur[3]]);
+        let max_v = i16::from_be_bytes([cur[4], cur[5]]);
+        cur = &cur[7..]; // 2+2+2 + 1 tag buffer
+        if api_key == 0 {
+            assert_eq!((min_v, max_v), (3, 9), "Produce min/max mismatch — expected 3..=9");
+            saw_produce = true;
+        }
+        if api_key == 1 {
+            assert_eq!((min_v, max_v), (4, 12), "Fetch min/max mismatch — expected 4..=12");
+            saw_fetch = true;
+        }
+    }
+
+    assert!(saw_produce, "Produce (api_key=0) not advertised");
+    assert!(saw_fetch, "Fetch (api_key=1) not advertised");
+
+    server_handle.abort();
+}
+
+fn read_uvarint(buf: &mut &[u8]) -> u32 {
+    let mut value: u32 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        let byte = buf[0];
+        *buf = &buf[1..];
+        value |= ((byte & 0x7F) as u32) << shift;
+        if (byte & 0x80) == 0 {
+            return value;
+        }
+        shift += 7;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #165.

Modern clients (rdkafka 2.x, confluent-kafka-python 2.x, Java 2.0+) auto-negotiate to Produce v9 / Fetch v12 — both flexible, and both already implemented. Older clients stuck on librdkafka 1.8.x — notably `edenhill/kcat:1.7.1` — cap at Produce v7 and Fetch v11, which are *non-flexible* and were previously rejected by the broker with a mangled response.

- Add `produce_nonflex` (v3–v8): one request parser across the range (the body shape is identical v3→v8), version-branched response serializer (v5 adds `log_start_offset`; v8 adds `record_errors` + `error_message`).
- Add `fetch_nonflex` (v4–v11): version-aware request parser (v5 log_start_offset, v7 session fields, v9 current_leader_epoch, v11 rack_id) and version-aware response serializer (v5 log_start_offset, v7 top-level session fields, v11 preferred_read_replica). v0–v3 stays unsupported — those predate `isolation_level`/`last_stable_offset` and serving them would mean a second response shape for essentially zero clients still on them.
- Broker `handle_produce` / `handle_fetch` now branch on `api_version` and call the non-flexible codec for v3–v8 / v4–v11 and the flexible codec for v9 / v12.
- `ApiVersions` advertisement lowers `min_version` to 3 for Produce and 4 for Fetch so auto-negotiating older clients land on a supported version.
- `tests/nonflex_e2e.rs` drives the broker over raw TCP with hand-rolled Produce v7 + Fetch v11 bytes and asserts the round-trip (plus a second test that verifies the advertised version ranges).

## Test plan

- [x] `cargo test -p mockforge-kafka` — 268+ lib tests pass; 2 new `nonflex_e2e` tests pass; no existing tests broken.
- [x] `cargo clippy -p mockforge-kafka --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [x] Wire-level `non_flexible_produce_v7_fetch_v11_round_trip` exercises the full dispatch path at v7/v11.
- [x] `api_versions_advertises_non_flexible_floor` asserts the ApiVersions response advertises Produce 3..=9 and Fetch 4..=12.
- [ ] kcat 1.7.1 docker round-trip (gated on docker availability — left for manual verification; the DoD from the issue is satisfied by the wire-level test).