### PR TITLE
ci: add concurrency groups + drop redundant push-on-main triggers

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,6 +12,12 @@ on:
       - main
   workflow_dispatch:
 
+# Push-on-main retained — it updates .github/benchmarks/baseline.json.
+# Concurrency keys are GitHub-internal context (not user-supplied), safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   REGRESSION_THRESHOLD: 5.0

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -7,6 +7,11 @@ on:
       - 'specs/**'
       - 'openapi.yaml'
 
+# Concurrency keys are GitHub-internal context, safe to interpolate.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-breaking-changes:
     runs-on: [self-hosted, linux, x64, rust]

--- a/.github/workflows/chaos-testing.yml
+++ b/.github/workflows/chaos-testing.yml
@@ -23,6 +23,12 @@ on:
         required: false
         default: '300'
 
+# If a cron tick fires while the previous tick is still running, supersede the
+# older one — the input is just "latest main", no value in running both.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   MOCKFORGE_CHAOS_ENABLED: true

--- a/.github/workflows/contract-diff.yml
+++ b/.github/workflows/contract-diff.yml
@@ -9,13 +9,6 @@ on:
       - 'crates/mockforge-core/src/ai_contract_diff/**'
       - 'crates/mockforge-cli/src/contract_diff_commands.rs'
       - '.github/workflows/contract-diff.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - '**/*.yaml'
-      - '**/*.yml'
-      - '**/*.json'
   workflow_dispatch:
     inputs:
       spec_path:
@@ -36,6 +29,12 @@ on:
           - anthropic
           - ollama
           - openai-compatible
+
+# Push-on-main trigger removed: PR run already verifies the change. Only
+# GitHub-internal context is interpolated below (workflow / ref / event_name).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,12 @@ on:
       - '.github/workflows/docker-build.yml'
   workflow_dispatch:
 
+# Push-on-main retained — publishes the GHCR image. Concurrency keys are
+# GitHub-internal context (not user-supplied), safe to interpolate.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
   # Must be lowercase for Docker image references

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -6,15 +6,13 @@ on:
       - 'book/**'
       - 'scripts/automated-tests/test-docs.sh'
       - '.github/workflows/docs-check.yml'
-  push:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'book/**'
-      - 'scripts/automated-tests/test-docs.sh'
-      - '.github/workflows/docs-check.yml'
   workflow_dispatch:
+
+# Push-on-main trigger removed: PR run already verifies the change. Only
+# GitHub-internal context is interpolated below (workflow / ref / event_name).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,6 +11,12 @@ on:
         required: false
         default: '300'
 
+# If a cron tick fires while the previous tick is still running, supersede the
+# older one — the input is just "latest main", no value in running both.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/jcs-fuzz.yml
+++ b/.github/workflows/jcs-fuzz.yml
@@ -20,6 +20,12 @@ on:
         required: false
         default: '10000'
 
+# If a cron tick fires while the previous tick is still running, supersede the
+# older one — the input is just "latest main", no value in running both.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -7,12 +7,13 @@ on:
       - 'k8s/**'
       - 'helm/**'
       - '.github/workflows/k8s-tests.yml'
-  push:
-    branches: [main, develop]
-    paths:
-      - 'k8s/**'
-      - 'helm/**'
   workflow_dispatch:
+
+# Push-on-main trigger removed: PR run already verifies the change. Only
+# GitHub-internal context is interpolated below (workflow / ref / event_name).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate-manifests:

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -29,6 +29,12 @@ on:
           - extended
           - stress
 
+# Push-on-main retained — Extended Load Test + Performance Benchmarks gate on
+# refs/heads/main. Concurrency keys are GitHub-internal context, safe to interpolate.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   standard-load-test:
     name: Standard Load Test

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -15,6 +15,12 @@ on:
         required: false
         default: '60'
 
+# If a cron tick fires while the previous tick is still running, supersede the
+# older one — the input is just "latest main", no value in running both.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/npm-publish-sdk.yml
+++ b/.github/workflows/npm-publish-sdk.yml
@@ -26,6 +26,11 @@ on:
         default: 'false'
         type: boolean
 
+# Serialize publishes — never abort an in-flight release mid-publish.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -17,6 +17,11 @@ on:
         type: boolean
         default: false
 
+# Serialize publishes — never abort an in-flight release mid-publish.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   MOCKFORGE_REGISTRY_URL: ${{ secrets.MOCKFORGE_REGISTRY_URL || 'https://registry.mockforge.dev' }}
   MOCKFORGE_REGISTRY_TOKEN: ${{ secrets.MOCKFORGE_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*.*.*'
 
+# Serialize releases — never abort an in-flight release mid-publish.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary

Fixes the queue-pile-up that left the `Deploy Admin UI` workflow run from #255 sitting behind 50+ stale runs (already-merged PR branches, superseded main commits, scheduled cron ticks layered on top of push runs). Three patterns drove the backlog:

1. **`pull_request` + `push` double-fire on merge** — 11 of 19 workflows triggered on both, so every merge effectively doubled the queue load. For pure-test workflows the post-merge push run is redundant; the PR run already gated the change.
2. **No `concurrency:` group on 14 of 19 workflows** — without one, queued PR runs from days ago never got superseded. We had `Load Testing` runs queued for already-merged PRs from a week prior.
3. **Schedule + push pile-up on heavyweights** — `load-testing`, `fuzz`, `jcs-fuzz`, `mutation-testing`, `chaos-testing` all run on cron AND push, with no group key keeping older ticks from queueing on top of newer ones.

## Changes per workflow

| Workflow | Change |
|---|---|
| `contract-diff`, `docs-check`, `k8s-tests` | Drop `push: branches: [main]` (PR run is the gate). Add `concurrency: cancel-in-progress: ${{ event_name == 'pull_request' }}`. |
| `benchmarks` | **Keep** push-on-main (it updates `.github/benchmarks/baseline.json`). Add same concurrency block. |
| `load-testing` | **Keep** push-on-main (Extended Load Test + Performance Benchmarks gate on `refs/heads/main`). Add same concurrency block. |
| `docker-build` | **Keep** push-on-main (publishes the GHCR image on main and tags). Add same concurrency block. |
| `breaking-changes` | PR-only, just adds concurrency with `cancel-in-progress: true`. |
| `chaos-testing`, `fuzz`, `jcs-fuzz`, `mutation-testing` | Schedule-only — add `concurrency: { group: ${{ github.workflow }}, cancel-in-progress: true }` so overlapping cron ticks supersede the older one (the input is just "latest main", no value running both). |
| `release`, `npm-publish-sdk`, `plugin-publish` | Add `concurrency: { group: ${{ github.workflow }}, cancel-in-progress: false }` — serialize publishes, never abort an in-flight release. |

## Why some workflows keep push-on-main

Three cases where `push:` to main is load-bearing and must stay:
- `benchmarks.yml` — the post-merge run saves a new baseline.json which subsequent PRs compare against.
- `load-testing.yml` — `Extended Load Test` and `Performance Benchmarks` jobs are gated on `refs/heads/main` and skip on PR.
- `docker-build.yml` — push to main publishes the GHCR image (`ghcr.io/saasy-solutions/mockforge`).

## Security / interpolation note

All concurrency expressions use GitHub-internal context only (`github.workflow`, `github.ref`, `github.event_name`). No untrusted event input is interpolated into shell commands.

## Test plan

- [ ] CI green on this PR (validates the YAML parses + workflows still execute).
- [ ] After merge, observe that the queue drains faster on the next PR cycle (push-on-main no longer fires for `contract-diff`, `docs-check`, `k8s-tests`).
- [ ] After the next push to a PR branch, observe that the prior queued/running run for the same workflow gets cancelled instead of accumulating.