### PR TITLE
fix(registry-core): drop duplicate migration blocking all sqlite migrations

### DIFF
--- a/crates/mockforge-registry-core/migrations/20260101000010_user_notification_and_preferences.sql
+++ b/crates/mockforge-registry-core/migrations/20260101000010_user_notification_and_preferences.sql
@@ -1,9 +1,0 @@
--- Per-user notification toggles and free-form UI preferences (SQLite).
---
--- SQLite does not support ADD COLUMN IF NOT EXISTS, but this migration
--- is only applied once by sqlx. `preferences` is stored as TEXT containing
--- serialized JSON — the Rust layer uses serde_json::Value for round-trip.
-
-ALTER TABLE users ADD COLUMN email_notifications BOOLEAN NOT NULL DEFAULT 1;
-ALTER TABLE users ADD COLUMN security_alerts BOOLEAN NOT NULL DEFAULT 1;
-ALTER TABLE users ADD COLUMN preferences TEXT NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## Summary

`crates/mockforge-registry-core/migrations/` had two files with the same version prefix `20260101000010`:

- `20260101000010_user_notification_and_preferences.sql` — orphan, byte-identical (`md5sum` matches) to `20260101000011_user_notification_and_preferences.sql`
- `20260101000010_federation_scenario_activations.sql` — legitimate slot-10 file

`_sqlx_migrations` has `UNIQUE(version)`, so when sqlx tries to apply both it errors:

```
UNIQUE constraint failed: _sqlx_migrations.version (code: 1555)
```

This made every test in mockforge-registry-core's `store::sqlite::tests::*` panic at `sqlite.rs:3490` ("connect and migrate in-memory sqlite") — 26 failures per `cargo test -p mockforge-registry-core`. It's also what just took down the v0.3.120 release.yml `Run tests` step (v0.3.119's was masked by the unrelated `test_data_protocol_generation` failure that aborted earlier; once #281 fixed that, this surfaced as the next-in-line failure).

## Origin

Commit c9b08a2a (#236, "close gaps so the cloud value claims are 100% true") added all three migration files at once, including the byte-identical `_000011_` copy of the notification migration. The intent was clearly to renumber the notification migration to slot 11 to free slot 10 for the federation file — but the original `_000010_` notification file was never deleted in that commit.

## Why this delete is safe (and why migration-guard fires incorrectly)

- The two notification files (`_000010_` and `_000011_`) are **byte-identical**; no schema content is being lost, just the duplicate filename.
- Production registry-server uses `crates/mockforge-registry-server/migrations/` (postgres), **not** the `registry-core` directory I'm touching. The Fly deployment is unaffected — its `Deploy Registry Server to Fly.io` step has been succeeding on every release.
- No production sqlx_migrations table has ever successfully recorded version `20260101000010` for the notification migration — sqlx errors on the duplicate before any migration applies.
- The only consumers of registry-core's migration set are tests and embedded sqlite users (`cargo install` consumers running the in-memory store), all of which are currently broken.

The `migration-guard` PR check will flag this as a forbidden deletion. The guard's premise ("a migration was applied to a long-lived DB") does not hold for a file that prevented every consumer from initializing in the first place. **Admin-merge is appropriate here.**

## Test plan

- [x] `cargo test -p mockforge-registry-core` — 242 passed; 0 failed (was 242 passed; 26 failed)
- [x] `cargo fmt --all --check` — clean
- [ ] Migration-guard CI check will fail; admin-merge after confirming the rationale above
- [ ] Next release tag (v0.3.121 or rebumped v0.3.120 if appropriate) should produce a fully green workflow