### PR TITLE
fix(test,ci): stop WebSocket e2e tests from racing on ports + metrics 9090

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,16 @@ jobs:
         with:
           key: ${{ matrix.os }}
 
+      # The mockforge binary must be built with all-protocols so the e2e
+      # tests in mockforge-integration-tests find a WebSocket and gRPC
+      # server to talk to when they spawn it as a subprocess. Without
+      # this step the binary ships with just its default features
+      # (no ws/grpc/mqtt), and every non-HTTP e2e probe gets
+      # Connection refused.
+      - name: Build mockforge binary with all protocols
+        run: cargo build --bin mockforge --features all-protocols
+        shell: bash
+
       - name: Run tests
         run: |
           EXCLUDES="--exclude mockforge-desktop"

--- a/crates/mockforge-test/src/process.rs
+++ b/crates/mockforge-test/src/process.rs
@@ -237,32 +237,30 @@ pub fn is_port_available(port: u16) -> bool {
     TcpListener::bind(("127.0.0.1", port)).is_ok()
 }
 
-/// Find an available port near `start_port`.
+/// Find an available port.
 ///
-/// Sequentially probes `start_port..start_port+100`, returning the first
-/// port that isn't currently bound. If every port in that range is taken
-/// (which happens under heavy parallel test load), falls back to asking
-/// the OS for an ephemeral port via binding to port 0 — the test will get
-/// *some* free port even when its preferred range is saturated.
-pub fn find_available_port(start_port: u16) -> Result<u16> {
-    for port in start_port..start_port.saturating_add(100) {
-        if is_port_available(port) {
-            return Ok(port);
-        }
-    }
-    // Fallback: ask the OS to assign an ephemeral port. Without this,
-    // running many integration tests in parallel could exhaust the
-    // sequential range and surface a confusing "no available ports"
-    // error even though the machine had thousands of free ports.
+/// Always asks the OS for an ephemeral port (binds to `127.0.0.1:0` and
+/// reads back the assigned port). The `start_port` argument is accepted
+/// for API compatibility but ignored — the old "sequentially probe
+/// `start_port..start_port+100`" strategy raced badly under parallel
+/// nextest runs, where two tests would both see the same port as free
+/// and both subprocesses would try to bind it. On macOS the loser's
+/// `bind` returns `EADDRINUSE` (errno 48) and the losing subprocess's
+/// `tokio::select!` over its admin handle would then short-circuit the
+/// entire mock server, taking HTTP + WS down with it. The test's
+/// `connect_async` saw `Connection refused` and failed.
+///
+/// The OS-assigned ephemeral range is ~30k ports wide, so the same race
+/// is still technically possible but astronomically unlikely in practice.
+///
+/// A tiny TOCTOU window remains — the listener drops before the caller's
+/// subprocess binds the same port — but in practice this hasn't been
+/// observed because the ephemeral range is large and no other process is
+/// typically aggressively snapping ports in that window.
+pub fn find_available_port(_start_port: u16) -> Result<u16> {
     use std::net::TcpListener;
-    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| {
-        Error::ConfigError(format!(
-            "No available ports in {}-{} and OS-assigned fallback failed: {}",
-            start_port,
-            start_port.saturating_add(100),
-            e
-        ))
-    })?;
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| Error::ConfigError(format!("OS-assigned port bind failed: {}", e)))?;
     let port = listener
         .local_addr()
         .map_err(|e| Error::ConfigError(format!("Failed to read OS-assigned port: {}", e)))?
@@ -282,25 +280,22 @@ mod tests {
     }
 
     #[test]
-    fn test_find_available_port() {
-        // Should find a port starting from 30000
+    fn test_find_available_port_returns_nonzero() {
+        // `find_available_port` always asks the OS for an ephemeral port.
+        // The `start_port` hint is ignored (see the function's doc comment
+        // for why), so the assigned port is from the OS ephemeral range
+        // rather than the argument's range.
         let port = find_available_port(30000).expect("Failed to find available port");
-        assert!(port >= 30000);
-        assert!(port < 30100);
+        assert!(port > 0);
     }
 
     #[test]
-    fn test_find_available_port_from_different_start() {
-        let port = find_available_port(40000).expect("Failed to find available port");
-        assert!(port >= 40000);
-        assert!(port < 40100);
-    }
-
-    #[test]
-    fn test_find_available_port_high_range() {
-        let port = find_available_port(60000).expect("Failed to find available port");
-        assert!(port >= 60000);
-        assert!(port < 60100);
+    fn test_find_available_port_ignores_hint() {
+        // Two calls with the same hint should hand back distinct ports
+        // (ephemeral allocation is effectively never reused back-to-back).
+        let port1 = find_available_port(30000).expect("Failed to find port 1");
+        let port2 = find_available_port(30000).expect("Failed to find port 2");
+        assert_ne!(port1, port2, "ephemeral allocator handed back the same port twice");
     }
 
     #[test]
@@ -314,14 +309,16 @@ mod tests {
 
     #[test]
     fn test_multiple_port_allocations() {
-        // Find multiple available ports
+        // Get three ports; they should all be nonzero and distinct.
         let port1 = find_available_port(31000).expect("Failed to find port 1");
         let port2 = find_available_port(32000).expect("Failed to find port 2");
         let port3 = find_available_port(33000).expect("Failed to find port 3");
 
-        // Ports should be in their respective ranges
-        assert!((31000..31100).contains(&port1));
-        assert!((32000..32100).contains(&port2));
-        assert!((33000..33100).contains(&port3));
+        assert!(port1 > 0);
+        assert!(port2 > 0);
+        assert!(port3 > 0);
+        assert_ne!(port1, port2);
+        assert_ne!(port1, port3);
+        assert_ne!(port2, port3);
     }
 }

--- a/crates/mockforge-test/src/server.rs
+++ b/crates/mockforge-test/src/server.rs
@@ -46,7 +46,13 @@ impl MockForgeServer {
             resolved_config.admin_port = Some(port);
             info!("Auto-assigned admin port: {}", port);
         }
-        if resolved_config.metrics_port == Some(0) {
+        // Prometheus metrics defaults to `enabled: true, port: 9090` in
+        // the CLI config. If we don't override, every subprocess races
+        // on 9090 and loses — and when the metrics handle errors out,
+        // the server's `tokio::select!` trips and the whole subprocess
+        // exits before HTTP health ever goes ready. Auto-assign whenever
+        // the caller didn't pin a port, so parallel tests never collide.
+        if resolved_config.metrics_port.is_none() || resolved_config.metrics_port == Some(0) {
             let port = find_available_port(32000)?;
             resolved_config.metrics_port = Some(port);
             info!("Auto-assigned metrics port: {}", port);

--- a/tests/tests/e2e/protocols/websocket_e2e_tests.rs
+++ b/tests/tests/e2e/protocols/websocket_e2e_tests.rs
@@ -5,7 +5,30 @@
 use futures_util::{SinkExt, StreamExt};
 use mockforge_test::MockForgeServer;
 use std::time::Duration;
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+
+/// Open a WebSocket connection with retries.
+///
+/// `MockForgeServer::build()` only waits for HTTP `/health` to go ready.
+/// The WS task binds a moment later, so the first `connect_async` after
+/// build() can occasionally race the bind on slower CI runners (macOS in
+/// particular). Retry a handful of times before giving up.
+async fn connect_with_retries(
+    ws_url: &str,
+) -> WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>> {
+    let overall_deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut last_err = String::new();
+    while std::time::Instant::now() < overall_deadline {
+        match connect_async(ws_url).await {
+            Ok((stream, _)) => return stream,
+            Err(e) => {
+                last_err = format!("{e:?}");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    panic!("Failed to connect to WebSocket {ws_url} after retries: {last_err}");
+}
 
 #[tokio::test]
 async fn test_websocket_connection() {
@@ -22,8 +45,8 @@ async fn test_websocket_connection() {
     let _ws_port = server.ws_port().expect("WebSocket port not assigned");
     let ws_url = server.ws_url().expect("WebSocket URL not available");
 
-    // Connect to WebSocket
-    let (mut ws_stream, _) = connect_async(&ws_url).await.expect("Failed to connect to WebSocket");
+    // Connect to WebSocket (retrying briefly so we don't race the bind)
+    let mut ws_stream = connect_with_retries(&ws_url).await;
 
     // Send a ping message
     ws_stream
@@ -66,9 +89,12 @@ async fn test_websocket_multiple_connections() {
 
     let ws_url = server.ws_url().expect("WebSocket URL not available");
 
-    // Connect multiple clients
+    // Connect multiple clients (retrying the first one to guard against
+    // the HTTP-ready-before-WS-bound race; once the first is up the rest
+    // should connect cleanly).
     let mut clients = Vec::new();
-    for _ in 0..3 {
+    clients.push(connect_with_retries(&ws_url).await);
+    for _ in 1..3 {
         let (ws_stream, _) = connect_async(&ws_url).await.expect("Failed to connect to WebSocket");
         clients.push(ws_stream);
     }
@@ -101,8 +127,8 @@ async fn test_websocket_binary_message() {
 
     let ws_url = server.ws_url().expect("WebSocket URL not available");
 
-    // Connect to WebSocket
-    let (mut ws_stream, _) = connect_async(&ws_url).await.expect("Failed to connect to WebSocket");
+    // Connect to WebSocket (retrying briefly so we don't race the bind)
+    let mut ws_stream = connect_with_retries(&ws_url).await;
 
     // Send binary message
     let binary_data = b"test binary data";


### PR DESCRIPTION
## Summary

Makes `protocols::websocket_e2e_tests` reliable in parallel nextest runs and on macOS Cross-Platform CI. Three independent bugs stacked to cause the failure.

## Root causes

1. **CI builds the binary without `ws` feature.** `mockforge-cli`'s default features intentionally exclude `ws`/`grpc`/`mqtt` etc. (that's `all-protocols`). The Cross-Platform Tests job ran `cargo nextest run --workspace`, which compiled the binary with only defaults — so the subprocess's `#[cfg(feature = "ws")] tokio::spawn(...)` for the WS server was compiled out entirely. Every `connect_async("ws://.../ws")` got `Connection refused`.
2. **Every subprocess raced on Prometheus port 9090.** `PrometheusConfig::default()` is `{ enabled: true, port: 9090 }`. The SDK auto-allocated random ports for http/ws/grpc/admin when callers didn't pin them, but *metrics* was only auto-allocated when the caller explicitly called `.metrics_port(0)`. Without that, every parallel test's subprocess fought for 9090, the loser's metrics task errored, the CLI's top-level `tokio::select!` short-circuited, HTTP never reached ready, and the test saw `HealthCheckTimeout(30)`.
3. **`find_available_port` had a TOCTOU race.** It sequentially probed a 100-port window and dropped the listener before the subprocess bound, leaving two parallel tests free to land on the same port.

## Fixes

- `.github/workflows/ci.yml` Cross-Platform Tests: add `cargo build --bin mockforge --features all-protocols` before `cargo nextest run` so the spawned binary has every protocol. Matches what `integration-tests.yml` already does.
- `mockforge-test::server::start()`: auto-allocate metrics port whenever the caller didn't pin one, mirroring existing ws/grpc/admin handling.
- `mockforge-test::process::find_available_port()`: always request an OS ephemeral port instead of sequentially probing a 100-port window. The `start_port` hint is preserved for API compatibility but ignored (see doc comment for why).
- `tests/tests/e2e/protocols/websocket_e2e_tests.rs`: wrap the first `connect_async` in a small retry loop as a belt-and-suspenders against the tiny HTTP-ready-before-WS-bound race.

## Test plan

- [x] `cargo test -p mockforge-integration-tests --test e2e protocols::websocket_e2e_tests` — 3/3 pass in 0.72s (was 2/3 FAIL with `HealthCheckTimeout(30)`).
- [x] `cargo test -p mockforge-integration-tests --test e2e` — 5/5 non-ignored pass; 5 ignored (pre-existing, documented in module note).
- [x] `cargo test -p mockforge-test --lib process::tests` — 5/5 pass (port-range assertions replaced with nonzero / distinctness checks).
- [x] `cargo fmt --all --check` + `cargo clippy -p mockforge-test --all-targets -- -D warnings` clean.
- [ ] The Cross-Platform Tests job on this PR will verify the CI side of the fix once it runs.

## Knock-on effect

PRs #205, #206, #207 were also failing Cross-Platform Tests with the same root causes. After this PR lands on main, rerunning those PRs' CI should clear them.