### PR TITLE
fix(http,test,ci): make release.yml's Run tests step actually pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,20 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
 
+    # mockforge-cli's default features do NOT include `ws`/`grpc`/`mqtt` (see
+    # crates/mockforge-cli/Cargo.toml). The mockforge-integration-tests crate
+    # spawns this binary as a subprocess for e2e tests and tries to connect
+    # to the WS / gRPC ports — without the protocol features compiled in,
+    # nothing is listening and the tests fail with `Connection refused`.
+    # The cross-platform-test job in ci.yml had this same step (added in
+    # PR #208) but it was never replicated here, so every release tag has
+    # been red on the `Run tests` step. The pre-built debug binary takes
+    # precedence in mockforge-test's binary-resolution order, which is why
+    # building it here (as `dev` profile) before `cargo test --release`
+    # is the right shape.
+    - name: Build mockforge binary with all protocols
+      run: cargo build --bin mockforge --features all-protocols
+
     - name: Run tests
       run: cargo test --workspace --release
     - name: Build release binaries

--- a/crates/mockforge-http/src/management/mod.rs
+++ b/crates/mockforge-http/src/management/mod.rs
@@ -1068,7 +1068,31 @@ pub async fn serve_dynamic_mock(state: &ManagementState, req: Request<Body>) -> 
         .and_then(|c| StatusCode::from_u16(c).ok())
         .unwrap_or(StatusCode::OK);
 
-    let body_bytes_out = serde_json::to_vec(&mock.response.body).unwrap_or_default();
+    // Honor MOCKFORGE_RESPONSE_TEMPLATE_EXPAND for mocks created via the
+    // management API. The full templater in mockforge-core handles
+    // `{{faker.email}}`, `{{uuid}}`, `{{randInt …}}`, etc. — it's gated
+    // on the env var because it's the same opt-in as everywhere else
+    // (config-loaded routes, OpenAPI overrides). Run inside spawn_blocking
+    // because the templater's rng() and faker providers are not Send-safe
+    // across `.await` points.
+    let template_expand = std::env::var("MOCKFORGE_RESPONSE_TEMPLATE_EXPAND")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    let body_value = if template_expand {
+        let body_clone = mock.response.body.clone();
+        match tokio::task::spawn_blocking(move || {
+            mockforge_core::templating::expand_tokens(&body_clone)
+        })
+        .await
+        {
+            Ok(expanded) => expanded,
+            Err(_) => mock.response.body.clone(),
+        }
+    } else {
+        mock.response.body.clone()
+    };
+
+    let body_bytes_out = serde_json::to_vec(&body_value).unwrap_or_default();
     let mut response = Response::builder().status(status);
 
     let mut has_content_type = false;

--- a/tests/tests/component_integration.rs
+++ b/tests/tests/component_integration.rs
@@ -144,11 +144,21 @@ async fn test_data_protocol_generation() {
     if response.status().is_success() {
         let body: serde_json::Value = response.json().await.expect("Failed to parse JSON");
 
-        // Verify data generation worked
+        // Verify data generation worked. The mock body is JSON with template
+        // tokens inside string values, so all expanded fields come back as
+        // strings even when the underlying generator (e.g. randInt) yields
+        // a number — that's the documented behavior of in-string {{…}}
+        // expansion. The original test asserted `random.is_number()`, which
+        // never matched reality and produced the chronic CI red on every
+        // release until v0.3.119.
         assert!(body["id"].is_string(), "ID should be generated");
         assert!(body["email"].as_str().unwrap().contains("@"), "Email should be generated");
         assert!(body["name"].is_string(), "Name should be generated");
-        assert!(body["random"].is_number(), "Random number should be generated");
+        let random_str = body["random"].as_str().expect("random field should be a string");
+        assert!(
+            random_str.parse::<i64>().is_ok(),
+            "Random number should be generated (got {random_str:?})"
+        );
     }
 
     server.stop().expect("Failed to stop server");


### PR DESCRIPTION
## Summary

The `Run tests` step in release.yml's `Create Release` job has been red on every release tag (v0.3.117, v0.3.118, v0.3.119) — the workflow run shows `failure` overall even though crates.io publish succeeds in parallel (the `publish` job has no `needs:` on `release`). Three independent issues were stacked:

### 1. `serve_dynamic_mock` ignored `MOCKFORGE_RESPONSE_TEMPLATE_EXPAND`
Mocks created via `POST /__mockforge/api/mocks` had their response bodies serialized verbatim. `{"email": "{{faker.email}}"}` shipped the literal `{{faker.email}}` string back to the client, even when the env var was set. The OpenAPI-loaded route handler in `lib.rs` (~line 1859) honors it but the management-API path was missed. Fixed by running `mockforge_core::templating::expand_tokens` inside `spawn_blocking` (the templater's faker/rng providers are not Send-safe across `.await`).

This is the bug `test_data_protocol_generation` was actually catching.

### 2. Test asserted `random.is_number()` on a JSON string field
The mock body declares `"random": "{{randInt 1 100}}"` — a JSON string containing a template token. In-string `{{…}}` expansion preserves the surrounding string type, so the field always comes back as a string. Asserting `is_number()` was a test design bug. Switched to parsing the string to verify it's numeric.

### 3. release.yml never built `mockforge` with `--features all-protocols`
The cross-platform-test job in ci.yml had this step (added in PR #208) but it was never replicated to release.yml. The `mockforge-integration-tests` crate spawns the binary as a subprocess for e2e tests; without `ws`/`grpc`/`mqtt` features compiled in, every non-HTTP probe got `Connection refused` and `protocols::websocket_e2e_tests::*` failed deterministically once `component_integration` started passing.

## Test plan

- [x] `cargo test -p mockforge-http` — all green (incl. the new `test_is_rate_limit_disabled_env_vars` from #280)
- [x] `cargo test -p mockforge-integration-tests` — 6/6 component_integration pass (was 5/6); 3/3 websocket_e2e_tests pass when binary is built with `--features all-protocols` (was 0/3 deterministically)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p mockforge-http --all-targets -- -D warnings` clean
- [x] Manual repro: `MOCKFORGE_RESPONSE_TEMPLATE_EXPAND=true mockforge serve --http-port 13399`, then `curl POST /__mockforge/api/mocks` + `curl GET /api/generated` returns `{"email":"…@…","id":"…uuid…","random":"42"}` instead of literal placeholders
- [ ] Next release tag should produce a fully green workflow run (validated by tagging v0.3.120 after this lands)