### PR TITLE
feat(recorder): persistent capture sync to cloud Postgres (#234 part 2)

### DIFF
--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -1890,9 +1890,46 @@ pub async fn handle_serve(
     #[cfg(feature = "recorder")]
     if let Some(ref recorder_config) = config.observability.recorder {
         if recorder_config.enabled {
+            use axum::extract::ConnectInfo;
+            use axum::extract::Request as AxumRequest;
+            use axum::middleware::{from_fn, Next};
+            use std::net::SocketAddr;
+
             match mockforge_recorder::RecorderDatabase::new(&recorder_config.database_path).await {
                 Ok(db) => {
-                    let recorder = std::sync::Arc::new(mockforge_recorder::Recorder::new(db));
+                    // Attach the cloud-sync handle when running on a hosted
+                    // mock (#234 part 2). On local / self-hosted runs the
+                    // env vars are absent and the handle is a no-op.
+                    let cloud_sync = mockforge_recorder::cloud_sync::from_env();
+                    if cloud_sync.is_active() {
+                        println!("✅ Recorder cloud-sync enabled — captures will mirror to MockForge Cloud");
+                    }
+                    let recorder = std::sync::Arc::new(
+                        mockforge_recorder::Recorder::new(db).with_cloud_sync(cloud_sync),
+                    );
+
+                    // Wire the recording middleware so HTTP requests actually
+                    // populate the recorder's database. Without this layer
+                    // the API mounts but `/api/recorder/requests` always
+                    // returns an empty list.
+                    let recorder_for_layer = recorder.clone();
+                    http_app = http_app.layer(from_fn(move |req: AxumRequest, next: Next| {
+                        let recorder = recorder_for_layer.clone();
+                        async move {
+                            let connect_info =
+                                req.extensions().get::<ConnectInfo<SocketAddr>>().cloned();
+                            match connect_info {
+                                Some(ci) => {
+                                    mockforge_recorder::recording_middleware(
+                                        recorder, ci, req, next,
+                                    )
+                                    .await
+                                }
+                                None => next.run(req).await,
+                            }
+                        }
+                    }));
+
                     let recorder_router = mockforge_recorder::create_api_router(recorder, None);
                     http_app = http_app.merge(recorder_router);
                     println!(

--- a/crates/mockforge-recorder/src/cloud_sync.rs
+++ b/crates/mockforge-recorder/src/cloud_sync.rs
@@ -1,0 +1,231 @@
+//! Capture cloud-sync shipper for hosted-mock deployments (#234 part 2).
+//!
+//! The recorder writes captures to local SQLite, which is wiped when the
+//! Fly machine restarts. This module ships each completed exchange to
+//! MockForge Cloud's capture-ingest endpoint so the captures survive
+//! container restart.
+//!
+//! Architecturally identical to `mockforge-observability::log_shipper`:
+//! a cloneable handle with a non-blocking `enqueue` is held by the
+//! recorder; a background task drains the channel, batches, and POSTs.
+//! When env vars aren't set, the handle is a no-op — local recorder
+//! usage outside hosted mocks is unaffected.
+//!
+//! ## Configuration
+//!
+//! - `MOCKFORGE_CAPTURE_INGEST_URL` — full URL of the ingest endpoint.
+//! - `MOCKFORGE_CAPTURE_INGEST_TOKEN` — short-lived deployment-scoped JWT.
+//! - `MOCKFORGE_CAPTURE_INGEST_BATCH_SIZE` — events per POST (default 25).
+//!   Smaller than log-ingest because capture rows are larger (full bodies).
+//! - `MOCKFORGE_CAPTURE_INGEST_FLUSH_MS` — max batch age (default 2000).
+//! - `MOCKFORGE_CAPTURE_INGEST_BUFFER` — channel capacity (default 256).
+
+use crate::models::RecordedExchange;
+use serde::Serialize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+#[derive(Debug, Serialize)]
+struct IngestPayload<'a> {
+    exchanges: &'a [RecordedExchange],
+}
+
+/// Cheap cloneable handle to the cloud-sync shipper. `enqueue` is
+/// non-blocking and never fails — safe to call from the recorder's
+/// hot path. When the shipper isn't configured the handle is `None`
+/// and calls are zero-cost.
+#[derive(Clone)]
+pub struct CaptureCloudSyncHandle {
+    inner: Option<Arc<Inner>>,
+}
+
+struct Inner {
+    sender: mpsc::Sender<RecordedExchange>,
+}
+
+impl Default for CaptureCloudSyncHandle {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl CaptureCloudSyncHandle {
+    /// No-op handle. Used when the shipper isn't configured.
+    pub fn disabled() -> Self {
+        Self { inner: None }
+    }
+
+    /// Non-blocking enqueue. Drops silently when the buffer is full
+    /// (under sustained back-pressure we'd rather drop the newest than
+    /// stall the recorder; the local SQLite is the canonical store).
+    pub fn enqueue(&self, exchange: RecordedExchange) {
+        if let Some(inner) = &self.inner {
+            let _ = inner.sender.try_send(exchange);
+        }
+    }
+
+    /// True when the shipper is actually running.
+    pub fn is_active(&self) -> bool {
+        self.inner.is_some()
+    }
+}
+
+/// Construct from environment variables. Returns a disabled handle when
+/// required vars are missing (the common case in dev / self-hosted).
+pub fn from_env() -> CaptureCloudSyncHandle {
+    let url = match std::env::var("MOCKFORGE_CAPTURE_INGEST_URL") {
+        Ok(u) if !u.trim().is_empty() => u,
+        _ => return CaptureCloudSyncHandle::disabled(),
+    };
+    let token = match std::env::var("MOCKFORGE_CAPTURE_INGEST_TOKEN") {
+        Ok(t) if !t.trim().is_empty() => t,
+        _ => return CaptureCloudSyncHandle::disabled(),
+    };
+    let batch_size: usize = std::env::var("MOCKFORGE_CAPTURE_INGEST_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(25);
+    let flush_ms: u64 = std::env::var("MOCKFORGE_CAPTURE_INGEST_FLUSH_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2000);
+    let buffer: usize = std::env::var("MOCKFORGE_CAPTURE_INGEST_BUFFER")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(256);
+
+    let client = match reqwest::Client::builder().timeout(Duration::from_secs(10)).build() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("CaptureCloudSync HTTP client init failed: {}", e);
+            return CaptureCloudSyncHandle::disabled();
+        }
+    };
+
+    let (sender, receiver) = mpsc::channel::<RecordedExchange>(buffer);
+    let inner = Arc::new(Inner { sender });
+
+    tokio::spawn(run(receiver, client, url, token, batch_size, flush_ms));
+
+    CaptureCloudSyncHandle { inner: Some(inner) }
+}
+
+async fn run(
+    mut receiver: mpsc::Receiver<RecordedExchange>,
+    client: reqwest::Client,
+    url: String,
+    token: String,
+    batch_size: usize,
+    flush_ms: u64,
+) {
+    let flush_after = Duration::from_millis(flush_ms);
+    let mut batch: Vec<RecordedExchange> = Vec::with_capacity(batch_size);
+    let mut deadline = tokio::time::Instant::now() + flush_after;
+
+    loop {
+        let timeout = tokio::time::sleep_until(deadline);
+        tokio::pin!(timeout);
+
+        tokio::select! {
+            biased;
+            evt = receiver.recv() => {
+                match evt {
+                    Some(e) => {
+                        batch.push(e);
+                        if batch.len() >= batch_size {
+                            send_batch(&client, &url, &token, &batch).await;
+                            batch.clear();
+                            deadline = tokio::time::Instant::now() + flush_after;
+                        }
+                    }
+                    None => {
+                        if !batch.is_empty() {
+                            send_batch(&client, &url, &token, &batch).await;
+                        }
+                        return;
+                    }
+                }
+            }
+            _ = &mut timeout => {
+                if !batch.is_empty() {
+                    send_batch(&client, &url, &token, &batch).await;
+                    batch.clear();
+                }
+                deadline = tokio::time::Instant::now() + flush_after;
+            }
+        }
+    }
+}
+
+async fn send_batch(
+    client: &reqwest::Client,
+    url: &str,
+    token: &str,
+    exchanges: &[RecordedExchange],
+) {
+    let payload = IngestPayload { exchanges };
+    debug!(count = exchanges.len(), "Shipping capture batch");
+    match client.post(url).bearer_auth(token).json(&payload).send().await {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            warn!(
+                status = %resp.status(),
+                count = exchanges.len(),
+                "Capture ingest non-success; dropping batch"
+            );
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                count = exchanges.len(),
+                "Capture ingest send failed; dropping batch"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{Protocol, RecordedRequest};
+    use chrono::Utc;
+
+    fn dummy_exchange() -> RecordedExchange {
+        RecordedExchange {
+            request: RecordedRequest {
+                id: "test".into(),
+                protocol: Protocol::Http,
+                timestamp: Utc::now(),
+                method: "GET".into(),
+                path: "/".into(),
+                query_params: None,
+                headers: "{}".into(),
+                body: None,
+                body_encoding: "utf8".into(),
+                client_ip: None,
+                trace_id: None,
+                span_id: None,
+                duration_ms: None,
+                status_code: None,
+                tags: None,
+            },
+            response: None,
+        }
+    }
+
+    #[test]
+    fn disabled_handle_is_inert() {
+        let h = CaptureCloudSyncHandle::disabled();
+        assert!(!h.is_active());
+        h.enqueue(dummy_exchange());
+    }
+
+    #[test]
+    fn from_env_disabled_without_url_or_token() {
+        std::env::remove_var("MOCKFORGE_CAPTURE_INGEST_URL");
+        std::env::remove_var("MOCKFORGE_CAPTURE_INGEST_TOKEN");
+        assert!(!from_env().is_active());
+    }
+}

--- a/crates/mockforge-recorder/src/lib.rs
+++ b/crates/mockforge-recorder/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod api;
 pub mod behavioral_cloning;
+pub mod cloud_sync;
 pub mod database;
 pub mod diff;
 pub mod har_export;
@@ -31,6 +32,7 @@ pub use behavioral_cloning::{
     FlowGroupingStrategy, FlowRecorder, FlowRecordingConfig, FlowStep, ReplayResponse,
     ScenarioInfo, ScenarioStorage, StateVariable,
 };
+pub use cloud_sync::{from_env as cloud_sync_from_env, CaptureCloudSyncHandle};
 pub use database::RecorderDatabase;
 pub use diff::{ComparisonResult, Difference, DifferenceType, ResponseComparator};
 pub use har_export::export_to_har;

--- a/crates/mockforge-recorder/src/recorder.rs
+++ b/crates/mockforge-recorder/src/recorder.rs
@@ -1,6 +1,8 @@
 //! Core recording functionality
 
-use crate::{database::RecorderDatabase, models::*, scrubbing::*, Result};
+use crate::{
+    cloud_sync::CaptureCloudSyncHandle, database::RecorderDatabase, models::*, scrubbing::*, Result,
+};
 use chrono::Utc;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -14,6 +16,7 @@ pub struct Recorder {
     enabled: Arc<RwLock<bool>>,
     scrubber: Arc<Scrubber>,
     filter: Arc<CaptureFilter>,
+    cloud_sync: CaptureCloudSyncHandle,
 }
 
 impl Recorder {
@@ -24,6 +27,7 @@ impl Recorder {
             enabled: Arc::new(RwLock::new(true)),
             scrubber: Scrubber::global(),
             filter: CaptureFilter::global(),
+            cloud_sync: CaptureCloudSyncHandle::disabled(),
         }
     }
 
@@ -34,7 +38,17 @@ impl Recorder {
             enabled: Arc::new(RwLock::new(true)),
             scrubber: Arc::new(scrubber),
             filter: Arc::new(filter),
+            cloud_sync: CaptureCloudSyncHandle::disabled(),
         }
+    }
+
+    /// Attach a cloud-sync handle. When configured, every completed
+    /// exchange (after `record_response`) is shipped to the cloud
+    /// ingest endpoint in addition to being stored locally. The local
+    /// SQLite stays the canonical store; cloud is the durable mirror.
+    pub fn with_cloud_sync(mut self, handle: CaptureCloudSyncHandle) -> Self {
+        self.cloud_sync = handle;
+        self
     }
 
     /// Get the scrubber
@@ -87,7 +101,22 @@ impl Recorder {
         // Apply scrubbing
         self.scrubber.scrub_response(&mut response);
 
+        let request_id = response.request_id.clone();
         self.db.insert_response(&response).await?;
+
+        // Ship the now-complete exchange to cloud Postgres if the handle
+        // is configured. Local SQLite stays canonical so a transient
+        // ship failure doesn't lose data — the cloud is a durable mirror,
+        // not the source of truth.
+        if self.cloud_sync.is_active() {
+            if let Ok(Some(request)) = self.db.get_request(&request_id).await {
+                self.cloud_sync.enqueue(RecordedExchange {
+                    request,
+                    response: Some(response),
+                });
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/mockforge-registry-server/migrations/20250101000053_runtime_captures.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000053_runtime_captures.sql
@@ -1,0 +1,64 @@
+-- #234 part 2: persistent recorder captures for hosted-mock deployments.
+--
+-- The recorder library stores captures in the deployment's local SQLite,
+-- which is wiped when the Fly machine restarts. This table is the
+-- durable counterpart: the in-container shipper POSTs each completed
+-- exchange (request + response) to the registry, which lands here.
+--
+-- Schema mirrors `RecordedRequest` + `RecordedResponse` in
+-- `mockforge-recorder::models` flattened into one row. The recorder's
+-- types already serialize headers and query_params as JSON-encoded
+-- strings, so we keep them as TEXT here — round-tripping through JSONB
+-- would force every consumer to know about the encoding shift.
+
+CREATE TABLE IF NOT EXISTS runtime_captures (
+    id BIGSERIAL PRIMARY KEY,
+    deployment_id UUID NOT NULL REFERENCES hosted_mocks(id) ON DELETE CASCADE,
+
+    -- The recorder's own UUID for this exchange. We store and surface it
+    -- so a row in cloud Postgres can be cross-referenced with the local
+    -- SQLite (e.g. when debugging a missing capture).
+    capture_id TEXT NOT NULL,
+
+    -- Request side.
+    protocol TEXT NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    method TEXT NOT NULL,
+    path TEXT NOT NULL,
+    query_params TEXT,
+    request_headers TEXT NOT NULL,
+    request_body TEXT,
+    request_body_encoding TEXT NOT NULL,
+    client_ip TEXT,
+    trace_id TEXT,
+    span_id TEXT,
+    duration_ms BIGINT,
+    status_code INTEGER,
+    tags TEXT,
+
+    -- Response side. Nullable because an exchange might be shipped
+    -- request-first if the response hasn't been recorded yet — though in
+    -- practice the shipper enqueues only after the response is in.
+    response_status_code INTEGER,
+    response_headers TEXT,
+    response_body TEXT,
+    response_body_encoding TEXT,
+    response_size_bytes BIGINT,
+    response_timestamp TIMESTAMPTZ,
+
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Same exchange ingested twice (retries, redeploy with cached
+    -- shipper buffer) is a no-op rather than a duplicate row.
+    UNIQUE (deployment_id, capture_id)
+);
+
+-- Most queries are "recent captures for this deployment", same shape as
+-- the request_logs index.
+CREATE INDEX IF NOT EXISTS runtime_captures_deployment_time_idx
+    ON runtime_captures (deployment_id, occurred_at DESC);
+
+-- Diagnostics: "show me the last N 5xxs the recorder caught."
+CREATE INDEX IF NOT EXISTS runtime_captures_status_idx
+    ON runtime_captures (deployment_id, status_code, occurred_at DESC)
+    WHERE status_code >= 500;

--- a/crates/mockforge-registry-server/src/deployment/orchestrator.rs
+++ b/crates/mockforge-registry-server/src/deployment/orchestrator.rs
@@ -238,14 +238,15 @@ impl DeploymentOrchestrator {
             env.insert("MOCKFORGE_KAFKA_ADVERTISED_PORT".to_string(), "9092".to_string());
         }
 
-        // Wire the in-container request log shipper (#232) to forward every
-        // request to MockForge Cloud's ingest endpoint. We only set the
-        // env vars when:
+        // Wire the in-container request log shipper (#232) and the recorder
+        // capture cloud-sync (#234 part 2) to forward to MockForge Cloud.
+        // We only set the env vars when:
         //   * a JWT secret is available (production deploys always have one)
         //   * a public ingest base URL is configured via MOCKFORGE_LOG_INGEST_BASE_URL
-        // Otherwise the shipper auto-disables and the deployment runs
-        // without structured request log capture — same behaviour as before
-        // this issue.
+        // Both shippers reuse the same deployment-scoped JWT — they're
+        // ingest-only, so a single token with the deployment subject
+        // suffices for both. When the base URL is absent the shippers
+        // auto-disable and the deployment runs without cloud forwarding.
         if let Ok(jwt_secret) = std::env::var("JWT_SECRET") {
             if let Ok(ingest_base) = std::env::var("MOCKFORGE_LOG_INGEST_BASE_URL") {
                 let trimmed_base = ingest_base.trim_end_matches('/');
@@ -263,7 +264,15 @@ impl DeploymentOrchestrator {
                             trimmed_base, deployment.id
                         ),
                     );
-                    env.insert("MOCKFORGE_LOG_INGEST_TOKEN".to_string(), token);
+                    env.insert("MOCKFORGE_LOG_INGEST_TOKEN".to_string(), token.clone());
+                    env.insert(
+                        "MOCKFORGE_CAPTURE_INGEST_URL".to_string(),
+                        format!(
+                            "{}/api/v1/hosted-mocks/{}/captures/ingest",
+                            trimmed_base, deployment.id
+                        ),
+                    );
+                    env.insert("MOCKFORGE_CAPTURE_INGEST_TOKEN".to_string(), token);
                 }
             }
         }

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -1308,6 +1308,161 @@ pub async fn ingest_runtime_logs(
     Ok(Json(IngestResponse { accepted }))
 }
 
+// === Capture ingest (#234 part 2) ===
+//
+// The recorder ships completed exchanges (request + response) here. The
+// wire format mirrors `mockforge_recorder::models::RecordedExchange` —
+// we duplicate just the fields rather than depend on the recorder crate
+// directly, since the registry server doesn't need any of the recorder's
+// behaviour. Both sides round-trip through serde, so renames on the
+// recorder side stay compatible as long as the JSON field names match.
+
+#[derive(Debug, Deserialize)]
+pub struct CaptureIngestRequest {
+    pub id: String,
+    pub protocol: String,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub method: String,
+    pub path: String,
+    #[serde(default)]
+    pub query_params: Option<String>,
+    pub headers: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    pub body_encoding: String,
+    #[serde(default)]
+    pub client_ip: Option<String>,
+    #[serde(default)]
+    pub trace_id: Option<String>,
+    #[serde(default)]
+    pub span_id: Option<String>,
+    #[serde(default)]
+    pub duration_ms: Option<i64>,
+    #[serde(default)]
+    pub status_code: Option<i32>,
+    #[serde(default)]
+    pub tags: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CaptureIngestResponse {
+    pub status_code: i32,
+    pub headers: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    pub body_encoding: String,
+    pub size_bytes: i64,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CaptureIngestExchange {
+    pub request: CaptureIngestRequest,
+    #[serde(default)]
+    pub response: Option<CaptureIngestResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CaptureIngestPayload {
+    pub exchanges: Vec<CaptureIngestExchange>,
+}
+
+/// Persist a batch of recorder captures shipped by an in-container
+/// `CaptureCloudSyncHandle`. Same deployment-scoped JWT contract as the
+/// log and OTLP ingest endpoints. Inserts use ON CONFLICT DO NOTHING so
+/// that re-shipped exchanges (retries, container restarts with cached
+/// buffer) don't produce duplicates.
+pub async fn ingest_runtime_captures(
+    State(state): State<AppState>,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(payload): Json<CaptureIngestPayload>,
+) -> ApiResult<Json<IngestResponse>> {
+    let auth = headers
+        .get("Authorization")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .ok_or_else(|| ApiError::InvalidRequest("Missing deployment ingest token".to_string()))?;
+
+    let token_deployment_id = mockforge_registry_core::auth::verify_deployment_ingest_token(
+        auth,
+        &state.config.jwt_secret,
+    )
+    .map_err(|e| {
+        tracing::warn!(error = %e, "Capture ingest token rejected");
+        ApiError::InvalidRequest("Invalid deployment ingest token".to_string())
+    })?;
+
+    if token_deployment_id != deployment_id {
+        return Err(ApiError::InvalidRequest(
+            "Token deployment id does not match URL path".to_string(),
+        ));
+    }
+
+    if payload.exchanges.is_empty() {
+        return Ok(Json(IngestResponse { accepted: 0 }));
+    }
+
+    // Capture rows are larger than log rows (full request + response
+    // bodies), so the cap is tighter — a runaway shipper shouldn't fill
+    // a single transaction with megabytes of payload.
+    const MAX_BATCH: usize = 100;
+    let exchanges: Vec<CaptureIngestExchange> =
+        payload.exchanges.into_iter().take(MAX_BATCH).collect();
+    let accepted = exchanges.len();
+
+    let pool = state.db.pool();
+    let mut tx = pool.begin().await.map_err(ApiError::Database)?;
+    for exchange in &exchanges {
+        let req = &exchange.request;
+        let resp = exchange.response.as_ref();
+        sqlx::query(
+            r#"
+            INSERT INTO runtime_captures (
+                deployment_id, capture_id, protocol, occurred_at, method, path,
+                query_params, request_headers, request_body, request_body_encoding,
+                client_ip, trace_id, span_id, duration_ms, status_code, tags,
+                response_status_code, response_headers, response_body,
+                response_body_encoding, response_size_bytes, response_timestamp
+            )
+            VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+                $15, $16, $17, $18, $19, $20, $21, $22
+            )
+            ON CONFLICT (deployment_id, capture_id) DO NOTHING
+            "#,
+        )
+        .bind(deployment_id)
+        .bind(&req.id)
+        .bind(&req.protocol)
+        .bind(req.timestamp)
+        .bind(&req.method)
+        .bind(&req.path)
+        .bind(req.query_params.as_ref())
+        .bind(&req.headers)
+        .bind(req.body.as_ref())
+        .bind(&req.body_encoding)
+        .bind(req.client_ip.as_ref())
+        .bind(req.trace_id.as_ref())
+        .bind(req.span_id.as_ref())
+        .bind(req.duration_ms)
+        .bind(req.status_code)
+        .bind(req.tags.as_ref())
+        .bind(resp.map(|r| r.status_code))
+        .bind(resp.map(|r| r.headers.as_str()))
+        .bind(resp.and_then(|r| r.body.as_deref()))
+        .bind(resp.map(|r| r.body_encoding.as_str()))
+        .bind(resp.map(|r| r.size_bytes))
+        .bind(resp.map(|r| r.timestamp))
+        .execute(&mut *tx)
+        .await
+        .map_err(ApiError::Database)?;
+    }
+    tx.commit().await.map_err(ApiError::Database)?;
+
+    Ok(Json(IngestResponse { accepted }))
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RuntimeRequestsQuery {
     /// Maximum entries to return. Capped at 500 server-side.

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -57,6 +57,13 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/hosted-mocks/{deployment_id}/otlp/v1/traces",
             post(handlers::otlp::ingest_traces),
         )
+        // Recorder capture ingest (#234 part 2). Same deployment-scoped JWT
+        // contract. The in-container recorder ships every completed exchange
+        // here; rows land in runtime_captures and survive container restart.
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/captures/ingest",
+            post(handlers::hosted_mocks::ingest_runtime_captures),
+        )
         // Waitlist signup (public)
         .route("/api/v1/waitlist/subscribe", post(handlers::waitlist::subscribe))
         .route("/api/v1/waitlist/unsubscribe", get(handlers::waitlist::unsubscribe))


### PR DESCRIPTION
## Summary

The recorder's local SQLite was wiped on container restart, so captures didn't survive Fly's normal lifecycle. This adds a cloud mirror: each completed exchange is shipped to MockForge Cloud and persisted in Postgres. Same architecture pattern as the log shipper (#232) and OTLP receiver (#233) — cloneable handle, non-blocking enqueue, background batcher, deployment-scoped JWT.

- Migration: \`runtime_captures\` table with idempotent ingest (UNIQUE on deployment_id+capture_id)
- New \`mockforge_recorder::cloud_sync\` module + \`Recorder::with_cloud_sync\` builder
- New ingest endpoint \`POST /api/v1/hosted-mocks/{id}/captures/ingest\` (deployment-scoped JWT)
- Orchestrator wires \`MOCKFORGE_CAPTURE_INGEST_{URL,TOKEN}\` onto new Fly machines (same JWT as the log shipper)

### Side fix

\`cli/serve.rs\` now wires \`recording_middleware\` when the recorder is enabled. Previously the API mounted but no layer actually recorded HTTP requests — so \`/api/recorder/requests\` always returned an empty list. The cloud-sync work made this gap impossible to ignore; without the middleware there's nothing to ship.

## Out of scope

- UI swap from proxy → cloud Postgres reads (proxy keeps working today)
- Capture retention worker (rows accumulate forever right now)

Both are tractable follow-ups — flagged in the issue.

## Test plan
- [x] \`cargo check / clippy / test -p mockforge-recorder\` — 233/233
- [x] \`cargo check / clippy / test -p mockforge-registry-server\` — 262/262
- [x] \`cargo check -p mockforge-cli --features recorder\`
- [x] \`cargo fmt --all --check\`
- [ ] Manual: deploy a hosted mock, send traffic, restart the machine, confirm captures still visible (post-merge)

Refs #234.