### PR TITLE
feat(http,cli): add --no-rate-limit flag (#79)

### DIFF
--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -540,6 +540,15 @@ struct ServeCliArgs {
     #[arg(long, help_heading = "Configuration")]
     pub no_config: bool,
 
+    /// Disable the built-in HTTP per-IP rate limiter (default: 1000 req/min, 2000 burst).
+    ///
+    /// Equivalent to setting `MOCKFORGE_RATE_LIMIT_ENABLED=false`. Useful when
+    /// load-testing against a spec — without this, sustained traffic from a
+    /// single client will start receiving `429 Too Many Requests` once the
+    /// per-minute budget is exhausted.
+    #[arg(long, help_heading = "Server Configuration")]
+    pub no_rate_limit: bool,
+
     #[command(flatten)]
     pub ports: PortArgs,
 
@@ -2286,6 +2295,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 progress: args.progress,
                 verbose: args.verbose,
                 no_config: args.no_config,
+                no_rate_limit: args.no_rate_limit,
             })
             .await?;
         }

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -92,6 +92,8 @@ pub(crate) struct ServeArgs {
     /// host project may happen to contain a `mockforge.yaml` that would
     /// otherwise be picked up and override explicit flags.
     pub(crate) no_config: bool,
+    /// Disable the built-in HTTP rate limiter (sets `MOCKFORGE_RATE_LIMIT_ENABLED=false`).
+    pub(crate) no_rate_limit: bool,
 }
 
 impl Default for ServeArgs {
@@ -161,6 +163,7 @@ impl Default for ServeArgs {
             progress: false,
             verbose: false,
             no_config: false,
+            no_rate_limit: false,
         }
     }
 }
@@ -626,6 +629,14 @@ pub(crate) fn initialize_opentelemetry_tracing(
 pub async fn handle_serve(
     serve_args: ServeArgs,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // CLI flags that influence library behavior via env vars must be applied
+    // before the HTTP router is constructed. `--no-rate-limit` only adds to
+    // (never overrides) what the operator already set in the environment, so
+    // a user who already disabled the limiter via env var sees no surprise.
+    if serve_args.no_rate_limit && std::env::var_os("MOCKFORGE_RATE_LIMIT_ENABLED").is_none() {
+        std::env::set_var("MOCKFORGE_RATE_LIMIT_ENABLED", "false");
+    }
+
     // Opt-in federation scenario poller. If the four env vars
     // (MOCKFORGE_FEDERATION_POLL_URL / WORKSPACE_ID / POLL_TOKEN /
     // POLL_INTERVAL_SECS) aren't set this is a no-op; otherwise a tokio

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -663,10 +663,18 @@ pub async fn build_router_with_multi_tenant(
         }
     }
 
+    let rate_limit_disabled = middleware::is_rate_limit_disabled();
     let rate_limiter =
         std::sync::Arc::new(middleware::GlobalRateLimiter::new(rate_limit_config.clone()));
 
-    let mut state = HttpServerState::new().with_rate_limiter(rate_limiter.clone());
+    let mut state = HttpServerState::new();
+    if rate_limit_disabled {
+        info!(
+            "HTTP rate limiting disabled (MOCKFORGE_RATE_LIMIT_ENABLED=false or --no-rate-limit)"
+        );
+    } else {
+        state = state.with_rate_limiter(rate_limiter.clone());
+    }
 
     // Add production headers to state if configured
     if let Some(headers) = production_headers.clone() {
@@ -3049,17 +3057,25 @@ pub async fn build_router_with_chains_and_multi_tenant(
     }
 
     // Initialize rate limiter and state
+    let rate_limit_disabled = middleware::is_rate_limit_disabled();
     let rate_limiter =
         std::sync::Arc::new(middleware::GlobalRateLimiter::new(rate_limit_config.clone()));
 
-    let mut state = HttpServerState::new().with_rate_limiter(rate_limiter.clone());
+    let mut state = HttpServerState::new();
+    if rate_limit_disabled {
+        info!(
+            "HTTP rate limiting disabled (MOCKFORGE_RATE_LIMIT_ENABLED=false or --no-rate-limit)"
+        );
+    } else {
+        state = state.with_rate_limiter(rate_limiter.clone());
+    }
 
     // Add production headers to state if configured
     if let Some(headers) = production_headers.clone() {
         state = state.with_production_headers(headers);
     }
 
-    // Add rate limiting middleware
+    // Add rate limiting middleware (no-op when state.rate_limiter is None)
     app = app.layer(from_fn_with_state(state.clone(), middleware::rate_limit_middleware));
 
     // Add production headers middleware if configured

--- a/crates/mockforge-http/src/middleware/mod.rs
+++ b/crates/mockforge-http/src/middleware/mod.rs
@@ -16,6 +16,8 @@ pub use behavioral_cloning::{behavioral_cloning_middleware, BehavioralCloningMid
 pub use deceptive_canary::{deceptive_canary_middleware, DeceptiveCanaryState};
 pub use drift_tracking::drift_tracking_middleware_with_extensions;
 pub use production_headers::production_headers_middleware;
-pub use rate_limit::{rate_limit_middleware, GlobalRateLimiter, RateLimitConfig};
+pub use rate_limit::{
+    is_rate_limit_disabled, rate_limit_middleware, GlobalRateLimiter, RateLimitConfig,
+};
 pub use response_buffer::{buffer_response_middleware, get_buffered_response, BufferedResponse};
 pub use security::security_middleware;

--- a/crates/mockforge-http/src/middleware/rate_limit.rs
+++ b/crates/mockforge-http/src/middleware/rate_limit.rs
@@ -21,6 +21,36 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::warn;
 
+/// Returns true when the operator has explicitly disabled HTTP rate limiting.
+///
+/// Honors `MOCKFORGE_RATE_LIMIT_ENABLED=false` (preferred, matches the
+/// `MOCKFORGE_LATENCY_ENABLED` / `MOCKFORGE_FAILURES_ENABLED` family) and the
+/// shorthand alias `MOCKFORGE_RATE_LIMIT_DISABLED=true`. The `--no-rate-limit`
+/// CLI flag funnels through these env vars as well.
+///
+/// When this returns true the router skips wiring a `GlobalRateLimiter` into
+/// state; the middleware then short-circuits and forwards every request.
+pub fn is_rate_limit_disabled() -> bool {
+    fn truthy(v: &str) -> bool {
+        matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    }
+    fn falsy(v: &str) -> bool {
+        matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no" | "off")
+    }
+
+    if let Ok(v) = std::env::var("MOCKFORGE_RATE_LIMIT_ENABLED") {
+        if falsy(&v) {
+            return true;
+        }
+    }
+    if let Ok(v) = std::env::var("MOCKFORGE_RATE_LIMIT_DISABLED") {
+        if truthy(&v) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Rate limiting configuration
 #[derive(Debug, Clone)]
 pub struct RateLimitConfig {
@@ -223,6 +253,55 @@ pub async fn rate_limit_middleware(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ==================== is_rate_limit_disabled Tests ====================
+
+    /// Snapshot + restore both env vars around the assertions so this test is
+    /// robust to other tests in the binary touching them in parallel.
+    #[test]
+    fn test_is_rate_limit_disabled_env_vars() {
+        let saved_enabled = std::env::var("MOCKFORGE_RATE_LIMIT_ENABLED").ok();
+        let saved_disabled = std::env::var("MOCKFORGE_RATE_LIMIT_DISABLED").ok();
+
+        // Default (unset): limiter is on
+        std::env::remove_var("MOCKFORGE_RATE_LIMIT_ENABLED");
+        std::env::remove_var("MOCKFORGE_RATE_LIMIT_DISABLED");
+        assert!(!is_rate_limit_disabled());
+
+        // ENABLED=false → disabled
+        for v in ["false", "0", "no", "off", "FALSE", "  False  "] {
+            std::env::set_var("MOCKFORGE_RATE_LIMIT_ENABLED", v);
+            assert!(is_rate_limit_disabled(), "ENABLED={v:?} should disable");
+        }
+        std::env::remove_var("MOCKFORGE_RATE_LIMIT_ENABLED");
+
+        // ENABLED=true → not disabled
+        std::env::set_var("MOCKFORGE_RATE_LIMIT_ENABLED", "true");
+        assert!(!is_rate_limit_disabled());
+        std::env::remove_var("MOCKFORGE_RATE_LIMIT_ENABLED");
+
+        // DISABLED=true → disabled (alias)
+        for v in ["true", "1", "yes", "on", "TRUE"] {
+            std::env::set_var("MOCKFORGE_RATE_LIMIT_DISABLED", v);
+            assert!(is_rate_limit_disabled(), "DISABLED={v:?} should disable");
+        }
+        std::env::remove_var("MOCKFORGE_RATE_LIMIT_DISABLED");
+
+        // DISABLED=false → not disabled
+        std::env::set_var("MOCKFORGE_RATE_LIMIT_DISABLED", "false");
+        assert!(!is_rate_limit_disabled());
+        std::env::remove_var("MOCKFORGE_RATE_LIMIT_DISABLED");
+
+        // Restore
+        match saved_enabled {
+            Some(v) => std::env::set_var("MOCKFORGE_RATE_LIMIT_ENABLED", v),
+            None => std::env::remove_var("MOCKFORGE_RATE_LIMIT_ENABLED"),
+        }
+        match saved_disabled {
+            Some(v) => std::env::set_var("MOCKFORGE_RATE_LIMIT_DISABLED", v),
+            None => std::env::remove_var("MOCKFORGE_RATE_LIMIT_DISABLED"),
+        }
+    }
 
     // ==================== RateLimitConfig Tests ====================
 


### PR DESCRIPTION
## Summary

- Adds `--no-rate-limit` to `mockforge serve` (and `MOCKFORGE_RATE_LIMIT_ENABLED=false` / `MOCKFORGE_RATE_LIMIT_DISABLED=true` env vars) so users running sustained load tests against a mocked spec can opt out of the built-in HTTP per-IP rate limiter (default 1000 req/min, burst 2000) without setting magic high values.
- Reported by @srikr in #79 after seeing tons of 429 responses while load-testing the `api.github.com` spec.
- Both `build_router_with_multi_tenant` and `build_router_with_traffic_shaping_and_multi_tenant` now skip wiring the limiter into `HttpServerState` when disabled. The middleware already short-circuits when `state.rate_limiter` is `None`, so no layer-order changes were needed.

## Test plan

- [x] `cargo test -p mockforge-http` (607 tests, including new `test_is_rate_limit_disabled_env_vars` covering both env vars and several truthy/falsy spellings)
- [x] `cargo test -p mockforge-cli` (passes)
- [x] `cargo clippy -p mockforge-http --all-targets -- -D warnings`
- [x] `cargo clippy -p mockforge-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Smoke: `mockforge serve --spec examples/openapi-demo.json --http-port 13334 --no-rate-limit` logs `HTTP rate limiting disabled (...)` and serves requests with 200s.
- [x] `--help` surfaces the new flag under `Server Configuration`.