### PR TITLE
feat(recorder): JSONL export for hosted-mocks captures (#234)

### DIFF
--- a/crates/mockforge-recorder/src/api.rs
+++ b/crates/mockforge-recorder/src/api.rs
@@ -57,6 +57,7 @@ pub fn create_api_router(
 
         // Export endpoints
         .route("/api/recorder/export/har", get(export_har))
+        .route("/api/recorder/export/jsonl", get(export_jsonl))
 
         // Control endpoints
         .route("/api/recorder/status", get(get_status))
@@ -181,6 +182,41 @@ async fn export_har(
     let har_json = serde_json::to_string_pretty(&har)?;
 
     Ok((StatusCode::OK, [("content-type", "application/json")], har_json).into_response())
+}
+
+/// Export recordings as JSONL — one `RecordedExchange` per line. Unlike
+/// HAR this works for every protocol (HAR is HTTP-only) and is directly
+/// replay-able by `mockforge-cli replay`. Each line is a self-contained
+/// JSON object so consumers can stream-parse without buffering the whole
+/// file.
+async fn export_jsonl(
+    State(state): State<ApiState>,
+    Query(params): Query<ExportParams>,
+) -> Result<Response, ApiError> {
+    let limit = params.limit.unwrap_or(1000);
+
+    let filter = QueryFilter {
+        limit: Some(limit),
+        ..Default::default()
+    };
+
+    let result = execute_query(state.recorder.database(), filter).await?;
+
+    let mut body = String::with_capacity(result.exchanges.len() * 256);
+    for exchange in &result.exchanges {
+        body.push_str(&serde_json::to_string(exchange)?);
+        body.push('\n');
+    }
+
+    Ok((
+        StatusCode::OK,
+        [
+            ("content-type", "application/x-ndjson"),
+            ("content-disposition", "attachment; filename=\"captures.jsonl\""),
+        ],
+        body,
+    )
+        .into_response())
 }
 
 /// Get recording status

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -1759,6 +1759,21 @@ pub async fn export_recorder_captures_har(
     proxy_to_deployment_recorder(&deployment, "/api/recorder/export/har").await
 }
 
+/// Export the deployment's recorder captures as JSONL — one
+/// `RecordedExchange` per line, all protocols. Companion to the HAR
+/// export. JSONL is the format the local `mockforge-cli replay` reads,
+/// so this is the round-trip path: capture in cloud → download → replay
+/// locally.
+pub async fn export_recorder_captures_jsonl(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(deployment_id): Path<Uuid>,
+) -> ApiResult<axum::http::Response<axum::body::Body>> {
+    let deployment = check_org_access(&state, user_id, &headers, deployment_id).await?;
+    proxy_to_deployment_recorder(&deployment, "/api/recorder/export/jsonl").await
+}
+
 /// Get deployment metrics
 pub async fn get_deployment_metrics(
     State(state): State<AppState>,

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -178,6 +178,7 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/{capture_id}", get(handlers::hosted_mocks::get_recorder_capture))
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/{capture_id}/response", get(handlers::hosted_mocks::get_recorder_capture_response))
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/export/har", get(handlers::hosted_mocks::export_recorder_captures_har))
+        .route("/api/v1/hosted-mocks/{deployment_id}/captures/export/jsonl", get(handlers::hosted_mocks::export_recorder_captures_jsonl))
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/enable", post(handlers::hosted_mocks::enable_recorder))
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/disable", post(handlers::hosted_mocks::disable_recorder))
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/clear", post(handlers::hosted_mocks::clear_recorder))

--- a/crates/mockforge-ui/ui/src/hooks/useDeploymentTraces.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useDeploymentTraces.ts
@@ -1,0 +1,143 @@
+/**
+ * Pulls trace summaries and individual trace detail from the registry's
+ * OTLP storage (#233). The deployment's mockforge-cli pushes spans through
+ * the OTLP/HTTP-JSON exporter; the registry persists them in Postgres.
+ *
+ * Polling (default 5s) is fine — like captures, the data volume is bounded
+ * by user traffic and the server-side aggregate query is cheap (indexed by
+ * deployment_id + occurred_at).
+ */
+
+import { useEffect, useState } from 'react';
+import { logger } from '@/utils/logger';
+
+/// Mirrors `handlers::otlp::TraceSummary` in mockforge-registry-server.
+export interface TraceSummary {
+  trace_id: string;
+  span_count: number;
+  start: string;
+  duration_ms: number;
+  root_name: string;
+  service_name: string | null;
+  has_error: boolean;
+}
+
+/// Mirrors `handlers::otlp::SpanResponse`. attributes / events / links are
+/// JSONB on the wire — surface as `unknown` and let consumers narrow.
+export interface TraceSpan {
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string | null;
+  service_name: string | null;
+  name: string;
+  kind: number | null;
+  start_unix_nano: number;
+  end_unix_nano: number;
+  status_code: number | null;
+  status_message: string | null;
+  attributes: Record<string, unknown>;
+  events: unknown[];
+  links: unknown[];
+}
+
+export interface UseDeploymentTracesOptions {
+  enabled?: boolean;
+  intervalMs?: number;
+  limit?: number;
+}
+
+export interface UseDeploymentTracesReturn {
+  traces: TraceSummary[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useDeploymentTraces(
+  deploymentId: string | undefined,
+  options: UseDeploymentTracesOptions = {},
+): UseDeploymentTracesReturn {
+  const { enabled = true, intervalMs = 5000, limit = 100 } = options;
+
+  const [traces, setTraces] = useState<TraceSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refetchTick, setRefetchTick] = useState(0);
+
+  useEffect(() => {
+    if (!enabled || !deploymentId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const poll = async () => {
+      const token = localStorage.getItem('auth_token');
+      if (!token) return;
+
+      const url = `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/traces?limit=${limit}`;
+
+      setLoading(true);
+      try {
+        const resp = await fetch(url, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) {
+          // 404 happens before any spans have been ingested — surface as
+          // empty rather than an error so the UI doesn't yell at users.
+          if (resp.status === 404) {
+            if (!cancelled) {
+              setTraces([]);
+              setError(null);
+            }
+            return;
+          }
+          throw new Error(`HTTP ${resp.status}`);
+        }
+        const data = await resp.json();
+        if (cancelled) return;
+        const list: TraceSummary[] = Array.isArray(data) ? data : [];
+        setTraces(list);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : 'Failed to fetch traces';
+        setError(msg);
+        logger.warn('Deployment traces poll failed', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void poll();
+    const handle = setInterval(poll, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [enabled, deploymentId, intervalMs, limit, refetchTick]);
+
+  return {
+    traces,
+    loading,
+    error,
+    refetch: () => setRefetchTick((t) => t + 1),
+  };
+}
+
+/// Fetch every span of a single trace on demand. Separate from the list
+/// endpoint so the list view stays cheap.
+export async function fetchTraceSpans(
+  deploymentId: string,
+  traceId: string,
+): Promise<TraceSpan[]> {
+  const token = localStorage.getItem('auth_token');
+  if (!token) return [];
+  const url = `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/traces/${encodeURIComponent(traceId)}`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) return [];
+  const data = await resp.json();
+  return Array.isArray(data) ? (data as TraceSpan[]) : [];
+}

--- a/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
@@ -16,6 +16,12 @@ import {
   type DeploymentCaptureResponse,
 } from '@/hooks/useDeploymentCaptures';
 import {
+  useDeploymentTraces,
+  fetchTraceSpans,
+  type TraceSummary,
+  type TraceSpan,
+} from '@/hooks/useDeploymentTraces';
+import {
   Box,
   Card,
   CardContent,
@@ -310,6 +316,38 @@ export const HostedMocksPage: React.FC = () => {
   const [replayResult, setReplayResult] = useState<unknown | null>(null);
   const [replayLoading, setReplayLoading] = useState(false);
   const [replayError, setReplayError] = useState<string | null>(null);
+
+  // OTLP traces (#233). Same proxy-pattern as captures: the deployment's
+  // mockforge-cli sends spans via OTLP/HTTP-JSON to the registry; we
+  // surface them here so the user can drill into a single request's
+  // span tree without leaving the admin UI.
+  const {
+    traces: deploymentTraces,
+    loading: tracesLoading,
+    error: tracesError,
+    refetch: refetchTraces,
+  } = useDeploymentTraces(detailsOpen ? selectedDeployment?.id : undefined, {
+    enabled: detailsOpen && !!selectedDeployment,
+  });
+  const [selectedTrace, setSelectedTrace] = useState<TraceSummary | null>(null);
+  const [selectedTraceSpans, setSelectedTraceSpans] = useState<TraceSpan[]>([]);
+  const [traceSpansLoading, setTraceSpansLoading] = useState(false);
+
+  const openTrace = useCallback(
+    async (trace: TraceSummary) => {
+      setSelectedTrace(trace);
+      setSelectedTraceSpans([]);
+      if (!selectedDeployment) return;
+      setTraceSpansLoading(true);
+      try {
+        const spans = await fetchTraceSpans(selectedDeployment.id, trace.trace_id);
+        setSelectedTraceSpans(spans);
+      } finally {
+        setTraceSpansLoading(false);
+      }
+    },
+    [selectedDeployment],
+  );
 
   const openCapture = useCallback(
     async (capture: DeploymentCapture) => {
@@ -1253,6 +1291,7 @@ export const HostedMocksPage: React.FC = () => {
                 <Tab icon={<ViewIcon />} label="Logs" />
                 <Tab icon={<ViewIcon />} label="Requests" />
                 <Tab icon={<ViewIcon />} label="Captures" />
+                <Tab icon={<ViewIcon />} label="Traces" />
                 <Tab icon={<AssessmentIcon />} label="Metrics" />
               </Tabs>
 
@@ -1928,6 +1967,96 @@ export const HostedMocksPage: React.FC = () => {
 
               {detailsTab === 5 && (
                 <Box>
+                  <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1, flexWrap: 'wrap' }}>
+                    <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
+                      Distributed traces from this deployment, ingested via OTLP. Spans are kept
+                      in the registry's Postgres store and pruned by the retention worker.
+                    </Typography>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={refetchTraces}
+                      disabled={tracesLoading}
+                    >
+                      Refresh
+                    </Button>
+                  </Box>
+
+                  {tracesError && (
+                    <Alert severity="warning" sx={{ mb: 2 }}>
+                      {tracesError}. The deployment may not have an OTLP exporter configured —
+                      enable <code>observability.tracing.enabled = true</code> with the registry as
+                      the OTLP endpoint and redeploy.
+                    </Alert>
+                  )}
+
+                  {deploymentTraces.length === 0 ? (
+                    <Alert severity="info">
+                      No traces yet. Once the deployment exports OTLP spans, they'll appear here
+                      within a few seconds.
+                    </Alert>
+                  ) : (
+                    <TableContainer
+                      component={Box}
+                      sx={{
+                        border: 1,
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                        maxHeight: 480,
+                      }}
+                    >
+                      <Table size="small" stickyHeader>
+                        <TableHead>
+                          <TableRow>
+                            <TableCell>Time</TableCell>
+                            <TableCell>Service</TableCell>
+                            <TableCell>Root span</TableCell>
+                            <TableCell align="right">Spans</TableCell>
+                            <TableCell align="right">Duration</TableCell>
+                            <TableCell>Status</TableCell>
+                            <TableCell />
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {deploymentTraces.map((trace) => (
+                            <TableRow key={trace.trace_id} hover>
+                              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                {new Date(trace.start).toLocaleTimeString()}
+                              </TableCell>
+                              <TableCell>{trace.service_name ?? '—'}</TableCell>
+                              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                {trace.root_name}
+                              </TableCell>
+                              <TableCell align="right">{trace.span_count}</TableCell>
+                              <TableCell
+                                align="right"
+                                sx={{ fontFamily: 'monospace', fontSize: 12 }}
+                              >
+                                {trace.duration_ms.toFixed(1)}ms
+                              </TableCell>
+                              <TableCell>
+                                {trace.has_error ? (
+                                  <Chip label="error" size="small" color="error" />
+                                ) : (
+                                  <Chip label="ok" size="small" color="success" />
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                <Button size="small" onClick={() => openTrace(trace)}>
+                                  View
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </Box>
+              )}
+
+              {detailsTab === 6 && (
+                <Box>
                   {streamConnected && streamMetrics && (
                     <Box sx={{ mb: 3 }}>
                       <Alert severity="success" sx={{ mb: 2 }}>
@@ -2252,6 +2381,58 @@ export const HostedMocksPage: React.FC = () => {
           </>
         )}
       </Dialog>
+
+      {/* Trace detail dialog — renders the full span list as an indented
+          waterfall. Sibling to the capture and deployment dialogs to keep
+          focus management simple. */}
+      <Dialog
+        open={!!selectedTrace}
+        onClose={() => {
+          setSelectedTrace(null);
+          setSelectedTraceSpans([]);
+        }}
+        maxWidth="lg"
+        fullWidth
+      >
+        {selectedTrace && (
+          <>
+            <DialogTitle>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                <Typography variant="body1">{selectedTrace.root_name}</Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontFamily: 'monospace' }}
+                >
+                  {selectedTrace.trace_id}
+                </Typography>
+                {selectedTrace.has_error && <Chip label="error" size="small" color="error" />}
+              </Box>
+            </DialogTitle>
+            <DialogContent>
+              {traceSpansLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+                  <CircularProgress />
+                </Box>
+              ) : selectedTraceSpans.length === 0 ? (
+                <Alert severity="info">No spans found for this trace.</Alert>
+              ) : (
+                <SpanWaterfall spans={selectedTraceSpans} />
+              )}
+            </DialogContent>
+            <DialogActions>
+              <Button
+                onClick={() => {
+                  setSelectedTrace(null);
+                  setSelectedTraceSpans([]);
+                }}
+              >
+                Close
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
     </Box>
   );
 };
@@ -2267,6 +2448,121 @@ function formatJsonString(raw: string): string {
   } catch {
     return raw;
   }
+}
+
+/**
+ * Renders the spans of a single trace as a waterfall: each row sized and
+ * offset relative to the trace's wall-clock window. The visual encoding —
+ * colored bar proportional to duration, indented by parent depth — is
+ * the standard tracing-UI idiom; we don't try to compete with Jaeger here,
+ * just give the user a glanceable shape.
+ */
+function SpanWaterfall({ spans }: { spans: TraceSpan[] }): React.ReactElement {
+  const traceStart = Math.min(...spans.map((s) => s.start_unix_nano));
+  const traceEnd = Math.max(...spans.map((s) => s.end_unix_nano));
+  const traceDuration = Math.max(1, traceEnd - traceStart);
+
+  // Build parent → children index, then walk it depth-first so the table
+  // shows spans in causal order rather than wall-clock order. Falls back
+  // to the original list if no parent is identified (e.g. partial trace).
+  const childrenOf = new Map<string | null, TraceSpan[]>();
+  for (const span of spans) {
+    const key = span.parent_span_id ?? null;
+    const list = childrenOf.get(key) ?? [];
+    list.push(span);
+    childrenOf.set(key, list);
+  }
+  for (const list of childrenOf.values()) {
+    list.sort((a, b) => a.start_unix_nano - b.start_unix_nano);
+  }
+
+  const ordered: { span: TraceSpan; depth: number }[] = [];
+  const visited = new Set<string>();
+  const walk = (parentId: string | null, depth: number) => {
+    const kids = childrenOf.get(parentId) ?? [];
+    for (const span of kids) {
+      if (visited.has(span.span_id)) continue;
+      visited.add(span.span_id);
+      ordered.push({ span, depth });
+      walk(span.span_id, depth + 1);
+    }
+  };
+  walk(null, 0);
+  // Pick up any orphans whose parent isn't in the result set.
+  for (const span of spans) {
+    if (!visited.has(span.span_id)) {
+      ordered.push({ span, depth: 0 });
+      visited.add(span.span_id);
+    }
+  }
+
+  return (
+    <TableContainer component={Box} sx={{ border: 1, borderColor: 'divider', borderRadius: 1 }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell align="right">Start</TableCell>
+            <TableCell align="right">Duration</TableCell>
+            <TableCell sx={{ width: '40%' }}>Timeline</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {ordered.map(({ span, depth }) => {
+            const startOffset = span.start_unix_nano - traceStart;
+            const duration = span.end_unix_nano - span.start_unix_nano;
+            const startPct = (startOffset / traceDuration) * 100;
+            const widthPct = Math.max(0.5, (duration / traceDuration) * 100);
+            const isError = span.status_code === 2;
+            return (
+              <TableRow key={span.span_id} hover>
+                <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                  <Box sx={{ pl: depth * 2 }}>
+                    {span.name}
+                    {isError && (
+                      <Chip
+                        label="error"
+                        size="small"
+                        color="error"
+                        sx={{ ml: 1, height: 16, fontSize: 10 }}
+                      />
+                    )}
+                  </Box>
+                </TableCell>
+                <TableCell align="right" sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                  {(startOffset / 1e6).toFixed(2)}ms
+                </TableCell>
+                <TableCell align="right" sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                  {(duration / 1e6).toFixed(2)}ms
+                </TableCell>
+                <TableCell>
+                  <Box
+                    sx={{
+                      position: 'relative',
+                      height: 14,
+                      bgcolor: 'action.hover',
+                      borderRadius: 0.5,
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        position: 'absolute',
+                        left: `${startPct}%`,
+                        width: `${widthPct}%`,
+                        height: '100%',
+                        bgcolor: isError ? 'error.main' : 'primary.main',
+                        borderRadius: 0.5,
+                      }}
+                    />
+                  </Box>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
 }
 
 /**

--- a/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
@@ -1814,6 +1814,17 @@ export const HostedMocksPage: React.FC = () => {
                     <Button
                       size="small"
                       variant="outlined"
+                      disabled={capturesLoading || recorderCaptures.length === 0 || !selectedDeployment}
+                      onClick={async () => {
+                        if (!selectedDeployment) return;
+                        await downloadCapturesJsonl(selectedDeployment.id, selectedDeployment.slug);
+                      }}
+                    >
+                      Export JSONL
+                    </Button>
+                    <Button
+                      size="small"
+                      variant="outlined"
                       onClick={refetchCaptures}
                       disabled={capturesLoading}
                     >
@@ -2606,12 +2617,24 @@ async function toggleRecorder(
 }
 
 async function downloadCapturesHar(deploymentId: string, slug: string): Promise<void> {
+  return downloadCaptures(deploymentId, slug, 'har');
+}
+
+async function downloadCapturesJsonl(deploymentId: string, slug: string): Promise<void> {
+  return downloadCaptures(deploymentId, slug, 'jsonl');
+}
+
+async function downloadCaptures(
+  deploymentId: string,
+  slug: string,
+  format: 'har' | 'jsonl',
+): Promise<void> {
   const token = localStorage.getItem('auth_token');
   if (!token) {
     alert('Not authenticated');
     return;
   }
-  const url = `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/captures/export/har`;
+  const url = `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/captures/export/${format}`;
   try {
     const resp = await fetch(url, {
       headers: { Authorization: `Bearer ${token}` },
@@ -2624,13 +2647,13 @@ async function downloadCapturesHar(deploymentId: string, slug: string): Promise<
     const a = document.createElement('a');
     a.href = objectUrl;
     const date = new Date().toISOString().split('T')[0];
-    a.download = `${slug}-captures-${date}.har`;
+    a.download = `${slug}-captures-${date}.${format}`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(objectUrl);
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'Download failed';
-    alert(`HAR export failed: ${msg}`);
+    alert(`${format.toUpperCase()} export failed: ${msg}`);
   }
 }


### PR DESCRIPTION
## Summary

The recorder already exported HAR; HAR is HTTP-only and isn't the format \`mockforge-cli replay\` consumes locally. This adds JSONL — one \`RecordedExchange\` per line, all protocols, directly replay-able. That round-trip path (capture in cloud → download → replay locally) is the third acceptance criterion on #234.

- New route on the recorder: \`GET /api/recorder/export/jsonl\`
- Cloud proxy: \`GET /api/v1/hosted-mocks/{id}/captures/export/jsonl\`
- UI: "Export JSONL" button next to the existing "Export HAR"
- Shared blob-URL helper between the two formats — no duplication

## Test plan
- [x] \`cargo check / clippy / test -p mockforge-recorder\`
- [x] \`cargo check / clippy -p mockforge-registry-server\`
- [x] \`cargo fmt --all --check\`
- [x] \`pnpm type-check\`
- [ ] Manual: deploy a hosted mock, send traffic, hit Export JSONL, run \`mockforge-cli replay captures.jsonl\` locally

Refs #234. Two acceptance criteria still open after this: (1) capture-survives-restart persistence path, (2) capture sync to cloud Postgres. Tracking those as separate work.