### PR TITLE
fix(ui-test): static_files test_static_assets_content_length skips when no Vite build

### DIFF
--- a/crates/mockforge-ui/tests/static_files.rs
+++ b/crates/mockforge-ui/tests/static_files.rs
@@ -1,5 +1,6 @@
 use axum::{body::Body, http::Request};
 use mockforge_ui::create_admin_router;
+use std::path::Path;
 use std::sync::Once;
 use tower::ServiceExt;
 
@@ -541,14 +542,23 @@ async fn test_static_assets_content_length() {
     let length_value = content_length.unwrap().to_str().unwrap().parse::<usize>().unwrap();
     assert!(length_value > 0, "Content-Length should be greater than 0");
 
-    // For JavaScript, it should be reasonably large (not empty)
-    assert!(
-        length_value > 100,
-        "JavaScript file should be reasonably large, got {} bytes",
-        length_value
-    );
+    // For JavaScript, it should be reasonably large (not empty) — but only
+    // when a real Vite build was present at compile time. When `pnpm build`
+    // hasn't run, build.rs (crates/mockforge-ui/build.rs:191) embeds a
+    // 15-byte `// UI not built` placeholder so the binary still links.
+    // release.yml's `Run tests` step doesn't invoke pnpm, so without this
+    // guard the test fails on every release tag.
+    let real_ui_built = Path::new(env!("CARGO_MANIFEST_DIR")).join("ui/dist/index.html").exists();
+    if real_ui_built {
+        assert!(
+            length_value > 100,
+            "JavaScript file should be reasonably large, got {} bytes",
+            length_value
+        );
+    }
 
-    // Verify actual body matches content length
+    // Verify actual body matches content length (true regardless of which
+    // version of the JS asset is embedded).
     let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     assert_eq!(body_bytes.len(), length_value, "Body length should match Content-Length header");
 }


### PR DESCRIPTION
## Summary

Same root cause as #283. `crates/mockforge-ui/build.rs:191` embeds a 15-byte `// UI not built` placeholder for `get_admin_js()` when `ui/dist/index.html` is absent at compile time, so the served `/assets/index.js` is 15 bytes. The test asserts > 100 bytes — true after `pnpm build`, false in release.yml's `Run tests` step (which doesn't invoke pnpm).

This was the next-in-line failure after #283 cleared `test_admin_ui_serves_built_assets` — caught in v0.3.122's release run.

## Fix

Gate the size assertion on the same `ui/dist/index.html` check #283 used. The Content-Length-matches-body assertion still runs in both modes (true regardless of which JS is embedded).

## Test plan

- [x] `cargo test -p mockforge-ui --test static_files` → 7/7 pass with real built UI
- [x] Same with `ui/dist/index.html` temporarily moved aside → still 7/7 pass (size assertion correctly skipped)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p mockforge-ui --all-targets -- -D warnings` clean