### PR TITLE
test(kafka): fix flaky test_broker_startup_timeout (#167)

### DIFF
--- a/crates/mockforge-kafka/tests/integration.rs
+++ b/crates/mockforge-kafka/tests/integration.rs
@@ -257,17 +257,30 @@ async fn test_offset_management() {
 
 #[tokio::test]
 async fn test_broker_startup_timeout() {
+    // Port 0 asks the OS for an ephemeral free port. The prior hardcoded 9093 was
+    // flaky under parallel multi-binary test execution: if any sibling test (or a
+    // leftover socket in TIME_WAIT) held 9093, `broker.start()` returned a bind
+    // error within milliseconds and this test's `assert!(start_result.is_err())`
+    // silently passed for the wrong reason — or, after compression landed, fired
+    // on a non-timeout error path and made the test unstable. With port 0, bind
+    // always succeeds and `start()` parks in its accept loop, so the 1s timeout
+    // reliably fires.
     let config = KafkaConfig {
-        port: 9093, // Use a different port for testing
+        port: 0,
         ..Default::default()
     };
     let broker = KafkaMockBroker::new(config).await.unwrap();
 
-    // Test that broker can start (with timeout to avoid hanging)
     let start_result = timeout(Duration::from_secs(1), broker.start()).await;
 
-    // Should timeout since we're not actually connecting
-    assert!(start_result.is_err());
+    // The outer Result is Err(Elapsed) because start()'s accept loop blocked
+    // through the whole 1s timeout.
+    assert!(
+        start_result.is_err(),
+        "broker.start() should have been blocked by its accept loop until the timeout fired, \
+         but returned early with {:?}",
+        start_result
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`test_broker_startup_timeout` in `crates/mockforge-kafka/tests/integration.rs` flakes under parallel multi-binary test execution. Surfaced during local verification of the Kafka-feature PR chain (#205/#206/#207) — the test failed once, then consistently passed on re-run.

## Root cause

The test hardcoded `port: 9093` and asserted that `broker.start()` would not complete within a 1-second `timeout()`. The invariant it actually wants — *`start()`'s accept loop blocks forever until interrupted* — is preserved regardless of the port. But when another Kafka test binary runs concurrently (or leaves a socket in TIME_WAIT), port 9093 can be occupied, `TcpListener::bind` returns an error within microseconds, `start()` returns early with `Err(bind)`, and the outer `timeout()` doesn't fire — so `start_result` is `Ok(Err(...))`, which `.is_err()` returns false, so the assertion fails.

## Fix

Switch `port: 9093` → `port: 0`. The OS picks an ephemeral free port on every run, so bind always succeeds and `start()` reliably parks in its accept loop until the 1s timeout fires.

Also tightened the assertion message to report `start_result`'s actual value if this ever regresses — the original "assertion failed" with no context was what made the flake slow to diagnose.

## Test plan

- [x] `cargo test -p mockforge-kafka --test integration test_broker_startup_timeout` passes in isolation (finishes in 1.00s as expected).
- [x] Full `cargo test -p mockforge-kafka` run 10× consecutively with default parallelism — `test_broker_startup_timeout ... ok` on every run, no other tests regressed.