### PR TITLE
fix(registry,ui): bind org_id in audit-log queries + parse comma-separated event_type

### DIFF
--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -68,6 +68,61 @@ pub enum AuditEventType {
     AdminImpersonation,
 }
 
+impl AuditEventType {
+    /// Parse the snake_case string representation back into an enum.
+    ///
+    /// Mirrors the `rename_all = "snake_case"` serde encoding used for the
+    /// sqlx `audit_event_type` Postgres enum and the SQLite TEXT column.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "member_added" => Some(Self::MemberAdded),
+            "member_removed" => Some(Self::MemberRemoved),
+            "member_role_changed" => Some(Self::MemberRoleChanged),
+            "org_created" => Some(Self::OrgCreated),
+            "org_updated" => Some(Self::OrgUpdated),
+            "org_deleted" => Some(Self::OrgDeleted),
+            "org_plan_changed" => Some(Self::OrgPlanChanged),
+            "billing_checkout" => Some(Self::BillingCheckout),
+            "billing_upgrade" => Some(Self::BillingUpgrade),
+            "billing_downgrade" => Some(Self::BillingDowngrade),
+            "billing_canceled" => Some(Self::BillingCanceled),
+            "api_token_created" => Some(Self::ApiTokenCreated),
+            "api_token_deleted" => Some(Self::ApiTokenDeleted),
+            "api_token_rotated" => Some(Self::ApiTokenRotated),
+            "settings_updated" => Some(Self::SettingsUpdated),
+            "byok_config_updated" => Some(Self::ByokConfigUpdated),
+            "byok_config_deleted" => Some(Self::ByokConfigDeleted),
+            "deployment_created" => Some(Self::DeploymentCreated),
+            "deployment_deleted" => Some(Self::DeploymentDeleted),
+            "deployment_updated" => Some(Self::DeploymentUpdated),
+            "plugin_published" => Some(Self::PluginPublished),
+            "template_published" => Some(Self::TemplatePublished),
+            "scenario_published" => Some(Self::ScenarioPublished),
+            "password_changed" => Some(Self::PasswordChanged),
+            "email_changed" => Some(Self::EmailChanged),
+            "two_factor_enabled" => Some(Self::TwoFactorEnabled),
+            "two_factor_disabled" => Some(Self::TwoFactorDisabled),
+            "federation_created" => Some(Self::FederationCreated),
+            "federation_updated" => Some(Self::FederationUpdated),
+            "federation_deleted" => Some(Self::FederationDeleted),
+            "federation_scenario_activated" => Some(Self::FederationScenarioActivated),
+            "federation_scenario_deactivated" => Some(Self::FederationScenarioDeactivated),
+            "workspace_created" => Some(Self::WorkspaceCreated),
+            "workspace_updated" => Some(Self::WorkspaceUpdated),
+            "workspace_deleted" => Some(Self::WorkspaceDeleted),
+            "service_created" => Some(Self::ServiceCreated),
+            "service_updated" => Some(Self::ServiceUpdated),
+            "service_deleted" => Some(Self::ServiceDeleted),
+            "fixture_created" => Some(Self::FixtureCreated),
+            "fixture_updated" => Some(Self::FixtureUpdated),
+            "fixture_deleted" => Some(Self::FixtureDeleted),
+            "admin_impersonation" => Some(Self::AdminImpersonation),
+            _ => None,
+        }
+    }
+}
+
 /// Audit log entry
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
 pub struct AuditLog {
@@ -114,19 +169,24 @@ impl AuditLog {
         .await
     }
 
-    /// Get audit logs for an organization
+    /// Get audit logs for an organization, optionally filtered to one or more event types.
     pub async fn get_by_org(
         pool: &sqlx::PgPool,
-        _org_id: Uuid,
+        org_id: Uuid,
         limit: Option<i64>,
         offset: Option<i64>,
-        event_type: Option<AuditEventType>,
+        event_types: &[AuditEventType],
     ) -> sqlx::Result<Vec<Self>> {
-        let mut query = sqlx::QueryBuilder::new("SELECT * FROM audit_logs WHERE org_id = $1");
+        let mut query = sqlx::QueryBuilder::new("SELECT * FROM audit_logs WHERE org_id = ");
+        query.push_bind(org_id);
 
-        if let Some(event_type) = event_type {
-            query.push(" AND event_type = $2");
-            query.push_bind(event_type);
+        if !event_types.is_empty() {
+            query.push(" AND event_type IN (");
+            let mut sep = query.separated(", ");
+            for et in event_types {
+                sep.push_bind(*et);
+            }
+            query.push(")");
         }
 
         query.push(" ORDER BY created_at DESC");
@@ -147,13 +207,15 @@ impl AuditLog {
     /// Get audit logs for a specific user within an organization
     pub async fn get_by_user_in_org(
         pool: &sqlx::PgPool,
-        _org_id: Uuid,
-        _user_id: Uuid,
+        org_id: Uuid,
+        user_id: Uuid,
         limit: Option<i64>,
     ) -> sqlx::Result<Vec<Self>> {
-        let mut query = sqlx::QueryBuilder::new(
-            "SELECT * FROM audit_logs WHERE org_id = $1 AND user_id = $2 ORDER BY created_at DESC",
-        );
+        let mut query = sqlx::QueryBuilder::new("SELECT * FROM audit_logs WHERE org_id = ");
+        query.push_bind(org_id);
+        query.push(" AND user_id = ");
+        query.push_bind(user_id);
+        query.push(" ORDER BY created_at DESC");
 
         if let Some(limit) = limit {
             query.push(" LIMIT ");

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -882,19 +882,21 @@ pub trait RegistryStore: Send + Sync + 'static {
     );
 
     /// List audit logs for an organization with optional filters.
+    ///
+    /// `event_types` is an OR filter: pass an empty slice to return logs of every type.
     async fn list_audit_logs(
         &self,
         org_id: Uuid,
         limit: Option<i64>,
         offset: Option<i64>,
-        event_type: Option<AuditEventType>,
+        event_types: &[AuditEventType],
     ) -> StoreResult<Vec<AuditLog>>;
 
     /// Count audit logs matching the filter (for pagination).
     async fn count_audit_logs(
         &self,
         org_id: Uuid,
-        event_type: Option<AuditEventType>,
+        event_types: &[AuditEventType],
     ) -> StoreResult<i64>;
 
     // ---------------------------------------------------------------------

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -278,9 +278,9 @@ impl RegistryStore for PgRegistryStore {
         org_id: Uuid,
         limit: Option<i64>,
         offset: Option<i64>,
-        event_type: Option<AuditEventType>,
+        event_types: &[AuditEventType],
     ) -> StoreResult<Vec<AuditLog>> {
-        AuditLog::get_by_org(&self.pool, org_id, limit, offset, event_type)
+        AuditLog::get_by_org(&self.pool, org_id, limit, offset, event_types)
             .await
             .map_err(Into::into)
     }
@@ -288,20 +288,21 @@ impl RegistryStore for PgRegistryStore {
     async fn count_audit_logs(
         &self,
         org_id: Uuid,
-        event_type: Option<AuditEventType>,
+        event_types: &[AuditEventType],
     ) -> StoreResult<i64> {
-        let count: (i64,) = if let Some(evt) = event_type {
-            sqlx::query_as("SELECT COUNT(*) FROM audit_logs WHERE org_id = $1 AND event_type = $2")
-                .bind(org_id)
-                .bind(evt)
-                .fetch_one(&self.pool)
-                .await?
-        } else {
-            sqlx::query_as("SELECT COUNT(*) FROM audit_logs WHERE org_id = $1")
-                .bind(org_id)
-                .fetch_one(&self.pool)
-                .await?
-        };
+        let mut query = sqlx::QueryBuilder::new("SELECT COUNT(*) FROM audit_logs WHERE org_id = ");
+        query.push_bind(org_id);
+
+        if !event_types.is_empty() {
+            query.push(" AND event_type IN (");
+            let mut sep = query.separated(", ");
+            for et in event_types {
+                sep.push_bind(*et);
+            }
+            query.push(")");
+        }
+
+        let count: (i64,) = query.build_query_as().fetch_one(&self.pool).await?;
         Ok(count.0)
     }
 

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -952,53 +952,54 @@ impl RegistryStore for SqliteRegistryStore {
         org_id: Uuid,
         limit: Option<i64>,
         offset: Option<i64>,
-        event_type: Option<AuditEventType>,
+        event_types: &[AuditEventType],
     ) -> StoreResult<Vec<AuditLog>> {
         let limit = limit.unwrap_or(100);
         let offset = offset.unwrap_or(0);
-        let rows = if let Some(et) = event_type {
-            let et_str = audit_event_type_to_str(&et);
-            sqlx::query(
-                "SELECT * FROM audit_logs WHERE org_id = ? AND event_type = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",
-            )
-            .bind(org_id.to_string())
-            .bind(&et_str)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?
-        } else {
-            sqlx::query(
-                "SELECT * FROM audit_logs WHERE org_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",
-            )
-            .bind(org_id.to_string())
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?
-        };
+        let event_strs: Vec<String> = event_types.iter().map(audit_event_type_to_str).collect();
+
+        let mut query =
+            sqlx::QueryBuilder::<sqlx::Sqlite>::new("SELECT * FROM audit_logs WHERE org_id = ");
+        query.push_bind(org_id.to_string());
+        if !event_strs.is_empty() {
+            query.push(" AND event_type IN (");
+            let mut sep = query.separated(", ");
+            for s in &event_strs {
+                sep.push_bind(s);
+            }
+            query.push(")");
+        }
+        query.push(" ORDER BY created_at DESC LIMIT ");
+        query.push_bind(limit);
+        query.push(" OFFSET ");
+        query.push_bind(offset);
+
+        let rows = query.build().fetch_all(&self.pool).await?;
         rows.iter().map(row_to_audit_log).collect()
     }
 
     async fn count_audit_logs(
         &self,
         org_id: Uuid,
-        event_type: Option<AuditEventType>,
+        event_types: &[AuditEventType],
     ) -> StoreResult<i64> {
         use sqlx::Row;
-        let row = if let Some(et) = event_type {
-            let et_str = audit_event_type_to_str(&et);
-            sqlx::query("SELECT COUNT(*) as c FROM audit_logs WHERE org_id = ? AND event_type = ?")
-                .bind(org_id.to_string())
-                .bind(&et_str)
-                .fetch_one(&self.pool)
-                .await?
-        } else {
-            sqlx::query("SELECT COUNT(*) as c FROM audit_logs WHERE org_id = ?")
-                .bind(org_id.to_string())
-                .fetch_one(&self.pool)
-                .await?
-        };
+        let event_strs: Vec<String> = event_types.iter().map(audit_event_type_to_str).collect();
+
+        let mut query = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+            "SELECT COUNT(*) as c FROM audit_logs WHERE org_id = ",
+        );
+        query.push_bind(org_id.to_string());
+        if !event_strs.is_empty() {
+            query.push(" AND event_type IN (");
+            let mut sep = query.separated(", ");
+            for s in &event_strs {
+                sep.push_bind(s);
+            }
+            query.push(")");
+        }
+
+        let row = query.build().fetch_one(&self.pool).await?;
         Ok(row.try_get::<i64, _>("c")?)
     }
 
@@ -5031,13 +5032,21 @@ mod tests {
             .await;
 
         // Count and list
-        assert_eq!(store.count_audit_logs(org.id, None).await.unwrap(), 2);
+        assert_eq!(store.count_audit_logs(org.id, &[]).await.unwrap(), 2);
+        assert_eq!(store.count_audit_logs(org.id, &[AuditEventType::OrgCreated]).await.unwrap(), 1);
+        // Multi-event filter (OR semantics)
         assert_eq!(
-            store.count_audit_logs(org.id, Some(AuditEventType::OrgCreated)).await.unwrap(),
-            1
+            store
+                .count_audit_logs(
+                    org.id,
+                    &[AuditEventType::OrgCreated, AuditEventType::ApiTokenCreated]
+                )
+                .await
+                .unwrap(),
+            2
         );
 
-        let logs = store.list_audit_logs(org.id, None, None, None).await.unwrap();
+        let logs = store.list_audit_logs(org.id, None, None, &[]).await.unwrap();
         assert_eq!(logs.len(), 2);
         // most recent first
         assert_eq!(logs[0].event_type, AuditEventType::ApiTokenCreated);
@@ -5047,7 +5056,7 @@ mod tests {
 
         // Filtered list
         let org_created = store
-            .list_audit_logs(org.id, None, None, Some(AuditEventType::OrgCreated))
+            .list_audit_logs(org.id, None, None, &[AuditEventType::OrgCreated])
             .await
             .unwrap();
         assert_eq!(org_created.len(), 1);

--- a/crates/mockforge-registry-server/src/handlers/audit.rs
+++ b/crates/mockforge-registry-server/src/handlers/audit.rs
@@ -71,52 +71,29 @@ pub async fn get_audit_logs(
         return Err(ApiError::PermissionDenied);
     }
 
-    // Parse event type if provided
-    let event_type = if let Some(event_type_str) = &query.event_type {
-        // Try to parse as enum
-        match event_type_str.as_str() {
-            "member_added" => Some(AuditEventType::MemberAdded),
-            "member_removed" => Some(AuditEventType::MemberRemoved),
-            "member_role_changed" => Some(AuditEventType::MemberRoleChanged),
-            "org_created" => Some(AuditEventType::OrgCreated),
-            "org_updated" => Some(AuditEventType::OrgUpdated),
-            "org_deleted" => Some(AuditEventType::OrgDeleted),
-            "org_plan_changed" => Some(AuditEventType::OrgPlanChanged),
-            "billing_checkout" => Some(AuditEventType::BillingCheckout),
-            "billing_upgrade" => Some(AuditEventType::BillingUpgrade),
-            "billing_downgrade" => Some(AuditEventType::BillingDowngrade),
-            "billing_canceled" => Some(AuditEventType::BillingCanceled),
-            "api_token_created" => Some(AuditEventType::ApiTokenCreated),
-            "api_token_deleted" => Some(AuditEventType::ApiTokenDeleted),
-            "api_token_rotated" => Some(AuditEventType::ApiTokenRotated),
-            "settings_updated" => Some(AuditEventType::SettingsUpdated),
-            "byok_config_updated" => Some(AuditEventType::ByokConfigUpdated),
-            "byok_config_deleted" => Some(AuditEventType::ByokConfigDeleted),
-            "deployment_created" => Some(AuditEventType::DeploymentCreated),
-            "deployment_deleted" => Some(AuditEventType::DeploymentDeleted),
-            "deployment_updated" => Some(AuditEventType::DeploymentUpdated),
-            "plugin_published" => Some(AuditEventType::PluginPublished),
-            "template_published" => Some(AuditEventType::TemplatePublished),
-            "scenario_published" => Some(AuditEventType::ScenarioPublished),
-            "password_changed" => Some(AuditEventType::PasswordChanged),
-            "email_changed" => Some(AuditEventType::EmailChanged),
-            "two_factor_enabled" => Some(AuditEventType::TwoFactorEnabled),
-            "two_factor_disabled" => Some(AuditEventType::TwoFactorDisabled),
-            "admin_impersonation" => Some(AuditEventType::AdminImpersonation),
-            _ => None,
-        }
-    } else {
-        None
-    };
+    // Parse event types if provided. Accepts a single value or a comma-separated list
+    // (e.g. `?event_type=byok_config_updated,byok_config_deleted`). Unknown values are
+    // silently ignored so a stale client can't 500 the endpoint.
+    let event_types: Vec<AuditEventType> = query
+        .event_type
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .filter_map(AuditEventType::from_str)
+                .collect()
+        })
+        .unwrap_or_default();
 
     // Get audit logs
     let logs = state
         .store
-        .list_audit_logs(org_id, query.limit.or(Some(100)), query.offset.or(Some(0)), event_type)
+        .list_audit_logs(org_id, query.limit.or(Some(100)), query.offset.or(Some(0)), &event_types)
         .await?;
 
     // Get total count
-    let total = state.store.count_audit_logs(org_id, event_type).await?;
+    let total = state.store.count_audit_logs(org_id, &event_types).await?;
 
     // Convert to response format
     let log_responses: Vec<AuditLogResponse> = logs

--- a/crates/mockforge-ui/ui/src/pages/BYOKConfigPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/BYOKConfigPage.tsx
@@ -186,7 +186,8 @@ async function fetchAuditLogs(orgId: string): Promise<AuditLogEntry[]> {
     { headers: authHeaders() }
   );
   if (!response.ok) throw new Error('Failed to fetch audit logs');
-  return response.json();
+  const body = (await response.json()) as { logs?: AuditLogEntry[] } | AuditLogEntry[];
+  return Array.isArray(body) ? body : (body.logs ?? []);
 }
 
 // Provider definitions with model options


### PR DESCRIPTION
## Summary
- `AuditLog::get_by_org` / `get_by_user_in_org` had literal `\$1`/`\$2` baked into the static SQL but never `push_bind`'d `org_id`/`user_id`. A later `push_bind(limit)` auto-numbered as `\$1`, so Postgres tried to coerce the i64 into uuid → every BYOK audit-logs request 500'd. Rewrote both to bind every parameter via `QueryBuilder`.
- Handler only matched a single `event_type` string. Frontend sends `?event_type=byok_config_updated,byok_config_deleted`; the comma-joined value fell to the catch-all `None` arm and silently disabled filtering. Trait now takes `&[AuditEventType]`, handler splits on commas, unknown values are ignored.
- Frontend `fetchAuditLogs` expected a bare array but the API returns `{ logs, total, limit, offset }` — unwrap `body.logs`.
- Added `AuditEventType::from_str` so the handler stops hand-rolling a 30-arm match. SQLite store impl mirrored.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-core -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-core` — 242/242
- [x] `pnpm type-check` (mockforge-ui/ui)
- [x] `pnpm lint` (0 errors)
- [ ] Verify on app.mockforge.dev BYOK page after Fly.io redeploy of mockforge-registry

## Out of scope (separate deploy step)
The `/api/v1/users/me/preferences` 404 reported alongside this is a stale-deploy issue, not a bug — the route landed in #213 (0.3.117) but Fly is running 0.3.116. This same Fly redeploy ships both fixes.