### PR TITLE
feat(http): reality-slider-driven mock/proxy switching (#222)

### DIFF
--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -201,6 +201,8 @@ pub mod proxy_server;
 pub mod quick_mock;
 /// RAG-powered AI response generation
 pub mod rag_ai_generator;
+/// Reality-slider-driven mock/proxy switching middleware (#222)
+pub mod reality_proxy;
 /// Replay listing and fixture management
 pub mod replay_listing;
 pub mod request_logging;
@@ -2602,6 +2604,29 @@ pub async fn build_router_with_chains_and_multi_tenant(
             adapter: http_adapter,
             xray_state: Some(xray_state.clone()),
         };
+
+        // Reality-driven mock/proxy middleware (#222). Must be added
+        // BEFORE the consistency layer so it ends up inner — that way
+        // each request hits consistency first (which injects UnifiedState
+        // including reality_continuum_ratio), then this middleware reads
+        // that state and either forwards to upstream or falls through to
+        // the mock chain. Activated only when MOCKFORGE_PROXY_UPSTREAM is
+        // set; absent that, the layer isn't even installed.
+        if let Some(reality_cfg) = crate::reality_proxy::RealityProxyConfig::from_env() {
+            tracing::info!(
+                upstream = %reality_cfg.upstream_base,
+                "Reality-driven proxy middleware enabled — requests will be split between mock and upstream based on reality_continuum_ratio"
+            );
+            app =
+                app.layer(axum::middleware::from_fn(
+                    move |req: axum::extract::Request, next: axum::middleware::Next| {
+                        let cfg = reality_cfg.clone();
+                        async move {
+                            crate::reality_proxy::reality_proxy_middleware(cfg, req, next).await
+                        }
+                    },
+                ));
+        }
 
         // Add consistency middleware (before other middleware to inject state early)
         let consistency_middleware_state_clone = consistency_middleware_state.clone();

--- a/crates/mockforge-http/src/reality_proxy.rs
+++ b/crates/mockforge-http/src/reality_proxy.rs
@@ -1,0 +1,280 @@
+//! Reality-slider-driven mock/proxy switching middleware (#222).
+//!
+//! When `MOCKFORGE_PROXY_UPSTREAM` is set on the process, this middleware
+//! probabilistically forwards a fraction of incoming requests to that URL
+//! based on the active workspace's `reality_continuum_ratio`. The fraction
+//! is per-request: ratio 0.0 = always-mock, 1.0 = always-proxy, 0.5 =
+//! coin-flip per request.
+//!
+//! ## Design
+//!
+//! The middleware is a no-op when:
+//!   - `MOCKFORGE_PROXY_UPSTREAM` is unset (e.g., local dev)
+//!   - the request has no associated `UnifiedState` extension (set by the
+//!     consistency middleware upstream of this one)
+//!   - the resolved ratio is exactly 0.0
+//!
+//! When proxying, the middleware reconstructs the request against the
+//! upstream base URL preserving method, path, query, headers, and body,
+//! then streams the upstream response back to the caller. Any failure
+//! falls through to the mock chain — the mock is the durable path; the
+//! upstream is best-effort.
+//!
+//! Wiring: insert the layer between `consistency_middleware` (which
+//! injects `UnifiedState`) and the route handlers. The dependency on
+//! `UnifiedState` is read-only, so ordering relative to recording or
+//! tracing layers doesn't matter.
+
+use axum::{
+    body::{to_bytes, Body},
+    extract::Request,
+    http::{HeaderName, HeaderValue, Method, StatusCode, Uri},
+    middleware::Next,
+    response::Response,
+};
+use mockforge_core::consistency::UnifiedState;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::warn;
+
+/// Cheap-to-clone handle holding the upstream base URL and a shared
+/// reqwest client. Constructed once at server startup; the layer closure
+/// holds an `Arc<RealityProxyConfig>` so per-request work is just an
+/// arc-clone.
+#[derive(Clone)]
+pub struct RealityProxyConfig {
+    /// Base URL — protocol + host + (optional) port, no trailing slash.
+    /// Path/query are taken from the incoming request.
+    pub upstream_base: String,
+    /// Shared HTTP client used for all upstream requests.
+    pub client: reqwest::Client,
+}
+
+impl RealityProxyConfig {
+    /// Construct from `MOCKFORGE_PROXY_UPSTREAM`. Returns None when the
+    /// env var is missing or empty (no-op middleware) or when the HTTP
+    /// client can't be built (logged as a warning).
+    pub fn from_env() -> Option<Arc<Self>> {
+        let base = std::env::var("MOCKFORGE_PROXY_UPSTREAM").ok()?;
+        let trimmed = base.trim().trim_end_matches('/');
+        if trimmed.is_empty() {
+            return None;
+        }
+        let client = match reqwest::Client::builder().timeout(Duration::from_secs(30)).build() {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "RealityProxy HTTP client init failed; middleware will no-op");
+                return None;
+            }
+        };
+        Some(Arc::new(Self {
+            upstream_base: trimmed.to_string(),
+            client,
+        }))
+    }
+}
+
+/// The middleware function. Reads `reality_continuum_ratio` from the
+/// `UnifiedState` request extension, rolls a per-request RNG, and either
+/// forwards to upstream or hands off to the next layer (mock chain).
+pub async fn reality_proxy_middleware(
+    config: Arc<RealityProxyConfig>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let ratio = req
+        .extensions()
+        .get::<UnifiedState>()
+        .map(|s| s.reality_continuum_ratio)
+        .unwrap_or(0.0);
+
+    // Fast path: no upstream desired for this request.
+    if ratio <= 0.0 {
+        return next.run(req).await;
+    }
+
+    let should_proxy = if ratio >= 1.0 {
+        true
+    } else {
+        rand::random::<f64>() < ratio
+    };
+
+    if !should_proxy {
+        return next.run(req).await;
+    }
+
+    match forward_to_upstream(&config, req).await {
+        Ok(resp) => resp,
+        Err(err) => {
+            // We've already consumed the request body to forward it, so
+            // we can't fall back to the mock chain. Surface 502 — the
+            // alternative (silent retry / synthetic mock) would hide
+            // real upstream incidents from operators.
+            warn!(error = %err, "Reality proxy upstream request failed");
+            let body = serde_json::to_vec(&serde_json::json!({
+                "error": "reality_proxy_upstream_failed",
+                "message": err.to_string(),
+            }))
+            .unwrap_or_default();
+            let mut resp = Response::new(Body::from(body));
+            *resp.status_mut() = StatusCode::BAD_GATEWAY;
+            resp.headers_mut().insert(
+                axum::http::header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+            resp
+        }
+    }
+}
+
+async fn forward_to_upstream(
+    config: &RealityProxyConfig,
+    req: Request,
+) -> Result<Response, ProxyError> {
+    let (parts, body) = req.into_parts();
+    // Cap at 16 MiB — same as Axum's default request size limit.
+    // Anything larger and we'd be holding too much in memory for a
+    // simple proxy hop; better to fail loudly than swap-thrash.
+    const MAX_BODY: usize = 16 * 1024 * 1024;
+    let body_bytes = to_bytes(body, MAX_BODY)
+        .await
+        .map_err(|e| ProxyError::ReadBody(e.to_string()))?;
+
+    let upstream_uri = build_upstream_uri(&config.upstream_base, &parts.uri)?;
+    let method = reqwest_method(&parts.method);
+    let mut req_builder = config.client.request(method, &upstream_uri);
+
+    // Copy headers, dropping hop-by-hop / Host so reqwest sets correct ones.
+    for (name, value) in parts.headers.iter() {
+        if is_hop_by_hop(name) {
+            continue;
+        }
+        if name == axum::http::header::HOST {
+            continue;
+        }
+        req_builder = req_builder.header(name.as_str(), value);
+    }
+
+    if !body_bytes.is_empty() {
+        req_builder = req_builder.body(body_bytes);
+    }
+
+    let upstream_resp = req_builder.send().await.map_err(ProxyError::Send)?;
+    let status = upstream_resp.status();
+    let headers = upstream_resp.headers().clone();
+    let resp_bytes = upstream_resp.bytes().await.map_err(ProxyError::ReadResponse)?;
+
+    let mut response = Response::builder().status(status.as_u16());
+    {
+        let response_headers = response.headers_mut().expect("Response builder must have headers");
+        for (name, value) in headers.iter() {
+            if is_hop_by_hop_str(name.as_str()) {
+                continue;
+            }
+            if let Ok(hname) = HeaderName::from_bytes(name.as_str().as_bytes()) {
+                if let Ok(hval) = HeaderValue::from_bytes(value.as_bytes()) {
+                    response_headers.insert(hname, hval);
+                }
+            }
+        }
+        response_headers.insert(
+            HeaderName::from_static("x-mockforge-source"),
+            HeaderValue::from_static("upstream"),
+        );
+    }
+    response
+        .body(Body::from(resp_bytes))
+        .map_err(|e| ProxyError::BuildResponse(e.to_string()))
+}
+
+fn build_upstream_uri(base: &str, original: &Uri) -> Result<String, ProxyError> {
+    let path = original.path();
+    let query = original.query().map(|q| format!("?{}", q)).unwrap_or_default();
+    Ok(format!("{}{}{}", base, path, query))
+}
+
+fn reqwest_method(m: &Method) -> reqwest::Method {
+    reqwest::Method::from_bytes(m.as_str().as_bytes()).unwrap_or(reqwest::Method::GET)
+}
+
+fn is_hop_by_hop(name: &HeaderName) -> bool {
+    is_hop_by_hop_str(name.as_str())
+}
+
+fn is_hop_by_hop_str(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailers"
+            | "transfer-encoding"
+            | "upgrade"
+            | "content-length"
+    )
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ProxyError {
+    #[error("failed to read request body: {0}")]
+    ReadBody(String),
+    #[error("upstream request send failed: {0}")]
+    Send(reqwest::Error),
+    #[error("upstream response read failed: {0}")]
+    ReadResponse(reqwest::Error),
+    #[error("response build failed: {0}")]
+    BuildResponse(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_env_disabled_when_unset() {
+        std::env::remove_var("MOCKFORGE_PROXY_UPSTREAM");
+        assert!(RealityProxyConfig::from_env().is_none());
+    }
+
+    #[test]
+    fn from_env_disabled_when_blank() {
+        std::env::set_var("MOCKFORGE_PROXY_UPSTREAM", "   ");
+        assert!(RealityProxyConfig::from_env().is_none());
+        std::env::remove_var("MOCKFORGE_PROXY_UPSTREAM");
+    }
+
+    #[test]
+    fn from_env_strips_trailing_slash() {
+        std::env::set_var("MOCKFORGE_PROXY_UPSTREAM", "https://api.example.com/");
+        let cfg = RealityProxyConfig::from_env().expect("config");
+        assert_eq!(cfg.upstream_base, "https://api.example.com");
+        std::env::remove_var("MOCKFORGE_PROXY_UPSTREAM");
+    }
+
+    #[test]
+    fn build_upstream_uri_preserves_path_and_query() {
+        let base = "https://api.example.com";
+        let uri: Uri = "/users/42?role=admin".parse().unwrap();
+        let result = build_upstream_uri(base, &uri).unwrap();
+        assert_eq!(result, "https://api.example.com/users/42?role=admin");
+    }
+
+    #[test]
+    fn build_upstream_uri_no_query() {
+        let base = "https://api.example.com";
+        let uri: Uri = "/health".parse().unwrap();
+        let result = build_upstream_uri(base, &uri).unwrap();
+        assert_eq!(result, "https://api.example.com/health");
+    }
+
+    #[test]
+    fn hop_by_hop_headers_are_filtered() {
+        assert!(is_hop_by_hop_str("Connection"));
+        assert!(is_hop_by_hop_str("transfer-encoding"));
+        assert!(is_hop_by_hop_str("UPGRADE"));
+        assert!(!is_hop_by_hop_str("authorization"));
+        assert!(!is_hop_by_hop_str("x-custom-header"));
+    }
+}

--- a/crates/mockforge-registry-core/src/models/hosted_mock.rs
+++ b/crates/mockforge-registry-core/src/models/hosted_mock.rs
@@ -329,6 +329,17 @@ impl HostedMock {
             .unwrap_or_else(|| vec![Protocol::Http])
     }
 
+    /// Optional upstream URL the deployment proxies to when the reality
+    /// slider is > 0 (#222). Persisted inside `config_json` under the
+    /// `"upstream_url"` key so we don't need a schema migration.
+    /// Returns `None` when no upstream is configured — in that case the
+    /// reality slider is a no-op and responses always come from the mock.
+    pub fn upstream_url(&self) -> Option<String> {
+        self.config_json
+            .get("upstream_url")
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+    }
+
     /// Compute the Fly.io app name used at deploy time.
     ///
     /// Mirrors the format built in

--- a/crates/mockforge-registry-server/src/deployment/orchestrator.rs
+++ b/crates/mockforge-registry-server/src/deployment/orchestrator.rs
@@ -294,6 +294,15 @@ impl DeploymentOrchestrator {
             }
         }
 
+        // Reality-driven proxy upstream (#222). When set, the deployed
+        // mockforge-cli's `reality_proxy` middleware forwards a per-request
+        // probabilistic share of traffic to this URL based on the
+        // workspace's reality_continuum_ratio. Unset = always-mock,
+        // current behaviour preserved.
+        if let Some(upstream) = deployment.upstream_url() {
+            env.insert("MOCKFORGE_PROXY_UPSTREAM".to_string(), upstream);
+        }
+
         // Use MockForge Docker image
         let image = std::env::var("MOCKFORGE_DOCKER_IMAGE")
             .unwrap_or_else(|_| "ghcr.io/saasy-solutions/mockforge:latest".to_string());

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -131,19 +131,27 @@ pub async fn create_deployment(
         )));
     }
 
-    // Persist enabled protocols into the deployment's config_json so the
-    // orchestrator can read them when building the Fly machine. Done as an
-    // additive merge to preserve any keys the caller already supplied.
+    // Persist enabled protocols and upstream_url into the deployment's
+    // config_json so the orchestrator can read them when building the
+    // Fly machine. Additive merge preserves any keys the caller supplied.
     let mut config_json = request.config_json.clone();
+    if !config_json.is_object() {
+        config_json = serde_json::json!({});
+    }
     if let Some(obj) = config_json.as_object_mut() {
         obj.insert(
             "enabled_protocols".to_string(),
             serde_json::to_value(&enabled_protocols).unwrap_or(serde_json::Value::Null),
         );
-    } else {
-        // Caller passed a non-object (e.g. null) — replace with a fresh
-        // object that only carries the protocol list.
-        config_json = serde_json::json!({ "enabled_protocols": enabled_protocols });
+        if let Some(upstream) = request.upstream_url.as_ref() {
+            let trimmed = upstream.trim();
+            if !trimmed.is_empty() {
+                obj.insert(
+                    "upstream_url".to_string(),
+                    serde_json::Value::String(trimmed.to_string()),
+                );
+            }
+        }
     }
 
     // Create deployment record
@@ -2342,6 +2350,12 @@ pub struct CreateDeploymentRequest {
     /// Persisted into `config_json["enabled_protocols"]`.
     #[serde(default)]
     pub enabled_protocols: Option<Vec<crate::models::Protocol>>,
+    /// Optional upstream URL the deployment proxies to when the reality
+    /// slider is > 0 (#222). When unset, the slider is a no-op and
+    /// responses always come from the mock. Persisted into
+    /// `config_json["upstream_url"]`.
+    #[serde(default)]
+    pub upstream_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
@@ -180,6 +180,7 @@ export const HostedMocksPage: React.FC = () => {
     description: '',
     config_json: '{}',
     openapi_spec_url: '',
+    upstream_url: '',
     region: 'iad',
     project_id: '',
   });
@@ -504,6 +505,7 @@ export const HostedMocksPage: React.FC = () => {
         description: formData.description || undefined,
         config_json: configJson,
         openapi_spec_url: formData.openapi_spec_url || undefined,
+        upstream_url: formData.upstream_url.trim() || undefined,
         region: formData.region || undefined,
         project_id: formData.project_id || undefined,
         enabled_protocols: enabledProtocols,
@@ -541,6 +543,7 @@ export const HostedMocksPage: React.FC = () => {
         description: '',
         config_json: '{}',
         openapi_spec_url: '',
+        upstream_url: '',
         region: 'iad',
         project_id: '',
       });
@@ -1180,6 +1183,16 @@ export const HostedMocksPage: React.FC = () => {
                 />
               </Button>
             </Box>
+
+            <TextField
+              label="Upstream URL (optional)"
+              fullWidth
+              value={formData.upstream_url}
+              onChange={(e) => setFormData({ ...formData, upstream_url: e.target.value })}
+              placeholder="https://api.production.example.com"
+              helperText="When set, the reality slider on the deployment will probabilistically forward requests to this URL. Leave blank for always-mock behavior."
+              sx={{ mb: 2 }}
+            />
 
             <Box sx={{ mb: 2 }}>
               <Typography variant="subtitle2" sx={{ mb: 0.5 }}>


### PR DESCRIPTION
## Summary

Closes the last functional gap the original audit flagged. \`reality_continuum_ratio\` existed in unified state, the consistency middleware decorated response headers with it — but **nothing consumed it**. The slider was inert.

This wires it end-to-end:

\`\`\`
ratio == 0.0  → always mock (fast path, no RNG roll)
ratio == 1.0  → always proxy to upstream
0 < r < 1.0   → coin-flip per request, P(proxy) = r
\`\`\`

### Pieces

- **Model**: \`HostedMock::upstream_url()\` reads from \`config_json["upstream_url"]\` (JSONB pattern, no migration)
- **API**: \`CreateDeploymentRequest.upstream_url: Option<String>\`
- **Orchestrator**: passes the value as \`MOCKFORGE_PROXY_UPSTREAM\` env on the Fly machine
- **HTTP middleware**: new \`mockforge-http::reality_proxy\` layered between consistency (outer) and routes (inner); only installed when the env var is set, so local / self-hosted runs are unchanged
- **UI**: "Upstream URL (optional)" field on the create dialog with helper text explaining the slider relationship

### Failure mode

On upstream send/read failure → 502 with a JSON error body. We can't fall back to mock once the body's been consumed; silent retry would hide upstream incidents. Responses include \`X-MockForge-Source: upstream\` so operators can tell which path served a given request from outside the system.

## Test plan
- [x] \`cargo check / clippy / test -p mockforge-http\` — 6 new tests for env parsing, URI building, hop-by-hop filtering
- [x] \`cargo check / clippy / test -p mockforge-registry-server\` — 266 passed
- [x] \`cargo fmt --all --check\`
- [x] \`pnpm type-check\`
- [ ] Live: deploy a hosted mock with upstream_url set, ratio=1.0, send traffic, confirm proxied responses arrive with \`X-MockForge-Source: upstream\` (post-merge)
- [ ] Live: ratio=0.5 → roughly half upstream / half mock under load (post-merge)

Refs #222. With this, every claim from the original "what you get with a hosted mock" audit is wired through.