### PR TITLE
fix(ui): widen organization page right panel and prevent tab wrapping

### DIFF
--- a/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
@@ -1601,7 +1601,7 @@ export function OrganizationPage() {
   const selectedOrg = organizations?.find((org) => org.id === selectedOrgId);
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
+    <div className="mx-auto max-w-screen-2xl p-6 space-y-6">
       <div>
         <h1 className="text-3xl font-bold">Organizations</h1>
         <p className="text-muted-foreground mt-2">
@@ -1609,7 +1609,7 @@ export function OrganizationPage() {
         </p>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-[1fr_2fr]">
+      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
         {/* Organizations List */}
         <Card>
           <CardHeader>
@@ -1668,7 +1668,7 @@ export function OrganizationPage() {
             </CardHeader>
             <CardContent>
               <Tabs defaultValue="members" className="w-full">
-                <TabsList className="flex flex-wrap">
+                <TabsList className="flex w-full overflow-x-auto">
                   <TabsTrigger value="members">
                     <Users className="w-4 h-4 mr-1" />
                     Members


### PR DESCRIPTION
## Summary
- Right panel of `/organization` was capped to 2/3 of a 1280px container, leaving ~740px for 9 tabs that wrapped to two rows.
- Made the org list a fixed 320px sidebar so the right panel takes all remaining width.
- Lifted the page container cap from `container` (1280px on `xl`) to `max-w-screen-2xl` (1536px).
- Tab strip now scrolls horizontally on narrow widths instead of wrapping to two rows.

## Test plan
- [ ] Visit `/organization` on a 1440px+ display: right panel should be ~1140px (vs ~740px before) and the 9 tabs fit on one row.
- [ ] Resize to ~1024px (laptop): tabs scroll horizontally, no two-row wrap.
- [ ] Resize to ~768px (tablet portrait): the two cards stack vertically (the breakpoint moved from `md` to `lg`).
- [ ] `pnpm type-check` and `pnpm lint` pass (no new warnings in `OrganizationPage.tsx`).