### PR TITLE
chore(ci): disable cross-platform test job (macos + windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,11 @@ jobs:
   cross-platform-test:
     name: Cross-Platform Tests
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'pull_request'
+    # Temporarily disabled — macos-latest and windows-latest have been
+    # failing on main and consume significant CI minutes. Re-enable once
+    # the cross-platform regressions are investigated and fixed.
+    # Was: if: github.event_name == 'pull_request'
+    if: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

`Cross-Platform Tests (macos-latest)` and `Cross-Platform Tests (windows-latest)` have been failing on main for several weeks. They don't gate merges but consume significant GitHub-hosted runner minutes on every PR.

Temporarily gating the job with `if: false` (original condition preserved as a comment) so the jobs appear as skipped rather than burn resources while the cross-platform regressions are diagnosed.

## What still runs on macos / windows

Release binary builds (`build-binaries` job, lines 456-485) still target `x86_64-apple-darwin`, `aarch64-apple-darwin`, and `x86_64-pc-windows-msvc` — but those only run on `main` / tag pushes, not on every PR, so release cadence is unaffected.

## Re-enabling

Delete the `# Temporarily disabled` comment block and restore:
```yaml
if: github.event_name == 'pull_request'
```

## Test plan

- [x] Edit is scoped to a single `if:` change plus an explanatory comment block — no changes to job steps, matrix, or other workflows
- [ ] Verify next PR run shows `Cross-Platform Tests` as skipped instead of consuming a runner