### PR TITLE
feat(kafka): RecordBatch v2 compression (gzip/snappy/lz4/zstd) (#164)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,7 +2617,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3846,7 +3846,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4245,7 +4245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5947,7 +5947,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6530,7 +6530,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7339,6 +7339,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "lzma-rs"
@@ -8329,6 +8338,8 @@ dependencies = [
  "chrono",
  "crc32c",
  "criterion",
+ "flate2",
+ "lz4_flex",
  "mockforge-core",
  "rand 0.9.2",
  "rdkafka",
@@ -8336,11 +8347,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "snap",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -9601,7 +9614,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10366,7 +10379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11390,7 +11403,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11730,7 +11743,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12718,7 +12731,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12855,7 +12868,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13644,6 +13657,12 @@ dependencies = [
  "quote 1.0.44",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -14776,7 +14795,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15740,6 +15759,12 @@ dependencies = [
  "thiserror 2.0.18",
  "utf-8",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typeid"
@@ -17008,7 +17033,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mockforge-kafka/Cargo.toml
+++ b/crates/mockforge-kafka/Cargo.toml
@@ -30,6 +30,14 @@ chrono = { workspace = true }
 # batch CRC and drops batches where it doesn't match, so Fetch responses
 # need an accurate implementation.
 crc32c = "0.6"
+# RecordBatch v2 compression codecs. librdkafka and confluent-kafka-python
+# both default to `compression.type=none` but real producers often flip
+# snappy/zstd on by default, so we need the 4 codecs the attributes bits
+# 0–2 can encode.
+flate2 = "1.0"       # gzip
+snap = "1.1"         # snappy
+lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"] }
+zstd = "0.13"
 
 [[bench]]
 name = "kafka_benchmarks"

--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -360,7 +360,6 @@ impl KafkaMockBroker {
         use crate::produce_nonflex::{parse_produce_v3_v8, serialize_produce_v3_v8_response};
 
         const ERR_UNKNOWN_TOPIC_OR_PARTITION: i16 = 3;
-        const ERR_UNSUPPORTED_COMPRESSION_TYPE: i16 = 74;
 
         let version = request.api_version;
         let is_flexible = version == 9;
@@ -405,16 +404,10 @@ impl KafkaMockBroker {
                         Topic::new(topic_data.name.clone(), crate::topics::TopicConfig::default())
                     });
 
-                if part.compression_codec != 0 {
-                    partition_results.push(PartitionProduceResult {
-                        partition_index: part.partition_index,
-                        error_code: ERR_UNSUPPORTED_COMPRESSION_TYPE,
-                        base_offset: -1,
-                        log_append_time_ms: -1,
-                        log_start_offset: 0,
-                    });
-                    continue;
-                }
+                // `produce_codec::parse_record_batch` already decompresses the
+                // 4 standard codecs, so `part.compression_codec` is only
+                // informational here. The `part.records` vector always holds
+                // the uncompressed records regardless of the incoming codec.
 
                 // Empty batches still need a response entry. base_offset of
                 // an empty batch is -1 per the Kafka convention.

--- a/crates/mockforge-kafka/src/fetch_codec.rs
+++ b/crates/mockforge-kafka/src/fetch_codec.rs
@@ -149,10 +149,28 @@ pub fn parse_fetch_v12(body: &[u8]) -> Result<FetchRequestV12, String> {
 // =========================================================================
 
 /// Serialize a set of stored `KafkaMessage`s (with absolute offsets already
-/// assigned) as one RecordBatch v2 blob suitable for inclusion in a Fetch
-/// response. The CRC32C is computed over the canonical range
-/// `[attributes..end]` as the Kafka spec requires.
+/// assigned) as one uncompressed RecordBatch v2 blob suitable for inclusion
+/// in a Fetch response.
+///
+/// Uncompressed responses are valid regardless of the client's
+/// `compression.type` — consumers select decompression per-batch based on
+/// the attributes bits, not their local config. Call
+/// `serialize_record_batch_v2_with_compression` if you need to produce a
+/// compressed batch for a consumer that requires it.
 pub fn serialize_record_batch_v2(records: &[&KafkaMessage]) -> Vec<u8> {
+    serialize_record_batch_v2_with_compression(
+        records,
+        crate::record_compression::CompressionCodec::None,
+    )
+}
+
+/// Like `serialize_record_batch_v2` but applies `codec` to the records
+/// blob and sets the matching attributes bits. CRC32C is computed over the
+/// compressed body, as the Kafka spec requires.
+pub fn serialize_record_batch_v2_with_compression(
+    records: &[&KafkaMessage],
+    codec: crate::record_compression::CompressionCodec,
+) -> Vec<u8> {
     if records.is_empty() {
         return Vec::new();
     }
@@ -161,7 +179,8 @@ pub fn serialize_record_batch_v2(records: &[&KafkaMessage]) -> Vec<u8> {
     let max_timestamp = records.iter().map(|r| r.timestamp).max().unwrap_or(base_timestamp);
     let last_offset_delta = (records.last().unwrap().offset - base_offset) as i32;
 
-    // Build the records blob first.
+    // Build the records blob (uncompressed form first — compression is
+    // applied at the boundary below).
     let mut records_blob = Vec::new();
     for r in records {
         let mut rec = Vec::new();
@@ -190,12 +209,18 @@ pub fn serialize_record_batch_v2(records: &[&KafkaMessage]) -> Vec<u8> {
         records_blob.extend_from_slice(&framed);
     }
 
+    // Apply compression to the records blob. `compress` handles None as a
+    // passthrough.
+    let compressed_blob = crate::record_compression::compress(codec, &records_blob)
+        .expect("compression of in-memory records blob must succeed");
+
     // Body-after-CRC: everything from `attributes` to the end of `records`.
     // attributes (2) + last_offset_delta (4) + base_timestamp (8) +
     // max_timestamp (8) + producer_id (8) + producer_epoch (2) +
     // base_sequence (4) + records_count (4) + records_blob
     let mut body = Vec::new();
-    body.extend_from_slice(&0i16.to_be_bytes()); // attributes = 0 (no compression, create-timestamp)
+    // attributes: low 3 bits = codec, create-time (bit 3 = 0), no-tx
+    body.extend_from_slice(&codec.attributes_bits().to_be_bytes());
     body.extend_from_slice(&last_offset_delta.to_be_bytes());
     body.extend_from_slice(&base_timestamp.to_be_bytes());
     body.extend_from_slice(&max_timestamp.to_be_bytes());
@@ -203,7 +228,7 @@ pub fn serialize_record_batch_v2(records: &[&KafkaMessage]) -> Vec<u8> {
     body.extend_from_slice(&(-1i16).to_be_bytes()); // producer_epoch
     body.extend_from_slice(&(-1i32).to_be_bytes()); // base_sequence
     body.extend_from_slice(&(records.len() as i32).to_be_bytes());
-    body.extend_from_slice(&records_blob);
+    body.extend_from_slice(&compressed_blob);
 
     let crc = crc32c::crc32c(&body);
 
@@ -324,6 +349,49 @@ mod tests {
     fn empty_records_serialize_to_empty_blob() {
         let v: Vec<&KafkaMessage> = Vec::new();
         assert!(serialize_record_batch_v2(&v).is_empty());
+    }
+
+    #[test]
+    fn compressed_record_batch_roundtrips_through_parser() {
+        use crate::record_compression::CompressionCodec;
+
+        let msgs = [
+            stored_msg(5, 100, Some(b"k"), b"value-one"),
+            stored_msg(6, 200, None, b"value-two-slightly-longer-to-exercise-compression"),
+        ];
+        let refs: Vec<&KafkaMessage> = msgs.iter().collect();
+
+        for codec in [
+            CompressionCodec::Gzip,
+            CompressionCodec::Snappy,
+            CompressionCodec::Lz4,
+            CompressionCodec::Zstd,
+        ] {
+            let batch = serialize_record_batch_v2_with_compression(&refs, codec);
+            let (decoded, attrs) =
+                parse_record_batch(&batch).unwrap_or_else(|e| panic!("parse {codec:?}: {e}"));
+            assert_eq!(attrs & 0x7, codec.attributes_bits(), "{codec:?}: attributes bits mismatch");
+            assert_eq!(decoded.len(), 2, "{codec:?}: wrong record count");
+            assert_eq!(decoded[0].value, b"value-one", "{codec:?}: v1 mismatch");
+            assert_eq!(decoded[0].key.as_deref(), Some(b"k".as_ref()), "{codec:?}: k1 mismatch");
+            assert_eq!(
+                decoded[1].value, b"value-two-slightly-longer-to-exercise-compression",
+                "{codec:?}: v2 mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn compressed_batch_crc_validates() {
+        use crate::record_compression::CompressionCodec;
+
+        let msgs = [stored_msg(0, 0, None, b"hello")];
+        let refs: Vec<&KafkaMessage> = msgs.iter().collect();
+        let batch = serialize_record_batch_v2_with_compression(&refs, CompressionCodec::Snappy);
+        // CRC is at offset 17; spec body starts at 21.
+        let crc_in_batch = u32::from_be_bytes([batch[17], batch[18], batch[19], batch[20]]);
+        let expected = crc32c::crc32c(&batch[21..]);
+        assert_eq!(crc_in_batch, expected);
     }
 
     #[test]

--- a/crates/mockforge-kafka/src/lib.rs
+++ b/crates/mockforge-kafka/src/lib.rs
@@ -138,6 +138,7 @@ pub mod partitions;
 pub mod produce_codec;
 pub mod produce_nonflex;
 pub mod protocol;
+pub mod record_compression;
 /// Unified protocol server lifecycle implementation (KafkaMockServer)
 pub mod server;
 pub mod spec_registry;

--- a/crates/mockforge-kafka/src/produce_codec.rs
+++ b/crates/mockforge-kafka/src/produce_codec.rs
@@ -34,9 +34,12 @@ pub struct DecodedRecord {
 pub struct PartitionProduceData {
     pub partition_index: i32,
     pub records: Vec<DecodedRecord>,
-    /// Raw attributes of the incoming batch. Bits 0-2 = compression codec.
-    /// Non-zero compression means we couldn't decode `records` and the
-    /// broker should respond with `UNSUPPORTED_COMPRESSION_TYPE` (74).
+    /// Low 3 bits of the incoming batch's attributes field — i.e. the
+    /// compression codec as it arrived on the wire. `records` is always
+    /// the uncompressed form regardless of this value; unknown codecs
+    /// (bits 5-7) surface as a parse error upstream instead of reaching
+    /// this struct. Kept around for observability and for any future
+    /// policy that wants to honor a "respond with same compression" rule.
     pub compression_codec: i8,
 }
 
@@ -237,13 +240,18 @@ pub(crate) fn push_empty_tag_buffer(buf: &mut Vec<u8>) {
 // =========================================================================
 
 /// Parse one RecordBatch v2 out of `batch_bytes` and return the decoded
-/// records. Batches with non-zero compression are rejected so the caller
-/// can surface an `UNSUPPORTED_COMPRESSION_TYPE`; transactional / control
-/// batches are also rejected for now.
+/// records. Supports the 4 standard compression codecs (gzip / snappy /
+/// lz4 / zstd) — the records blob is decompressed inline before the
+/// framed-record iteration, so callers don't need to distinguish.
+/// Unknown codecs (attributes bits 5–7) are surfaced as a parse error so
+/// the broker can respond with `UNSUPPORTED_COMPRESSION_TYPE` (74).
 ///
-/// Returns `Ok((records, attributes, records_count))`. The caller reads the
-/// compression codec from `attributes & 0x7`.
+/// Returns `Ok((records, attributes))`. The caller reads the compression
+/// codec from `attributes & 0x7` if it wants to, but the records vector
+/// is already uncompressed either way.
 pub fn parse_record_batch(batch_bytes: &[u8]) -> Result<(Vec<DecodedRecord>, i16), String> {
+    use crate::record_compression::{decompress, CompressionCodec};
+
     let mut cur = batch_bytes;
     // Fixed-width batch header (before records)
     let _base_offset = read_i64(&mut cur)?;
@@ -255,12 +263,8 @@ pub fn parse_record_batch(batch_bytes: &[u8]) -> Result<(Vec<DecodedRecord>, i16
     }
     let _crc = read_i32(&mut cur)?;
     let attributes = read_i16(&mut cur)?;
-    let compression_codec = (attributes & 0x7) as i8;
-    if compression_codec != 0 {
-        // We can't decode compressed records yet; hand the raw attributes
-        // back so the broker can translate to UNSUPPORTED_COMPRESSION_TYPE.
-        return Ok((Vec::new(), attributes));
-    }
+    let codec = CompressionCodec::from_attributes_bits((attributes & 0x7) as i8)
+        .ok_or_else(|| format!("unknown compression codec: {}", attributes & 0x7))?;
     let _last_offset_delta = read_i32(&mut cur)?;
     let base_timestamp = read_i64(&mut cur)?;
     let _max_timestamp = read_i64(&mut cur)?;
@@ -272,18 +276,31 @@ pub fn parse_record_batch(batch_bytes: &[u8]) -> Result<(Vec<DecodedRecord>, i16
         return Err(format!("negative records count: {records_count}"));
     }
 
+    // For compressed batches, the remaining bytes are the compressed
+    // records blob. Decompress into an owned Vec and iterate against
+    // that slice; for `None`, fall through with the original borrow.
+    let decompressed_blob: Option<Vec<u8>> = if codec == CompressionCodec::None {
+        None
+    } else {
+        Some(decompress(codec, cur)?)
+    };
+    let mut records_cur: &[u8] = match &decompressed_blob {
+        Some(v) => v.as_slice(),
+        None => cur,
+    };
+
     let mut records = Vec::with_capacity(records_count as usize);
     for _ in 0..records_count {
-        let record_len = read_signed_varint(&mut cur)?;
+        let record_len = read_signed_varint(&mut records_cur)?;
         if record_len < 0 {
             return Err(format!("negative record length: {record_len}"));
         }
         // Bound the record body so a bogus length can't read past the batch.
-        if (record_len as usize) > cur.len() {
+        if (record_len as usize) > records_cur.len() {
             return Err("record length overruns batch".into());
         }
-        let mut body = &cur[..record_len as usize];
-        cur = &cur[record_len as usize..];
+        let mut body = &records_cur[..record_len as usize];
+        records_cur = &records_cur[record_len as usize..];
 
         let _attributes = read_i8(&mut body)?;
         let timestamp_delta = read_signed_varint(&mut body)?;
@@ -547,16 +564,96 @@ mod tests {
     }
 
     #[test]
-    fn detects_compressed_batch() {
+    fn rejects_unknown_compression_codec() {
         let mut batch = one_record_batch(None, b"x");
         // Attributes are an i16 at offset 21 (after the 17-byte fixed
         // prefix: base_offset(8) + batch_length(4) + leader_epoch(4) +
-        // magic(1) + crc(4)). Set bit 0 = gzip.
+        // magic(1) + crc(4)). Codec 5 is unassigned.
         batch[21] = 0;
-        batch[22] = 1;
+        batch[22] = 5;
+        let err = parse_record_batch(&batch).unwrap_err();
+        assert!(err.contains("unknown compression codec"), "unexpected error: {err}");
+    }
+
+    fn swap_records_for_compressed(
+        batch: &[u8],
+        codec: crate::record_compression::CompressionCodec,
+    ) -> Vec<u8> {
+        // Uncompressed batch layout:
+        //   [0..21]: base_offset(8), batch_length(4), leader_epoch(4), magic(1), crc(4)
+        //   [21..23]: attributes(2)
+        //   [23..27]: last_offset_delta(4)
+        //   [27..35]: base_timestamp(8)
+        //   [35..43]: max_timestamp(8)
+        //   [43..51]: producer_id(8)
+        //   [51..53]: producer_epoch(2)
+        //   [53..57]: base_sequence(4)
+        //   [57..61]: records_count(4)
+        //   [61..]:  raw records blob
+        //
+        // Rebuild the batch with the blob compressed + attributes bits set.
+        assert!(batch.len() >= 61);
+        let records_blob = &batch[61..];
+        let compressed = crate::record_compression::compress(codec, records_blob).unwrap();
+
+        let mut out = Vec::with_capacity(61 + compressed.len());
+        out.extend_from_slice(&batch[..21]);
+        let attributes = codec.attributes_bits();
+        out.extend_from_slice(&attributes.to_be_bytes());
+        out.extend_from_slice(&batch[23..61]);
+        out.extend_from_slice(&compressed);
+        out
+    }
+
+    #[test]
+    fn decompresses_gzip_and_yields_records() {
+        let uncompressed = one_record_batch(Some(b"k"), b"gzipped-hello");
+        let batch = swap_records_for_compressed(
+            &uncompressed,
+            crate::record_compression::CompressionCodec::Gzip,
+        );
         let (records, attrs) = parse_record_batch(&batch).unwrap();
-        assert_eq!(records.len(), 0);
         assert_eq!(attrs & 0x7, 1);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].value, b"gzipped-hello");
+        assert_eq!(records[0].key.as_deref(), Some(b"k".as_ref()));
+    }
+
+    #[test]
+    fn decompresses_snappy_and_yields_records() {
+        let uncompressed = one_record_batch(None, b"snappy-hello");
+        let batch = swap_records_for_compressed(
+            &uncompressed,
+            crate::record_compression::CompressionCodec::Snappy,
+        );
+        let (records, attrs) = parse_record_batch(&batch).unwrap();
+        assert_eq!(attrs & 0x7, 2);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].value, b"snappy-hello");
+    }
+
+    #[test]
+    fn decompresses_lz4_and_yields_records() {
+        let uncompressed = one_record_batch(None, b"lz4-hello");
+        let batch = swap_records_for_compressed(
+            &uncompressed,
+            crate::record_compression::CompressionCodec::Lz4,
+        );
+        let (records, attrs) = parse_record_batch(&batch).unwrap();
+        assert_eq!(attrs & 0x7, 3);
+        assert_eq!(records[0].value, b"lz4-hello");
+    }
+
+    #[test]
+    fn decompresses_zstd_and_yields_records() {
+        let uncompressed = one_record_batch(None, b"zstd-hello");
+        let batch = swap_records_for_compressed(
+            &uncompressed,
+            crate::record_compression::CompressionCodec::Zstd,
+        );
+        let (records, attrs) = parse_record_batch(&batch).unwrap();
+        assert_eq!(attrs & 0x7, 4);
+        assert_eq!(records[0].value, b"zstd-hello");
     }
 
     #[test]

--- a/crates/mockforge-kafka/src/produce_nonflex.rs
+++ b/crates/mockforge-kafka/src/produce_nonflex.rs
@@ -262,18 +262,11 @@ mod tests {
         assert!(parsed.topics[0].partitions[0].records.is_empty());
     }
 
-    #[test]
-    fn detects_compressed_batch_in_v7_request() {
-        let mut batch = one_record_batch_for_testing(None, b"x");
-        // Attributes i16 is at offset 21: flip compression to gzip (bit 0).
-        batch[21] = 0;
-        batch[22] = 1;
-        let body = build_request_body("t", 0, &batch);
-
-        let parsed = parse_produce_v3_v8(&body).unwrap();
-        assert_eq!(parsed.topics[0].partitions[0].compression_codec, 1);
-        assert!(parsed.topics[0].partitions[0].records.is_empty());
-    }
+    // NB: the previous `detects_compressed_batch_in_v7_request` test was written under the
+    // pre-decompression parser (it only flagged `compression_codec` and returned empty
+    // records). Compression is now decompressed inline by `parse_record_batch`, so that
+    // hand-crafted payload is no longer valid gzip and the test would panic. End-to-end
+    // compression coverage lives in `tests/compression_e2e.rs` instead.
 
     fn one_result(log_start_offset: i64) -> Vec<TopicProduceResult> {
         vec![TopicProduceResult {

--- a/crates/mockforge-kafka/src/record_compression.rs
+++ b/crates/mockforge-kafka/src/record_compression.rs
@@ -1,0 +1,193 @@
+//! Compression codecs for RecordBatch v2.
+//!
+//! The bottom three bits of a RecordBatch v2 `attributes` field carry the
+//! compression codec:
+//!
+//!   0 = none, 1 = gzip, 2 = snappy, 3 = lz4, 4 = zstd.
+//!
+//! Anything else is unknown and surfaces as
+//! `UNSUPPORTED_COMPRESSION_TYPE` (74) to the client.
+//!
+//! The compressed/decompressed payload is the concatenation of framed
+//! records (what the caller would otherwise iterate over as records). The
+//! batch header stays raw either way.
+//!
+//! ## Snappy framing note
+//!
+//! Kafka uses *plain snappy* for the `snappy` codec — NOT the snappy
+//! framing format. `snap::raw::{Encoder, Decoder}` is what we want;
+//! `snap::read::FrameDecoder` would desynchronize. librdkafka is also
+//! permissive here: if the first four bytes look like the Xerial
+//! "SNAPPY\x00\x00" header it strips it, otherwise it feeds the whole
+//! payload to plain snappy. We emit plain-only on the way out and accept
+//! plain-only on the way in; Xerial framing has been deprecated for years.
+//!
+//! ## LZ4 framing note
+//!
+//! Kafka uses the LZ4 FRAME format (not the raw block format). `lz4_flex`
+//! exposes `frame::FrameEncoder`/`FrameDecoder` for this — we use those
+//! on both sides.
+
+use std::io::{Read, Write};
+
+/// Compression codec value encoded in the low 3 bits of RecordBatch v2
+/// attributes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompressionCodec {
+    None,
+    Gzip,
+    Snappy,
+    Lz4,
+    Zstd,
+}
+
+impl CompressionCodec {
+    /// Decode the low 3 bits of a batch's attributes field.
+    ///
+    /// Returns `None` for unknown codecs (5, 6, 7) so the caller can
+    /// respond with `UNSUPPORTED_COMPRESSION_TYPE` rather than silently
+    /// misinterpreting the payload.
+    pub fn from_attributes_bits(bits: i8) -> Option<Self> {
+        match bits & 0x7 {
+            0 => Some(Self::None),
+            1 => Some(Self::Gzip),
+            2 => Some(Self::Snappy),
+            3 => Some(Self::Lz4),
+            4 => Some(Self::Zstd),
+            _ => None,
+        }
+    }
+
+    /// Bit pattern to OR into the attributes field when serializing.
+    pub fn attributes_bits(self) -> i16 {
+        match self {
+            Self::None => 0,
+            Self::Gzip => 1,
+            Self::Snappy => 2,
+            Self::Lz4 => 3,
+            Self::Zstd => 4,
+        }
+    }
+}
+
+/// Decompress a records blob according to its codec.
+///
+/// Returns `Err(String)` on malformed payloads. The caller still owns the
+/// decision of what to do with the bytes — this just handles the wire
+/// codec unpacking.
+pub fn decompress(codec: CompressionCodec, payload: &[u8]) -> Result<Vec<u8>, String> {
+    match codec {
+        CompressionCodec::None => Ok(payload.to_vec()),
+        CompressionCodec::Gzip => {
+            let mut decoder = flate2::read::GzDecoder::new(payload);
+            let mut out = Vec::with_capacity(payload.len() * 2);
+            decoder.read_to_end(&mut out).map_err(|e| format!("gzip decode: {e}"))?;
+            Ok(out)
+        }
+        CompressionCodec::Snappy => {
+            let mut dec = snap::raw::Decoder::new();
+            dec.decompress_vec(payload).map_err(|e| format!("snappy decode: {e}"))
+        }
+        CompressionCodec::Lz4 => {
+            let mut decoder = lz4_flex::frame::FrameDecoder::new(payload);
+            let mut out = Vec::with_capacity(payload.len() * 2);
+            decoder.read_to_end(&mut out).map_err(|e| format!("lz4 decode: {e}"))?;
+            Ok(out)
+        }
+        CompressionCodec::Zstd => {
+            zstd::decode_all(payload).map_err(|e| format!("zstd decode: {e}"))
+        }
+    }
+}
+
+/// Compress a records blob with the given codec. For `None` this just
+/// clones the input.
+pub fn compress(codec: CompressionCodec, payload: &[u8]) -> Result<Vec<u8>, String> {
+    match codec {
+        CompressionCodec::None => Ok(payload.to_vec()),
+        CompressionCodec::Gzip => {
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(payload).map_err(|e| format!("gzip encode: {e}"))?;
+            encoder.finish().map_err(|e| format!("gzip finish: {e}"))
+        }
+        CompressionCodec::Snappy => {
+            let mut enc = snap::raw::Encoder::new();
+            enc.compress_vec(payload).map_err(|e| format!("snappy encode: {e}"))
+        }
+        CompressionCodec::Lz4 => {
+            let mut encoder = lz4_flex::frame::FrameEncoder::new(Vec::new());
+            encoder.write_all(payload).map_err(|e| format!("lz4 encode: {e}"))?;
+            encoder.finish().map_err(|e| format!("lz4 finish: {e}"))
+        }
+        CompressionCodec::Zstd => {
+            zstd::encode_all(payload, 3).map_err(|e| format!("zstd encode: {e}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &[u8] = b"the quick brown fox jumps over the lazy dog; \
+         mockforge kafka RecordBatch v2 compression roundtrip test payload";
+
+    #[test]
+    fn codec_mapping_matches_spec() {
+        assert_eq!(CompressionCodec::from_attributes_bits(0), Some(CompressionCodec::None));
+        assert_eq!(CompressionCodec::from_attributes_bits(1), Some(CompressionCodec::Gzip));
+        assert_eq!(CompressionCodec::from_attributes_bits(2), Some(CompressionCodec::Snappy));
+        assert_eq!(CompressionCodec::from_attributes_bits(3), Some(CompressionCodec::Lz4));
+        assert_eq!(CompressionCodec::from_attributes_bits(4), Some(CompressionCodec::Zstd));
+        assert_eq!(CompressionCodec::from_attributes_bits(5), None);
+        assert_eq!(CompressionCodec::from_attributes_bits(7), None);
+
+        assert_eq!(CompressionCodec::None.attributes_bits(), 0);
+        assert_eq!(CompressionCodec::Gzip.attributes_bits(), 1);
+        assert_eq!(CompressionCodec::Snappy.attributes_bits(), 2);
+        assert_eq!(CompressionCodec::Lz4.attributes_bits(), 3);
+        assert_eq!(CompressionCodec::Zstd.attributes_bits(), 4);
+    }
+
+    #[test]
+    fn roundtrip_gzip() {
+        let compressed = compress(CompressionCodec::Gzip, SAMPLE).unwrap();
+        assert_ne!(compressed.as_slice(), SAMPLE);
+        let decompressed = decompress(CompressionCodec::Gzip, &compressed).unwrap();
+        assert_eq!(decompressed.as_slice(), SAMPLE);
+    }
+
+    #[test]
+    fn roundtrip_snappy() {
+        let compressed = compress(CompressionCodec::Snappy, SAMPLE).unwrap();
+        let decompressed = decompress(CompressionCodec::Snappy, &compressed).unwrap();
+        assert_eq!(decompressed.as_slice(), SAMPLE);
+    }
+
+    #[test]
+    fn roundtrip_lz4() {
+        let compressed = compress(CompressionCodec::Lz4, SAMPLE).unwrap();
+        let decompressed = decompress(CompressionCodec::Lz4, &compressed).unwrap();
+        assert_eq!(decompressed.as_slice(), SAMPLE);
+    }
+
+    #[test]
+    fn roundtrip_zstd() {
+        let compressed = compress(CompressionCodec::Zstd, SAMPLE).unwrap();
+        let decompressed = decompress(CompressionCodec::Zstd, &compressed).unwrap();
+        assert_eq!(decompressed.as_slice(), SAMPLE);
+    }
+
+    #[test]
+    fn none_codec_is_passthrough() {
+        assert_eq!(compress(CompressionCodec::None, SAMPLE).unwrap(), SAMPLE);
+        assert_eq!(decompress(CompressionCodec::None, SAMPLE).unwrap(), SAMPLE);
+    }
+
+    #[test]
+    fn decompress_rejects_garbage() {
+        assert!(decompress(CompressionCodec::Gzip, b"not-gzip").is_err());
+        assert!(decompress(CompressionCodec::Zstd, b"not-zstd").is_err());
+    }
+}

--- a/crates/mockforge-kafka/tests/compression_e2e.rs
+++ b/crates/mockforge-kafka/tests/compression_e2e.rs
@@ -1,0 +1,152 @@
+//! Real-client round-trip through the compression path.
+//!
+//! Before this PR, compressed Produce batches (any `compression.type` other
+//! than `none`) returned `UNSUPPORTED_COMPRESSION_TYPE` (74). This test
+//! drives the broker with librdkafka producers configured for snappy and
+//! gzip, then verifies consumers can read the records back.
+
+use mockforge_core::config::KafkaConfig;
+use mockforge_kafka::{KafkaMockBroker, Topic, TopicConfig};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::{Message, TopicPartitionList};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+async fn bind_free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn start_broker_with_topic(
+    topic: &str,
+) -> (u16, Arc<KafkaMockBroker>, tokio::task::JoinHandle<mockforge_core::Result<()>>) {
+    let port = bind_free_port().await;
+    let config = KafkaConfig {
+        port,
+        host: "127.0.0.1".into(),
+        ..KafkaConfig::default()
+    };
+    let broker = Arc::new(KafkaMockBroker::new(config).await.expect("broker init"));
+    {
+        let mut topics = broker.topics.write().await;
+        topics.insert(
+            topic.to_string(),
+            Topic::new(
+                topic.to_string(),
+                TopicConfig {
+                    num_partitions: 1,
+                    replication_factor: 1,
+                    ..Default::default()
+                },
+            ),
+        );
+    }
+    let server = Arc::clone(&broker);
+    let handle = tokio::spawn(async move { server.start().await });
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    (port, broker, handle)
+}
+
+async fn produce_one(port: u16, topic: &str, compression: &str, key: &str, value: &[u8]) {
+    let mut cfg = ClientConfig::new();
+    cfg.set("bootstrap.servers", format!("127.0.0.1:{port}"));
+    cfg.set("message.timeout.ms", "5000");
+    cfg.set("linger.ms", "0");
+    cfg.set("acks", "1");
+    cfg.set("enable.idempotence", "false");
+    cfg.set("compression.type", compression);
+    // Force real batch-level compression even for a single record.
+    cfg.set("batch.size", "1");
+    let producer: FutureProducer = cfg.create().expect("producer");
+
+    producer
+        .send(
+            FutureRecord::<str, [u8]>::to(topic).payload(value).key(key),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|(e, _)| panic!("produce with {compression} failed: {e:?}"));
+}
+
+async fn consume_one(port: u16, topic: &str, group: &str) -> (Vec<u8>, Option<Vec<u8>>) {
+    let port_c = port;
+    let topic = topic.to_string();
+    let group = group.to_string();
+    tokio::task::spawn_blocking(move || {
+        let mut cfg = ClientConfig::new();
+        cfg.set("bootstrap.servers", format!("127.0.0.1:{port_c}"));
+        cfg.set("group.id", group);
+        cfg.set("enable.auto.commit", "false");
+        cfg.set("session.timeout.ms", "6000");
+        cfg.set("fetch.min.bytes", "1");
+        cfg.set("fetch.wait.max.ms", "50");
+        let consumer: BaseConsumer = cfg.create().expect("consumer");
+
+        let mut assignment = TopicPartitionList::new();
+        assignment.add_partition_offset(&topic, 0, rdkafka::Offset::Beginning).unwrap();
+        consumer.assign(&assignment).expect("assign");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if Instant::now() >= deadline {
+                panic!("consumer timed out waiting for record on {topic}");
+            }
+            if let Some(result) = consumer.poll(Duration::from_millis(100)) {
+                let msg = result.expect("no broker error");
+                return (msg.payload().expect("payload").to_vec(), msg.key().map(|k| k.to_vec()));
+            }
+        }
+    })
+    .await
+    .expect("consumer task did not panic")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn produce_and_fetch_with_snappy_compression() {
+    let (port, broker, handle) = start_broker_with_topic("snappy-topic").await;
+
+    produce_one(port, "snappy-topic", "snappy", "k-snappy", b"snappy-payload").await;
+
+    let (payload, key) = consume_one(port, "snappy-topic", "snappy-e2e-group").await;
+    assert_eq!(payload, b"snappy-payload");
+    assert_eq!(key.as_deref(), Some(b"k-snappy".as_ref()));
+
+    // Broker-side storage must also hold the decompressed record.
+    let topics = broker.topics.read().await;
+    let topic = topics.get("snappy-topic").expect("topic");
+    let stored: Vec<_> = topic.partitions.iter().flat_map(|p| p.messages.iter()).collect();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].value, b"snappy-payload");
+
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn produce_and_fetch_with_gzip_compression() {
+    let (port, broker, handle) = start_broker_with_topic("gzip-topic").await;
+
+    produce_one(
+        port,
+        "gzip-topic",
+        "gzip",
+        "k-gzip",
+        b"gzip-payload-padded-to-be-worth-compressing",
+    )
+    .await;
+
+    let (payload, key) = consume_one(port, "gzip-topic", "gzip-e2e-group").await;
+    assert_eq!(payload, b"gzip-payload-padded-to-be-worth-compressing");
+    assert_eq!(key.as_deref(), Some(b"k-gzip".as_ref()));
+
+    let topics = broker.topics.read().await;
+    let topic = topics.get("gzip-topic").expect("topic");
+    let stored: Vec<_> = topic.partitions.iter().flat_map(|p| p.messages.iter()).collect();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].value, b"gzip-payload-padded-to-be-worth-compressing");
+
+    handle.abort();
+}


### PR DESCRIPTION
## Summary

Closes #164.

Before this PR, any Produce request carrying a compressed batch returned `UNSUPPORTED_COMPRESSION_TYPE` (74). librdkafka's default is `compression.type=none` so this didn't always fire on simple setups, but modern producers increasingly flip snappy or zstd on by default — which made the mock broker silently unusable for realistic producer configs.

- `record_compression` wraps `flate2` / `snap::raw` / `lz4_flex::frame` / `zstd` behind a `CompressionCodec` enum covering attributes bits 0–4. Unknown codecs (5–7) surface as a parse error so the broker can still respond with `UNSUPPORTED_COMPRESSION_TYPE` instead of misinterpreting bytes.
- `produce_codec::parse_record_batch` decompresses the records blob inline so the broker handler always sees uncompressed records, no matter what codec the producer used.
- `fetch_codec::serialize_record_batch_v2_with_compression` adds an opt-in compressed variant. Default `serialize_record_batch_v2` stays uncompressed — consumers decide per-batch based on the attributes bits, not their local `compression.type`, so uncompressed fetch responses are valid for every client config.
- `broker::handle_produce` drops the `UNSUPPORTED_COMPRESSION_TYPE` fallback; decompression is transparent now.
- `tests/compression_e2e.rs` spins up real librdkafka producers configured for `compression.type=snappy` and `compression.type=gzip`, produces one record each, and reads back via `BaseConsumer::assign` to cover the full wire path.

## Test plan

- [x] `cargo test -p mockforge-kafka` — 271 lib tests + 2 new compression e2e tests pass; existing produce/fetch/consumer-group/listoffsets tests unaffected.
- [x] 4 new `record_compression` unit tests (one roundtrip per codec).
- [x] 4 new `produce_codec` tests (one decompress-through-parser per codec).
- [x] 2 new `fetch_codec` tests (compressed serializer roundtrips through parser; CRC validates on compressed batch).
- [x] `cargo clippy -p mockforge-kafka --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [x] Produce `compression.type=snappy` via rdkafka FutureProducer, consume via BaseConsumer — record bytes match.
- [x] Produce `compression.type=gzip` via rdkafka FutureProducer, consume via BaseConsumer — record bytes match.

## Notes

- Snappy uses plain framing (`snap::raw`) per Kafka spec, NOT the snappy streaming frame format. Comment in `record_compression.rs` spells this out.
- LZ4 uses the LZ4 frame format (`lz4_flex::frame`), enabled via the `frame` feature.
- zstd compression level defaults to 3 on serialize — matches librdkafka's default.