### PR TITLE
feat(registry,ui): wire avatar dropdown to real backends (Stage 1)

### DIFF
--- a/crates/mockforge-registry-core/src/models/user.rs
+++ b/crates/mockforge-registry-core/src/models/user.rs
@@ -21,8 +21,45 @@ pub struct User {
     #[serde(skip_serializing)]
     pub two_factor_backup_codes: Option<Vec<String>>, // Array of hashed backup codes
     pub two_factor_verified_at: Option<DateTime<Utc>>,
+    #[serde(default = "default_true")]
+    pub email_notifications: bool,
+    #[serde(default = "default_true")]
+    pub security_alerts: bool,
+    #[serde(default)]
+    pub preferences: serde_json::Value,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl User {
+    /// Build an "unknown user" placeholder for the given id. Used by read
+    /// handlers when the referenced user has been deleted but we still need
+    /// to render the surrounding record (reviews, plugins, templates, etc.).
+    pub fn placeholder(id: Uuid) -> Self {
+        let now = Utc::now();
+        Self {
+            id,
+            username: "Unknown".to_string(),
+            email: String::new(),
+            password_hash: String::new(),
+            api_token: None,
+            is_verified: false,
+            is_admin: false,
+            two_factor_enabled: false,
+            two_factor_secret: None,
+            two_factor_backup_codes: None,
+            two_factor_verified_at: None,
+            email_notifications: true,
+            security_alerts: true,
+            preferences: serde_json::Value::Object(Default::default()),
+            created_at: now,
+            updated_at: now,
+        }
+    }
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1018,6 +1018,30 @@ pub trait RegistryStore: Send + Sync + 'static {
     /// Mark a user's email as verified.
     async fn mark_user_verified(&self, user_id: Uuid) -> StoreResult<()>;
 
+    /// Update a user's username and/or email. Pass `None` to leave a field unchanged.
+    /// Returns the updated user.
+    async fn update_user_profile(
+        &self,
+        user_id: Uuid,
+        username: Option<&str>,
+        email: Option<&str>,
+    ) -> StoreResult<User>;
+
+    /// Update a user's notification-preference flags.
+    async fn update_user_notification_prefs(
+        &self,
+        user_id: Uuid,
+        email_notifications: bool,
+        security_alerts: bool,
+    ) -> StoreResult<()>;
+
+    /// Replace a user's UI preferences JSON blob.
+    async fn update_user_preferences(
+        &self,
+        user_id: Uuid,
+        preferences: &serde_json::Value,
+    ) -> StoreResult<()>;
+
     // ---------------------------------------------------------------------
     // Verification / password-reset tokens
     // ---------------------------------------------------------------------

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -523,6 +523,69 @@ impl RegistryStore for PgRegistryStore {
             .map_err(Into::into)
     }
 
+    async fn update_user_profile(
+        &self,
+        user_id: Uuid,
+        username: Option<&str>,
+        email: Option<&str>,
+    ) -> StoreResult<User> {
+        sqlx::query_as::<_, User>(
+            r#"
+            UPDATE users
+            SET
+                username = COALESCE($2, username),
+                email    = COALESCE($3, email),
+                updated_at = NOW()
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(user_id)
+        .bind(username)
+        .bind(email)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    async fn update_user_notification_prefs(
+        &self,
+        user_id: Uuid,
+        email_notifications: bool,
+        security_alerts: bool,
+    ) -> StoreResult<()> {
+        sqlx::query(
+            r#"
+            UPDATE users
+            SET email_notifications = $2,
+                security_alerts     = $3,
+                updated_at          = NOW()
+            WHERE id = $1
+            "#,
+        )
+        .bind(user_id)
+        .bind(email_notifications)
+        .bind(security_alerts)
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+        .map_err(Into::into)
+    }
+
+    async fn update_user_preferences(
+        &self,
+        user_id: Uuid,
+        preferences: &serde_json::Value,
+    ) -> StoreResult<()> {
+        sqlx::query("UPDATE users SET preferences = $2, updated_at = NOW() WHERE id = $1")
+            .bind(user_id)
+            .bind(preferences)
+            .execute(&self.pool)
+            .await
+            .map(|_| ())
+            .map_err(Into::into)
+    }
+
     async fn create_verification_token(&self, user_id: Uuid) -> StoreResult<VerificationToken> {
         VerificationToken::create(&self.pool, user_id).await.map_err(Into::into)
     }

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -494,6 +494,9 @@ fn row_to_user(row: &sqlx::sqlite::SqliteRow) -> StoreResult<User> {
     let two_factor_verified_at_str: Option<String> = row.try_get("two_factor_verified_at")?;
     let created_at_str: String = row.try_get("created_at")?;
     let updated_at_str: String = row.try_get("updated_at")?;
+    let preferences_str: String = row.try_get("preferences").unwrap_or_else(|_| "{}".to_string());
+    let preferences: serde_json::Value = serde_json::from_str(&preferences_str)
+        .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
 
     Ok(User {
         id: parse_uuid(&id_str)?,
@@ -509,6 +512,9 @@ fn row_to_user(row: &sqlx::sqlite::SqliteRow) -> StoreResult<User> {
         // loading them for now. A future commit can JSON-decode the column.
         two_factor_backup_codes: None,
         two_factor_verified_at: two_factor_verified_at_str.as_deref().map(parse_dt).transpose()?,
+        email_notifications: row.try_get("email_notifications").unwrap_or(true),
+        security_alerts: row.try_get("security_alerts").unwrap_or(true),
+        preferences,
         created_at: parse_dt(&created_at_str)?,
         updated_at: parse_dt(&updated_at_str)?,
     })
@@ -1170,6 +1176,67 @@ impl RegistryStore for SqliteRegistryStore {
 
     async fn mark_user_verified(&self, user_id: Uuid) -> StoreResult<()> {
         sqlx::query("UPDATE users SET is_verified = 1, updated_at = ? WHERE id = ?")
+            .bind(Utc::now().to_rfc3339())
+            .bind(user_id.to_string())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn update_user_profile(
+        &self,
+        user_id: Uuid,
+        username: Option<&str>,
+        email: Option<&str>,
+    ) -> StoreResult<User> {
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            "UPDATE users
+             SET username = COALESCE(?, username),
+                 email    = COALESCE(?, email),
+                 updated_at = ?
+             WHERE id = ?",
+        )
+        .bind(username)
+        .bind(email)
+        .bind(&now)
+        .bind(user_id.to_string())
+        .execute(&self.pool)
+        .await?;
+        self.find_user_by_id(user_id).await?.ok_or(StoreError::NotFound)
+    }
+
+    async fn update_user_notification_prefs(
+        &self,
+        user_id: Uuid,
+        email_notifications: bool,
+        security_alerts: bool,
+    ) -> StoreResult<()> {
+        sqlx::query(
+            "UPDATE users
+             SET email_notifications = ?,
+                 security_alerts     = ?,
+                 updated_at          = ?
+             WHERE id = ?",
+        )
+        .bind(email_notifications)
+        .bind(security_alerts)
+        .bind(Utc::now().to_rfc3339())
+        .bind(user_id.to_string())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn update_user_preferences(
+        &self,
+        user_id: Uuid,
+        preferences: &serde_json::Value,
+    ) -> StoreResult<()> {
+        let encoded = serde_json::to_string(preferences)
+            .map_err(|e| StoreError::Hash(format!("encode preferences: {}", e)))?;
+        sqlx::query("UPDATE users SET preferences = ?, updated_at = ? WHERE id = ?")
+            .bind(&encoded)
             .bind(Utc::now().to_rfc3339())
             .bind(user_id.to_string())
             .execute(&self.pool)

--- a/crates/mockforge-registry-server/migrations-sqlite/20260101000011_user_notification_and_preferences.sql
+++ b/crates/mockforge-registry-server/migrations-sqlite/20260101000011_user_notification_and_preferences.sql
@@ -1,0 +1,9 @@
+-- Per-user notification toggles and free-form UI preferences (SQLite).
+--
+-- SQLite does not support ADD COLUMN IF NOT EXISTS, but this migration
+-- is only applied once by sqlx. `preferences` is stored as TEXT containing
+-- serialized JSON — the Rust layer uses serde_json::Value for round-trip.
+
+ALTER TABLE users ADD COLUMN email_notifications BOOLEAN NOT NULL DEFAULT 1;
+ALTER TABLE users ADD COLUMN security_alerts BOOLEAN NOT NULL DEFAULT 1;
+ALTER TABLE users ADD COLUMN preferences TEXT NOT NULL DEFAULT '{}';

--- a/crates/mockforge-registry-server/migrations/20250101000040_user_notification_and_preferences.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000040_user_notification_and_preferences.sql
@@ -1,0 +1,20 @@
+-- Per-user notification toggles and free-form UI preferences.
+--
+-- `email_notifications` gates optional transactional emails (welcome,
+-- subscription updates, token-rotation reminders). Critical emails
+-- (password reset, email verification, 2FA setup) are always sent.
+--
+-- `security_alerts` gates notifications about account-level security
+-- events (e.g., password changed, 2FA enabled/disabled).
+--
+-- `preferences` stores the admin UI preferences blob. Shape is owned by
+-- the UI; the server just round-trips and merges partial updates.
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS email_notifications BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS security_alerts BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN users.email_notifications IS 'Opt-in for optional transactional emails';
+COMMENT ON COLUMN users.security_alerts IS 'Opt-in for security-related account change notifications';
+COMMENT ON COLUMN users.preferences IS 'Free-form admin UI preferences (JSON blob)';

--- a/crates/mockforge-registry-server/src/email.rs
+++ b/crates/mockforge-registry-server/src/email.rs
@@ -367,6 +367,55 @@ Privacy: https://mockforge.dev/privacy
         }
     }
 
+    /// Generate a security-alert email for an account-level event (password
+    /// change, 2FA enabled/disabled, etc). Gated by `users.security_alerts`
+    /// at the call site.
+    pub fn generate_security_alert_email(
+        username: &str,
+        email: &str,
+        headline: &str,
+        detail: &str,
+    ) -> EmailMessage {
+        let year = chrono::Utc::now().year();
+        let html_body = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }}
+        .header {{ background: #dc2626; color: white; padding: 30px 20px; text-align: center; border-radius: 8px 8px 0 0; }}
+        .content {{ background: #ffffff; padding: 30px; border: 1px solid #e0e0e0; border-top: none; border-radius: 0 0 8px 8px; }}
+        .footer {{ text-align: center; color: #666; font-size: 12px; margin-top: 30px; padding-top: 20px; border-top: 1px solid #e0e0e0; }}
+        .detail {{ background: #fef3f2; border-left: 4px solid #dc2626; padding: 12px 16px; margin: 16px 0; }}
+    </style>
+</head>
+<body>
+    <div class="header"><h1>🔒 Security Alert</h1></div>
+    <div class="content">
+        <p>Hi {username},</p>
+        <p><strong>{headline}</strong></p>
+        <div class="detail">{detail}</div>
+        <p>You're receiving this because you have security alerts enabled. You can manage this preference in <a href="https://app.mockforge.dev">your account settings</a>.</p>
+        <p>— The MockForge Team</p>
+    </div>
+    <div class="footer"><p>© {year} MockForge</p></div>
+</body>
+</html>"#,
+        );
+
+        let text_body = format!(
+            "Security Alert — {headline}\n\nHi {username},\n\n{detail}\n\nYou're receiving this because you have security alerts enabled. Manage this preference at https://app.mockforge.dev.\n\n— The MockForge Team\n© {year} MockForge\n",
+        );
+
+        EmailMessage {
+            to: email.to_string(),
+            subject: format!("[MockForge] {}", headline),
+            html_body,
+            text_body,
+        }
+    }
+
     /// Generate subscription confirmation email
     pub fn generate_subscription_confirmation(
         username: &str,

--- a/crates/mockforge-registry-server/src/handlers/auth.rs
+++ b/crates/mockforge-registry-server/src/handlers/auth.rs
@@ -461,6 +461,9 @@ pub struct MeResponse {
     pub is_verified: bool,
     pub is_admin: bool,
     pub two_factor_enabled: bool,
+    pub email_notifications: bool,
+    pub security_alerts: bool,
+    pub preferences: serde_json::Value,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -482,6 +485,90 @@ pub async fn me(
         is_verified: user.is_verified,
         is_admin: user.is_admin,
         two_factor_enabled: user.two_factor_enabled,
+        email_notifications: user.email_notifications,
+        security_alerts: user.security_alerts,
+        preferences: user.preferences,
         created_at: user.created_at,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChangePasswordRequest {
+    pub current_password: String,
+    pub new_password: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChangePasswordResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+/// Change password for the authenticated user.
+///
+/// Verifies the user's current password, stores the new hash, revokes any
+/// outstanding refresh tokens (so other sessions are cut off), and — when
+/// the user has opted in to security alerts — sends a notification email.
+pub async fn change_password(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Json(request): Json<ChangePasswordRequest>,
+) -> ApiResult<Json<ChangePasswordResponse>> {
+    if request.new_password.len() < 8 {
+        return Err(ApiError::InvalidRequest("Password must be at least 8 characters".to_string()));
+    }
+    if request.new_password == request.current_password {
+        return Err(ApiError::InvalidRequest(
+            "New password must differ from the current password".to_string(),
+        ));
+    }
+
+    let user = state
+        .store
+        .find_user_by_id(user_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("User not found".to_string()))?;
+
+    if !verify_password(&request.current_password, &user.password_hash)
+        .map_err(ApiError::Internal)?
+    {
+        return Err(ApiError::InvalidRequest("Current password is incorrect".to_string()));
+    }
+
+    let password_hash = hash_password(&request.new_password).map_err(ApiError::Internal)?;
+    state.store.update_user_password_hash(user.id, &password_hash).await?;
+
+    let revoked_count = state
+        .db
+        .revoke_all_user_tokens(user.id, "password_changed")
+        .await
+        .map_err(|e| {
+            tracing::warn!("Failed to revoke user tokens on password change: {}", e);
+            ApiError::Internal(e)
+        })?;
+    tracing::info!(
+        "Password changed: user_id={}, revoked {} refresh tokens",
+        user.id,
+        revoked_count
+    );
+
+    // Best-effort security-alert email. Never fails the request.
+    if user.security_alerts {
+        if let Ok(email_service) = EmailService::from_env() {
+            let msg = EmailService::generate_security_alert_email(
+                &user.username,
+                &user.email,
+                "Your password was changed",
+                "If you did not perform this change, reset your password immediately and contact support.",
+            );
+            if let Err(e) = email_service.send(msg).await {
+                tracing::warn!("Failed to send password-change security alert: {}", e);
+            }
+        }
+    }
+
+    Ok(Json(ChangePasswordResponse {
+        success: true,
+        message: "Password changed successfully. Other sessions have been signed out.".to_string(),
     }))
 }

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -403,11 +403,14 @@ async fn handle_checkout_completed(
     Ok(())
 }
 
-/// Get organization owner's email for sending notifications
+/// Get organization owner's email for sending notifications.
+///
+/// Returns `(email, username, email_notifications)`. Callers should skip
+/// non-critical sends when `email_notifications` is false.
 async fn get_org_owner_email(
     pool: &sqlx::PgPool,
     org_id: Uuid,
-) -> Result<(String, String), ApiError> {
+) -> Result<(String, String, bool), ApiError> {
     // Get organization
     let org = Organization::find_by_id(pool, org_id)
         .await
@@ -420,7 +423,7 @@ async fn get_org_owner_email(
         .map_err(ApiError::Database)?
         .ok_or_else(|| ApiError::InvalidRequest("Organization owner not found".to_string()))?;
 
-    Ok((owner.email, owner.username))
+    Ok((owner.email, owner.username, owner.email_notifications))
 }
 
 async fn handle_subscription_event(
@@ -549,31 +552,34 @@ async fn handle_subscription_event(
         .await;
     }
 
-    // Send subscription confirmation email (non-blocking)
-    if let Ok((email_addr, username)) = get_org_owner_email(pool, org_id).await {
-        if let Ok(email_service) = EmailService::from_env() {
-            let amount = subscription
-                .items
-                .data
-                .first()
-                .and_then(|item| item.price.as_ref())
-                .and_then(|price| price.unit_amount)
-                .map(|amount| amount as f64 / 100.0); // Convert cents to dollars
+    // Send subscription confirmation email (non-blocking, gated on owner pref)
+    if let Ok((email_addr, username, email_notifications)) = get_org_owner_email(pool, org_id).await
+    {
+        if email_notifications {
+            if let Ok(email_service) = EmailService::from_env() {
+                let amount = subscription
+                    .items
+                    .data
+                    .first()
+                    .and_then(|item| item.price.as_ref())
+                    .and_then(|price| price.unit_amount)
+                    .map(|amount| amount as f64 / 100.0); // Convert cents to dollars
 
-            let plan_str = plan.to_string();
-            let email_msg = EmailService::generate_subscription_confirmation(
-                &username,
-                &email_addr,
-                &plan_str,
-                amount,
-                Some(current_period_end),
-            );
+                let plan_str = plan.to_string();
+                let email_msg = EmailService::generate_subscription_confirmation(
+                    &username,
+                    &email_addr,
+                    &plan_str,
+                    amount,
+                    Some(current_period_end),
+                );
 
-            tokio::spawn(async move {
-                if let Err(e) = email_service.send(email_msg).await {
-                    tracing::warn!("Failed to send subscription confirmation email: {}", e);
-                }
-            });
+                tokio::spawn(async move {
+                    if let Err(e) = email_service.send(email_msg).await {
+                        tracing::warn!("Failed to send subscription confirmation email: {}", e);
+                    }
+                });
+            }
         }
     }
 
@@ -629,23 +635,26 @@ async fn handle_subscription_deleted(
     )
     .await;
 
-    // Send subscription canceled email (non-blocking)
-    if let Ok((email_addr, username)) = get_org_owner_email(pool, subscription_record.org_id).await
+    // Send subscription canceled email (non-blocking, gated on owner pref)
+    if let Ok((email_addr, username, email_notifications)) =
+        get_org_owner_email(pool, subscription_record.org_id).await
     {
-        if let Ok(email_service) = EmailService::from_env() {
-            let plan_str = old_plan.to_string();
-            let email_msg = EmailService::generate_subscription_canceled(
-                &username,
-                &email_addr,
-                &plan_str,
-                Some(subscription_record.current_period_end),
-            );
+        if email_notifications {
+            if let Ok(email_service) = EmailService::from_env() {
+                let plan_str = old_plan.to_string();
+                let email_msg = EmailService::generate_subscription_canceled(
+                    &username,
+                    &email_addr,
+                    &plan_str,
+                    Some(subscription_record.current_period_end),
+                );
 
-            tokio::spawn(async move {
-                if let Err(e) = email_service.send(email_msg).await {
-                    tracing::warn!("Failed to send subscription canceled email: {}", e);
-                }
-            });
+                tokio::spawn(async move {
+                    if let Err(e) = email_service.send(email_msg).await {
+                        tracing::warn!("Failed to send subscription canceled email: {}", e);
+                    }
+                });
+            }
         }
     }
 
@@ -729,33 +738,39 @@ async fn handle_payment_failed(
     )
     .await;
 
-    // Send payment failed email (non-blocking)
-    if let Ok((email_addr, username)) = get_org_owner_email(pool, subscription.org_id).await {
-        if let Ok(email_service) = EmailService::from_env() {
-            let org = Organization::find_by_id(pool, subscription.org_id)
-                .await
-                .map_err(ApiError::Database)?
-                .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
+    // Send payment failed email (non-blocking, gated on owner pref)
+    if let Ok((email_addr, username, email_notifications)) =
+        get_org_owner_email(pool, subscription.org_id).await
+    {
+        if email_notifications {
+            if let Ok(email_service) = EmailService::from_env() {
+                let org = Organization::find_by_id(pool, subscription.org_id)
+                    .await
+                    .map_err(ApiError::Database)?
+                    .ok_or_else(|| {
+                        ApiError::InvalidRequest("Organization not found".to_string())
+                    })?;
 
-            let amount = invoice.amount_due.map(|a| a as f64 / 100.0).unwrap_or(0.0); // Convert cents to dollars
-            let retry_date = invoice
-                .next_payment_attempt
-                .and_then(|ts| chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0));
+                let amount = invoice.amount_due.map(|a| a as f64 / 100.0).unwrap_or(0.0);
+                let retry_date = invoice
+                    .next_payment_attempt
+                    .and_then(|ts| chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0));
 
-            let plan_str = org.plan().to_string();
-            let email_msg = EmailService::generate_payment_failed(
-                &username,
-                &email_addr,
-                &plan_str,
-                amount,
-                retry_date,
-            );
+                let plan_str = org.plan().to_string();
+                let email_msg = EmailService::generate_payment_failed(
+                    &username,
+                    &email_addr,
+                    &plan_str,
+                    amount,
+                    retry_date,
+                );
 
-            tokio::spawn(async move {
-                if let Err(e) = email_service.send(email_msg).await {
-                    tracing::warn!("Failed to send payment failed email: {}", e);
-                }
-            });
+                tokio::spawn(async move {
+                    if let Err(e) = email_service.send(email_msg).await {
+                        tracing::warn!("Failed to send payment failed email: {}", e);
+                    }
+                });
+            }
         }
     }
 

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -31,6 +31,7 @@ pub mod support;
 pub mod tokens;
 pub mod two_factor;
 pub mod usage;
+pub mod users_me;
 pub mod verification;
 
 // Marketplace, settings, security, GDPR, and audit handlers

--- a/crates/mockforge-registry-server/src/handlers/oauth.rs
+++ b/crates/mockforge-registry-server/src/handlers/oauth.rs
@@ -209,10 +209,11 @@ pub async fn oauth_callback(
     // Create personal organization if it doesn't exist
     let _personal_org = state.store.get_or_create_personal_org(user.id, &user.username).await?;
 
-    // Send welcome email for new OAuth users (non-blocking)
-    // Check if this is a new user by checking if they were just created
+    // Send welcome email for new OAuth users (non-blocking). Gated on the
+    // user's `email_notifications` preference — new accounts default to
+    // opted-in so a brand-new signup still gets the welcome.
     let is_new_user = user.created_at > chrono::Utc::now() - chrono::Duration::minutes(1);
-    if is_new_user {
+    if is_new_user && user.email_notifications {
         if let Ok(email_service) = crate::email::EmailService::from_env() {
             let welcome_email =
                 crate::email::EmailService::generate_welcome_email(&user.username, &user.email);

--- a/crates/mockforge-registry-server/src/handlers/plugins.rs
+++ b/crates/mockforge-registry-server/src/handlers/plugins.rs
@@ -113,25 +113,7 @@ pub async fn search_plugins(
         let author = User::find_by_id(pool, plugin.author_id)
             .await
             .map_err(ApiError::Database)?
-            .unwrap_or_else(|| {
-                // Create a minimal user struct for display purposes
-                // This should not happen in production, but handle gracefully
-                User {
-                    id: plugin.author_id,
-                    username: "Unknown".to_string(),
-                    email: String::new(),
-                    password_hash: String::new(),
-                    api_token: None,
-                    is_verified: false,
-                    is_admin: false,
-                    two_factor_enabled: false,
-                    two_factor_secret: None,
-                    two_factor_backup_codes: None,
-                    two_factor_verified_at: None,
-                    created_at: chrono::Utc::now(),
-                    updated_at: chrono::Utc::now(),
-                }
-            });
+            .unwrap_or_else(|| User::placeholder(plugin.author_id));
 
         let security_score = derive_security_score(&plugin);
         let language = plugin.language.clone();
@@ -220,21 +202,11 @@ pub async fn get_plugin(
     }
 
     // Fetch author information
-    let author = state.store.find_user_by_id(plugin.author_id).await?.unwrap_or_else(|| User {
-        id: plugin.author_id,
-        username: "Unknown".to_string(),
-        email: String::new(),
-        password_hash: String::new(),
-        api_token: None,
-        is_verified: false,
-        is_admin: false,
-        two_factor_enabled: false,
-        two_factor_secret: None,
-        two_factor_backup_codes: None,
-        two_factor_verified_at: None,
-        created_at: chrono::Utc::now(),
-        updated_at: chrono::Utc::now(),
-    });
+    let author = state
+        .store
+        .find_user_by_id(plugin.author_id)
+        .await?
+        .unwrap_or_else(|| User::placeholder(plugin.author_id));
 
     let security_score = derive_security_score(&plugin);
     let language = plugin.language.clone();

--- a/crates/mockforge-registry-server/src/handlers/scenario_reviews.rs
+++ b/crates/mockforge-registry-server/src/handlers/scenario_reviews.rs
@@ -35,22 +35,11 @@ pub async fn get_scenario_reviews(
 
     let mut review_responses = Vec::new();
     for review in reviews {
-        let reviewer =
-            state.store.find_user_by_id(review.reviewer_id).await?.unwrap_or_else(|| User {
-                id: review.reviewer_id,
-                username: "unknown".to_string(),
-                email: "unknown@example.com".to_string(),
-                password_hash: String::new(),
-                api_token: None,
-                is_verified: false,
-                is_admin: false,
-                two_factor_enabled: false,
-                two_factor_secret: None,
-                two_factor_backup_codes: None,
-                two_factor_verified_at: None,
-                created_at: chrono::Utc::now(),
-                updated_at: chrono::Utc::now(),
-            });
+        let reviewer = state
+            .store
+            .find_user_by_id(review.reviewer_id)
+            .await?
+            .unwrap_or_else(|| User::placeholder(review.reviewer_id));
 
         review_responses.push(ScenarioReviewResponse {
             id: review.id.to_string(),

--- a/crates/mockforge-registry-server/src/handlers/scenarios.rs
+++ b/crates/mockforge-registry-server/src/handlers/scenarios.rs
@@ -91,21 +91,7 @@ pub async fn search_scenarios(
         let author = User::find_by_id(pool, scenario.author_id)
             .await
             .map_err(ApiError::Database)?
-            .unwrap_or_else(|| User {
-                id: scenario.author_id,
-                username: "unknown".to_string(),
-                email: "unknown@example.com".to_string(),
-                password_hash: String::new(),
-                api_token: None,
-                is_verified: false,
-                is_admin: false,
-                two_factor_enabled: false,
-                two_factor_secret: None,
-                two_factor_backup_codes: None,
-                two_factor_verified_at: None,
-                created_at: chrono::Utc::now(),
-                updated_at: chrono::Utc::now(),
-            });
+            .unwrap_or_else(|| User::placeholder(scenario.author_id));
 
         let version_entries: Vec<ScenarioVersionEntry> = versions
             .into_iter()
@@ -142,22 +128,10 @@ pub async fn search_scenarios(
         let review_responses: Vec<ScenarioReviewResponse> = reviews
             .into_iter()
             .map(|review| {
-                let reviewer =
-                    reviewers.get(&review.reviewer_id).cloned().unwrap_or_else(|| User {
-                        id: review.reviewer_id,
-                        username: "unknown".to_string(),
-                        email: "unknown@example.com".to_string(),
-                        password_hash: String::new(),
-                        api_token: None,
-                        is_verified: false,
-                        is_admin: false,
-                        two_factor_enabled: false,
-                        two_factor_secret: None,
-                        two_factor_backup_codes: None,
-                        two_factor_verified_at: None,
-                        created_at: chrono::Utc::now(),
-                        updated_at: chrono::Utc::now(),
-                    });
+                let reviewer = reviewers
+                    .get(&review.reviewer_id)
+                    .cloned()
+                    .unwrap_or_else(|| User::placeholder(review.reviewer_id));
 
                 ScenarioReviewResponse {
                     id: review.id.to_string(),
@@ -223,21 +197,11 @@ pub async fn get_scenario(
         .await
         .map_err(ApiError::Database)?;
 
-    let author = state.store.find_user_by_id(scenario.author_id).await?.unwrap_or_else(|| User {
-        id: scenario.author_id,
-        username: "unknown".to_string(),
-        email: "unknown@example.com".to_string(),
-        password_hash: String::new(),
-        api_token: None,
-        is_verified: false,
-        is_admin: false,
-        two_factor_enabled: false,
-        two_factor_secret: None,
-        two_factor_backup_codes: None,
-        two_factor_verified_at: None,
-        created_at: chrono::Utc::now(),
-        updated_at: chrono::Utc::now(),
-    });
+    let author = state
+        .store
+        .find_user_by_id(scenario.author_id)
+        .await?
+        .unwrap_or_else(|| User::placeholder(scenario.author_id));
 
     let version_entries: Vec<ScenarioVersionEntry> = versions
         .into_iter()
@@ -273,21 +237,10 @@ pub async fn get_scenario(
     let review_responses: Vec<ScenarioReviewResponse> = reviews
         .into_iter()
         .map(|review| {
-            let reviewer = reviewers.get(&review.reviewer_id).cloned().unwrap_or_else(|| User {
-                id: review.reviewer_id,
-                username: "unknown".to_string(),
-                email: "unknown@example.com".to_string(),
-                password_hash: String::new(),
-                api_token: None,
-                is_verified: false,
-                is_admin: false,
-                two_factor_enabled: false,
-                two_factor_secret: None,
-                two_factor_backup_codes: None,
-                two_factor_verified_at: None,
-                created_at: chrono::Utc::now(),
-                updated_at: chrono::Utc::now(),
-            });
+            let reviewer = reviewers
+                .get(&review.reviewer_id)
+                .cloned()
+                .unwrap_or_else(|| User::placeholder(review.reviewer_id));
 
             ScenarioReviewResponse {
                 id: review.id.to_string(),

--- a/crates/mockforge-registry-server/src/handlers/template_reviews.rs
+++ b/crates/mockforge-registry-server/src/handlers/template_reviews.rs
@@ -35,22 +35,11 @@ pub async fn get_template_reviews(
 
     let mut review_responses = Vec::new();
     for review in reviews {
-        let reviewer =
-            state.store.find_user_by_id(review.reviewer_id).await?.unwrap_or_else(|| User {
-                id: review.reviewer_id,
-                username: "unknown".to_string(),
-                email: "unknown@example.com".to_string(),
-                password_hash: String::new(),
-                api_token: None,
-                is_verified: false,
-                is_admin: false,
-                two_factor_enabled: false,
-                two_factor_secret: None,
-                two_factor_backup_codes: None,
-                two_factor_verified_at: None,
-                created_at: chrono::Utc::now(),
-                updated_at: chrono::Utc::now(),
-            });
+        let reviewer = state
+            .store
+            .find_user_by_id(review.reviewer_id)
+            .await?
+            .unwrap_or_else(|| User::placeholder(review.reviewer_id));
 
         review_responses.push(TemplateReviewResponse {
             id: review.id.to_string(),

--- a/crates/mockforge-registry-server/src/handlers/templates.rs
+++ b/crates/mockforge-registry-server/src/handlers/templates.rs
@@ -82,22 +82,11 @@ pub async fn search_templates(
             .await
             .map_err(ApiError::Database)?;
 
-        let author =
-            state.store.find_user_by_id(template.author_id).await?.unwrap_or_else(|| User {
-                id: template.author_id,
-                username: "unknown".to_string(),
-                email: "unknown@example.com".to_string(),
-                password_hash: String::new(),
-                api_token: None,
-                is_verified: false,
-                is_admin: false,
-                two_factor_enabled: false,
-                two_factor_secret: None,
-                two_factor_backup_codes: None,
-                two_factor_verified_at: None,
-                created_at: chrono::Utc::now(),
-                updated_at: chrono::Utc::now(),
-            });
+        let author = state
+            .store
+            .find_user_by_id(template.author_id)
+            .await?
+            .unwrap_or_else(|| User::placeholder(template.author_id));
 
         let stats = template.stats_json.clone();
         let compatibility = template.compatibility_json.clone();
@@ -172,21 +161,11 @@ pub async fn get_template(
         .await?
         .ok_or_else(|| ApiError::TemplateNotFound(format!("{}@{}", name, version)))?;
 
-    let author = state.store.find_user_by_id(template.author_id).await?.unwrap_or_else(|| User {
-        id: template.author_id,
-        username: "unknown".to_string(),
-        email: "unknown@example.com".to_string(),
-        password_hash: String::new(),
-        api_token: None,
-        is_verified: false,
-        is_admin: false,
-        two_factor_enabled: false,
-        two_factor_secret: None,
-        two_factor_backup_codes: None,
-        two_factor_verified_at: None,
-        created_at: chrono::Utc::now(),
-        updated_at: chrono::Utc::now(),
-    });
+    let author = state
+        .store
+        .find_user_by_id(template.author_id)
+        .await?
+        .unwrap_or_else(|| User::placeholder(template.author_id));
 
     let stats = template.stats_json.clone();
     let compatibility = template.compatibility_json.clone();

--- a/crates/mockforge-registry-server/src/handlers/token_rotation.rs
+++ b/crates/mockforge-registry-server/src/handlers/token_rotation.rs
@@ -203,6 +203,16 @@ pub async fn send_rotation_reminders(
             .await?
             .ok_or_else(|| anyhow::anyhow!("User not found"))?;
 
+        // Respect the user's opt-out — this is a non-critical reminder.
+        if !user.email_notifications {
+            tracing::debug!(
+                "Skipping rotation reminder for token {}: user {} has email notifications disabled",
+                token.id,
+                user.id
+            );
+            continue;
+        }
+
         // Build rotation URL
         let rotation_url = format!(
             "{}/settings/api-tokens/rotate/{}",

--- a/crates/mockforge-registry-server/src/handlers/two_factor.rs
+++ b/crates/mockforge-registry-server/src/handlers/two_factor.rs
@@ -208,12 +208,45 @@ pub async fn verify_2fa_setup(
 
     tracing::info!("2FA enabled for user {}", user_id);
 
+    send_2fa_security_alert(&user, true).await;
+
     Ok(Json(Verify2FASetupResponse {
         success: true,
         message:
             "2FA has been enabled successfully. Please save your backup codes in a safe place."
                 .to_string(),
     }))
+}
+
+/// Send a best-effort security-alert email when 2FA is enabled or disabled.
+/// Gated on the user's `security_alerts` preference. Never fails the request.
+async fn send_2fa_security_alert(user: &mockforge_registry_core::models::User, enabled: bool) {
+    if !user.security_alerts {
+        return;
+    }
+    let Ok(email_service) = crate::email::EmailService::from_env() else {
+        return;
+    };
+    let (headline, detail) = if enabled {
+        (
+            "Two-factor authentication was enabled",
+            "If you did not enable 2FA, contact support immediately — your account may be compromised.",
+        )
+    } else {
+        (
+            "Two-factor authentication was disabled",
+            "If you did not disable 2FA, reset your password immediately and contact support.",
+        )
+    };
+    let msg = crate::email::EmailService::generate_security_alert_email(
+        &user.username,
+        &user.email,
+        headline,
+        detail,
+    );
+    if let Err(e) = email_service.send(msg).await {
+        tracing::warn!("Failed to send 2FA security alert: {}", e);
+    }
 }
 
 /// Simplified verify_2fa_setup that accepts secret
@@ -277,6 +310,8 @@ pub async fn verify_2fa_setup_with_secret(
         )
         .await;
 
+    send_2fa_security_alert(&user, true).await;
+
     Ok(Json(Verify2FASetupResponse {
         success: true,
         message:
@@ -338,6 +373,8 @@ pub async fn disable_2fa(
             None,
         )
         .await;
+
+    send_2fa_security_alert(&user, false).await;
 
     Ok(Json(Disable2FAResponse {
         success: true,

--- a/crates/mockforge-registry-server/src/handlers/users_me.rs
+++ b/crates/mockforge-registry-server/src/handlers/users_me.rs
@@ -1,0 +1,219 @@
+//! `/api/v1/users/me` — profile, preferences, and notification toggles
+//! for the currently-authenticated user.
+
+use axum::{extract::State, Json};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::AuthUser,
+    AppState,
+};
+
+fn serialize_user(user: mockforge_registry_core::models::User) -> UserResponse {
+    UserResponse {
+        user_id: user.id.to_string(),
+        username: user.username,
+        email: user.email,
+        is_verified: user.is_verified,
+        is_admin: user.is_admin,
+        two_factor_enabled: user.two_factor_enabled,
+        email_notifications: user.email_notifications,
+        security_alerts: user.security_alerts,
+        preferences: user.preferences,
+        created_at: user.created_at,
+        updated_at: user.updated_at,
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct UserResponse {
+    pub user_id: String,
+    pub username: String,
+    pub email: String,
+    pub is_verified: bool,
+    pub is_admin: bool,
+    pub two_factor_enabled: bool,
+    pub email_notifications: bool,
+    pub security_alerts: bool,
+    pub preferences: serde_json::Value,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// `GET /api/v1/users/me`
+pub async fn get_me(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+) -> ApiResult<Json<UserResponse>> {
+    let user = state
+        .store
+        .find_user_by_id(user_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("User not found".to_string()))?;
+    Ok(Json(serialize_user(user)))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateProfileRequest {
+    pub username: Option<String>,
+    pub email: Option<String>,
+}
+
+/// `PATCH /api/v1/users/me` — update username and/or email.
+pub async fn update_me(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Json(request): Json<UpdateProfileRequest>,
+) -> ApiResult<Json<UserResponse>> {
+    if request.username.is_none() && request.email.is_none() {
+        return Err(ApiError::InvalidRequest(
+            "At least one of `username` or `email` is required".to_string(),
+        ));
+    }
+
+    let username = request
+        .username
+        .as_ref()
+        .map(|u| u.trim().to_string())
+        .filter(|u| !u.is_empty());
+    if let Some(ref u) = username {
+        if u.len() < 3 {
+            return Err(ApiError::InvalidRequest(
+                "Username must be at least 3 characters".to_string(),
+            ));
+        }
+        if let Some(existing) = state.store.find_user_by_username(u).await? {
+            if existing.id != user_id {
+                return Err(ApiError::InvalidRequest("Username is already taken".to_string()));
+            }
+        }
+    }
+
+    let email = request
+        .email
+        .as_ref()
+        .map(|e| e.trim().to_lowercase())
+        .filter(|e| !e.is_empty());
+    if let Some(ref e) = email {
+        // Very permissive check — the registration endpoint uses the same
+        // rule elsewhere (`contains('@')`) so we stay consistent.
+        if !e.contains('@') || !e.contains('.') {
+            return Err(ApiError::InvalidRequest("Email address is not valid".to_string()));
+        }
+        if let Some(existing) = state.store.find_user_by_email(e).await? {
+            if existing.id != user_id {
+                return Err(ApiError::InvalidRequest("Email is already in use".to_string()));
+            }
+        }
+    }
+
+    let updated = state
+        .store
+        .update_user_profile(user_id, username.as_deref(), email.as_deref())
+        .await?;
+
+    Ok(Json(serialize_user(updated)))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateNotificationsRequest {
+    pub email_notifications: Option<bool>,
+    pub security_alerts: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NotificationsResponse {
+    pub email_notifications: bool,
+    pub security_alerts: bool,
+}
+
+/// `PATCH /api/v1/users/me/notifications` — update notification toggles.
+pub async fn update_notifications(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Json(request): Json<UpdateNotificationsRequest>,
+) -> ApiResult<Json<NotificationsResponse>> {
+    let user = state
+        .store
+        .find_user_by_id(user_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("User not found".to_string()))?;
+
+    let email_notifications = request.email_notifications.unwrap_or(user.email_notifications);
+    let security_alerts = request.security_alerts.unwrap_or(user.security_alerts);
+
+    state
+        .store
+        .update_user_notification_prefs(user_id, email_notifications, security_alerts)
+        .await?;
+
+    Ok(Json(NotificationsResponse {
+        email_notifications,
+        security_alerts,
+    }))
+}
+
+#[derive(Debug, Serialize)]
+pub struct PreferencesResponse {
+    pub preferences: serde_json::Value,
+}
+
+/// `GET /api/v1/users/me/preferences`
+pub async fn get_preferences(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+) -> ApiResult<Json<PreferencesResponse>> {
+    let user = state
+        .store
+        .find_user_by_id(user_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("User not found".to_string()))?;
+    Ok(Json(PreferencesResponse {
+        preferences: user.preferences,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdatePreferencesRequest {
+    /// Partial update — merged into the stored preferences blob at the top
+    /// level. Nested objects are replaced, not deep-merged.
+    pub preferences: serde_json::Value,
+}
+
+/// `PATCH /api/v1/users/me/preferences` — merge-update the preferences blob.
+pub async fn update_preferences(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Json(request): Json<UpdatePreferencesRequest>,
+) -> ApiResult<Json<PreferencesResponse>> {
+    let mut current = state
+        .store
+        .find_user_by_id(user_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("User not found".to_string()))?
+        .preferences;
+
+    if !current.is_object() {
+        current = serde_json::Value::Object(serde_json::Map::new());
+    }
+
+    match request.preferences {
+        serde_json::Value::Object(patch) => {
+            if let Some(obj) = current.as_object_mut() {
+                for (k, v) in patch {
+                    obj.insert(k, v);
+                }
+            }
+        }
+        other => {
+            // Non-object body overwrites the blob outright.
+            current = other;
+        }
+    }
+
+    state.store.update_user_preferences(user_id, &current).await?;
+    Ok(Json(PreferencesResponse {
+        preferences: current,
+    }))
+}

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -89,6 +89,14 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/auth/2fa/verify-setup", post(handlers::two_factor::verify_2fa_setup_with_secret))
         .route("/api/v1/auth/2fa/disable", post(handlers::two_factor::disable_2fa))
         .route("/api/v1/auth/2fa/status", get(handlers::two_factor::get_2fa_status))
+        // Authenticated password change
+        .route("/api/v1/auth/change-password", post(handlers::auth::change_password))
+        // Current-user profile, notification toggles, preferences
+        .route("/api/v1/users/me", get(handlers::users_me::get_me))
+        .route("/api/v1/users/me", patch(handlers::users_me::update_me))
+        .route("/api/v1/users/me/notifications", patch(handlers::users_me::update_notifications))
+        .route("/api/v1/users/me/preferences", get(handlers::users_me::get_preferences))
+        .route("/api/v1/users/me/preferences", patch(handlers::users_me::update_preferences))
         // Organization routes
         .route("/api/v1/organizations", get(handlers::organizations::list_organizations))
         .route("/api/v1/organizations", post(handlers::organizations::create_organization))

--- a/crates/mockforge-ui/ui/src/App.tsx
+++ b/crates/mockforge-ui/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { ToastProvider } from './components/ui/ToastProvider';
 import { useStartupPrefetch } from './hooks/usePrefetch';
 import { useWorkspaceStore } from './stores/useWorkspaceStore';
 import { useAuthStore } from './stores/useAuthStore';
+import { usePreferencesStore } from './stores/usePreferencesStore';
 import { useI18n } from './i18n/I18nProvider';
 import { routes } from './routes';
 
@@ -42,6 +43,7 @@ function App() {
   const navigate = useNavigate();
   const loadWorkspaces = useWorkspaceStore(state => state.loadWorkspaces);
   const isAuthenticated = useAuthStore(state => state.isAuthenticated);
+  const loadPreferences = usePreferencesStore(state => state.loadPreferences);
 
   // Prefetch data on startup for better performance
   useStartupPrefetch();
@@ -52,8 +54,10 @@ function App() {
   useEffect(() => {
     if (isAuthenticated) {
       loadWorkspaces();
+      // Hydrate preferences from the server; merges over the localStorage cache.
+      void loadPreferences();
     }
-  }, [isAuthenticated, loadWorkspaces]);
+  }, [isAuthenticated, loadWorkspaces, loadPreferences]);
 
   // Handle deep-link navigation events (e.g., from RealityTracePanel)
   useEffect(() => {

--- a/crates/mockforge-ui/ui/src/components/auth/AccountSettings.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/AccountSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import {
@@ -11,260 +11,558 @@ import {
     DialogClose,
 } from '../ui/Dialog';
 import { useAuthStore } from '../../stores/useAuthStore';
-import { Shield, Bell, Lock, Mail } from 'lucide-react';
+import { authApi, type TwoFactorSetup } from '../../services/authApi';
+import { Shield, Bell, Lock, Mail, Copy, CheckCircle2 } from 'lucide-react';
 
 interface AccountSettingsProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
 }
 
+type Banner =
+    | { kind: 'success'; message: string }
+    | { kind: 'error'; message: string }
+    | null;
+
 export function AccountSettings({ open, onOpenChange }: AccountSettingsProps) {
     const { user } = useAuthStore();
-    const [formData, setFormData] = useState({
-        currentPassword: '',
-        newPassword: '',
-        confirmPassword: '',
-        twoFactorEnabled: false,
-        emailNotifications: true,
-        securityAlerts: true,
-    });
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [errors, setErrors] = useState<Record<string, string>>({});
-    const [successMessage, setSuccessMessage] = useState('');
 
-    // Reset form when modal opens
-    React.useEffect(() => {
-        if (open) {
-            setFormData({
-                currentPassword: '',
-                newPassword: '',
-                confirmPassword: '',
-                twoFactorEnabled: false,
-                emailNotifications: true,
-                securityAlerts: true,
+    // Password change state
+    const [pwCurrent, setPwCurrent] = useState('');
+    const [pwNew, setPwNew] = useState('');
+    const [pwConfirm, setPwConfirm] = useState('');
+    const [pwSubmitting, setPwSubmitting] = useState(false);
+    const [pwErrors, setPwErrors] = useState<Record<string, string>>({});
+    const [pwBanner, setPwBanner] = useState<Banner>(null);
+
+    // 2FA state
+    const [twoFactorEnabled, setTwoFactorEnabled] = useState(false);
+    const [twoFactorLoading, setTwoFactorLoading] = useState(false);
+    const [twoFactorSetup, setTwoFactorSetup] = useState<TwoFactorSetup | null>(null);
+    const [twoFactorCode, setTwoFactorCode] = useState('');
+    const [twoFactorBanner, setTwoFactorBanner] = useState<Banner>(null);
+    const [showDisableForm, setShowDisableForm] = useState(false);
+    const [disablePassword, setDisablePassword] = useState('');
+    const [copiedCodes, setCopiedCodes] = useState(false);
+
+    // Notification prefs state
+    const [emailNotifications, setEmailNotifications] = useState(true);
+    const [securityAlerts, setSecurityAlerts] = useState(true);
+    const [notifSaving, setNotifSaving] = useState(false);
+    const [notifBanner, setNotifBanner] = useState<Banner>(null);
+
+    // Hydrate state from server when the dialog opens
+    useEffect(() => {
+        if (!open || !user) return;
+        let cancelled = false;
+        setPwCurrent('');
+        setPwNew('');
+        setPwConfirm('');
+        setPwErrors({});
+        setPwBanner(null);
+        setTwoFactorSetup(null);
+        setTwoFactorCode('');
+        setTwoFactorBanner(null);
+        setShowDisableForm(false);
+        setDisablePassword('');
+        setCopiedCodes(false);
+        setNotifBanner(null);
+
+        authApi
+            .getMe()
+            .then((profile) => {
+                if (cancelled) return;
+                setTwoFactorEnabled(profile.two_factor_enabled);
+                setEmailNotifications(profile.email_notifications);
+                setSecurityAlerts(profile.security_alerts);
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setTwoFactorBanner({
+                    kind: 'error',
+                    message: err instanceof Error ? err.message : 'Failed to load account',
+                });
             });
-            setErrors({});
-            setSuccessMessage('');
-        }
-    }, [open]);
 
-    const validateForm = () => {
-        const newErrors: Record<string, string> = {};
+        return () => {
+            cancelled = true;
+        };
+    }, [open, user]);
 
-        if (formData.newPassword) {
-            if (!formData.currentPassword) {
-                newErrors.currentPassword = 'Current password is required to set a new password';
-            }
-            if (formData.newPassword.length < 8) {
-                newErrors.newPassword = 'Password must be at least 8 characters';
-            }
-            if (formData.newPassword !== formData.confirmPassword) {
-                newErrors.confirmPassword = 'Passwords do not match';
-            }
-        }
-
-        setErrors(newErrors);
-        return Object.keys(newErrors).length === 0;
-    };
-
-    const handleSubmit = async (e: React.FormEvent) => {
+    const handlePasswordSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+        const errors: Record<string, string> = {};
+        if (!pwCurrent) errors.current = 'Current password is required';
+        if (pwNew.length < 8) errors.new = 'Password must be at least 8 characters';
+        if (pwNew !== pwConfirm) errors.confirm = 'Passwords do not match';
+        if (pwNew && pwNew === pwCurrent) {
+            errors.new = 'New password must differ from the current password';
+        }
+        setPwErrors(errors);
+        if (Object.keys(errors).length > 0) return;
 
-        if (!validateForm() || !user) return;
-
-        setIsSubmitting(true);
-        setSuccessMessage('');
-
+        setPwSubmitting(true);
+        setPwBanner(null);
         try {
-            // In a real app, this would make an API call to update security settings
-            // For now, we'll simulate a successful update
-            await new Promise(resolve => setTimeout(resolve, 1000));
-
-            setSuccessMessage('Account settings updated successfully');
-
-            // Clear password fields after successful update
-            setFormData(prev => ({
-                ...prev,
-                currentPassword: '',
-                newPassword: '',
-                confirmPassword: '',
-            }));
-        } catch {
-            setErrors({ general: 'Failed to update account settings. Please try again.' });
+            const res = await authApi.changePassword(pwCurrent, pwNew);
+            setPwBanner({ kind: 'success', message: res.message });
+            setPwCurrent('');
+            setPwNew('');
+            setPwConfirm('');
+        } catch (err) {
+            setPwBanner({
+                kind: 'error',
+                message: err instanceof Error ? err.message : 'Failed to change password',
+            });
         } finally {
-            setIsSubmitting(false);
+            setPwSubmitting(false);
         }
     };
 
-    const handleInputChange = (field: string, value: string | boolean) => {
-        setFormData(prev => ({ ...prev, [field]: value }));
-        // Clear error when user starts typing
-        if (errors[field]) {
-            setErrors(prev => ({ ...prev, [field]: '' }));
+    const handleBeginSetup2FA = async () => {
+        setTwoFactorLoading(true);
+        setTwoFactorBanner(null);
+        try {
+            const setup = await authApi.setup2FA();
+            setTwoFactorSetup(setup);
+            setCopiedCodes(false);
+        } catch (err) {
+            setTwoFactorBanner({
+                kind: 'error',
+                message: err instanceof Error ? err.message : 'Failed to start 2FA setup',
+            });
+        } finally {
+            setTwoFactorLoading(false);
         }
-        setSuccessMessage('');
+    };
+
+    const handleCancelSetup2FA = () => {
+        setTwoFactorSetup(null);
+        setTwoFactorCode('');
+        setTwoFactorBanner(null);
+    };
+
+    const handleVerify2FA = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!twoFactorSetup) return;
+        if (twoFactorCode.trim().length < 6) {
+            setTwoFactorBanner({ kind: 'error', message: 'Enter the 6-digit code from your authenticator app' });
+            return;
+        }
+        setTwoFactorLoading(true);
+        setTwoFactorBanner(null);
+        try {
+            await authApi.verify2FASetup(
+                twoFactorSetup.secret,
+                twoFactorCode.trim(),
+                twoFactorSetup.backup_codes,
+            );
+            setTwoFactorEnabled(true);
+            setTwoFactorSetup(null);
+            setTwoFactorCode('');
+            setTwoFactorBanner({
+                kind: 'success',
+                message: 'Two-factor authentication is now enabled.',
+            });
+        } catch (err) {
+            setTwoFactorBanner({
+                kind: 'error',
+                message: err instanceof Error ? err.message : 'Verification failed',
+            });
+        } finally {
+            setTwoFactorLoading(false);
+        }
+    };
+
+    const handleDisable2FA = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!disablePassword) {
+            setTwoFactorBanner({ kind: 'error', message: 'Enter your password to disable 2FA' });
+            return;
+        }
+        setTwoFactorLoading(true);
+        setTwoFactorBanner(null);
+        try {
+            await authApi.disable2FA(disablePassword);
+            setTwoFactorEnabled(false);
+            setShowDisableForm(false);
+            setDisablePassword('');
+            setTwoFactorBanner({
+                kind: 'success',
+                message: 'Two-factor authentication has been disabled.',
+            });
+        } catch (err) {
+            setTwoFactorBanner({
+                kind: 'error',
+                message: err instanceof Error ? err.message : 'Failed to disable 2FA',
+            });
+        } finally {
+            setTwoFactorLoading(false);
+        }
+    };
+
+    const handleCopyBackupCodes = async () => {
+        if (!twoFactorSetup) return;
+        try {
+            await navigator.clipboard.writeText(twoFactorSetup.backup_codes.join('\n'));
+            setCopiedCodes(true);
+            setTimeout(() => setCopiedCodes(false), 2000);
+        } catch {
+            /* clipboard denied — no-op */
+        }
+    };
+
+    const handleSaveNotifications = async (
+        patch: { email_notifications?: boolean; security_alerts?: boolean },
+    ) => {
+        setNotifSaving(true);
+        setNotifBanner(null);
+        try {
+            const res = await authApi.updateNotifications(patch);
+            setEmailNotifications(res.email_notifications);
+            setSecurityAlerts(res.security_alerts);
+        } catch (err) {
+            setNotifBanner({
+                kind: 'error',
+                message: err instanceof Error ? err.message : 'Failed to save preferences',
+            });
+        } finally {
+            setNotifSaving(false);
+        }
     };
 
     if (!user) return null;
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-lg bg-white dark:bg-gray-900">
+            <DialogContent className="sm:max-w-lg bg-white dark:bg-gray-900 max-h-[90vh] overflow-y-auto">
                 <DialogHeader className="space-y-2">
-                    <DialogTitle className="text-xl font-semibold text-gray-900 dark:text-gray-100">Account Settings</DialogTitle>
+                    <DialogTitle className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                        Account Settings
+                    </DialogTitle>
                     <DialogDescription className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-                        Manage your account security and notification preferences.
+                        Manage your password, two-factor authentication, and notification preferences.
                     </DialogDescription>
                     <DialogClose onClick={() => onOpenChange(false)} />
                 </DialogHeader>
 
-                <form onSubmit={handleSubmit} className="space-y-6">
-                    {errors.general && (
-                        <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-md">
-                            {errors.general}
-                        </div>
-                    )}
-
-                    {successMessage && (
-                        <div className="text-sm text-green-700 dark:text-green-300 bg-green-100 dark:bg-green-900/30 p-3 rounded-md">
-                            {successMessage}
-                        </div>
-                    )}
-
-                    {/* Security Section */}
-                    <div className="space-y-4">
+                <div className="space-y-8">
+                    {/* Password section */}
+                    <form onSubmit={handlePasswordSubmit} className="space-y-3">
                         <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
                             <Shield className="h-4 w-4" />
-                            <span>Security</span>
+                            <span>Change password</span>
                         </div>
 
-                        <div className="space-y-2">
-                            <label htmlFor="currentPassword" className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                                Current Password
-                            </label>
-                            <Input
-                                id="currentPassword"
-                                type="password"
-                                value={formData.currentPassword}
-                                onChange={(e) => handleInputChange('currentPassword', e.target.value)}
-                                placeholder="Enter current password"
-                                className={`bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400 ${errors.currentPassword ? 'border-destructive' : ''}`}
-                            />
-                            {errors.currentPassword && (
-                                <p className="text-sm text-destructive">{errors.currentPassword}</p>
-                            )}
+                        {pwBanner && (
+                            <Banner banner={pwBanner} />
+                        )}
+
+                        <LabeledInput
+                            id="currentPassword"
+                            label="Current password"
+                            type="password"
+                            value={pwCurrent}
+                            onChange={setPwCurrent}
+                            error={pwErrors.current}
+                        />
+                        <LabeledInput
+                            id="newPassword"
+                            label="New password"
+                            type="password"
+                            value={pwNew}
+                            onChange={setPwNew}
+                            error={pwErrors.new}
+                            placeholder="At least 8 characters"
+                        />
+                        <LabeledInput
+                            id="confirmPassword"
+                            label="Confirm new password"
+                            type="password"
+                            value={pwConfirm}
+                            onChange={setPwConfirm}
+                            error={pwErrors.confirm}
+                        />
+                        <div className="flex justify-end">
+                            <Button type="submit" disabled={pwSubmitting}>
+                                {pwSubmitting ? 'Updating…' : 'Update password'}
+                            </Button>
+                        </div>
+                    </form>
+
+                    {/* 2FA section */}
+                    <div className="space-y-3">
+                        <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                            <Lock className="h-4 w-4" />
+                            <span>Two-factor authentication</span>
                         </div>
 
-                        <div className="space-y-2">
-                            <label htmlFor="newPassword" className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                                New Password
-                            </label>
-                            <Input
-                                id="newPassword"
-                                type="password"
-                                value={formData.newPassword}
-                                onChange={(e) => handleInputChange('newPassword', e.target.value)}
-                                placeholder="Enter new password (min 8 characters)"
-                                className={`bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400 ${errors.newPassword ? 'border-destructive' : ''}`}
-                            />
-                            {errors.newPassword && (
-                                <p className="text-sm text-destructive">{errors.newPassword}</p>
-                            )}
-                        </div>
+                        {twoFactorBanner && <Banner banner={twoFactorBanner} />}
 
-                        <div className="space-y-2">
-                            <label htmlFor="confirmPassword" className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                                Confirm New Password
-                            </label>
-                            <Input
-                                id="confirmPassword"
-                                type="password"
-                                value={formData.confirmPassword}
-                                onChange={(e) => handleInputChange('confirmPassword', e.target.value)}
-                                placeholder="Confirm new password"
-                                className={`bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400 ${errors.confirmPassword ? 'border-destructive' : ''}`}
-                            />
-                            {errors.confirmPassword && (
-                                <p className="text-sm text-destructive">{errors.confirmPassword}</p>
-                            )}
-                        </div>
-
-                        <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-md">
-                            <div className="flex items-center gap-2">
-                                <Lock className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-                                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">Two-Factor Authentication</span>
+                        {!twoFactorSetup && !showDisableForm && (
+                            <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-md">
+                                <div>
+                                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                        {twoFactorEnabled ? '2FA is enabled' : '2FA is disabled'}
+                                    </div>
+                                    <div className="text-xs text-gray-600 dark:text-gray-400">
+                                        {twoFactorEnabled
+                                            ? 'A TOTP code is required to sign in.'
+                                            : 'Require a TOTP code at sign-in for added security.'}
+                                    </div>
+                                </div>
+                                {twoFactorEnabled ? (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => setShowDisableForm(true)}
+                                        disabled={twoFactorLoading}
+                                    >
+                                        Disable
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        type="button"
+                                        onClick={handleBeginSetup2FA}
+                                        disabled={twoFactorLoading}
+                                    >
+                                        {twoFactorLoading ? 'Starting…' : 'Enable'}
+                                    </Button>
+                                )}
                             </div>
-                            <label className="relative inline-flex items-center cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    checked={formData.twoFactorEnabled}
-                                    onChange={(e) => handleInputChange('twoFactorEnabled', e.target.checked)}
-                                    className="sr-only peer"
+                        )}
+
+                        {twoFactorSetup && (
+                            <form onSubmit={handleVerify2FA} className="space-y-3 rounded-md border border-gray-200 dark:border-gray-700 p-4">
+                                <p className="text-sm text-gray-700 dark:text-gray-300">
+                                    Scan this QR code with an authenticator app, then enter the 6-digit code to confirm.
+                                </p>
+                                <img
+                                    src={twoFactorSetup.qr_code_url}
+                                    alt="TOTP QR code"
+                                    className="mx-auto h-40 w-40 bg-white p-2 rounded"
                                 />
-                                <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-brand-300 dark:peer-focus:ring-brand-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-brand-600"></div>
-                            </label>
-                        </div>
+                                <div className="text-xs text-gray-600 dark:text-gray-400">
+                                    Secret: <code className="font-mono">{twoFactorSetup.secret}</code>
+                                </div>
+
+                                <div className="rounded-md bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 p-3 text-sm">
+                                    <div className="flex items-center justify-between">
+                                        <strong className="text-yellow-900 dark:text-yellow-200">
+                                            Save these backup codes
+                                        </strong>
+                                        <button
+                                            type="button"
+                                            onClick={handleCopyBackupCodes}
+                                            className="text-xs inline-flex items-center gap-1 text-yellow-900 dark:text-yellow-200 hover:underline"
+                                        >
+                                            {copiedCodes ? (
+                                                <>
+                                                    <CheckCircle2 className="h-3.5 w-3.5" /> Copied
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <Copy className="h-3.5 w-3.5" /> Copy
+                                                </>
+                                            )}
+                                        </button>
+                                    </div>
+                                    <p className="text-xs mt-1 text-yellow-800 dark:text-yellow-300">
+                                        Each code works once if you lose access to your authenticator. They won't be shown again.
+                                    </p>
+                                    <pre className="mt-2 text-xs font-mono grid grid-cols-2 gap-1 text-yellow-900 dark:text-yellow-100">
+                                        {twoFactorSetup.backup_codes.map((code) => (
+                                            <span key={code}>{code}</span>
+                                        ))}
+                                    </pre>
+                                </div>
+
+                                <LabeledInput
+                                    id="totpCode"
+                                    label="6-digit code"
+                                    value={twoFactorCode}
+                                    onChange={setTwoFactorCode}
+                                    placeholder="000000"
+                                    inputMode="numeric"
+                                    maxLength={6}
+                                />
+
+                                <div className="flex justify-end gap-2">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={handleCancelSetup2FA}
+                                        disabled={twoFactorLoading}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button type="submit" disabled={twoFactorLoading}>
+                                        {twoFactorLoading ? 'Verifying…' : 'Verify & enable'}
+                                    </Button>
+                                </div>
+                            </form>
+                        )}
+
+                        {showDisableForm && (
+                            <form onSubmit={handleDisable2FA} className="space-y-3 rounded-md border border-gray-200 dark:border-gray-700 p-4">
+                                <p className="text-sm text-gray-700 dark:text-gray-300">
+                                    Enter your password to disable two-factor authentication.
+                                </p>
+                                <LabeledInput
+                                    id="disablePassword"
+                                    label="Password"
+                                    type="password"
+                                    value={disablePassword}
+                                    onChange={setDisablePassword}
+                                    autoFocus
+                                />
+                                <div className="flex justify-end gap-2">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => {
+                                            setShowDisableForm(false);
+                                            setDisablePassword('');
+                                            setTwoFactorBanner(null);
+                                        }}
+                                        disabled={twoFactorLoading}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button type="submit" variant="destructive" disabled={twoFactorLoading}>
+                                        {twoFactorLoading ? 'Disabling…' : 'Disable 2FA'}
+                                    </Button>
+                                </div>
+                            </form>
+                        )}
                     </div>
 
-                    {/* Notifications Section */}
-                    <div className="space-y-4">
+                    {/* Notification prefs section */}
+                    <div className="space-y-3">
                         <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
                             <Bell className="h-4 w-4" />
                             <span>Notifications</span>
                         </div>
+                        {notifBanner && <Banner banner={notifBanner} />}
 
-                        <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-md">
-                            <div className="flex items-center gap-2">
-                                <Mail className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-                                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">Email Notifications</span>
-                            </div>
-                            <label className="relative inline-flex items-center cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    checked={formData.emailNotifications}
-                                    onChange={(e) => handleInputChange('emailNotifications', e.target.checked)}
-                                    className="sr-only peer"
-                                />
-                                <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-brand-300 dark:peer-focus:ring-brand-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-brand-600"></div>
-                            </label>
-                        </div>
-
-                        <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-md">
-                            <div className="flex items-center gap-2">
-                                <Shield className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-                                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">Security Alerts</span>
-                            </div>
-                            <label className="relative inline-flex items-center cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    checked={formData.securityAlerts}
-                                    onChange={(e) => handleInputChange('securityAlerts', e.target.checked)}
-                                    className="sr-only peer"
-                                />
-                                <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-brand-300 dark:peer-focus:ring-brand-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-brand-600"></div>
-                            </label>
-                        </div>
+                        <ToggleRow
+                            icon={<Mail className="h-4 w-4 text-gray-600 dark:text-gray-400" />}
+                            label="Email notifications"
+                            description="Welcome messages, subscription updates, and API-token reminders."
+                            checked={emailNotifications}
+                            onChange={(v) => {
+                                setEmailNotifications(v);
+                                handleSaveNotifications({ email_notifications: v });
+                            }}
+                            disabled={notifSaving}
+                        />
+                        <ToggleRow
+                            icon={<Shield className="h-4 w-4 text-gray-600 dark:text-gray-400" />}
+                            label="Security alerts"
+                            description="Emails when your password or 2FA is changed."
+                            checked={securityAlerts}
+                            onChange={(v) => {
+                                setSecurityAlerts(v);
+                                handleSaveNotifications({ security_alerts: v });
+                            }}
+                            disabled={notifSaving}
+                        />
                     </div>
-                </form>
+                </div>
 
                 <DialogFooter>
-                    <Button
-                        type="button"
-                        variant="outline"
-                        onClick={() => onOpenChange(false)}
-                        disabled={isSubmitting}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        type="submit"
-                        onClick={handleSubmit}
-                        disabled={isSubmitting}
-                    >
-                        {isSubmitting ? 'Saving...' : 'Save Changes'}
+                    <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                        Close
                     </Button>
                 </DialogFooter>
             </DialogContent>
         </Dialog>
+    );
+}
+
+function Banner({ banner }: { banner: NonNullable<Banner> }) {
+    const className =
+        banner.kind === 'success'
+            ? 'text-sm text-green-700 dark:text-green-300 bg-green-100 dark:bg-green-900/30 p-3 rounded-md'
+            : 'text-sm text-destructive bg-destructive/10 p-3 rounded-md';
+    return <div className={className}>{banner.message}</div>;
+}
+
+interface LabeledInputProps {
+    id: string;
+    label: string;
+    type?: string;
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    error?: string;
+    autoFocus?: boolean;
+    inputMode?: 'text' | 'numeric';
+    maxLength?: number;
+}
+
+function LabeledInput({
+    id,
+    label,
+    type = 'text',
+    value,
+    onChange,
+    placeholder,
+    error,
+    autoFocus,
+    inputMode,
+    maxLength,
+}: LabeledInputProps) {
+    return (
+        <div className="space-y-1.5">
+            <label htmlFor={id} className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {label}
+            </label>
+            <Input
+                id={id}
+                type={type}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder={placeholder}
+                autoFocus={autoFocus}
+                inputMode={inputMode}
+                maxLength={maxLength}
+                className={`bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 ${error ? 'border-destructive' : ''}`}
+            />
+            {error && <p className="text-xs text-destructive">{error}</p>}
+        </div>
+    );
+}
+
+interface ToggleRowProps {
+    icon: React.ReactNode;
+    label: string;
+    description: string;
+    checked: boolean;
+    onChange: (value: boolean) => void;
+    disabled?: boolean;
+}
+
+function ToggleRow({ icon, label, description, checked, onChange, disabled }: ToggleRowProps) {
+    return (
+        <div className="flex items-start justify-between gap-4 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-md">
+            <div className="flex items-start gap-2">
+                {icon}
+                <div>
+                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{label}</div>
+                    <div className="text-xs text-gray-600 dark:text-gray-400">{description}</div>
+                </div>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer shrink-0">
+                <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(e) => onChange(e.target.checked)}
+                    disabled={disabled}
+                    className="sr-only peer"
+                />
+                <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-brand-300 dark:peer-focus:ring-brand-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-brand-600" />
+            </label>
+        </div>
     );
 }

--- a/crates/mockforge-ui/ui/src/components/auth/HelpSupport.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/HelpSupport.tsx
@@ -1,4 +1,3 @@
-import { logger } from '@/utils/logger';
 import { useState } from 'react';
 import { Button } from '../ui/button';
 import {
@@ -39,7 +38,7 @@ export function HelpSupport({ open, onOpenChange }: HelpSupportProps) {
   const shortcuts = [
     { keys: `${modKey} + K`, description: 'Focus global search' },
     { keys: 'Esc', description: 'Clear search / Close dialogs' },
-    { keys: `${modKey} + /`, description: 'Show keyboard shortcuts' },
+    { keys: 'Shift + ?', description: 'Open Help & Support' },
   ];
 
   const faqs = [

--- a/crates/mockforge-ui/ui/src/components/auth/ProfileSettings.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/ProfileSettings.tsx
@@ -63,8 +63,6 @@ export function ProfileSettings({ open, onOpenChange }: ProfileSettingsProps) {
     setIsSubmitting(true);
 
     try {
-      // In a real app, this would make an API call
-      // For now, we'll just update the local state
       await updateProfile({
         ...user,
         username: formData.username.trim(),
@@ -72,8 +70,9 @@ export function ProfileSettings({ open, onOpenChange }: ProfileSettingsProps) {
       });
 
       onOpenChange(false);
-    } catch {
-      setErrors({ general: 'Failed to update profile. Please try again.' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update profile. Please try again.';
+      setErrors({ general: message });
     } finally {
       setIsSubmitting(false);
     }

--- a/crates/mockforge-ui/ui/src/components/auth/UserProfile.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/UserProfile.tsx
@@ -1,18 +1,27 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '../ui/button';
 import { useAuthStore } from '../../stores/useAuthStore';
+import { useHelpStore } from '../../stores/useHelpStore';
 import { AccountSettings } from './AccountSettings';
 import { ProfileSettings } from './ProfileSettings';
 import { Preferences } from './Preferences';
-import { HelpSupport } from './HelpSupport';
 
 export function UserProfile() {
   const { user, logout } = useAuthStore();
+  const openHelp = useHelpStore(state => state.open);
   const [showDropdown, setShowDropdown] = useState(false);
   const [showAccountSettings, setShowAccountSettings] = useState(false);
   const [showProfileSettings, setShowProfileSettings] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
-  const [showHelpSupport, setShowHelpSupport] = useState(false);
+
+  useEffect(() => {
+    if (!showDropdown) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowDropdown(false);
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [showDropdown]);
 
   if (!user) return null;
 
@@ -38,9 +47,9 @@ export function UserProfile() {
     }
   };
 
-  const handleLogout = () => {
-    logout();
+  const handleLogout = async () => {
     setShowDropdown(false);
+    await logout();
   };
 
   return (
@@ -148,7 +157,7 @@ export function UserProfile() {
                   className="w-full text-left px-3 py-2 text-sm hover:bg-accent rounded-md transition-colors"
                   onClick={() => {
                     setShowDropdown(false);
-                    setShowHelpSupport(true);
+                    openHelp();
                   }}
                 >
                   Help & Support
@@ -182,11 +191,6 @@ export function UserProfile() {
       <Preferences
         open={showPreferences}
         onOpenChange={setShowPreferences}
-      />
-
-      <HelpSupport
-        open={showHelpSupport}
-        onOpenChange={setShowHelpSupport}
       />
     </div>
   );

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -4,10 +4,12 @@ import { cn } from '../../utils/cn';
 import { Button } from '../ui/button';
 import { SimpleThemeToggle } from '../ui/ThemeToggle';
 import { UserProfile } from '../auth/UserProfile';
+import { HelpSupport } from '../auth/HelpSupport';
 import { Logo } from '../ui/Logo';
 import { Input } from '../ui/input';
 import { useLogStore } from '../../stores/useLogStore';
 import { useServiceStore } from '../../stores/useServiceStore';
+import { useHelpStore } from '../../stores/useHelpStore';
 import { useAppShortcuts } from '../../hooks/useKeyboardNavigation';
 import { useSkipLinks } from '../../hooks/useFocusManagement';
 import { useI18n } from '../../i18n/I18nProvider';
@@ -239,6 +241,10 @@ export function AppShell({ children, onRefresh }: AppShellProps) {
   const [globalQuery, setGlobalQuery] = useState('');
   const [isMac, setIsMac] = useState(false);
 
+  const helpOpen = useHelpStore(state => state.isOpen);
+  const openHelp = useHelpStore(state => state.open);
+  const setHelpOpen = useHelpStore(state => state.setOpen);
+
   // Setup keyboard shortcuts
   useAppShortcuts({
     onSearch: () => {
@@ -248,6 +254,7 @@ export function AppShell({ children, onRefresh }: AppShellProps) {
         searchInput.select();
       }
     },
+    onHelp: () => openHelp(),
   });
 
   // Skip links functionality
@@ -463,6 +470,9 @@ export function AppShell({ children, onRefresh }: AppShellProps) {
           </main>
         </div>
       </div>
+
+      {/* Shared Help & Support modal — opened by Shift+? or the avatar menu. */}
+      <HelpSupport open={helpOpen} onOpenChange={setHelpOpen} />
     </div>
   );
 }

--- a/crates/mockforge-ui/ui/src/services/authApi.ts
+++ b/crates/mockforge-ui/ui/src/services/authApi.ts
@@ -28,6 +28,28 @@ interface LocalApiResponse<T> {
 class AuthApiService {
   private cloud = isCloudMode();
 
+  private authHeader(): Record<string, string> {
+    const token = localStorage.getItem('auth_token');
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }
+
+  private async authedFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const response = await fetch(path, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.authHeader(),
+        ...options.headers,
+      },
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(apiErrorMessage(response, body, `HTTP ${response.status}`));
+    }
+    if (response.status === 204) return undefined as unknown as T;
+    return response.json();
+  }
+
   private async fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
     const response = await fetch(url, {
       ...options,
@@ -163,9 +185,141 @@ class AuthApiService {
     }
   }
 
+  /**
+   * Fetch the full profile of the currently-authenticated user.
+   * Cloud-mode only — local admin mode doesn't persist user state.
+   */
+  async getMe(): Promise<UserProfile> {
+    return this.authedFetch<UserProfile>('/api/v1/users/me');
+  }
+
+  async updateProfile(patch: UpdateProfilePayload): Promise<UserProfile> {
+    return this.authedFetch<UserProfile>('/api/v1/users/me', {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    });
+  }
+
+  async changePassword(
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<{ success: boolean; message: string }> {
+    return this.authedFetch<{ success: boolean; message: string }>(
+      '/api/v1/auth/change-password',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          current_password: currentPassword,
+          new_password: newPassword,
+        }),
+      },
+    );
+  }
+
+  async updateNotifications(
+    patch: UpdateNotificationsPayload,
+  ): Promise<NotificationsPrefs> {
+    return this.authedFetch<NotificationsPrefs>(
+      '/api/v1/users/me/notifications',
+      {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      },
+    );
+  }
+
+  async getPreferences(): Promise<Record<string, unknown>> {
+    const res = await this.authedFetch<{ preferences: Record<string, unknown> }>(
+      '/api/v1/users/me/preferences',
+    );
+    return res.preferences ?? {};
+  }
+
+  async updatePreferences(
+    patch: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const res = await this.authedFetch<{ preferences: Record<string, unknown> }>(
+      '/api/v1/users/me/preferences',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ preferences: patch }),
+      },
+    );
+    return res.preferences ?? {};
+  }
+
+  async setup2FA(): Promise<TwoFactorSetup> {
+    return this.authedFetch<TwoFactorSetup>('/api/v1/auth/2fa/setup');
+  }
+
+  async verify2FASetup(
+    secret: string,
+    code: string,
+    backupCodes: string[],
+  ): Promise<{ success: boolean; message: string }> {
+    return this.authedFetch<{ success: boolean; message: string }>(
+      '/api/v1/auth/2fa/verify-setup',
+      {
+        method: 'POST',
+        body: JSON.stringify({ secret, code, backup_codes: backupCodes }),
+      },
+    );
+  }
+
+  async disable2FA(password: string): Promise<{ success: boolean; message: string }> {
+    return this.authedFetch<{ success: boolean; message: string }>(
+      '/api/v1/auth/2fa/disable',
+      {
+        method: 'POST',
+        body: JSON.stringify({ password }),
+      },
+    );
+  }
+
+  async get2FAStatus(): Promise<{ enabled: boolean; verified_at: string | null }> {
+    return this.authedFetch<{ enabled: boolean; verified_at: string | null }>(
+      '/api/v1/auth/2fa/status',
+    );
+  }
+
   isCloud(): boolean {
     return this.cloud;
   }
+}
+
+export interface UserProfile {
+  user_id: string;
+  username: string;
+  email: string;
+  is_verified: boolean;
+  is_admin: boolean;
+  two_factor_enabled: boolean;
+  email_notifications: boolean;
+  security_alerts: boolean;
+  preferences: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpdateProfilePayload {
+  username?: string;
+  email?: string;
+}
+
+export interface UpdateNotificationsPayload {
+  email_notifications?: boolean;
+  security_alerts?: boolean;
+}
+
+export interface NotificationsPrefs {
+  email_notifications: boolean;
+  security_alerts: boolean;
+}
+
+export interface TwoFactorSetup {
+  secret: string;
+  qr_code_url: string;
+  backup_codes: string[];
 }
 
 export const authApi = new AuthApiService();

--- a/crates/mockforge-ui/ui/src/stores/__tests__/useAuthStore.test.ts
+++ b/crates/mockforge-ui/ui/src/stores/__tests__/useAuthStore.test.ts
@@ -13,6 +13,8 @@ vi.mock('../../services/authApi', () => ({
     login: vi.fn(),
     logout: vi.fn(),
     refreshToken: vi.fn(),
+    isCloud: vi.fn(() => false),
+    updateProfile: vi.fn(),
   },
 }));
 

--- a/crates/mockforge-ui/ui/src/stores/useAuthStore.ts
+++ b/crates/mockforge-ui/ui/src/stores/useAuthStore.ts
@@ -181,18 +181,29 @@ export const useAuthStore = create<AuthStore>()(
         set({ isLoading: true });
 
         try {
-          // Update local state immediately for responsive UI
-          // Note: Profile persistence would require a backend API endpoint
-          // For now, profile updates are stored in local state only
+          const current = get().user;
+          const patch: { username?: string; email?: string } = {};
+          if (current?.username !== userData.username) patch.username = userData.username;
+          if (current?.email !== userData.email) patch.email = userData.email;
+
+          let updatedUser = userData;
+
+          // Cloud mode persists to the registry; local mode keeps client-side state
+          // since the OSS admin doesn't back users with a mutable profile store.
+          if (authApi.isCloud() && Object.keys(patch).length > 0) {
+            const profile = await authApi.updateProfile(patch);
+            updatedUser = {
+              ...userData,
+              id: profile.user_id,
+              username: profile.username,
+              email: profile.email,
+            };
+          }
+
           set({
-            user: userData,
+            user: updatedUser,
             isLoading: false,
           });
-
-          // Optionally persist to localStorage as backup
-          if (typeof window !== 'undefined') {
-            localStorage.setItem('mockforge-user-profile', JSON.stringify(userData));
-          }
         } catch (error) {
           set({ isLoading: false });
           const errorMessage = error instanceof Error ? error.message : 'Profile update failed';

--- a/crates/mockforge-ui/ui/src/stores/useHelpStore.ts
+++ b/crates/mockforge-ui/ui/src/stores/useHelpStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface HelpStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  setOpen: (open: boolean) => void;
+}
+
+/** Global visibility of the Help & Support modal.
+ *
+ * Shared so the avatar menu, the Shift+? shortcut, and anything else can
+ * open the same dialog without each owning its own state. The modal itself
+ * is mounted once in {@link AppShell}.
+ */
+export const useHelpStore = create<HelpStore>()((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  setOpen: (open) => set({ isOpen: open }),
+}));

--- a/crates/mockforge-ui/ui/src/stores/usePreferencesStore.ts
+++ b/crates/mockforge-ui/ui/src/stores/usePreferencesStore.ts
@@ -11,6 +11,7 @@ import type {
   SearchPreferences,
   UIBehaviorPreferences,
 } from '../types';
+import { authApi } from '../services/authApi';
 
 // Default preferences
 const defaultThemePreferences: UIThemePreferences = {
@@ -62,10 +63,37 @@ const defaultPreferences: UserPreferences = {
   ui: defaultUIBehaviorPreferences,
 };
 
+// Debounced server save — module-level so re-renders don't reset the timer.
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+const SAVE_DEBOUNCE_MS = 800;
+
 interface PreferencesStore extends PreferencesState, PreferencesActions {}
 
-// Simulate API delay
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+function mergePartial(
+  current: UserPreferences,
+  partial: Partial<UserPreferences>,
+): UserPreferences {
+  return {
+    ...current,
+    ...partial,
+    theme: { ...current.theme, ...(partial.theme ?? {}) },
+    logs: { ...current.logs, ...(partial.logs ?? {}) },
+    notifications: { ...current.notifications, ...(partial.notifications ?? {}) },
+    search: { ...current.search, ...(partial.search ?? {}) },
+    ui: { ...current.ui, ...(partial.ui ?? {}) },
+  };
+}
+
+/** Schedule a best-effort server save after the user stops twiddling controls. */
+function scheduleSync(get: () => PreferencesStore) {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    void get()
+      .savePreferences()
+      .catch((err) => logger.warn('Preference auto-save failed', err));
+  }, SAVE_DEBOUNCE_MS);
+}
 
 export const usePreferencesStore = create<PreferencesStore>()(
   persist(
@@ -75,83 +103,53 @@ export const usePreferencesStore = create<PreferencesStore>()(
       error: null,
 
       updatePreferences: (newPreferences) => {
-        const current = get().preferences;
         set({
-          preferences: { ...current, ...newPreferences },
+          preferences: mergePartial(get().preferences, newPreferences),
           error: null,
         });
+        scheduleSync(get);
       },
 
       updateTheme: (themeUpdates) => {
-        const current = get().preferences;
         set({
-          preferences: {
-            ...current,
-            theme: { ...current.theme, ...themeUpdates },
-          },
+          preferences: mergePartial(get().preferences, { theme: themeUpdates }),
           error: null,
         });
+        scheduleSync(get);
       },
 
       updateLogs: (logsUpdates) => {
-        const current = get().preferences;
         set({
-          preferences: {
-            ...current,
-            logs: { ...current.logs, ...logsUpdates },
-          },
+          preferences: mergePartial(get().preferences, { logs: logsUpdates }),
           error: null,
         });
+        scheduleSync(get);
       },
 
       updateNotifications: (notificationUpdates) => {
-        const current = get().preferences;
         set({
-          preferences: {
-            ...current,
-            notifications: { ...current.notifications, ...notificationUpdates },
-          },
+          preferences: mergePartial(get().preferences, {
+            notifications: notificationUpdates,
+          }),
           error: null,
         });
+        scheduleSync(get);
       },
 
       updateSearch: (searchUpdates) => {
-        const current = get().preferences;
         set({
-          preferences: {
-            ...current,
-            search: { ...current.search, ...searchUpdates },
-          },
+          preferences: mergePartial(get().preferences, { search: searchUpdates }),
           error: null,
         });
+        scheduleSync(get);
       },
 
       updateUI: (uiUpdates) => {
-        const current = get().preferences;
         set({
-          preferences: {
-            ...current,
-            ui: { ...current.ui, ...uiUpdates },
-          },
+          preferences: mergePartial(get().preferences, { ui: uiUpdates }),
           error: null,
         });
-      },
-
-      loadPreferences: async () => {
-        set({ loading: true, error: null });
-
-        try {
-          // Simulate API call to load preferences
-          await delay(800);
-          // In a real app, this would make an API call to load preferences
-          set({ loading: false });
-        } catch (error) {
-          set({
-            loading: false,
-            error: error instanceof Error ? error.message : 'Failed to load preferences',
-          });
-          throw error;
-        }
+        scheduleSync(get);
       },
 
       resetToDefaults: () => {
@@ -159,22 +157,50 @@ export const usePreferencesStore = create<PreferencesStore>()(
           preferences: defaultPreferences,
           error: null,
         });
+        scheduleSync(get);
+      },
+
+      loadPreferences: async () => {
+        if (!authApi.isCloud()) return; // local mode keeps localStorage only
+        set({ loading: true, error: null });
+        try {
+          const remote = (await authApi.getPreferences()) as Partial<UserPreferences>;
+          const hasRemote = remote && Object.keys(remote).length > 0;
+          if (hasRemote) {
+            set({
+              preferences: mergePartial(defaultPreferences, remote),
+              loading: false,
+            });
+          } else {
+            set({ loading: false });
+          }
+        } catch (err) {
+          set({
+            loading: false,
+            error: err instanceof Error ? err.message : 'Failed to load preferences',
+          });
+          logger.warn('Loading preferences from server failed', err);
+        }
       },
 
       savePreferences: async () => {
+        if (!authApi.isCloud()) return;
+        if (saveTimer) {
+          clearTimeout(saveTimer);
+          saveTimer = null;
+        }
         set({ loading: true, error: null });
-
         try {
-          // Simulate API call to save preferences
-          await delay(800);
-          // In a real app, this would make an API call
+          await authApi.updatePreferences(
+            get().preferences as unknown as Record<string, unknown>,
+          );
           set({ loading: false });
-        } catch (error) {
+        } catch (err) {
           set({
             loading: false,
-            error: error instanceof Error ? error.message : 'Failed to save preferences',
+            error: err instanceof Error ? err.message : 'Failed to save preferences',
           });
-          throw error;
+          throw err;
         }
       },
     }),


### PR DESCRIPTION
## Summary
Stage 1 of the avatar-dropdown audit. All four modals (Account Settings, Profile Settings, Preferences, Help & Support) were previously stubbed with \`setTimeout\` fakes and/or dead UI. This PR wires them to real backends.

- **Backend:** new \`POST /auth/change-password\`, \`GET/PATCH /users/me\`, \`PATCH /users/me/notifications\`, \`GET/PATCH /users/me/preferences\`. User model gains \`email_notifications\`, \`security_alerts\`, \`preferences\` with migrations for both Postgres and SQLite. Non-critical transactional emails (welcome, subscription, payment-failed, token-rotation reminders) now respect \`email_notifications\`. 2FA enable/disable and password change send a security-alert email when \`security_alerts\` is on.
- **Frontend:** \`AccountSettings\` is no longer stubbed — real password change, full 2FA enrollment flow (QR, backup codes, verify, disable-with-password), and notification toggles. \`ProfileSettings\` persists via \`PATCH /users/me\` in cloud mode. \`Preferences\` auto-saves (debounced) to the server and hydrates on login. \`UserProfile\` awaits logout and closes on Escape. \`Shift+?\` opens Help & Support via a shared \`useHelpStore\`.
- Stage 2 (wiring each preference field to an actual UI consumer) is a separate follow-up PR.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-registry-core -p mockforge-registry-server --all-targets -- -D warnings\` clean
- [x] \`cargo test\` registry-core + registry-server: all tests pass (244 + core)
- [x] \`pnpm type-check\` clean
- [x] \`pnpm lint\` no new errors
- [x] \`vitest\` targeted (\`usePreferencesStore\`, \`useAuthStore\`, \`Layout\`): 25/25 pass
- [ ] Manual browser verification of the dropdown modals (recommended before merging)