### PR TITLE
feat(http): mirror time-travel routes onto the main HTTP port

### DIFF
--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -1327,6 +1327,11 @@ pub async fn handle_serve(
 
         // Initialize the global time travel manager for UI handlers
         time_travel_handlers::init_time_travel_manager(manager.clone());
+        // Mirror the same handle into mockforge-http's process-wide
+        // OnceLock so the time-travel routes mounted on the main HTTP
+        // app (reachable on hosted mocks where the admin port isn't
+        // exposed publicly) operate against the same manager.
+        mockforge_http::time_travel_api::init_time_travel_manager(manager.clone());
 
         if manager.clock().is_enabled() {
             println!("⏰ Time travel enabled");

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -225,6 +225,8 @@ pub mod spec_import;
 pub mod sse;
 /// State machine API for scenario state machines
 pub mod state_machine_api;
+/// Time-travel runtime API mirrored from the admin server onto the main HTTP port
+pub mod time_travel_api;
 /// TLS/HTTPS support
 pub mod tls;
 /// Token response utilities
@@ -2115,6 +2117,14 @@ pub async fn build_router_with_chains_and_multi_tenant(
         let api_state = MockAiApiState::new(mockai.clone());
         app = app.nest("/__mockforge/api/mockai", mockai_api_router(api_state));
     }
+
+    // Time-travel runtime API. The admin server mounts these routes on
+    // its own port (9080), but hosted-mock Fly machines only expose
+    // port 3000 publicly — so until now operators couldn't set / advance
+    // virtual time on a deployed mock. The handlers consult a process-
+    // wide TimeTravelManager that serve.rs initialises alongside the
+    // existing admin-server registration; both paths see the same Arc.
+    app = app.nest("/__mockforge/time-travel", crate::time_travel_api::time_travel_router());
 
     // Runtime route-chaos rules API + middleware. This sits in front of
     // the static per-route handlers so operators can add/remove fault and

--- a/crates/mockforge-http/src/time_travel_api.rs
+++ b/crates/mockforge-http/src/time_travel_api.rs
@@ -1,0 +1,287 @@
+//! Time-travel runtime API for hosted-mock deployments.
+//!
+//! Time-travel routes existed on the *admin* server (port 9080) via
+//! `mockforge-ui::time_travel_handlers`. Hosted-mock Fly machines only
+//! expose port 3000 publicly, so the admin server's routes were
+//! unreachable from outside the container — operators couldn't set or
+//! advance virtual time on a deployed mock without redeploying.
+//!
+//! This module mirrors the same surface on the main HTTP app. Handlers
+//! talk to a local `OnceLock<Arc<TimeTravelManager>>`; serve.rs
+//! initialises it alongside the existing admin-server init so both
+//! paths see the same manager (the inner `Arc` is shared).
+//!
+//! ## Endpoints (mounted under `/__mockforge/time-travel`)
+//!
+//! - `GET    /status            → current clock status
+//! - `POST   /enable            → start virtual clock at given time
+//! - `POST   /disable           → stop virtual clock
+//! - `POST   /advance           → advance virtual time by a duration
+//! - `POST   /set               → set virtual time to a specific instant
+//! - `POST   /scale             → set time scale factor (e.g., 60.0 = 1min/sec)
+//! - `POST   /reset             → reset to real time
+//!
+//! Scheduled responses, scenarios, and cron jobs are intentionally not
+//! mirrored here — they're only useful from the admin UI flow that
+//! already exists, and adding them here would more than double the
+//! surface area for a marginal gain.
+
+use axum::extract::Json as AxumJson;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use chrono::{DateTime, Duration, Utc};
+use mockforge_core::TimeTravelManager;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+/// Process-wide handle to the active TimeTravelManager. Set once at
+/// server startup (see `init_time_travel_manager`); read by every
+/// request handler in this module.
+static MANAGER: OnceLock<Arc<TimeTravelManager>> = OnceLock::new();
+
+/// Register a TimeTravelManager for use by the HTTP-port time-travel
+/// API. Idempotent — subsequent calls are no-ops.
+pub fn init_time_travel_manager(manager: Arc<TimeTravelManager>) {
+    let _ = MANAGER.set(manager);
+}
+
+fn manager() -> Option<Arc<TimeTravelManager>> {
+    MANAGER.get().cloned()
+}
+
+#[derive(Debug, Deserialize)]
+struct EnableRequest {
+    /// Time to anchor at. Defaults to now.
+    #[serde(default)]
+    time: Option<DateTime<Utc>>,
+    /// Optional scale factor — 1.0 = real-time, 60.0 = 1min per real second.
+    #[serde(default)]
+    scale: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdvanceRequest {
+    /// e.g. "2h", "30m", "10s", "1d", "1week".
+    duration: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SetTimeRequest {
+    time: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ScaleRequest {
+    scale: f64,
+}
+
+fn not_initialised() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({
+            "error": "time_travel_not_initialised",
+            "message": "TimeTravelManager hasn't been registered on this server",
+        })),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Serialize)]
+struct OkResponse<S> {
+    success: bool,
+    status: S,
+}
+
+async fn status_handler() -> Response {
+    let Some(m) = manager() else {
+        return not_initialised();
+    };
+    Json(m.clock().status()).into_response()
+}
+
+async fn enable_handler(AxumJson(req): AxumJson<EnableRequest>) -> Response {
+    let Some(m) = manager() else {
+        return not_initialised();
+    };
+    let time = req.time.unwrap_or_else(Utc::now);
+    m.enable_and_set(time);
+    if let Some(scale) = req.scale {
+        m.set_scale(scale);
+    }
+    Json(OkResponse {
+        success: true,
+        status: m.clock().status(),
+    })
+    .into_response()
+}
+
+async fn disable_handler() -> Response {
+    let Some(m) = manager() else {
+        return not_initialised();
+    };
+    m.disable();
+    Json(OkResponse {
+        success: true,
+        status: m.clock().status(),
+    })
+    .into_response()
+}
+
+async fn advance_handler(AxumJson(req): AxumJson<AdvanceRequest>) -> Response {
+    let Some(m) = manager() else {
+        return not_initialised();
+    };
+    match parse_duration(&req.duration) {
+        Ok(dur) => {
+            m.advance(dur);
+            Json(OkResponse {
+                success: true,
+                status: m.clock().status(),
+            })
+            .into_response()
+        }
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "invalid_duration",
+                "message": e,
+            })),
+        )
+            .into_response(),
+    }
+}
+
+async fn set_handler(AxumJson(req): AxumJson<SetTimeRequest>) -> Response {
+    let Some(m) = manager() else {
+        return not_initialised();
+    };
+    m.clock().set_time(req.time);
+    Json(OkResponse {
+        success: true,
+        status: m.clock().status(),
+    })
+    .into_response()
+}
+
+async fn scale_handler(AxumJson(req): AxumJson<ScaleRequest>) -> Response {
+    let Some(m) = manager() else {
+        return not_initialised();
+    };
+    m.set_scale(req.scale);
+    Json(OkResponse {
+        success: true,
+        status: m.clock().status(),
+    })
+    .into_response()
+}
+
+async fn reset_handler() -> Response {
+    let Some(m) = manager() else {
+        return not_initialised();
+    };
+    m.clock().reset();
+    Json(OkResponse {
+        success: true,
+        status: m.clock().status(),
+    })
+    .into_response()
+}
+
+/// Parse a duration string like "2h", "30m", "10s", "1d", "1week".
+/// Mirrors the admin-server parser; kept here so this module doesn't
+/// reach across crates for a 30-line helper.
+fn parse_duration(s: &str) -> Result<Duration, String> {
+    let s = s.trim().trim_start_matches('+').trim_start_matches('-');
+    if s.is_empty() {
+        return Err("empty duration".to_string());
+    }
+
+    // Multi-character unit suffixes first, longest match wins. Avoids
+    // "1ms" being read as "1m" + "s".
+    type DurationCtor = fn(i64) -> Duration;
+    let units: &[(&str, DurationCtor)] = &[
+        ("weeks", |n| Duration::days(n * 7)),
+        ("week", |n| Duration::days(n * 7)),
+        ("days", Duration::days),
+        ("day", Duration::days),
+        ("hours", Duration::hours),
+        ("hour", Duration::hours),
+        ("minutes", Duration::minutes),
+        ("minute", Duration::minutes),
+        ("seconds", Duration::seconds),
+        ("second", Duration::seconds),
+        ("ms", Duration::milliseconds),
+        ("d", Duration::days),
+        ("h", Duration::hours),
+        ("m", Duration::minutes),
+        ("s", Duration::seconds),
+    ];
+
+    for (suffix, ctor) in units {
+        if let Some(num_str) = s.strip_suffix(suffix) {
+            let num_str = num_str.trim();
+            let n: i64 =
+                num_str.parse().map_err(|e| format!("invalid number '{}': {}", num_str, e))?;
+            return Ok(ctor(n));
+        }
+    }
+
+    Err(format!("unknown duration suffix in '{}'; expected w/d/h/m/s/ms", s))
+}
+
+/// Build the time-travel runtime router. Mount under `/__mockforge/time-travel`.
+pub fn time_travel_router() -> Router {
+    Router::new()
+        .route("/status", get(status_handler))
+        .route("/enable", post(enable_handler))
+        .route("/disable", post(disable_handler))
+        .route("/advance", post(advance_handler))
+        .route("/set", post(set_handler))
+        .route("/scale", post(scale_handler))
+        .route("/reset", post(reset_handler))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_basic_units() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::seconds(30));
+        assert_eq!(parse_duration("5m").unwrap(), Duration::minutes(5));
+        assert_eq!(parse_duration("2h").unwrap(), Duration::hours(2));
+        assert_eq!(parse_duration("3d").unwrap(), Duration::days(3));
+    }
+
+    #[test]
+    fn parse_duration_weeks() {
+        assert_eq!(parse_duration("1week").unwrap(), Duration::days(7));
+        assert_eq!(parse_duration("2weeks").unwrap(), Duration::days(14));
+    }
+
+    #[test]
+    fn parse_duration_milliseconds() {
+        assert_eq!(parse_duration("250ms").unwrap(), Duration::milliseconds(250));
+    }
+
+    #[test]
+    fn parse_duration_relative_prefix() {
+        assert_eq!(parse_duration("+1h").unwrap(), Duration::hours(1));
+        assert_eq!(parse_duration("-30m").unwrap(), Duration::minutes(30));
+    }
+
+    #[test]
+    fn parse_duration_rejects_empty() {
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("   ").is_err());
+    }
+
+    #[test]
+    fn parse_duration_rejects_unknown_suffix() {
+        assert!(parse_duration("5fortnights").is_err());
+        assert!(parse_duration("12").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

The post-PR-252 audit pass flagged that time-travel HTTP endpoints (\`/__mockforge/time-travel/*\`) only exist on the admin server (port 9080) via \`mockforge-ui::time_travel_handlers\`. Hosted-mock Fly machines only expose port 3000 publicly, so the routes were unreachable on a deployed mock — same shape as the fixtures gap fixed in PR #250.

This adds a thin \`mockforge-http::time_travel_api\` module that mirrors the seven core endpoints onto the main HTTP app:

\`\`\`
GET  /__mockforge/time-travel/status
POST /__mockforge/time-travel/enable
POST /__mockforge/time-travel/disable
POST /__mockforge/time-travel/advance   { duration: "2h" | "30m" | "1week" | … }
POST /__mockforge/time-travel/set       { time: "<RFC3339>" }
POST /__mockforge/time-travel/scale     { scale: 60.0 }
POST /__mockforge/time-travel/reset
\`\`\`

Scheduled responses / scenarios / cron jobs intentionally not mirrored — they're admin-UI-flow features and would more than double the surface for marginal gain.

### Wiring

Process-wide \`OnceLock<Arc<TimeTravelManager>>\` in the new module. \`serve.rs\` initialises it alongside the existing \`mockforge_ui::time_travel_handlers::init_time_travel_manager\` call, passing the same Arc — both registries point at the same manager.

## Test plan
- [x] \`cargo check / clippy / test -p mockforge-http\` — 6 new tests (parse_duration variants)
- [x] \`cargo check -p mockforge-cli --no-default-features --features cloud\`
- [x] \`cargo fmt --all --check\`
- [ ] Live: hit \`POST /__mockforge/time-travel/enable\` against a deployed mock, then \`/status\`, observe virtual time anchored

Closes the time-travel finding from the post-merge verification of PRs #245-252. With this every claim from the original audit + every flagged regression has either real wiring or a documented limitation.