### PR TITLE
feat(ui): surface full nav in cloud mode with self-hosted indicators

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -27,6 +27,7 @@ Ns = "Ns"  # Template syntax: {{now±Nd|Nh|Nm|Ns}} (Seconds)
 abd = "abd"  # Part of git commit hashes (e.g., abd3306)
 existant = "existant"  # CSS variable name (--sidebar-non-existant) - consistently used in book CSS
 Configuracion = "Configuracion"  # Spanish translation for "Configuration" in i18n
+Requiere = "Requiere"  # Spanish translation for "Requires" in i18n
 
 [files]
 extend-exclude = [

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -113,7 +113,6 @@ const navSections = [
       { id: 'logs', labelKey: 'tab.logs', icon: FileText },
       { id: 'traces', labelKey: 'tab.traces', icon: Network },
       { id: 'metrics', labelKey: 'tab.metrics', icon: Activity },
-      { id: 'analytics', labelKey: 'tab.analytics', icon: BarChart3 },
       { id: 'pillar-analytics', labelKey: 'tab.pillarAnalytics', icon: Layout },
       { id: 'fitness-functions', labelKey: 'tab.fitnessFunctions', icon: HeartPulse },
       { id: 'verification', labelKey: 'tab.verification', icon: CheckCircle2 },
@@ -201,6 +200,7 @@ const cloudNavItemIds = new Set([
   'scenario-marketplace',
   'plugin-registry',
   'pillar-analytics',
+  'status',
   'config',
   'organization',
   'billing',
@@ -210,14 +210,16 @@ const cloudNavItemIds = new Set([
   'usage',
 ]);
 
-const effectiveNavSections = isCloudMode
-  ? navSections
-      .map(section => ({
-        ...section,
-        items: section.items.filter(item => cloudNavItemIds.has(item.id)),
-      }))
-      .filter(section => section.items.length > 0)
-  : navSections;
+// In cloud mode, items outside the allowlist are shown as disabled "Local only"
+// entries so users can discover the full product surface and understand what
+// requires a local MockForge instance. In self-hosted mode every item is active.
+const effectiveNavSections = navSections.map(section => ({
+  ...section,
+  items: section.items.map(item => ({
+    ...item,
+    localOnly: isCloudMode && !cloudNavItemIds.has(item.id),
+  })),
+}));
 
 // Flattened items for title lookup (includes non-sidebar pages for breadcrumb resolution)
 const allNavItems = [
@@ -293,25 +295,37 @@ export function AppShell({ children, onRefresh }: AppShellProps) {
                   <div className="space-y-1">
                     {section.items.map((item, itemIndex) => {
                       const Icon = item.icon;
+                      const isLocalOnly = item.localOnly;
                       return (
                         <Button
                           key={item.id}
                           variant={activeTab === item.id ? 'default' : 'ghost'}
+                          disabled={isLocalOnly}
+                          title={isLocalOnly ? t('nav.localOnly.tooltip') : undefined}
                           className={cn(
                             'w-full justify-start gap-4 h-10 text-sm nav-item-hover focus-ring spring-hover',
                             'animate-slide-in-up',
-                            activeTab === item.id
+                            isLocalOnly
+                              ? 'text-muted-foreground/60 cursor-not-allowed opacity-70'
+                              : activeTab === item.id
                               ? 'bg-brand-500 text-white shadow-md hover:bg-brand-600'
                               : 'text-foreground/80 dark:text-gray-400 hover:text-foreground dark:hover:text-gray-100 hover:bg-muted/50'
                           )}
                           style={{ animationDelay: `${(sectionIndex * 5 + itemIndex) * 20}ms` }}
                           onClick={() => {
+                            if (isLocalOnly) return;
                             navigate('/' + item.id);
                             setSidebarOpen(false);
                           }}
                         >
                           <Icon className="h-4 w-4" />
-                          {t(item.labelKey)}
+                          <span className="flex-1 text-left">{t(item.labelKey)}</span>
+                          {isLocalOnly && (
+                            <span className="flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                              <LockIcon className="h-3 w-3" />
+                              {t('nav.localOnly.badge')}
+                            </span>
+                          )}
                         </Button>
                       );
                     })}
@@ -340,20 +354,34 @@ export function AppShell({ children, onRefresh }: AppShellProps) {
                   <div className="space-y-1">
                     {section.items.map((item) => {
                       const Icon = item.icon;
+                      const isLocalOnly = item.localOnly;
                       return (
                         <Button
                           key={item.id}
                           variant={activeTab === item.id ? 'default' : 'ghost'}
+                          disabled={isLocalOnly}
+                          title={isLocalOnly ? t('nav.localOnly.tooltip') : undefined}
                           className={cn(
                             'w-full justify-start gap-3 h-9 transition-all duration-200 nav-item-hover focus-ring spring-hover',
-                            activeTab === item.id
+                            isLocalOnly
+                              ? 'text-muted-foreground/60 cursor-not-allowed opacity-70'
+                              : activeTab === item.id
                               ? 'bg-brand-600 text-white shadow-lg ring-1 ring-brand-200/60 dark:ring-brand-600/70 hover:bg-brand-700'
                               : 'text-foreground/80 dark:text-gray-200 hover:text-foreground dark:hover:text-white hover:bg-muted/50 dark:hover:bg-white/5'
                           )}
-                          onClick={() => navigate('/' + item.id)}
+                          onClick={() => {
+                            if (isLocalOnly) return;
+                            navigate('/' + item.id);
+                          }}
                         >
                           <Icon className="h-4 w-4" />
-                          {t(item.labelKey)}
+                          <span className="flex-1 text-left">{t(item.labelKey)}</span>
+                          {isLocalOnly && (
+                            <span className="flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                              <LockIcon className="h-3 w-3" />
+                              {t('nav.localOnly.badge')}
+                            </span>
+                          )}
                         </Button>
                       );
                     })}

--- a/crates/mockforge-ui/ui/src/hooks/useAnalyticsV2.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useAnalyticsV2.ts
@@ -3,7 +3,7 @@
  * Provides integration with the new persistent analytics database
  */
 
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 // API Base URL
 const API_BASE = '/api/v2/analytics';

--- a/crates/mockforge-ui/ui/src/hooks/usePipelines.ts
+++ b/crates/mockforge-ui/ui/src/hooks/usePipelines.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import { apiErrorMessage } from '@/utils/errorHandling';
 
 const API_BASE = '/api/v1/pipelines';

--- a/crates/mockforge-ui/ui/src/i18n/translations.ts
+++ b/crates/mockforge-ui/ui/src/i18n/translations.ts
@@ -89,6 +89,9 @@ const en: Dictionary = {
   'tab.usage': 'Plan & Usage',
   'tab.userManagement': 'User Management',
 
+  'nav.localOnly.badge': 'Local',
+  'nav.localOnly.tooltip': 'Requires a local MockForge instance',
+
   'page.config.title': 'Configuration',
   'page.config.subtitle': 'Manage MockForge settings and preferences',
   'page.plugins.title': 'Plugin Management',
@@ -132,6 +135,9 @@ const es: Dictionary = {
   'nav.community': 'Comunidad',
   'nav.plugins': 'Plugins',
   'nav.configuration': 'Configuracion',
+
+  'nav.localOnly.badge': 'Local',
+  'nav.localOnly.tooltip': 'Requiere una instancia local de MockForge',
 };
 
 export const translations: Record<Locale, Dictionary> = { en, es };

--- a/crates/mockforge-ui/ui/src/routes/index.tsx
+++ b/crates/mockforge-ui/ui/src/routes/index.tsx
@@ -37,7 +37,6 @@ const WorldStatePage = lazy(() => import('../pages/WorldStatePage').then(m => ({
 const PerformancePage = lazy(() => import('../pages/PerformancePage').then(m => ({ default: m.default })));
 const ScenarioStateMachineEditor = lazy(() => import('../pages/ScenarioStateMachineEditor').then(m => ({ default: m.ScenarioStateMachineEditor })));
 const ScenarioStudioPage = lazy(() => import('../pages/ScenarioStudioPage').then(m => ({ default: m.ScenarioStudioPage })));
-const AnalyticsPage = lazy(() => import('../pages/AnalyticsPage'));
 const PillarAnalyticsPage = lazy(() => import('../pages/PillarAnalyticsPage').then(m => ({ default: m.PillarAnalyticsPage })));
 const HostedMocksPage = lazy(() => import('../pages/HostedMocksPage').then(m => ({ default: m.HostedMocksPage })));
 const ApiExplorerPage = lazy(() => import('../pages/ApiExplorerPage').then(m => ({ default: m.ApiExplorerPage })));
@@ -146,7 +145,6 @@ export const routes: RouteConfig[] = [
   { path: '/logs', element: <LogsPage /> },
   { path: '/traces', element: <TracesPage /> },
   { path: '/metrics', element: <MetricsPage /> },
-  { path: '/analytics', element: <AnalyticsPage /> },
   { path: '/pillar-analytics', element: <PillarAnalyticsPage /> },
   { path: '/verification', element: <VerificationPage /> },
   { path: '/contract-diff', element: <ContractDiffPage /> },


### PR DESCRIPTION
## Summary

Cloud users at `app.mockforge.dev` previously saw only **16 of ~70 nav items** — the rest were filtered out entirely by `cloudNavItemIds` in `AppShell.tsx`. The product's self-hosted-only surface (chaos engineering, MQTT/Kafka/SMTP monitors, orchestration, world state, testing, etc.) was invisible to cloud users, with no signal that those features exist.

This PR replaces the filter with a decorator pass: every nav item renders, but items outside the cloud allowlist are disabled and marked with a lock icon + "Local" badge + tooltip (\"Requires a local MockForge instance\"). Users can discover the full product surface; clicks on local-only items are blocked so no one lands on a page that 404s against the cloud API.

### Also included

- Add `status` to `cloudNavItemIds` — `/api/v1/status` is on the registry server, unlike other observability items.
- Remove `/analytics` route + nav entry. `AnalyticsDashboardV2` calls `/api/v2/analytics/overview`/`/requests`/`/latency`/`/errors` which are **not wired** on any backend (the handler module `analytics_v2.rs` exists but isn't mounted in `routes.rs`). `Pillar Analytics` remains as the working analytics view. The page and hook stay on disk for future backend wire-up.
- Fix two files that import `UseQueryResult` as a value — `verbatimModuleSyntax: true` in `tsconfig.app.json` requires `import type`. Note: the same pattern exists elsewhere in the repo (useFederation, useCoverageMetrics, and their consumers); those are a pre-existing `pnpm dev` hazard out of scope for this PR.
- i18n: add `nav.localOnly.badge` / `nav.localOnly.tooltip` in en/es; add `Requiere` to `.typos.toml` allowlist (same pattern as existing `Configuracion`).

## Before / After

**Before (cloud):** 16 visible items — Dashboard, Workspaces, Federation, Services, Fixtures, Hosted Mocks, Pillar Analytics, Template Marketplace, Scenario Marketplace, Plugin Registry, Config, Organization, Billing, API Tokens, Publisher Keys, BYOK Keys, Plan & Usage.

**After (cloud):** all nav sections visible. Local-only items disabled with 🔒 LOCAL badge and tooltip. Self-hosted mode unchanged.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm lint` — 0 new errors (911 pre-existing warnings unchanged)
- [x] `VITE_MOCKFORGE_MODE=cloud VITE_API_BASE_URL=... pnpm build` succeeds
- [x] Visual verification via preview server with a real `app.mockforge.dev` JWT — confirmed badges on Virtual Backends, Tunnels, Proxy Inspector, Chains, Graph, State Machines, Scenario Studio, Orchestration, Observability, World State, Performance, Logs, Traces, Metrics, Fitness Functions, Verification, Contract Diff, Testing, etc., while Workspaces/Federation/Services/Fixtures/Hosted Mocks/Pillar Analytics/System Status remain active
- [ ] Verify on Cloudflare Pages preview once deployed
- [ ] Confirm self-hosted mode (no `VITE_MOCKFORGE_MODE`) still shows all items as active