### PR TITLE
feat(hosted-mocks): state-machines tab on deployment detail dialog

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -1630,6 +1630,84 @@ async fn proxy_to_deployment_recorder(
     })
 }
 
+/// Proxy a list/get to the deployment's state-machine API. Mirrors
+/// `proxy_to_deployment_recorder` exactly — the only difference is the
+/// upstream path is `/__mockforge/api/state-machines/*`. Kept as a thin
+/// wrapper so the call sites read the same way as the recorder ones.
+async fn proxy_to_deployment_state_machines(
+    deployment: &HostedMock,
+    path_and_query: &str,
+) -> ApiResult<axum::http::Response<axum::body::Body>> {
+    let base = deployment.internal_url.as_deref().or(deployment.deployment_url.as_deref());
+    let Some(base) = base else {
+        return Err(ApiError::InvalidRequest("Deployment has no resolved URL yet".to_string()));
+    };
+    let url = format!("{}{}", base.trim_end_matches('/'), path_and_query);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("HTTP client init failed: {}", e)))?;
+
+    let resp = client.get(&url).send().await.map_err(|e| {
+        ApiError::Internal(anyhow::anyhow!("State-machine proxy fetch failed: {}", e))
+    })?;
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let body = resp.bytes().await.map_err(|e| {
+        ApiError::Internal(anyhow::anyhow!("State-machine proxy read body failed: {}", e))
+    })?;
+
+    let mut builder = axum::http::Response::builder().status(status);
+    if let Some(ct) = headers.get(axum::http::header::CONTENT_TYPE) {
+        builder = builder.header(axum::http::header::CONTENT_TYPE, ct);
+    }
+    builder.body(axum::body::Body::from(body)).map_err(|e| {
+        ApiError::Internal(anyhow::anyhow!("State-machine proxy response build failed: {}", e))
+    })
+}
+
+/// List state machines configured on a hosted-mock deployment. Proxies
+/// `GET /__mockforge/api/state-machines` on the deployed instance.
+pub async fn list_deployment_state_machines(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(deployment_id): Path<Uuid>,
+) -> ApiResult<axum::http::Response<axum::body::Body>> {
+    let deployment = check_org_access(&state, user_id, &headers, deployment_id).await?;
+    proxy_to_deployment_state_machines(&deployment, "/__mockforge/api/state-machines").await
+}
+
+/// Get a single state machine definition. Proxies the deployment's
+/// `GET /__mockforge/api/state-machines/{resource_type}`.
+pub async fn get_deployment_state_machine(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path((deployment_id, resource_type)): Path<(Uuid, String)>,
+) -> ApiResult<axum::http::Response<axum::body::Body>> {
+    let deployment = check_org_access(&state, user_id, &headers, deployment_id).await?;
+    if resource_type.contains('/') || resource_type.contains('?') || resource_type.contains('#') {
+        return Err(ApiError::InvalidRequest("Invalid resource type".to_string()));
+    }
+    let path = format!("/__mockforge/api/state-machines/{}", urlencoding::encode(&resource_type));
+    proxy_to_deployment_state_machines(&deployment, &path).await
+}
+
+/// List instances of state machines on the deployment. Proxies
+/// `GET /__mockforge/api/state-machines/instances`.
+pub async fn list_deployment_state_machine_instances(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(deployment_id): Path<Uuid>,
+) -> ApiResult<axum::http::Response<axum::body::Body>> {
+    let deployment = check_org_access(&state, user_id, &headers, deployment_id).await?;
+    proxy_to_deployment_state_machines(&deployment, "/__mockforge/api/state-machines/instances")
+        .await
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RecorderCapturesQuery {
     pub limit: Option<u32>,

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -190,6 +190,13 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/disable", post(handlers::hosted_mocks::disable_recorder))
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/clear", post(handlers::hosted_mocks::clear_recorder))
         .route("/api/v1/hosted-mocks/{deployment_id}/captures/{capture_id}/replay", post(handlers::hosted_mocks::replay_recorder_capture))
+        // State machines (cloud-side proxy to the deployed instance).
+        // Mirrors the captures pattern: read-only proxy gated by org
+        // membership; writes go via the same management API as today
+        // (the deployed instance handles auth at the org boundary).
+        .route("/api/v1/hosted-mocks/{deployment_id}/state-machines", get(handlers::hosted_mocks::list_deployment_state_machines))
+        .route("/api/v1/hosted-mocks/{deployment_id}/state-machines/instances", get(handlers::hosted_mocks::list_deployment_state_machine_instances))
+        .route("/api/v1/hosted-mocks/{deployment_id}/state-machines/{resource_type}", get(handlers::hosted_mocks::get_deployment_state_machine))
         // Trace reads (#233). The ingest endpoint stays on the public router
         // since it authenticates with the deployment-scoped token; these are
         // user-facing reads gated by org membership.

--- a/crates/mockforge-ui/ui/src/hooks/useDeploymentStateMachines.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useDeploymentStateMachines.ts
@@ -1,0 +1,128 @@
+/**
+ * Pulls state-machine definitions and instances from a hosted-mock
+ * deployment via the cloud-side proxy. Mirrors useDeploymentCaptures —
+ * polling, no SSE, since the data is small and changes infrequently
+ * relative to request traffic.
+ */
+
+import { useEffect, useState } from 'react';
+import { logger } from '@/utils/logger';
+
+export interface DeploymentStateMachineSummary {
+  resource_type: string;
+  state_count: number;
+  transition_count: number;
+  sub_scenario_count: number;
+  has_visual_layout: boolean;
+}
+
+export interface DeploymentStateMachineInstance {
+  resource_id: string;
+  resource_type: string;
+  current_state: string;
+  history_count: number;
+  state_data: Record<string, unknown>;
+}
+
+export interface UseDeploymentStateMachinesOptions {
+  enabled?: boolean;
+  intervalMs?: number;
+}
+
+export interface UseDeploymentStateMachinesReturn {
+  machines: DeploymentStateMachineSummary[];
+  instances: DeploymentStateMachineInstance[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useDeploymentStateMachines(
+  deploymentId: string | undefined,
+  options: UseDeploymentStateMachinesOptions = {},
+): UseDeploymentStateMachinesReturn {
+  const { enabled = true, intervalMs = 10000 } = options;
+
+  const [machines, setMachines] = useState<DeploymentStateMachineSummary[]>([]);
+  const [instances, setInstances] = useState<DeploymentStateMachineInstance[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refetchTick, setRefetchTick] = useState(0);
+
+  useEffect(() => {
+    if (!enabled || !deploymentId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const poll = async () => {
+      const token = localStorage.getItem('auth_token');
+      if (!token) return;
+
+      const base = `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/state-machines`;
+      setLoading(true);
+      try {
+        const [definitionsResp, instancesResp] = await Promise.all([
+          fetch(base, { headers: { Authorization: `Bearer ${token}` } }),
+          fetch(`${base}/instances`, { headers: { Authorization: `Bearer ${token}` } }),
+        ]);
+
+        if (cancelled) return;
+
+        if (definitionsResp.status === 404) {
+          // Deployment doesn't expose state-machine API yet — surface as
+          // empty rather than error.
+          setMachines([]);
+          setInstances([]);
+          setError(null);
+          return;
+        }
+
+        if (!definitionsResp.ok) {
+          throw new Error(`HTTP ${definitionsResp.status}`);
+        }
+
+        const defsData = await definitionsResp.json();
+        const machinesList: DeploymentStateMachineSummary[] = Array.isArray(defsData?.state_machines)
+          ? defsData.state_machines
+          : [];
+        setMachines(machinesList);
+
+        if (instancesResp.ok) {
+          const instData = await instancesResp.json();
+          const instancesList: DeploymentStateMachineInstance[] = Array.isArray(instData?.instances)
+            ? instData.instances
+            : [];
+          setInstances(instancesList);
+        } else {
+          setInstances([]);
+        }
+
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : 'Failed to fetch state machines';
+        setError(msg);
+        logger.warn('Deployment state machines poll failed', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void poll();
+    const handle = setInterval(poll, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [enabled, deploymentId, intervalMs, refetchTick]);
+
+  return {
+    machines,
+    instances,
+    loading,
+    error,
+    refetch: () => setRefetchTick((t) => t + 1),
+  };
+}

--- a/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/HostedMocksPage.tsx
@@ -21,6 +21,7 @@ import {
   type TraceSummary,
   type TraceSpan,
 } from '@/hooks/useDeploymentTraces';
+import { useDeploymentStateMachines } from '@/hooks/useDeploymentStateMachines';
 import {
   Box,
   Card,
@@ -333,6 +334,19 @@ export const HostedMocksPage: React.FC = () => {
   const [selectedTrace, setSelectedTrace] = useState<TraceSummary | null>(null);
   const [selectedTraceSpans, setSelectedTraceSpans] = useState<TraceSpan[]>([]);
   const [traceSpansLoading, setTraceSpansLoading] = useState(false);
+
+  // State-machine definitions + instances on the deployment, via the
+  // cloud-side proxy. Polled because the data is small and changes are
+  // user-driven (no SSE needed).
+  const {
+    machines: deploymentStateMachines,
+    instances: deploymentStateMachineInstances,
+    loading: stateMachinesLoading,
+    error: stateMachinesError,
+    refetch: refetchStateMachines,
+  } = useDeploymentStateMachines(detailsOpen ? selectedDeployment?.id : undefined, {
+    enabled: detailsOpen && !!selectedDeployment,
+  });
 
   const openTrace = useCallback(
     async (trace: TraceSummary) => {
@@ -1306,6 +1320,7 @@ export const HostedMocksPage: React.FC = () => {
                 <Tab icon={<ViewIcon />} label="Captures" />
                 <Tab icon={<ViewIcon />} label="Traces" />
                 <Tab icon={<AssessmentIcon />} label="Metrics" />
+                <Tab icon={<ViewIcon />} label="State Machines" />
               </Tabs>
 
               {detailsTab === 0 && (
@@ -2219,6 +2234,119 @@ export const HostedMocksPage: React.FC = () => {
                       </Grid>
                     </Box>
                   ) : null}
+                </Box>
+              )}
+
+              {detailsTab === 7 && (
+                <Box>
+                  <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1, flexWrap: 'wrap' }}>
+                    <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
+                      State machines configured on this deployment via the management API.
+                      Live instances reflect requests that have driven state transitions.
+                    </Typography>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={refetchStateMachines}
+                      disabled={stateMachinesLoading}
+                    >
+                      Refresh
+                    </Button>
+                  </Box>
+
+                  {stateMachinesError && (
+                    <Alert severity="warning" sx={{ mb: 2 }}>
+                      {stateMachinesError}. The state-machine API may not be available on
+                      this deployment image yet.
+                    </Alert>
+                  )}
+
+                  <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                    Definitions ({deploymentStateMachines.length})
+                  </Typography>
+                  {deploymentStateMachines.length === 0 ? (
+                    <Alert severity="info" sx={{ mb: 3 }}>
+                      No state machines defined on this deployment. Define one by POSTing
+                      to <code>/__mockforge/api/state-machines</code> against the deployment URL.
+                    </Alert>
+                  ) : (
+                    <TableContainer
+                      component={Box}
+                      sx={{ border: 1, borderColor: 'divider', borderRadius: 1, mb: 3 }}
+                    >
+                      <Table size="small">
+                        <TableHead>
+                          <TableRow>
+                            <TableCell>Resource type</TableCell>
+                            <TableCell align="right">States</TableCell>
+                            <TableCell align="right">Transitions</TableCell>
+                            <TableCell align="right">Sub-scenarios</TableCell>
+                            <TableCell>Visual layout</TableCell>
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {deploymentStateMachines.map((m) => (
+                            <TableRow key={m.resource_type} hover>
+                              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                {m.resource_type}
+                              </TableCell>
+                              <TableCell align="right">{m.state_count}</TableCell>
+                              <TableCell align="right">{m.transition_count}</TableCell>
+                              <TableCell align="right">{m.sub_scenario_count}</TableCell>
+                              <TableCell>
+                                {m.has_visual_layout ? (
+                                  <Chip label="yes" size="small" color="success" />
+                                ) : (
+                                  <Chip label="no" size="small" />
+                                )}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+
+                  <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                    Live instances ({deploymentStateMachineInstances.length})
+                  </Typography>
+                  {deploymentStateMachineInstances.length === 0 ? (
+                    <Alert severity="info">
+                      No instances yet. They appear once requests drive state transitions.
+                    </Alert>
+                  ) : (
+                    <TableContainer
+                      component={Box}
+                      sx={{ border: 1, borderColor: 'divider', borderRadius: 1 }}
+                    >
+                      <Table size="small">
+                        <TableHead>
+                          <TableRow>
+                            <TableCell>Resource ID</TableCell>
+                            <TableCell>Resource type</TableCell>
+                            <TableCell>Current state</TableCell>
+                            <TableCell align="right">History</TableCell>
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {deploymentStateMachineInstances.map((inst) => (
+                            <TableRow key={inst.resource_id} hover>
+                              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                {inst.resource_id}
+                              </TableCell>
+                              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                {inst.resource_type}
+                              </TableCell>
+                              <TableCell>
+                                <Chip label={inst.current_state} size="small" color="primary" />
+                              </TableCell>
+                              <TableCell align="right">{inst.history_count}</TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
                 </Box>
               )}
             </DialogContent>


### PR DESCRIPTION
## Summary

The standalone \`/state-machine-editor\` route existed in the UI but it talked to \`/__mockforge/api/state-machines\` on the same origin — so in the cloud admin context (where many users land first) it didn't show state machines for any specific deployed mock. The audit's PR-5 gap.

This adds a "State Machines" tab on the HostedMocksPage deployment detail dialog, fed by new cloud-side proxy endpoints. Same pattern as Captures: read-only proxy through the cloud server, gated by org membership.

\`\`\`
GET /api/v1/hosted-mocks/{id}/state-machines               → list
GET /api/v1/hosted-mocks/{id}/state-machines/instances     → list instances
GET /api/v1/hosted-mocks/{id}/state-machines/{resource_type} → detail
\`\`\`

UI: new \`useDeploymentStateMachines\` hook (polls every 10s while dialog open), new tab with two tables (definitions + live instances).

### Honest scope

Edit (POST/PUT/DELETE) intentionally not exposed via the cloud proxy yet — those mutate state and want a more careful auth design. Read-only is enough to close the "no UI surfaces it for cloud-hosted user management" gap.

## Test plan
- [x] \`cargo check / clippy / test -p mockforge-registry-server\` — 266 pass
- [x] \`pnpm type-check\`
- [x] \`cargo fmt --all --check\`
- [ ] Live: hit a deployment that has state machines defined, click the tab (post-merge)

PR 5 of 7. Only MockAI standalone endpoint left.