### PR TITLE
fix(ui): register Tailwind v4 utilities for custom palettes

### DIFF
--- a/crates/mockforge-ui/ui/src/components/ai/ApiCritique.tsx
+++ b/crates/mockforge-ui/ui/src/components/ai/ApiCritique.tsx
@@ -233,10 +233,24 @@ export function ApiCritique({ onUsageUpdate }: ApiCritiqueProps) {
     }
   };
 
+  const getSeverityBadgeClasses = (severity: string) => {
+    switch (severity.toLowerCase()) {
+      case 'critical':
+        return 'text-red-600 dark:text-red-400 bg-red-600/10';
+      case 'high':
+        return 'text-orange-600 dark:text-orange-400 bg-orange-600/10';
+      case 'medium':
+        return 'text-yellow-600 dark:text-yellow-400 bg-yellow-600/10';
+      case 'low':
+        return 'text-blue-600 dark:text-blue-400 bg-blue-600/10';
+      default:
+        return 'text-gray-600 dark:text-gray-400 bg-gray-600/10';
+    }
+  };
+
   const getSeverityBadge = (severity: string) => {
-    const color = getSeverityColor(severity);
     return (
-      <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${color} bg-opacity-10`}>
+      <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getSeverityBadgeClasses(severity)}`}>
         {severity.toUpperCase()}
       </span>
     );

--- a/crates/mockforge-ui/ui/src/components/ui/IconSystem.tsx
+++ b/crates/mockforge-ui/ui/src/components/ui/IconSystem.tsx
@@ -74,7 +74,7 @@ export const iconColors = {
   success: 'text-success',
   warning: 'text-warning',
   danger: 'text-danger',
-  muted: 'text-tertiary',
+  muted: 'text-text-tertiary',
 } as const;
 
 interface IconProps {

--- a/crates/mockforge-ui/ui/src/components/ui/ResponsiveTable.tsx
+++ b/crates/mockforge-ui/ui/src/components/ui/ResponsiveTable.tsx
@@ -183,7 +183,7 @@ function DesktopTable<T>({
               <th
                 key={column.key}
                 className={cn(
-                  'px-6 py-3 text-left text-xs font-medium text-tertiary uppercase tracking-wider',
+                  'px-6 py-3 text-left text-xs font-medium text-text-tertiary uppercase tracking-wider',
                   column.width && `w-[${column.width}]`,
                   column.minWidth && `min-w-[${column.minWidth}]`,
                   sortable && column.sortable && 'cursor-pointer hover:text-primary transition-colors'

--- a/crates/mockforge-ui/ui/src/components/ui/Section.tsx
+++ b/crates/mockforge-ui/ui/src/components/ui/Section.tsx
@@ -21,7 +21,7 @@ export function Section({
       {(title || subtitle || actions) && (
         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-5">
           <div>
-            {title && <h2 className="text-h2">{title}</h2>}
+            {title && <h2 className="text-2xl font-semibold">{title}</h2>}
             {subtitle && <p className="text-gray-600 dark:text-gray-400 mt-1">{subtitle}</p>}
           </div>
           {actions && <div>{actions}</div>}

--- a/crates/mockforge-ui/ui/src/components/ui/StatusBadge.tsx
+++ b/crates/mockforge-ui/ui/src/components/ui/StatusBadge.tsx
@@ -70,7 +70,6 @@ export function StatusBadge({ status, className, showDot = true, size = 'md' }: 
         cfg.color,
         cfg.ring,
         sizes[size],
-        'dark:ring-opacity-20',
         className
       )}
       role="status"

--- a/crates/mockforge-ui/ui/src/components/ui/design-system/ContextMenu.tsx
+++ b/crates/mockforge-ui/ui/src/components/ui/design-system/ContextMenu.tsx
@@ -22,7 +22,7 @@ export function ContextMenu({ children, items, position, onClose }: ContextMenuP
         onClick={onClose}
       />
       <div
-        className="absolute z-50 min-w-48 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 py-1"
+        className="absolute z-50 min-w-48 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black/5 py-1"
         style={{ left: position.x, top: position.y }}
       >
         {items.map((item, index) => (

--- a/crates/mockforge-ui/ui/src/components/ui/design-system/Dialog.tsx
+++ b/crates/mockforge-ui/ui/src/components/ui/design-system/Dialog.tsx
@@ -13,7 +13,7 @@ export function Dialog({ open, onOpenChange, children }: DialogProps) {
   return (
     <>
       <div
-        className="fixed inset-0 bg-black bg-opacity-50 z-40"
+        className="fixed inset-0 bg-black/50 z-40"
         onClick={() => onOpenChange(false)}
       />
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">

--- a/crates/mockforge-ui/ui/src/components/ui/design-system/FormControls.tsx
+++ b/crates/mockforge-ui/ui/src/components/ui/design-system/FormControls.tsx
@@ -17,7 +17,7 @@ export function Input({ className, size = 'md', ...props }: InputProps) {
     <input
       className={cn(
         'w-full rounded-xl border-2 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
-        'text-primary placeholder-tertiary',
+        'text-text-primary placeholder:text-text-tertiary',
         'focus:border-brand focus:outline-none focus:ring-4 focus:ring-brand/20',
         'hover:border-gray-300 dark:hover:border-gray-600',
         'transition-all duration-200 ease-out',
@@ -46,7 +46,7 @@ export function Textarea({ className, size = 'md', ...props }: TextareaProps) {
     <textarea
       className={cn(
         'w-full rounded-xl border-2 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
-        'text-primary placeholder-tertiary',
+        'text-text-primary placeholder:text-text-tertiary',
         'focus:border-brand focus:outline-none focus:ring-4 focus:ring-brand/20',
         'hover:border-gray-300 dark:hover:border-gray-600',
         'transition-all duration-200 ease-out',
@@ -79,7 +79,7 @@ export function Select({ className, size = 'md', children, ...props }: SelectPro
     <select
       className={cn(
         'w-full rounded-xl border-2 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
-        'text-primary',
+        'text-text-primary',
         'focus:border-brand focus:outline-none focus:ring-4 focus:ring-brand/20',
         'hover:border-gray-300 dark:hover:border-gray-600',
         'transition-all duration-200 ease-out',

--- a/crates/mockforge-ui/ui/src/components/ui/design-system/Modal.tsx
+++ b/crates/mockforge-ui/ui/src/components/ui/design-system/Modal.tsx
@@ -22,7 +22,7 @@ export function Modal({ open, onClose, onOpenChange, title, children, className 
   return (
     <>
       <div
-        className="fixed inset-0 bg-black bg-opacity-50 z-40"
+        className="fixed inset-0 bg-black/50 z-40"
         onClick={handleClose}
       />
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">

--- a/crates/mockforge-ui/ui/src/index.css
+++ b/crates/mockforge-ui/ui/src/index.css
@@ -22,6 +22,67 @@
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
+
+  /* Background and text hierarchy — referenced as bg-bg-* / text-text-* across
+     the UI (Dialog, Card, Tabs, ThemeToggle, etc.). Without these mappings
+     Tailwind v4 emits no utility class and the elements render transparent. */
+  --color-bg-primary: hsl(var(--bg-primary));
+  --color-bg-secondary: hsl(var(--bg-secondary));
+  --color-bg-tertiary: hsl(var(--bg-tertiary));
+  --color-bg-overlay: hsl(var(--bg-overlay));
+  --color-text-primary: hsl(var(--text-primary));
+  --color-text-secondary: hsl(var(--text-secondary));
+  --color-text-tertiary: hsl(var(--text-tertiary));
+  --color-text-inverse: hsl(var(--text-inverse));
+
+  /* Brand and status palettes — referenced via bg-brand-*, text-success-*,
+     border-danger-*, ring-warning-*, etc. Light/dark swap is driven by the
+     :root/.dark variable definitions below. */
+  --color-brand: hsl(var(--brand));
+  --color-brand-50: hsl(var(--brand-50));
+  --color-brand-100: hsl(var(--brand-100));
+  --color-brand-200: hsl(var(--brand-200));
+  --color-brand-300: hsl(var(--brand-300));
+  --color-brand-400: hsl(var(--brand-400));
+  --color-brand-500: hsl(var(--brand-500));
+  --color-brand-600: hsl(var(--brand-600));
+  --color-brand-700: hsl(var(--brand-700));
+  --color-brand-800: hsl(var(--brand-800));
+  --color-brand-900: hsl(var(--brand-900));
+
+  --color-success: hsl(var(--success));
+  --color-success-50: hsl(var(--success-50));
+  --color-success-100: hsl(var(--success-100));
+  --color-success-400: hsl(var(--success-400));
+  --color-success-500: hsl(var(--success-500));
+  --color-success-600: hsl(var(--success-600));
+  --color-success-700: hsl(var(--success-700));
+  --color-success-900: hsl(var(--success-900));
+
+  --color-warning: hsl(var(--warning));
+  --color-warning-50: hsl(var(--warning-50));
+  --color-warning-100: hsl(var(--warning-100));
+  --color-warning-400: hsl(var(--warning-400));
+  --color-warning-500: hsl(var(--warning-500));
+  --color-warning-600: hsl(var(--warning-600));
+  --color-warning-900: hsl(var(--warning-900));
+
+  --color-danger: hsl(var(--danger));
+  --color-danger-50: hsl(var(--danger-50));
+  --color-danger-100: hsl(var(--danger-100));
+  --color-danger-400: hsl(var(--danger-400));
+  --color-danger-500: hsl(var(--danger-500));
+  --color-danger-600: hsl(var(--danger-600));
+  --color-danger-700: hsl(var(--danger-700));
+  --color-danger-900: hsl(var(--danger-900));
+
+  --color-info: hsl(var(--info));
+  --color-info-50: hsl(var(--info-50));
+  --color-info-100: hsl(var(--info-100));
+  --color-info-400: hsl(var(--info-400));
+  --color-info-500: hsl(var(--info-500));
+  --color-info-600: hsl(var(--info-600));
+  --color-info-900: hsl(var(--info-900));
 }
 
 /* Modern design tokens via CSS variables */
@@ -62,33 +123,49 @@
     --brand: 24 86% 42%;
     --brand-50: 24 100% 97%;
     --brand-100: 24 95% 92%;
+    --brand-200: 24 90% 84%;
+    --brand-300: 24 85% 70%;
+    --brand-400: 24 85% 55%;
     --brand-500: 24 86% 42%;
     --brand-600: 24 88% 36%;
+    --brand-700: 24 92% 30%;
+    --brand-800: 24 95% 24%;
+    --brand-900: 24 98% 18%;
 
     /* Enhanced Status Colors - WCAG AA Compliant */
     --success: 142 76% 36%;
     --success-50: 142 100% 97%;
     --success-100: 142 90% 92%;
+    --success-400: 142 70% 45%;
     --success-500: 142 76% 36%;
     --success-600: 142 78% 32%;
+    --success-700: 142 80% 26%;
+    --success-900: 142 85% 14%;
 
     --warning: 42 96% 50%;
     --warning-50: 42 100% 96%;
     --warning-100: 42 95% 90%;
+    --warning-400: 42 96% 60%;
     --warning-500: 42 96% 50%;
     --warning-600: 42 98% 45%;
+    --warning-900: 42 95% 18%;
 
     --danger: 0 84% 50%;
     --danger-50: 0 100% 97%;
     --danger-100: 0 95% 92%;
+    --danger-400: 0 84% 60%;
     --danger-500: 0 84% 50%;
     --danger-600: 0 86% 45%;
+    --danger-700: 0 86% 38%;
+    --danger-900: 0 80% 18%;
 
     --info: 217 91% 60%;
     --info-50: 217 100% 97%;
     --info-100: 217 95% 92%;
+    --info-400: 217 91% 70%;
     --info-500: 217 91% 60%;
     --info-600: 217 93% 55%;
+    --info-900: 217 80% 18%;
 
     /* Background Hierarchy */
     --bg-primary: 0 0% 100%;

--- a/crates/mockforge-ui/ui/src/pages/MockAIOpenApiGeneratorPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/MockAIOpenApiGeneratorPage.tsx
@@ -384,7 +384,7 @@ export function MockAIOpenApiGeneratorPage() {
               {/* Confidence Scores */}
               {Object.keys(result.metadata.path_confidence).length > 0 && (
                 <div>
-                  <h3 className="text-md font-semibold mb-3 flex items-center gap-2">
+                  <h3 className="text-base font-semibold mb-3 flex items-center gap-2">
                     <TrendingUp className="h-4 w-4" />
                     Path Confidence Scores
                   </h3>


### PR DESCRIPTION
## Summary

The admin UI was missing 200+ Tailwind utilities at runtime — most visibly the API tokens modal at `app.mockforge.dev/api-tokens` rendered transparent because `bg-bg-primary` produced no CSS rule.

**Root cause:** Tailwind v4 switched to CSS-first config and ignores `tailwind.config.js` unless loaded via `@config`. Only utilities mapped in `@theme inline` get emitted. The CSS vars `--bg-primary`, `--text-tertiary`, `--brand-*`, `--success-*`, `--warning-*`, `--danger-*`, `--info-*` were defined in `:root`/`.dark` but never registered as `--color-*` tokens, so every `bg-bg-primary`, `text-success-700`, `bg-brand-50`, etc. silently rendered no styling — affecting Dialog, Card, Tabs, ThemeToggle, StatusBadge, ApiCritique, and many pages.

## Changes

- Register `--color-bg-*`, `--color-text-*`, and the full brand/success/warning/danger/info palettes (50–900 shades) in `@theme inline`
- Add the 200/300/400/700/800/900 shade variables to `:root` that the codebase referenced but were never defined
- Fix typo class names:
  - `text-tertiary` → `text-text-tertiary` (IconSystem, ResponsiveTable)
  - `text-h2` → `text-2xl font-semibold` (Section)
  - `text-md` → `text-base` (MockAIOpenApiGeneratorPage)
- Replace deprecated `bg-opacity-*`/`ring-opacity-*` (dead in Tailwind v4) with slash-opacity syntax in ApiCritique, StatusBadge, and the design-system files
- Fix dead-code typos in `design-system/FormControls` (`text-primary placeholder-tertiary` → `text-text-primary placeholder:text-text-tertiary`)

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm type-check` passes
- [x] Built CSS now contains `.bg-bg-primary{background-color:hsl(var(--bg-primary))}` and the full custom palette
- [ ] Verify the API tokens modal renders with an opaque background on the next `app.mockforge.dev` deploy
- [ ] Spot-check Card/Tabs/ThemeToggle/StatusBadge for visible backgrounds in light and dark mode