### PR TITLE
fix(ui,analytics): wire /api/v2/analytics + repo-wide type-only imports

### DIFF
--- a/crates/mockforge-ui/src/handlers/analytics_v2.rs
+++ b/crates/mockforge-ui/src/handlers/analytics_v2.rs
@@ -5,30 +5,18 @@
 //! - Historical data from the analytics database
 //! - Advanced queries (time-series, trends, patterns)
 
-use axum::{
-    extract::{Query, State},
-    http::StatusCode,
-    Json,
-};
+use axum::{extract::Query, http::StatusCode, Json};
 use chrono::Utc;
-use mockforge_analytics::{AnalyticsDatabase, AnalyticsFilter, Granularity, OverviewMetrics};
+use mockforge_analytics::{AnalyticsFilter, Granularity, OverviewMetrics};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 use tracing::{debug, error};
 
+use crate::handlers::coverage_metrics::CoverageMetricsState;
 use crate::models::ApiResponse;
 
-/// Enhanced analytics state with both Prometheus and database access
-#[derive(Clone)]
-pub struct AnalyticsV2State {
-    pub db: Arc<AnalyticsDatabase>,
-}
-
-impl AnalyticsV2State {
-    pub fn new(db: AnalyticsDatabase) -> Self {
-        Self { db: Arc::new(db) }
-    }
-}
+// Note: These handlers share the lazily-initialized AnalyticsDatabase with
+// coverage_metrics / pillar_analytics via CoverageMetricsState. Routes are
+// mounted in routes.rs alongside the other /api/v2/analytics/* endpoints.
 
 /// Query parameters for analytics endpoints
 #[derive(Debug, Deserialize)]
@@ -120,12 +108,13 @@ impl AnalyticsQuery {
 /// - Active connections, throughput
 /// - Top protocols and endpoints
 pub async fn get_overview(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<AnalyticsQuery>,
 ) -> Result<Json<ApiResponse<OverviewMetrics>>, StatusCode> {
     debug!("Fetching analytics overview for duration: {}s", query.duration);
 
-    match state.db.get_overview_metrics(query.duration).await {
+    let db = state.get_db().await?;
+    match db.get_overview_metrics(query.duration).await {
         Ok(overview) => Ok(Json(ApiResponse::success(overview))),
         Err(e) => {
             error!("Failed to get overview metrics: {}", e);
@@ -155,7 +144,7 @@ pub struct DataPoint {
 }
 
 pub async fn get_requests_timeseries(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<AnalyticsQuery>,
 ) -> Result<Json<ApiResponse<TimeSeriesResponse>>, StatusCode> {
     debug!("Fetching request time-series");
@@ -163,7 +152,8 @@ pub async fn get_requests_timeseries(
     let filter = query.to_filter();
     let granularity = query.get_granularity();
 
-    match state.db.get_request_time_series(&filter, granularity).await {
+    let db = state.get_db().await?;
+    match db.get_request_time_series(&filter, granularity).await {
         Ok(time_series) => {
             let series = time_series
                 .into_iter()
@@ -209,14 +199,15 @@ pub struct LatencyTrendData {
 }
 
 pub async fn get_latency_trends(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<AnalyticsQuery>,
 ) -> Result<Json<ApiResponse<LatencyResponse>>, StatusCode> {
     debug!("Fetching latency trends");
 
     let filter = query.to_filter();
 
-    match state.db.get_latency_trends(&filter).await {
+    let db = state.get_db().await?;
+    match db.get_latency_trends(&filter).await {
         Ok(trends) => {
             let trend_data = trends
                 .into_iter()
@@ -258,14 +249,15 @@ pub struct ErrorSummaryData {
 }
 
 pub async fn get_error_summary(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<AnalyticsQuery>,
 ) -> Result<Json<ApiResponse<ErrorResponse>>, StatusCode> {
     debug!("Fetching error summary");
 
     let filter = query.to_filter();
 
-    match state.db.get_error_summary(&filter, query.limit).await {
+    let db = state.get_db().await?;
+    match db.get_error_summary(&filter, query.limit).await {
         Ok(errors) => {
             let error_data = errors
                 .into_iter()
@@ -310,12 +302,13 @@ pub struct EndpointData {
 }
 
 pub async fn get_top_endpoints(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<AnalyticsQuery>,
 ) -> Result<Json<ApiResponse<EndpointsResponse>>, StatusCode> {
     debug!("Fetching top {} endpoints", query.limit);
 
-    match state.db.get_top_endpoints(query.limit, query.workspace_id.as_deref()).await {
+    let db = state.get_db().await?;
+    match db.get_top_endpoints(query.limit, query.workspace_id.as_deref()).await {
         Ok(endpoints) => {
             let endpoint_data = endpoints
                 .into_iter()
@@ -369,12 +362,13 @@ pub struct ProtocolData {
 }
 
 pub async fn get_protocol_breakdown(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<AnalyticsQuery>,
 ) -> Result<Json<ApiResponse<ProtocolsResponse>>, StatusCode> {
     debug!("Fetching protocol breakdown");
 
-    match state.db.get_top_protocols(10, query.workspace_id.as_deref()).await {
+    let db = state.get_db().await?;
+    match db.get_top_protocols(10, query.workspace_id.as_deref()).await {
         Ok(protocols) => {
             let protocol_data = protocols
                 .into_iter()
@@ -427,12 +421,13 @@ fn default_pattern_days() -> i64 {
 }
 
 pub async fn get_traffic_patterns(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<TrafficPatternsQuery>,
 ) -> Result<Json<ApiResponse<TrafficPatternsResponse>>, StatusCode> {
     debug!("Fetching traffic patterns for {} days", query.days);
 
-    match state.db.get_traffic_patterns(query.days, query.workspace_id.as_deref()).await {
+    let db = state.get_db().await?;
+    match db.get_traffic_patterns(query.days, query.workspace_id.as_deref()).await {
         Ok(patterns) => {
             let pattern_data = patterns
                 .into_iter()
@@ -461,7 +456,7 @@ pub async fn get_traffic_patterns(
 ///
 /// Export analytics data to CSV format
 pub async fn export_csv(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<AnalyticsQuery>,
 ) -> Result<(StatusCode, String), StatusCode> {
     debug!("Exporting analytics to CSV");
@@ -469,7 +464,8 @@ pub async fn export_csv(
     let filter = query.to_filter();
     let mut buffer = Vec::new();
 
-    match state.db.export_to_csv(&mut buffer, &filter).await {
+    let db = state.get_db().await?;
+    match db.export_to_csv(&mut buffer, &filter).await {
         Ok(_) => {
             let csv_data = String::from_utf8(buffer).unwrap_or_default();
             Ok((StatusCode::OK, csv_data))
@@ -485,14 +481,15 @@ pub async fn export_csv(
 ///
 /// Export analytics data to JSON format
 pub async fn export_json(
-    State(state): State<AnalyticsV2State>,
+    axum::extract::Extension(state): axum::extract::Extension<CoverageMetricsState>,
     Query(query): Query<AnalyticsQuery>,
 ) -> Result<(StatusCode, String), StatusCode> {
     debug!("Exporting analytics to JSON");
 
     let filter = query.to_filter();
 
-    match state.db.export_to_json(&filter).await {
+    let db = state.get_db().await?;
+    match db.export_to_json(&filter).await {
         Ok(json) => Ok((StatusCode::OK, json)),
         Err(e) => {
             error!("Failed to export to JSON: {}", e);

--- a/crates/mockforge-ui/src/handlers/coverage_metrics.rs
+++ b/crates/mockforge-ui/src/handlers/coverage_metrics.rs
@@ -27,7 +27,7 @@ impl CoverageMetricsState {
         Self { db: Arc::new(cell) }
     }
 
-    async fn get_db(&self) -> Result<&AnalyticsDatabase, StatusCode> {
+    pub(crate) async fn get_db(&self) -> Result<&AnalyticsDatabase, StatusCode> {
         self.db.get().ok_or_else(|| {
             error!("Analytics database not initialized");
             StatusCode::SERVICE_UNAVAILABLE

--- a/crates/mockforge-ui/src/routes.rs
+++ b/crates/mockforge-ui/src/routes.rs
@@ -467,6 +467,7 @@ pub fn create_admin_router(
         let coverage_state = CoverageMetricsState { db: coverage_db };
 
         // Add routes directly to main router to avoid state type conflicts
+        use crate::handlers::analytics_v2;
         use crate::handlers::coverage_metrics;
         use crate::handlers::pillar_analytics::{self, PillarAnalyticsState};
         router = router
@@ -484,6 +485,19 @@ pub fn create_admin_router(
                 "/api/v2/analytics/drift/percentage",
                 get(coverage_metrics::get_drift_percentage),
             )
+            // Dashboard analytics (share the same CoverageMetricsState / OnceCell)
+            .route("/api/v2/analytics/overview", get(analytics_v2::get_overview))
+            .route("/api/v2/analytics/requests", get(analytics_v2::get_requests_timeseries))
+            .route("/api/v2/analytics/latency", get(analytics_v2::get_latency_trends))
+            .route("/api/v2/analytics/errors", get(analytics_v2::get_error_summary))
+            .route("/api/v2/analytics/endpoints", get(analytics_v2::get_top_endpoints))
+            .route("/api/v2/analytics/protocols", get(analytics_v2::get_protocol_breakdown))
+            .route(
+                "/api/v2/analytics/traffic-patterns",
+                get(analytics_v2::get_traffic_patterns),
+            )
+            .route("/api/v2/analytics/export/csv", get(analytics_v2::export_csv))
+            .route("/api/v2/analytics/export/json", get(analytics_v2::export_json))
             // Pillar usage analytics (shares the same AnalyticsDatabase OnceCell)
             .route(
                 "/api/v2/analytics/pillars/workspace/{workspace_id}",

--- a/crates/mockforge-ui/tests/analytics_api_tests.rs
+++ b/crates/mockforge-ui/tests/analytics_api_tests.rs
@@ -10,6 +10,7 @@ mod tests {
     };
     use mockforge_analytics::AnalyticsDatabase;
     use mockforge_ui::handlers::analytics_v2::*;
+    use mockforge_ui::handlers::coverage_metrics::CoverageMetricsState;
     use std::path::PathBuf;
     use tower::ServiceExt; // for `oneshot`
 
@@ -22,7 +23,7 @@ mod tests {
     }
 
     fn create_test_router(db: AnalyticsDatabase) -> Router {
-        let state = AnalyticsV2State::new(db);
+        let state = CoverageMetricsState::new(db);
 
         Router::new()
             .route("/overview", axum::routing::get(get_overview))
@@ -32,7 +33,7 @@ mod tests {
             .route("/endpoints", axum::routing::get(get_top_endpoints))
             .route("/protocols", axum::routing::get(get_protocol_breakdown))
             .route("/export/csv", axum::routing::get(export_csv))
-            .with_state(state)
+            .layer(axum::extract::Extension(state))
     }
 
     #[tokio::test]

--- a/crates/mockforge-ui/ui/src/components/federation/ActiveScenarioPanel.tsx
+++ b/crates/mockforge-ui/ui/src/components/federation/ActiveScenarioPanel.tsx
@@ -8,10 +8,10 @@
 
 import React, { useMemo, useState } from 'react';
 import {
-  Federation,
-  FederationService,
-  PerServiceActivationState,
-  ServiceScenarioOverride,
+  type Federation,
+  type FederationService,
+  type PerServiceActivationState,
+  type ServiceScenarioOverride,
   useActivateFederationScenario,
   useActiveFederationScenario,
   useDeactivateFederationScenario,

--- a/crates/mockforge-ui/ui/src/components/federation/FederationDashboard.tsx
+++ b/crates/mockforge-ui/ui/src/components/federation/FederationDashboard.tsx
@@ -8,7 +8,7 @@ import React, { useState } from 'react';
 import { FederationList } from './FederationList';
 import { FederationDetail } from './FederationDetail';
 import { FederationForm } from './FederationForm';
-import { Federation } from '../../hooks/useFederation';
+import type { Federation } from '../../hooks/useFederation';
 
 export interface FederationDashboardProps {
   orgId: string;

--- a/crates/mockforge-ui/ui/src/components/federation/FederationDetail.tsx
+++ b/crates/mockforge-ui/ui/src/components/federation/FederationDetail.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState } from 'react';
-import { useFederation, useRouteRequest, Federation } from '../../hooks/useFederation';
+import { useFederation, useRouteRequest, type Federation } from '../../hooks/useFederation';
 import { Card } from '../ui/Card';
 import { ActiveScenarioPanel } from './ActiveScenarioPanel';
 import { ArrowLeft, Edit, Network, Play, CheckCircle } from 'lucide-react';

--- a/crates/mockforge-ui/ui/src/components/federation/FederationForm.tsx
+++ b/crates/mockforge-ui/ui/src/components/federation/FederationForm.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { useCreateFederation, useUpdateFederation, Federation, FederationService } from '../../hooks/useFederation';
+import { useCreateFederation, useUpdateFederation, type Federation, type FederationService } from '../../hooks/useFederation';
 import { Card } from '../ui/Card';
 import { ArrowLeft, Save, Plus, Trash2 } from 'lucide-react';
 

--- a/crates/mockforge-ui/ui/src/components/federation/FederationList.tsx
+++ b/crates/mockforge-ui/ui/src/components/federation/FederationList.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { useFederations, useDeleteFederation, Federation } from '../../hooks/useFederation';
+import { useFederations, useDeleteFederation, type Federation } from '../../hooks/useFederation';
 import { Card } from '../ui/Card';
 import { Edit, Trash2, Plus, Network, ArrowRight } from 'lucide-react';
 

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -113,6 +113,7 @@ const navSections = [
       { id: 'logs', labelKey: 'tab.logs', icon: FileText },
       { id: 'traces', labelKey: 'tab.traces', icon: Network },
       { id: 'metrics', labelKey: 'tab.metrics', icon: Activity },
+      { id: 'analytics', labelKey: 'tab.analytics', icon: BarChart3 },
       { id: 'pillar-analytics', labelKey: 'tab.pillarAnalytics', icon: Layout },
       { id: 'fitness-functions', labelKey: 'tab.fitnessFunctions', icon: HeartPulse },
       { id: 'verification', labelKey: 'tab.verification', icon: CheckCircle2 },

--- a/crates/mockforge-ui/ui/src/components/pipelines/PipelineDashboard.tsx
+++ b/crates/mockforge-ui/ui/src/components/pipelines/PipelineDashboard.tsx
@@ -10,7 +10,7 @@ import { PipelineDetail } from './PipelineDetail';
 import { PipelineForm } from './PipelineForm';
 import { PipelineExecutions } from './PipelineExecutions';
 import { Card } from '../ui/Card';
-import { Pipeline } from '../../hooks/usePipelines';
+import type { Pipeline } from '../../hooks/usePipelines';
 
 export interface PipelineDashboardProps {
   workspaceId?: string;

--- a/crates/mockforge-ui/ui/src/components/pipelines/PipelineDetail.tsx
+++ b/crates/mockforge-ui/ui/src/components/pipelines/PipelineDetail.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { usePipeline, useTriggerPipeline, Pipeline } from '../../hooks/usePipelines';
+import { usePipeline, useTriggerPipeline, type Pipeline } from '../../hooks/usePipelines';
 import { Card } from '../ui/Card';
 import { ArrowLeft, Edit, Play, CheckCircle, XCircle, Clock, Settings } from 'lucide-react';
 

--- a/crates/mockforge-ui/ui/src/components/pipelines/PipelineExecutions.tsx
+++ b/crates/mockforge-ui/ui/src/components/pipelines/PipelineExecutions.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { usePipelineExecutions, PipelineExecution } from '../../hooks/usePipelines';
+import { usePipelineExecutions, type PipelineExecution } from '../../hooks/usePipelines';
 import { Card } from '../ui/Card';
 import { ArrowLeft, CheckCircle, XCircle, Clock, Loader } from 'lucide-react';
 

--- a/crates/mockforge-ui/ui/src/components/pipelines/PipelineForm.tsx
+++ b/crates/mockforge-ui/ui/src/components/pipelines/PipelineForm.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { useCreatePipeline, useUpdatePipeline, Pipeline, PipelineDefinition } from '../../hooks/usePipelines';
+import { useCreatePipeline, useUpdatePipeline, type Pipeline, type PipelineDefinition } from '../../hooks/usePipelines';
 import { Card } from '../ui/Card';
 import { ArrowLeft, Save } from 'lucide-react';
 

--- a/crates/mockforge-ui/ui/src/components/pipelines/PipelineList.tsx
+++ b/crates/mockforge-ui/ui/src/components/pipelines/PipelineList.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { usePipelines, useDeletePipeline, Pipeline } from '../../hooks/usePipelines';
+import { usePipelines, useDeletePipeline, type Pipeline } from '../../hooks/usePipelines';
 import { Card } from '../ui/Card';
 import { Play, Edit, Trash2, Plus, CheckCircle, XCircle, Clock } from 'lucide-react';
 

--- a/crates/mockforge-ui/ui/src/components/scenario-studio/FlowPropertiesPanel.tsx
+++ b/crates/mockforge-ui/ui/src/components/scenario-studio/FlowPropertiesPanel.tsx
@@ -10,11 +10,11 @@ import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { X } from 'lucide-react';
 import { Node } from '@xyflow/react';
-import { ApiCallNodeData } from './ApiCallNode';
-import { ConditionNodeData } from './ConditionNode';
-import { DelayNodeData } from './DelayNode';
-import { LoopNodeData } from './LoopNode';
-import { ParallelNodeData } from './ParallelNode';
+import type { ApiCallNodeData } from './ApiCallNode';
+import type { ConditionNodeData } from './ConditionNode';
+import type { DelayNodeData } from './DelayNode';
+import type { LoopNodeData } from './LoopNode';
+import type { ParallelNodeData } from './ParallelNode';
 
 interface FlowPropertiesPanelProps {
   selectedNode: Node | null;

--- a/crates/mockforge-ui/ui/src/hooks/useCoverageMetrics.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useCoverageMetrics.ts
@@ -3,7 +3,7 @@
  * Provides integration with scenario usage, persona CI hits, endpoint coverage, etc.
  */
 
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 // API Base URL
 const API_BASE = '/api/v2/analytics';

--- a/crates/mockforge-ui/ui/src/hooks/useFederation.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useFederation.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import { apiErrorMessage } from '@/utils/errorHandling';
 
 const API_BASE = '/api/v1/federation';

--- a/crates/mockforge-ui/ui/src/pages/GraphPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/GraphPage.tsx
@@ -20,7 +20,7 @@ import { apiService } from '../services/api';
 import type { GraphData, GraphNode, GraphEdge } from '../types/graph';
 import { EndpointNode } from '../components/graph/EndpointNode';
 import { ServiceNode } from '../components/graph/ServiceNode';
-import { GraphControls, LayoutType, FilterType, ProtocolFilter } from '../components/graph/GraphControls';
+import { GraphControls, type LayoutType, type FilterType, type ProtocolFilter } from '../components/graph/GraphControls';
 import { GraphDetailsPanel } from '../components/graph/GraphDetailsPanel';
 import { applyLayout } from '../utils/graphLayouts';
 import { applyClusterLayout } from '../utils/graphClustering';

--- a/crates/mockforge-ui/ui/src/pages/ScenarioStudioPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ScenarioStudioPage.tsx
@@ -37,11 +37,11 @@ import {
   Layers,
   Settings,
 } from 'lucide-react';
-import { ApiCallNode, ApiCallNodeData } from '@/components/scenario-studio/ApiCallNode';
-import { ConditionNode, ConditionNodeData } from '@/components/scenario-studio/ConditionNode';
-import { DelayNode, DelayNodeData } from '@/components/scenario-studio/DelayNode';
-import { LoopNode, LoopNodeData } from '@/components/scenario-studio/LoopNode';
-import { ParallelNode, ParallelNodeData } from '@/components/scenario-studio/ParallelNode';
+import { ApiCallNode, type ApiCallNodeData } from '@/components/scenario-studio/ApiCallNode';
+import { ConditionNode, type ConditionNodeData } from '@/components/scenario-studio/ConditionNode';
+import { DelayNode, type DelayNodeData } from '@/components/scenario-studio/DelayNode';
+import { LoopNode, type LoopNodeData } from '@/components/scenario-studio/LoopNode';
+import { ParallelNode, type ParallelNodeData } from '@/components/scenario-studio/ParallelNode';
 import { FlowPropertiesPanel } from '@/components/scenario-studio/FlowPropertiesPanel';
 import { FlowExecutor } from '@/components/scenario-studio/FlowExecutor';
 import { useHistory } from '@/hooks/useHistory';

--- a/crates/mockforge-ui/ui/src/pages/VoicePage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/VoicePage.tsx
@@ -4,11 +4,11 @@
 //! natural language voice commands powered by LLM.
 
 import React, { useState } from 'react';
-import { VoiceInput, VoiceCommandResult } from '../components/voice/VoiceInput';
-import { NLHookEditor, HookResult } from '../components/hooks/NLHookEditor';
+import { VoiceInput, type VoiceCommandResult } from '../components/voice/VoiceInput';
+import { NLHookEditor, type HookResult } from '../components/hooks/NLHookEditor';
 import {
   WorkspaceScenarioCreator,
-  WorkspaceScenarioResult,
+  type WorkspaceScenarioResult,
 } from '../components/workspace/WorkspaceScenarioCreator';
 import { Card } from '../components/ui/Card';
 import { Mic, Sparkles, FileCode, Code2, Building2 } from 'lucide-react';

--- a/crates/mockforge-ui/ui/src/routes/index.tsx
+++ b/crates/mockforge-ui/ui/src/routes/index.tsx
@@ -37,6 +37,7 @@ const WorldStatePage = lazy(() => import('../pages/WorldStatePage').then(m => ({
 const PerformancePage = lazy(() => import('../pages/PerformancePage').then(m => ({ default: m.default })));
 const ScenarioStateMachineEditor = lazy(() => import('../pages/ScenarioStateMachineEditor').then(m => ({ default: m.ScenarioStateMachineEditor })));
 const ScenarioStudioPage = lazy(() => import('../pages/ScenarioStudioPage').then(m => ({ default: m.ScenarioStudioPage })));
+const AnalyticsPage = lazy(() => import('../pages/AnalyticsPage'));
 const PillarAnalyticsPage = lazy(() => import('../pages/PillarAnalyticsPage').then(m => ({ default: m.PillarAnalyticsPage })));
 const HostedMocksPage = lazy(() => import('../pages/HostedMocksPage').then(m => ({ default: m.HostedMocksPage })));
 const ApiExplorerPage = lazy(() => import('../pages/ApiExplorerPage').then(m => ({ default: m.ApiExplorerPage })));
@@ -145,6 +146,7 @@ export const routes: RouteConfig[] = [
   { path: '/logs', element: <LogsPage /> },
   { path: '/traces', element: <TracesPage /> },
   { path: '/metrics', element: <MetricsPage /> },
+  { path: '/analytics', element: <AnalyticsPage /> },
   { path: '/pillar-analytics', element: <PillarAnalyticsPage /> },
   { path: '/verification', element: <VerificationPage /> },
   { path: '/contract-diff', element: <ContractDiffPage /> },


### PR DESCRIPTION
## Summary

Follow-up to #211. Two orthogonal fixes bundled because they share a blast radius (UI) and both stem from `pnpm dev` being broken.

### 1. `pnpm dev` no longer errors on startup

`tsconfig.app.json` has `verbatimModuleSyntax: true`, which requires types to be imported via `import type` / inline `type` modifier. ~10 files were still importing types as values — vite's esbuild drops type-only exports from external deps (e.g. `@tanstack/react-query`), and TS interfaces erase at runtime, so every consumer of those modules got browser errors like:

```
The requested module '/src/hooks/useFederation.ts' does not provide an export named 'Federation'
```

Fixed mechanically across `src/`: add `type` modifier to type-only imports. Behavior-preserving; no runtime changes.

**Files touched:** `useFederation`, `useCoverageMetrics`, all federation components (Dashboard/Detail/Form/List/ActiveScenarioPanel), all pipelines components (Dashboard/Detail/Form/List/Executions), `FlowPropertiesPanel`, `GraphPage`, `ScenarioStudioPage`, `VoicePage`.

### 2. `/api/v2/analytics` dashboard endpoints now return data

`mockforge-ui` had a full `analytics_v2.rs` handler sitting unused because it required its own axum `State<AnalyticsV2State>` extractor, conflicting with the main router's state type. The coverage-metrics and pillar-analytics routes already worked around this by using `Extension<CoverageMetricsState>` and a shared lazily-initialized `AnalyticsDatabase` `OnceCell`.

Changes:
- Delete `AnalyticsV2State` — its only wrapper over `Arc<AnalyticsDatabase>` is now redundant.
- Switch all 9 handlers (`get_overview`, `get_requests_timeseries`, `get_latency_trends`, `get_error_summary`, `get_top_endpoints`, `get_protocol_breakdown`, `get_traffic_patterns`, `export_csv`, `export_json`) to take `Extension<CoverageMetricsState>` and unwrap the db via the existing `get_db()` helper (promoted from private to `pub(crate)`).
- Add the 9 routes to `routes.rs` alongside the existing `/api/v2/analytics/*` entries.
- Update `analytics_api_tests.rs` to the new wiring. All 8 integration tests pass.

### 3. UI: re-add `/analytics` route + sidebar entry

Removed in #211 when the endpoint was broken. Now restored. Still marked "Local" in cloud mode since the analytics DB runs on the self-hosted mockforge-ui server, not the registry server.

## Test plan

- [x] `cargo build -p mockforge-ui --lib` ✅
- [x] `cargo clippy -p mockforge-ui --all-targets -- -D warnings` ✅
- [x] `cargo test -p mockforge-ui --test analytics_api_tests` — 8/8 pass ✅
- [x] `cargo fmt --all --check` ✅
- [x] `pnpm type-check` ✅
- [x] `pnpm lint` — 0 new errors (911 pre-existing warnings unchanged) ✅
- [x] `pnpm dev` boots clean — no console errors on `/dashboard`, `/federation`, `/scenario-studio`, `/analytics` ✅
- [ ] Follow-up: confirm AnalyticsDashboardV2 actually renders data when analytics DB has entries (requires live data for full end-to-end)