### PR TITLE
feat(cloud): three quick wires — chains, pipelines, response validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,11 @@ EXPOSE 3000 3001 50051 9080 1025 1883 9092 5672 9999
 ENV MOCKFORGE_LATENCY_ENABLED=true
 ENV MOCKFORGE_FAILURES_ENABLED=false
 ENV MOCKFORGE_RESPONSE_TEMPLATE_EXPAND=true
+# Enable response-side OpenAPI schema validation by default. Without this,
+# the mock can quietly drift from the contract — and that's the entire
+# value prop of running a contract-bound mock. Users who want the older
+# permissive behaviour can override with MOCKFORGE_RESPONSE_VALIDATION=0.
+ENV MOCKFORGE_RESPONSE_VALIDATION=1
 # Mark that we're running in Docker (for Admin UI host detection)
 ENV DOCKER_CONTAINER=true
 # Default Admin UI to be accessible from outside container

--- a/crates/mockforge-cli/Cargo.toml
+++ b/crates/mockforge-cli/Cargo.toml
@@ -108,6 +108,7 @@ cloud = [
     "federation",
     "tunnel",
     "vbr",
+    "pipelines",
     "ws",
     "graphql",
     "grpc",
@@ -143,7 +144,7 @@ kafka = ["mockforge-kafka", "rdkafka"]
 amqp = ["mockforge-amqp", "lapin", "futures-lite"]
 smtp = ["mockforge-smtp", "mockforge-http/smtp"]
 tcp = ["mockforge-tcp"]
-pipelines = ["dep:mockforge-pipelines"]
+pipelines = ["dep:mockforge-pipelines", "mockforge-http/pipelines"]
 tui = ["dep:mockforge-tui"]
 vue = []
 

--- a/crates/mockforge-http/src/chain_handlers.rs
+++ b/crates/mockforge-http/src/chain_handlers.rs
@@ -5,6 +5,8 @@
 
 use axum::extract::{Path, State};
 use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::Router;
 use axum::{http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -31,6 +33,21 @@ pub fn create_chain_state(
     engine: Arc<ChainExecutionEngine>,
 ) -> ChainState {
     ChainState { registry, engine }
+}
+
+/// Build the chain management router. Endpoints are mounted under
+/// `/__mockforge/chains` by the caller; the UI's `chains.ts` API client
+/// expects exactly that prefix. Kept as a free function so callers can
+/// `nest("/chains", chains_router(state))` or merge with a different
+/// prefix.
+pub fn chains_router(state: ChainState) -> Router {
+    Router::new()
+        .route("/", get(list_chains).post(create_chain))
+        .route("/{chain_id}", get(get_chain).put(update_chain).delete(delete_chain))
+        .route("/{chain_id}/execute", post(execute_chain))
+        .route("/{chain_id}/validate", post(validate_chain))
+        .route("/{chain_id}/history", get(get_chain_history))
+        .with_state(state)
 }
 
 /// Request body for executing a request chain

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -2049,6 +2049,26 @@ pub async fn build_router_with_chains_and_multi_tenant(
     // Add verification API endpoint
     app = app.merge(verification_router());
 
+    // Mount the request-chains management API at the prefix the UI's
+    // ChainsPage expects (`/__mockforge/chains/*`). Without this nest the
+    // page 404s on every call. The registry/engine are constructed from
+    // the chain_config param when supplied, otherwise from defaults.
+    {
+        use crate::chain_handlers::{chains_router, create_chain_state};
+        let chain_config = _circling_config.clone().unwrap_or_default();
+        let chain_registry = Arc::new(mockforge_core::request_chaining::RequestChainRegistry::new(
+            chain_config.clone(),
+        ));
+        let chain_engine = Arc::new(mockforge_core::chain_execution::ChainExecutionEngine::new(
+            chain_registry.clone(),
+            chain_config,
+        ));
+        app = app.nest(
+            "/__mockforge/chains",
+            chains_router(create_chain_state(chain_registry, chain_engine)),
+        );
+    }
+
     // Add OIDC well-known endpoints
     use crate::auth::oidc::oidc_router;
     app = app.merge(oidc_router());


### PR DESCRIPTION
## Summary

Audit follow-up. Three things were claimed but not reaching the hosted-mock binary or its callers:

1. **Request chains** — \`chain_handlers.rs\` had handlers but no \`Router\` and the chain_config param into \`build_router_with_chains_and_multi_tenant\` was unused (\`_circling_config\`). UI's ChainsPage 404'd. Added \`chains_router(state)\`, nested at \`/__mockforge/chains\` where the UI already calls.

2. **Pipelines** — Two-layer feature gap: \`pipelines\` not in \`cloud\` bundle, AND cli's pipelines feature didn't propagate to \`mockforge-http/pipelines\`. Fixed both.

3. **Response validation** — Existed but defaulted off. Set \`MOCKFORGE_RESPONSE_VALIDATION=1\` in the Dockerfile so the hosted mock catches contract drift out of the box. Override-able with \`=0\`.

## Test plan
- [x] \`cargo check / clippy / test -p mockforge-http\` — 580 passed
- [x] \`cargo check -p mockforge-cli --no-default-features --features cloud\`
- [x] \`cargo clippy ... --features cloud --all-targets -- -D warnings\`
- [x] \`cargo fmt --all --check\`
- [ ] Live: redeploy a hosted mock, confirm ChainsPage round-trips, confirm pipeline routes mount, confirm response-validation logs/errors on a bad response (post-merge)

This is PR 1 of 6 closing the verification gaps from the latest audit pass.