### PR TITLE
feat(billing,usage): quota merge fix + egress, lifetime, invoices, threshold alerts

### DIFF
--- a/crates/mockforge-registry-core/src/models/mod.rs
+++ b/crates/mockforge-registry-core/src/models/mod.rs
@@ -63,7 +63,7 @@ pub use scenario::Scenario;
 pub use scenario_promotion::{PromotionStatus, ScenarioEnvironmentVersion, ScenarioPromotion};
 pub use settings::{BYOKConfig, OrgAiSettings, OrgSetting};
 pub use sso::{SSOConfiguration, SSOSession};
-pub use subscription::{Subscription, SubscriptionStatus, UsageCounter};
+pub use subscription::{Subscription, SubscriptionStatus, UsageAlert, UsageCounter};
 pub use user::User;
 
 // Re-export deployment-related models for convenience

--- a/crates/mockforge-registry-core/src/models/subscription.rs
+++ b/crates/mockforge-registry-core/src/models/subscription.rs
@@ -333,6 +333,87 @@ impl UsageCounter {
     }
 }
 
+/// One alert row per (org, metric, period, threshold_pct) — see migration
+/// 20250101000054_usage_alerts.sql.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct UsageAlert {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub metric: String,
+    pub period_start: NaiveDate,
+    pub threshold_pct: i16,
+    pub notified_at: DateTime<Utc>,
+    pub dismissed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(feature = "postgres")]
+impl UsageAlert {
+    /// Idempotent insert. Returns `Some(row)` if newly inserted (worker should
+    /// then send an email), `None` if a matching alert already exists.
+    pub async fn try_insert(
+        pool: &sqlx::PgPool,
+        org_id: Uuid,
+        metric: &str,
+        period_start: NaiveDate,
+        threshold_pct: i16,
+    ) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            INSERT INTO usage_alerts (org_id, metric, period_start, threshold_pct)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (org_id, metric, period_start, threshold_pct) DO NOTHING
+            RETURNING *
+            "#,
+        )
+        .bind(org_id)
+        .bind(metric)
+        .bind(period_start)
+        .bind(threshold_pct)
+        .fetch_optional(pool)
+        .await
+    }
+
+    /// Active (non-dismissed) alerts for the given period, newest first.
+    pub async fn list_active_for_period(
+        pool: &sqlx::PgPool,
+        org_id: Uuid,
+        period_start: NaiveDate,
+    ) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT * FROM usage_alerts
+            WHERE org_id = $1 AND period_start = $2 AND dismissed_at IS NULL
+            ORDER BY notified_at DESC
+            "#,
+        )
+        .bind(org_id)
+        .bind(period_start)
+        .fetch_all(pool)
+        .await
+    }
+
+    /// Dismiss an alert. Returns the updated row if it was active and owned by
+    /// the given org; `None` if it was already dismissed or didn't exist.
+    pub async fn dismiss(
+        pool: &sqlx::PgPool,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            UPDATE usage_alerts SET dismissed_at = NOW()
+            WHERE id = $1 AND org_id = $2 AND dismissed_at IS NULL
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(pool)
+        .await
+    }
+}
+
 #[cfg(all(test, feature = "postgres"))]
 mod tests {
     use super::*;

--- a/crates/mockforge-registry-server/migrations/20250101000054_usage_alerts.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000054_usage_alerts.sql
@@ -1,0 +1,26 @@
+-- Usage threshold alerts for MockForge Cloud.
+--
+-- A row is inserted by the threshold-checker worker the first time an org's
+-- usage of a metric crosses a band (e.g. 75%, 90%) within a billing period.
+-- The unique index makes inserts idempotent so the worker is safe to run on
+-- any cadence.
+
+CREATE TABLE usage_alerts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    -- Metric whose threshold was crossed: 'requests', 'storage', 'ai_tokens'.
+    metric VARCHAR(64) NOT NULL,
+    -- First-of-month, matches usage_counters.period_start.
+    period_start DATE NOT NULL,
+    -- Crossed band: 75 or 90.
+    threshold_pct SMALLINT NOT NULL CHECK (threshold_pct BETWEEN 1 AND 100),
+    -- When the worker observed the crossing (and emailed if applicable).
+    notified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Set when the user dismisses the alert in the UI.
+    dismissed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (org_id, metric, period_start, threshold_pct)
+);
+
+CREATE INDEX idx_usage_alerts_org_period ON usage_alerts(org_id, period_start);
+CREATE INDEX idx_usage_alerts_active ON usage_alerts(org_id) WHERE dismissed_at IS NULL;

--- a/crates/mockforge-registry-server/src/email.rs
+++ b/crates/mockforge-registry-server/src/email.rs
@@ -724,6 +724,108 @@ Privacy: https://mockforge.dev/privacy
         }
     }
 
+    /// Generate usage-threshold warning email (e.g. crossed 75% or 90% of a
+    /// metric limit on the current billing period).
+    pub fn generate_usage_threshold_warning(
+        username: &str,
+        email: &str,
+        metric_label: &str,
+        plan: &str,
+        used_pretty: &str,
+        limit_pretty: &str,
+        threshold_pct: u16,
+    ) -> EmailMessage {
+        let html_body = format!(
+            r#"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }}
+        .header {{ background: #f59e0b; color: white; padding: 40px 20px; text-align: center; border-radius: 8px 8px 0 0; }}
+        .content {{ background: #ffffff; padding: 30px; border: 1px solid #e0e0e0; border-top: none; border-radius: 0 0 8px 8px; }}
+        .button {{ display: inline-block; padding: 12px 24px; background: #667eea; color: white; text-decoration: none; border-radius: 6px; margin: 20px 0; }}
+        .info-box {{ background: #fff7ed; border-left: 4px solid #f59e0b; padding: 15px; margin: 20px 0; }}
+        .footer {{ text-align: center; color: #666; font-size: 12px; margin-top: 30px; padding-top: 20px; border-top: 1px solid #e0e0e0; }}
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>Usage Approaching Limit</h1>
+    </div>
+    <div class="content">
+        <p>Hi {username},</p>
+        <p>Your MockForge Cloud organization has crossed <strong>{threshold_pct}%</strong> of its <strong>{metric_label}</strong> limit on the current billing period.</p>
+        <div class="info-box">
+            <p><strong>Metric:</strong> {metric_label}</p>
+            <p><strong>Plan:</strong> {plan}</p>
+            <p><strong>Used:</strong> {used_pretty} of {limit_pretty}</p>
+        </div>
+        <p>If you continue at the current rate, you may hit your plan limit before the end of the period. Consider upgrading or contacting us if you expect a temporary spike.</p>
+        <p style="text-align: center;">
+            <a href="https://app.mockforge.dev/usage" class="button">View Usage</a>
+        </p>
+        <p>You can dismiss this alert from the usage dashboard.</p>
+        <p>Best regards,<br>The MockForge Team</p>
+    </div>
+    <div class="footer">
+        <p>© {year} MockForge. All rights reserved.</p>
+        <p><a href="https://mockforge.dev/terms">Terms of Service</a> | <a href="https://mockforge.dev/privacy">Privacy Policy</a></p>
+    </div>
+</body>
+</html>
+"#,
+            username = username,
+            plan = plan,
+            metric_label = metric_label,
+            used_pretty = used_pretty,
+            limit_pretty = limit_pretty,
+            threshold_pct = threshold_pct,
+            year = chrono::Utc::now().year()
+        );
+
+        let text_body = format!(
+            r#"
+Usage Approaching Limit
+
+Hi {username},
+
+Your MockForge Cloud organization has crossed {threshold_pct}% of its {metric_label} limit on the current billing period.
+
+Metric: {metric_label}
+Plan: {plan}
+Used: {used_pretty} of {limit_pretty}
+
+If you continue at the current rate, you may hit your plan limit before the end of the period. Consider upgrading or contact us if you expect a temporary spike.
+
+View usage: https://app.mockforge.dev/usage
+
+Best regards,
+The MockForge Team
+
+© {year} MockForge. All rights reserved.
+"#,
+            username = username,
+            plan = plan,
+            metric_label = metric_label,
+            used_pretty = used_pretty,
+            limit_pretty = limit_pretty,
+            threshold_pct = threshold_pct,
+            year = chrono::Utc::now().year()
+        );
+
+        EmailMessage {
+            to: email.to_string(),
+            subject: format!(
+                "MockForge: {}% of {} used on {} plan",
+                threshold_pct, metric_label, plan
+            ),
+            html_body,
+            text_body,
+        }
+    }
+
     /// Generate support request confirmation email
     pub fn generate_support_confirmation(
         username: &str,

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -4,7 +4,8 @@ use axum::{extract::State, http::HeaderMap, Json};
 use serde::{Deserialize, Serialize};
 use stripe::{
     BillingPortalSession, CheckoutSession, CheckoutSessionMode, Client, CreateBillingPortalSession,
-    CreateCheckoutSession, CreateCheckoutSessionLineItems, EventObject, EventType,
+    CreateCheckoutSession, CreateCheckoutSessionLineItems, EventObject, EventType, Invoice,
+    ListInvoices,
 };
 use uuid::Uuid;
 
@@ -41,8 +42,8 @@ pub async fn get_subscription(
         .await
         .map_err(ApiError::Database)?;
 
-    // Get plan limits
-    let limits = org_ctx.org.limits_json.clone();
+    // Effective limits = plan defaults + custom org quota overrides
+    let limits = super::usage::effective_limits(&state, &org_ctx.org).await?;
 
     Ok(Json(SubscriptionResponse {
         org_id: org_ctx.org_id,
@@ -68,6 +69,13 @@ pub async fn get_subscription(
             storage_bytes: usage.storage_bytes,
             storage_limit_bytes: limits.get("storage_gb").and_then(|v| v.as_i64()).unwrap_or(1)
                 * 1_000_000_000, // Convert GB to bytes
+            egress_bytes: usage.egress_bytes,
+            // -1 = no plan-defined cap (egress is tracked but not capped today)
+            egress_limit_bytes: limits
+                .get("egress_gb")
+                .and_then(|v| v.as_i64())
+                .map(|gb| gb * 1_000_000_000)
+                .unwrap_or(-1),
             ai_tokens_used: usage.ai_tokens_used,
             ai_tokens_limit: limits
                 .get("ai_tokens_per_month")
@@ -95,6 +103,8 @@ pub struct UsageStats {
     pub requests_limit: i64,
     pub storage_bytes: i64,
     pub storage_limit_bytes: i64,
+    pub egress_bytes: i64,
+    pub egress_limit_bytes: i64,
     pub ai_tokens_used: i64,
     pub ai_tokens_limit: i64,
 }
@@ -290,6 +300,103 @@ pub async fn create_portal_session(
 
     Ok(Json(CreatePortalResponse {
         portal_url: session.url,
+    }))
+}
+
+/// Single invoice line in the API response (subset of Stripe's full Invoice).
+#[derive(Debug, Serialize)]
+pub struct InvoiceItem {
+    pub id: String,
+    pub number: Option<String>,
+    pub status: Option<String>,
+    pub amount_due: i64,
+    pub amount_paid: i64,
+    pub currency: Option<String>,
+    pub created: Option<i64>,
+    pub period_start: Option<i64>,
+    pub period_end: Option<i64>,
+    pub hosted_invoice_url: Option<String>,
+    pub invoice_pdf: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListInvoicesResponse {
+    pub org_id: Uuid,
+    pub invoices: Vec<InvoiceItem>,
+}
+
+/// GET /api/v1/billing/invoices
+///
+/// Lists the org's invoices via Stripe. Returns an empty list if the org has
+/// no Stripe customer ID yet (e.g. free tier never upgraded).
+pub async fn list_invoices(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+) -> ApiResult<Json<ListInvoicesResponse>> {
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    // Owner-only — invoices contain financial info
+    if org_ctx.org.owner_id != user_id {
+        return Err(ApiError::PermissionDenied);
+    }
+
+    // No customer yet → empty list (not an error). Same for un-configured Stripe.
+    let stripe_customer_id = match org_ctx.org.stripe_customer_id.as_ref() {
+        Some(id) => id,
+        None => {
+            return Ok(Json(ListInvoicesResponse {
+                org_id: org_ctx.org_id,
+                invoices: vec![],
+            }));
+        }
+    };
+    let stripe_secret = match state.config.stripe_secret_key.as_ref() {
+        Some(s) => s,
+        None => {
+            return Ok(Json(ListInvoicesResponse {
+                org_id: org_ctx.org_id,
+                invoices: vec![],
+            }));
+        }
+    };
+
+    let customer_id = stripe_customer_id
+        .parse()
+        .map_err(|_| ApiError::Internal(anyhow::anyhow!("Invalid Stripe customer ID")))?;
+    let client = Client::new(stripe_secret);
+
+    let mut params = ListInvoices::new();
+    params.customer = Some(customer_id);
+    params.limit = Some(20);
+
+    let list = Invoice::list(&client, &params)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("Stripe invoices error: {}", e)))?;
+
+    let invoices = list
+        .data
+        .into_iter()
+        .map(|inv| InvoiceItem {
+            id: inv.id.to_string(),
+            number: inv.number,
+            status: inv.status.map(|s| s.as_str().to_string()),
+            amount_due: inv.amount_due.unwrap_or(0),
+            amount_paid: inv.amount_paid.unwrap_or(0),
+            currency: inv.currency.map(|c| c.to_string()),
+            created: inv.created,
+            period_start: inv.period_start,
+            period_end: inv.period_end,
+            hosted_invoice_url: inv.hosted_invoice_url,
+            invoice_pdf: inv.invoice_pdf,
+        })
+        .collect();
+
+    Ok(Json(ListInvoicesResponse {
+        org_id: org_ctx.org_id,
+        invoices,
     }))
 }
 

--- a/crates/mockforge-registry-server/src/handlers/usage.rs
+++ b/crates/mockforge-registry-server/src/handlers/usage.rs
@@ -3,7 +3,11 @@
 //! Provides endpoints for organizations to view their current usage
 //! and limits across requests, storage, AI tokens, etc.
 
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -11,9 +15,35 @@ use uuid::Uuid;
 use crate::{
     error::{ApiError, ApiResult},
     middleware::{resolve_org_context, AuthUser},
-    models::UsageCounter,
+    models::{Organization, UsageAlert, UsageCounter},
     AppState,
 };
+
+/// Effective per-key limits = plan defaults (org.limits_json) shallow-merged with
+/// the org's optional `quota` setting (org_settings.setting_key = "quota"). The
+/// admin-set quota overrides plan defaults per top-level key; missing keys fall
+/// back to the plan.
+pub(crate) async fn effective_limits(
+    state: &AppState,
+    org: &Organization,
+) -> ApiResult<serde_json::Value> {
+    let mut limits = org.limits_json.clone();
+    let setting = state.store.get_org_setting(org.id, "quota").await?;
+    if let Some(setting) = setting {
+        merge_quota_overrides(&mut limits, &setting.setting_value);
+    }
+    Ok(limits)
+}
+
+/// Shallow-merge `overrides` into `limits` in-place. Both must be JSON objects
+/// for any change to occur; otherwise this is a no-op.
+fn merge_quota_overrides(limits: &mut serde_json::Value, overrides: &serde_json::Value) {
+    if let (Some(base), Some(over)) = (limits.as_object_mut(), overrides.as_object()) {
+        for (k, v) in over {
+            base.insert(k.clone(), v.clone());
+        }
+    }
+}
 
 /// Get current usage statistics for the organization
 pub async fn get_usage(
@@ -29,8 +59,8 @@ pub async fn get_usage(
     // Get current usage counter
     let usage = state.store.get_or_create_current_usage_counter(org_ctx.org_id).await?;
 
-    // Get plan limits
-    let limits = &org_ctx.org.limits_json;
+    // Effective limits = plan defaults + custom org quota overrides
+    let limits = effective_limits(&state, &org_ctx.org).await?;
 
     // Build response with usage and limits
     Ok(Json(UsageResponse {
@@ -200,4 +230,129 @@ fn calculate_period_end(period_start: chrono::NaiveDate) -> chrono::NaiveDate {
     NaiveDate::from_ymd_opt(next_year, next_month, 1)
         .and_then(|d| d.pred_opt())
         .unwrap_or(period_start)
+}
+
+/// First day of the current month — used to scope alerts to a billing period.
+pub(crate) fn current_period_start() -> chrono::NaiveDate {
+    let today = chrono::Utc::now().date_naive();
+    chrono::NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap_or(today)
+}
+
+#[derive(Debug, Serialize)]
+pub struct UsageAlertItem {
+    pub id: Uuid,
+    pub metric: String,
+    pub period_start: chrono::NaiveDate,
+    pub threshold_pct: i16,
+    pub notified_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListUsageAlertsResponse {
+    pub org_id: Uuid,
+    pub period_start: chrono::NaiveDate,
+    pub alerts: Vec<UsageAlertItem>,
+}
+
+/// GET /api/v1/usage/alerts — active (non-dismissed) alerts for the org's
+/// current billing period.
+pub async fn list_usage_alerts(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+) -> ApiResult<Json<ListUsageAlertsResponse>> {
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    let period_start = current_period_start();
+    let rows = UsageAlert::list_active_for_period(state.db.pool(), org_ctx.org_id, period_start)
+        .await
+        .map_err(ApiError::Database)?;
+
+    let alerts = rows
+        .into_iter()
+        .map(|a| UsageAlertItem {
+            id: a.id,
+            metric: a.metric,
+            period_start: a.period_start,
+            threshold_pct: a.threshold_pct,
+            notified_at: a.notified_at,
+        })
+        .collect();
+
+    Ok(Json(ListUsageAlertsResponse {
+        org_id: org_ctx.org_id,
+        period_start,
+        alerts,
+    }))
+}
+
+#[derive(Debug, Serialize)]
+pub struct DismissUsageAlertResponse {
+    pub dismissed: bool,
+}
+
+/// POST /api/v1/usage/alerts/{alert_id}/dismiss — soft-dismiss an alert.
+pub async fn dismiss_usage_alert(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(alert_id): Path<Uuid>,
+) -> ApiResult<Json<DismissUsageAlertResponse>> {
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    let result = UsageAlert::dismiss(state.db.pool(), alert_id, org_ctx.org_id)
+        .await
+        .map_err(ApiError::Database)?;
+
+    Ok(Json(DismissUsageAlertResponse {
+        dismissed: result.is_some(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn merge_quota_overrides_replaces_existing_keys() {
+        let mut limits = json!({"requests_per_30d": 10_000, "storage_gb": 1});
+        let overrides = json!({"requests_per_30d": 50_000});
+        merge_quota_overrides(&mut limits, &overrides);
+        assert_eq!(limits["requests_per_30d"], 50_000);
+        assert_eq!(limits["storage_gb"], 1);
+    }
+
+    #[test]
+    fn merge_quota_overrides_adds_new_keys() {
+        let mut limits = json!({"requests_per_30d": 10_000});
+        let overrides = json!({"egress_gb": 5});
+        merge_quota_overrides(&mut limits, &overrides);
+        assert_eq!(limits["requests_per_30d"], 10_000);
+        assert_eq!(limits["egress_gb"], 5);
+    }
+
+    #[test]
+    fn merge_quota_overrides_noop_for_non_objects() {
+        let mut limits = json!({"requests_per_30d": 10_000});
+        let original = limits.clone();
+        merge_quota_overrides(&mut limits, &json!("not an object"));
+        assert_eq!(limits, original);
+
+        let mut not_object = json!(42);
+        merge_quota_overrides(&mut not_object, &json!({"x": 1}));
+        assert_eq!(not_object, json!(42));
+    }
+
+    #[test]
+    fn merge_quota_overrides_empty_override_keeps_plan() {
+        let mut limits = json!({"requests_per_30d": 10_000, "storage_gb": 1});
+        let original = limits.clone();
+        merge_quota_overrides(&mut limits, &json!({}));
+        assert_eq!(limits, original);
+    }
 }

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -177,6 +177,7 @@ async fn main() -> Result<()> {
     workers::runtime_observability_retention::start_runtime_observability_retention_worker(
         db.pool().clone(),
     );
+    workers::usage_threshold_checker::start_usage_threshold_checker(state.clone());
 
     // Start deployment orchestrator for hosted mocks
     let flyio_token = std::env::var("FLYIO_API_TOKEN").ok();

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -164,6 +164,7 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/billing/subscription", get(handlers::billing::get_subscription))
         .route("/api/v1/billing/checkout", post(handlers::billing::create_checkout))
         .route("/api/v1/billing/portal", post(handlers::billing::create_portal_session))
+        .route("/api/v1/billing/invoices", get(handlers::billing::list_invoices))
         // Email verification (resend requires auth)
         .route("/api/v1/auth/verify-email/resend", post(handlers::verification::resend_verification))
         // Hosted mocks deployment routes
@@ -213,6 +214,11 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/usage", get(handlers::usage::get_usage))
         .route("/api/v1/usage/history", get(handlers::usage::get_usage_history))
         .route("/api/v1/usage/ai-tokens", post(handlers::usage::report_ai_tokens))
+        .route("/api/v1/usage/alerts", get(handlers::usage::list_usage_alerts))
+        .route(
+            "/api/v1/usage/alerts/{alert_id}/dismiss",
+            post(handlers::usage::dismiss_usage_alert),
+        )
         // Audit logs
         .route("/api/v1/organizations/{org_id}/audit-logs", get(handlers::audit::get_audit_logs))
         // GDPR compliance

--- a/crates/mockforge-registry-server/src/workers/mod.rs
+++ b/crates/mockforge-registry-server/src/workers/mod.rs
@@ -5,3 +5,4 @@ pub mod plugin_scanner;
 pub mod runtime_logs_retention;
 pub mod runtime_observability_retention;
 pub mod saml_cleanup;
+pub mod usage_threshold_checker;

--- a/crates/mockforge-registry-server/src/workers/usage_threshold_checker.rs
+++ b/crates/mockforge-registry-server/src/workers/usage_threshold_checker.rs
@@ -1,0 +1,291 @@
+//! Background worker that scans every org's current-month usage against its
+//! effective limits (plan + custom quota) and inserts a `usage_alerts` row the
+//! first time a 75% or 90% band is crossed. Inserts are idempotent on the
+//! unique index, so the worker is safe to re-run on any cadence.
+//!
+//! On a newly inserted alert, the worker emails the org owner (gated on
+//! `users.email_notifications`). Both bands can be inserted in a single run if
+//! usage hops past them between checks; only the highest newly-inserted band
+//! per (org, metric) triggers an email so users are not double-pinged.
+
+use std::time::Duration;
+
+use chrono::{Datelike, NaiveDate};
+use sqlx::PgPool;
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    email::EmailService,
+    models::{Organization, UsageAlert, UsageCounter, User},
+    AppState,
+};
+
+const DEFAULT_INTERVAL_SECS: u64 = 30 * 60; // 30 minutes
+const BANDS: [i16; 2] = [75, 90];
+
+/// Start the usage-threshold checker. Interval can be overridden by the
+/// `USAGE_THRESHOLD_CHECK_INTERVAL_SECS` env var; falls back to 30 minutes.
+pub fn start_usage_threshold_checker(state: AppState) {
+    let interval_secs = std::env::var("USAGE_THRESHOLD_CHECK_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|n| *n >= 60)
+        .unwrap_or(DEFAULT_INTERVAL_SECS);
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        // Skip the immediate first tick — give the server a moment to settle.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if let Err(e) = run_once(&state).await {
+                error!("usage_threshold_checker: scan failed: {e:?}");
+            }
+        }
+    });
+
+    info!("Usage threshold checker started (every {interval_secs}s)");
+}
+
+async fn run_once(state: &AppState) -> Result<(), sqlx::Error> {
+    let pool = state.db.pool();
+    let period_start = current_period_start();
+
+    // Only scan orgs that have a usage counter for this period — i.e. orgs
+    // with any activity. Avoids enumerating every org when most are idle.
+    let counters: Vec<UsageCounter> =
+        sqlx::query_as::<_, UsageCounter>("SELECT * FROM usage_counters WHERE period_start = $1")
+            .bind(period_start)
+            .fetch_all(pool)
+            .await?;
+
+    debug!(
+        "usage_threshold_checker: scanning {} active counters for {}",
+        counters.len(),
+        period_start
+    );
+
+    let mut alerts_emitted = 0usize;
+    for counter in counters {
+        match check_org(state, pool, period_start, &counter).await {
+            Ok(n) => alerts_emitted += n,
+            Err(e) => {
+                warn!(org_id = %counter.org_id, "threshold check failed: {e:?}");
+            }
+        }
+    }
+
+    if alerts_emitted > 0 {
+        info!("usage_threshold_checker: emitted {alerts_emitted} new alert(s)");
+    }
+    Ok(())
+}
+
+async fn check_org(
+    state: &AppState,
+    pool: &PgPool,
+    period_start: NaiveDate,
+    counter: &UsageCounter,
+) -> Result<usize, sqlx::Error> {
+    let Some(org) = Organization::find_by_id(pool, counter.org_id).await? else {
+        return Ok(0);
+    };
+
+    // Effective limits: plan defaults + custom quota override (matches
+    // handlers::usage::effective_limits semantics, but inlined to avoid taking
+    // an ApiError dependency in worker code).
+    let mut limits = org.limits_json.clone();
+    if let Ok(Some(setting)) = state.store.get_org_setting(org.id, "quota").await {
+        if let (Some(base), Some(over)) =
+            (limits.as_object_mut(), setting.setting_value.as_object())
+        {
+            for (k, v) in over {
+                base.insert(k.clone(), v.clone());
+            }
+        }
+    }
+
+    let metrics: [(&str, i64, i64); 3] = [
+        (
+            "requests",
+            counter.requests,
+            limits.get("requests_per_30d").and_then(|v| v.as_i64()).unwrap_or(0),
+        ),
+        (
+            "storage",
+            counter.storage_bytes,
+            limits
+                .get("storage_gb")
+                .and_then(|v| v.as_i64())
+                .map(|gb| gb.saturating_mul(1_000_000_000))
+                .unwrap_or(0),
+        ),
+        (
+            "ai_tokens",
+            counter.ai_tokens_used,
+            limits.get("ai_tokens_per_month").and_then(|v| v.as_i64()).unwrap_or(0),
+        ),
+    ];
+
+    let mut emitted = 0usize;
+    for (metric, used, limit) in metrics {
+        if limit <= 0 || used <= 0 {
+            continue;
+        }
+        let pct_crossed = compute_pct(used, limit);
+        let mut highest_new: Option<i16> = None;
+        for &band in &BANDS {
+            if pct_crossed >= band
+                && UsageAlert::try_insert(pool, org.id, metric, period_start, band)
+                    .await?
+                    .is_some()
+            {
+                // BANDS is ascending; this overwrites with the highest.
+                highest_new = Some(band);
+                emitted += 1;
+            }
+        }
+        if let Some(band) = highest_new {
+            send_email(state, pool, &org, metric, used, limit, band).await;
+        }
+    }
+    Ok(emitted)
+}
+
+fn compute_pct(used: i64, limit: i64) -> i16 {
+    if limit <= 0 {
+        return 0;
+    }
+    let pct = (used as f64 / limit as f64 * 100.0).floor();
+    pct.clamp(0.0, 1000.0) as i16
+}
+
+async fn send_email(
+    state: &AppState,
+    pool: &PgPool,
+    org: &Organization,
+    metric: &str,
+    used: i64,
+    limit: i64,
+    band: i16,
+) {
+    let owner = match User::find_by_id(pool, org.owner_id).await {
+        Ok(Some(u)) if u.email_notifications => u,
+        Ok(_) => return,
+        Err(e) => {
+            warn!(org_id = %org.id, "threshold email skipped — owner lookup failed: {e:?}");
+            return;
+        }
+    };
+
+    let metric_label: String = match metric {
+        "requests" => "API Requests",
+        "storage" => "Storage",
+        "ai_tokens" => "AI Tokens",
+        other => other,
+    }
+    .to_string();
+    let used_pretty = format_metric_value(metric, used);
+    let limit_pretty = format_metric_value(metric, limit);
+    let plan = org.plan().to_string();
+    let owner_email = owner.email.clone();
+    let username = owner.username.clone();
+    let band_u = band as u16;
+
+    // Same pattern as billing.rs — read config from env per send.
+    let _ = state; // suppress unused-var warning; future config use lives here
+    tokio::spawn(async move {
+        let email_service = match EmailService::from_env() {
+            Ok(s) => s,
+            Err(e) => {
+                debug!("usage threshold email skipped — service init failed: {e:?}");
+                return;
+            }
+        };
+        let msg = EmailService::generate_usage_threshold_warning(
+            &username,
+            &owner_email,
+            &metric_label,
+            &plan,
+            &used_pretty,
+            &limit_pretty,
+            band_u,
+        );
+        if let Err(e) = email_service.send(msg).await {
+            warn!("usage threshold email send failed: {e:?}");
+        }
+    });
+}
+
+fn format_metric_value(metric: &str, value: i64) -> String {
+    match metric {
+        "storage" => format_bytes_si(value),
+        _ => format_count(value),
+    }
+}
+
+fn format_count(n: i64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+fn format_bytes_si(b: i64) -> String {
+    if b <= 0 {
+        return "0 B".into();
+    }
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut v = b as f64;
+    let mut idx = 0;
+    while v >= 1000.0 && idx < UNITS.len() - 1 {
+        v /= 1000.0;
+        idx += 1;
+    }
+    format!("{:.2} {}", v, UNITS[idx])
+}
+
+fn current_period_start() -> NaiveDate {
+    let today = chrono::Utc::now().date_naive();
+    NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap_or(today)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pct_basic() {
+        assert_eq!(compute_pct(0, 100), 0);
+        assert_eq!(compute_pct(74, 100), 74);
+        assert_eq!(compute_pct(75, 100), 75);
+        assert_eq!(compute_pct(90, 100), 90);
+        assert_eq!(compute_pct(150, 100), 150);
+    }
+
+    #[test]
+    fn pct_zero_or_negative_limit_is_zero() {
+        assert_eq!(compute_pct(50, 0), 0);
+        assert_eq!(compute_pct(50, -1), 0);
+    }
+
+    #[test]
+    fn count_formatting() {
+        assert_eq!(format_count(0), "0");
+        assert_eq!(format_count(999), "999");
+        assert_eq!(format_count(1_500), "1.5K");
+        assert_eq!(format_count(2_500_000), "2.5M");
+    }
+
+    #[test]
+    fn bytes_formatting_si() {
+        assert_eq!(format_bytes_si(0), "0 B");
+        assert_eq!(format_bytes_si(500), "500.00 B");
+        assert_eq!(format_bytes_si(1_000), "1.00 KB");
+        assert_eq!(format_bytes_si(1_500_000), "1.50 MB");
+        assert_eq!(format_bytes_si(20_000_000_000), "20.00 GB");
+    }
+}

--- a/crates/mockforge-ui/ui/src/pages/BillingPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/BillingPage.tsx
@@ -11,6 +11,7 @@ import {
   TrendingUp,
   HardDrive,
   Zap,
+  Activity,
   AlertCircle,
   ExternalLink,
   ArrowUpCircle,
@@ -21,7 +22,14 @@ import { useToast } from '@/components/ui/ToastProvider';
 interface Subscription {
   org_id: string;
   plan: 'free' | 'pro' | 'team';
-  status: 'active' | 'trialing' | 'past_due' | 'canceled' | 'unpaid';
+  status:
+    | 'active'
+    | 'trialing'
+    | 'past_due'
+    | 'canceled'
+    | 'unpaid'
+    | 'incomplete'
+    | 'incomplete_expired';
   cancel_at_period_end?: boolean;
   current_period_end?: string;
   usage: UsageStats;
@@ -33,6 +41,10 @@ interface Subscription {
     storage_gb: number;
     ai_tokens_per_month: number;
     hosted_mocks: boolean;
+    max_hosted_mocks: number;
+    max_plugins_published: number;
+    max_templates_published: number;
+    max_scenarios_published: number;
   };
 }
 
@@ -41,6 +53,8 @@ interface UsageStats {
   requests_limit: number;
   storage_bytes: number;
   storage_limit_bytes: number;
+  egress_bytes: number;
+  egress_limit_bytes: number;
   ai_tokens_used: number;
   ai_tokens_limit: number;
 }
@@ -57,6 +71,25 @@ interface CreateCheckoutResponse {
 
 interface CreatePortalResponse {
   portal_url: string;
+}
+
+interface InvoiceItem {
+  id: string;
+  number: string | null;
+  status: string | null;
+  amount_due: number;
+  amount_paid: number;
+  currency: string | null;
+  created: number | null;
+  period_start: number | null;
+  period_end: number | null;
+  hosted_invoice_url: string | null;
+  invoice_pdf: string | null;
+}
+
+interface ListInvoicesResponse {
+  org_id: string;
+  invoices: InvoiceItem[];
 }
 
 // API base URL - adjust based on your setup
@@ -107,6 +140,20 @@ async function createCheckout(request: CreateCheckoutRequest): Promise<CreateChe
   return response.json();
 }
 
+async function fetchInvoices(): Promise<ListInvoicesResponse> {
+  const token = localStorage.getItem('auth_token');
+  const response = await fetch(`${API_BASE}/billing/invoices`, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response, 'Failed to fetch invoices'));
+  }
+  return response.json();
+}
+
 async function createPortalSession(): Promise<CreatePortalResponse> {
   const token = localStorage.getItem('auth_token');
   const response = await fetch(`${API_BASE}/billing/portal`, {
@@ -139,6 +186,19 @@ export function BillingPage() {
   } = useQuery({
     queryKey: ['subscription'],
     queryFn: fetchSubscription,
+  });
+
+  // Fetch invoices (only meaningful once we have a Stripe customer; backend
+  // returns an empty list otherwise so this is safe to fire eagerly)
+  const {
+    data: invoiceList,
+    isLoading: invoicesLoading,
+    isError: invoicesError,
+    refetch: refetchInvoices,
+  } = useQuery({
+    queryKey: ['invoices'],
+    queryFn: fetchInvoices,
+    staleTime: 5 * 60_000,
   });
 
   // Create checkout mutation
@@ -204,6 +264,9 @@ export function BillingPage() {
     return num.toString();
   };
 
+  // -1 = unlimited, 0 = not included, otherwise show the number
+  const formatLimit = (n: number) => (n === -1 ? 'Unlimited' : n === 0 ? 'Not included' : String(n));
+
   const getUsagePercentage = (used: number, limit: number) => {
     if (limit <= 0) return 0;
     return Math.min((used / limit) * 100, 100);
@@ -217,6 +280,12 @@ export function BillingPage() {
         return <Badge className="bg-blue-500"><Calendar className="w-3 h-3 mr-1" />Trialing</Badge>;
       case 'past_due':
         return <Badge className="bg-yellow-500"><AlertCircle className="w-3 h-3 mr-1" />Past Due</Badge>;
+      case 'unpaid':
+        return <Badge className="bg-red-500"><AlertCircle className="w-3 h-3 mr-1" />Unpaid</Badge>;
+      case 'incomplete':
+        return <Badge className="bg-yellow-500"><AlertCircle className="w-3 h-3 mr-1" />Incomplete</Badge>;
+      case 'incomplete_expired':
+        return <Badge className="bg-gray-500"><XCircle className="w-3 h-3 mr-1" />Incomplete (expired)</Badge>;
       case 'canceled':
         return <Badge className="bg-gray-500"><XCircle className="w-3 h-3 mr-1" />Canceled</Badge>;
       default:
@@ -282,6 +351,7 @@ export function BillingPage() {
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="usage">Usage</TabsTrigger>
+          <TabsTrigger value="invoices">Invoices</TabsTrigger>
           <TabsTrigger value="plans">Plans</TabsTrigger>
         </TabsList>
 
@@ -309,23 +379,35 @@ export function BillingPage() {
                 <div className="space-y-2">
                   <div className="flex justify-between text-sm">
                     <span>Projects</span>
-                    <span>
-                      {subscription.limits.max_projects === -1
-                        ? 'Unlimited'
-                        : subscription.limits.max_projects}
-                    </span>
+                    <span>{formatLimit(subscription.limits.max_projects)}</span>
                   </div>
                   <div className="flex justify-between text-sm">
                     <span>Collaborators</span>
-                    <span>{subscription.limits.max_collaborators}</span>
+                    <span>{formatLimit(subscription.limits.max_collaborators)}</span>
                   </div>
                   <div className="flex justify-between text-sm">
                     <span>Environments</span>
-                    <span>{subscription.limits.max_environments}</span>
+                    <span>{formatLimit(subscription.limits.max_environments)}</span>
                   </div>
                   <div className="flex justify-between text-sm">
                     <span>Hosted Mocks</span>
-                    <span>{subscription.limits.hosted_mocks ? 'Yes' : 'No'}</span>
+                    <span>
+                      {subscription.limits.hosted_mocks
+                        ? formatLimit(subscription.limits.max_hosted_mocks)
+                        : 'Not included'}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span>Plugins published</span>
+                    <span>{formatLimit(subscription.limits.max_plugins_published)}</span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span>Templates published</span>
+                    <span>{formatLimit(subscription.limits.max_templates_published)}</span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span>Scenarios published</span>
+                    <span>{formatLimit(subscription.limits.max_scenarios_published)}</span>
                   </div>
                 </div>
                 {subscription.plan === 'free' ? (
@@ -404,6 +486,35 @@ export function BillingPage() {
                     />
                   </div>
                 </div>
+                {(subscription.usage.egress_limit_bytes > 0 || subscription.usage.egress_bytes > 0) && (
+                  <div>
+                    <div className="flex justify-between text-sm mb-1">
+                      <span className="flex items-center">
+                        <Activity className="w-4 h-4 mr-1" />
+                        Egress
+                      </span>
+                      <span>
+                        {formatBytes(subscription.usage.egress_bytes)}
+                        {subscription.usage.egress_limit_bytes > 0
+                          ? ` / ${formatBytes(subscription.usage.egress_limit_bytes)}`
+                          : ''}
+                      </span>
+                    </div>
+                    {subscription.usage.egress_limit_bytes > 0 && (
+                      <div className="w-full bg-secondary rounded-full h-2">
+                        <div
+                          className="bg-primary h-2 rounded-full transition-all"
+                          style={{
+                            width: `${getUsagePercentage(
+                              subscription.usage.egress_bytes,
+                              subscription.usage.egress_limit_bytes
+                            )}%`,
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
                 {subscription.usage.ai_tokens_limit > 0 && (
                   <div>
                     <div className="flex justify-between text-sm mb-1">
@@ -460,6 +571,17 @@ export function BillingPage() {
                     {formatBytes(subscription.usage.storage_bytes)} / {formatBytes(subscription.usage.storage_limit_bytes)}
                   </div>
                 </div>
+                {(subscription.usage.egress_limit_bytes > 0 || subscription.usage.egress_bytes > 0) && (
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Egress</div>
+                    <div className="text-lg font-semibold">
+                      {formatBytes(subscription.usage.egress_bytes)}
+                      {subscription.usage.egress_limit_bytes > 0
+                        ? ` / ${formatBytes(subscription.usage.egress_limit_bytes)}`
+                        : ''}
+                    </div>
+                  </div>
+                )}
                 {subscription.usage.ai_tokens_limit > 0 && (
                   <div className="rounded-lg border p-3">
                     <div className="text-sm text-muted-foreground">AI Tokens</div>
@@ -476,6 +598,94 @@ export function BillingPage() {
                 View full usage dashboard
                 <ExternalLink className="w-3 h-3 ml-1" />
               </a>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Invoices Tab */}
+        <TabsContent value="invoices" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Invoices</CardTitle>
+              <CardDescription>
+                Past invoices from Stripe. Use the Stripe portal for payment-method changes.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {invoicesLoading ? (
+                <div className="text-center py-6 text-sm text-muted-foreground">
+                  Loading invoices...
+                </div>
+              ) : invoicesError ? (
+                <div className="text-center py-6 space-y-3">
+                  <AlertCircle className="w-8 h-8 mx-auto text-red-500" />
+                  <p className="text-sm text-muted-foreground">Failed to load invoices</p>
+                  <Button variant="outline" size="sm" onClick={() => refetchInvoices()}>
+                    Retry
+                  </Button>
+                </div>
+              ) : !invoiceList || invoiceList.invoices.length === 0 ? (
+                <div className="text-center py-6 text-sm text-muted-foreground">
+                  No invoices yet.{' '}
+                  {subscription.plan === 'free'
+                    ? 'Upgrade to a paid plan to start receiving invoices.'
+                    : 'Your first invoice will appear after the next billing cycle.'}
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-muted-foreground">
+                        <th className="py-2 pr-4 font-medium">Date</th>
+                        <th className="py-2 pr-4 font-medium">Number</th>
+                        <th className="py-2 pr-4 font-medium">Period</th>
+                        <th className="py-2 pr-4 font-medium">Amount</th>
+                        <th className="py-2 pr-4 font-medium">Status</th>
+                        <th className="py-2 pr-4 font-medium text-right">Links</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {invoiceList.invoices.map((inv) => (
+                        <tr key={inv.id} className="border-b last:border-0">
+                          <td className="py-2 pr-4">{formatUnix(inv.created)}</td>
+                          <td className="py-2 pr-4 font-mono text-xs">{inv.number ?? '—'}</td>
+                          <td className="py-2 pr-4 text-xs text-muted-foreground">
+                            {formatPeriod(inv.period_start, inv.period_end)}
+                          </td>
+                          <td className="py-2 pr-4 font-medium">
+                            {formatMoney(inv.amount_paid || inv.amount_due, inv.currency)}
+                          </td>
+                          <td className="py-2 pr-4">
+                            <InvoiceStatusBadge status={inv.status} />
+                          </td>
+                          <td className="py-2 pr-4 text-right space-x-2">
+                            {inv.hosted_invoice_url && (
+                              <a
+                                href={inv.hosted_invoice_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline dark:text-blue-400"
+                              >
+                                View
+                              </a>
+                            )}
+                            {inv.invoice_pdf && (
+                              <a
+                                href={inv.invoice_pdf}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline dark:text-blue-400"
+                              >
+                                PDF
+                              </a>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
@@ -633,4 +843,44 @@ export function BillingPage() {
       </Tabs>
     </div>
   );
+}
+
+function formatUnix(unixSeconds: number | null): string {
+  if (!unixSeconds) return '—';
+  return new Date(unixSeconds * 1000).toLocaleDateString();
+}
+
+function formatPeriod(start: number | null, end: number | null): string {
+  if (!start || !end) return '—';
+  const s = new Date(start * 1000).toLocaleDateString();
+  const e = new Date(end * 1000).toLocaleDateString();
+  return `${s} – ${e}`;
+}
+
+function formatMoney(cents: number, currency: string | null): string {
+  const code = (currency ?? 'usd').toUpperCase();
+  const amount = cents / 100;
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency: code }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${code}`;
+  }
+}
+
+function InvoiceStatusBadge({ status }: { status: string | null }) {
+  if (!status) return <Badge>—</Badge>;
+  switch (status) {
+    case 'paid':
+      return <Badge className="bg-green-500"><CheckCircle2 className="w-3 h-3 mr-1" />Paid</Badge>;
+    case 'open':
+      return <Badge className="bg-yellow-500"><AlertCircle className="w-3 h-3 mr-1" />Open</Badge>;
+    case 'uncollectible':
+      return <Badge className="bg-red-500"><XCircle className="w-3 h-3 mr-1" />Uncollectible</Badge>;
+    case 'void':
+      return <Badge className="bg-gray-500"><XCircle className="w-3 h-3 mr-1" />Void</Badge>;
+    case 'draft':
+      return <Badge className="bg-gray-400">Draft</Badge>;
+    default:
+      return <Badge>{status}</Badge>;
+  }
 }

--- a/crates/mockforge-ui/ui/src/pages/UsageDashboardPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/UsageDashboardPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { Badge } from '@/components/ui/Badge';
@@ -16,6 +16,9 @@ import {
   ArrowUpRight,
   ChevronLeft,
   ChevronRight,
+  Package,
+  Key,
+  Server,
 } from 'lucide-react';
 import { authenticatedFetch } from '@/utils/apiClient';
 
@@ -51,6 +54,30 @@ interface UsageHistoryResponse {
   }>;
 }
 
+interface OrgLifetimeUsageResponse {
+  org_id: string;
+  total_requests: number;
+  total_storage_gb: number;
+  total_ai_tokens: number;
+  hosted_mocks_count: number;
+  plugins_published: number;
+  api_tokens_count: number;
+}
+
+interface UsageAlertItem {
+  id: string;
+  metric: string;
+  period_start: string;
+  threshold_pct: number;
+  notified_at: string;
+}
+
+interface ListUsageAlertsResponse {
+  org_id: string;
+  period_start: string;
+  alerts: UsageAlertItem[];
+}
+
 // API base URL
 const API_BASE = '/api/v1';
 
@@ -70,6 +97,31 @@ async function fetchUsageHistory(): Promise<UsageHistoryResponse> {
     throw new Error('Failed to fetch usage history');
   }
   return response.json();
+}
+
+async function fetchLifetimeUsage(orgId: string): Promise<OrgLifetimeUsageResponse> {
+  const response = await authenticatedFetch(`${API_BASE}/organizations/${orgId}/usage`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch lifetime usage');
+  }
+  return response.json();
+}
+
+async function fetchUsageAlerts(): Promise<ListUsageAlertsResponse> {
+  const response = await authenticatedFetch(`${API_BASE}/usage/alerts`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch usage alerts');
+  }
+  return response.json();
+}
+
+async function dismissUsageAlert(alertId: string): Promise<void> {
+  const response = await authenticatedFetch(`${API_BASE}/usage/alerts/${alertId}/dismiss`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    throw new Error('Failed to dismiss alert');
+  }
 }
 
 // Use SI units (base-1000) to match backend which stores limits in SI bytes
@@ -164,6 +216,32 @@ export function UsageDashboardPage() {
     refetchInterval: 60_000,
   });
 
+  const {
+    data: lifetime,
+    isLoading: lifetimeLoading,
+    isError: lifetimeError,
+    refetch: refetchLifetime,
+  } = useQuery({
+    queryKey: ['usage-lifetime', usage?.org_id],
+    queryFn: () => fetchLifetimeUsage(usage!.org_id),
+    enabled: !!usage?.org_id,
+    staleTime: 60_000,
+  });
+
+  const queryClient = useQueryClient();
+  const { data: alertsData } = useQuery({
+    queryKey: ['usage-alerts'],
+    queryFn: fetchUsageAlerts,
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+  const dismissMutation = useMutation({
+    mutationFn: dismissUsageAlert,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['usage-alerts'] });
+    },
+  });
+
   if (usageLoading) {
     return (
       <div className="container mx-auto p-6 space-y-6">
@@ -245,6 +323,7 @@ export function UsageDashboardPage() {
         <TabsList>
           <TabsTrigger value="current">Current Usage</TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
+          <TabsTrigger value="lifetime">All Time</TabsTrigger>
         </TabsList>
 
         {/* Current Usage Tab */}
@@ -269,14 +348,16 @@ export function UsageDashboardPage() {
               formatValue={formatBytes}
             />
 
-            {/* Egress */}
-            <UsageCard
-              icon={<Activity className="w-5 h-5 mr-2" />}
-              title="Data Egress"
-              description="Data transfer usage"
-              metric={usage.usage.egress}
-              formatValue={formatBytes}
-            />
+            {/* Egress - show only if a limit is defined OR there's actual usage */}
+            {(usage.usage.egress.limit > 0 || usage.usage.egress.used > 0) && (
+              <UsageCard
+                icon={<Activity className="w-5 h-5 mr-2" />}
+                title="Data Egress"
+                description="Data transfer usage"
+                metric={usage.usage.egress}
+                formatValue={formatBytes}
+              />
+            )}
 
             {/* AI Tokens - show if limit > 0 OR if there's actual usage */}
             {(usage.usage.ai_tokens.limit > 0 || usage.usage.ai_tokens.used > 0) && (
@@ -291,7 +372,54 @@ export function UsageDashboardPage() {
             )}
           </div>
 
-          {/* Usage Warnings */}
+          {/* Server-driven alerts (persistent, dismissible) */}
+          {alertsData && alertsData.alerts.length > 0 && (
+            <Card className="border-yellow-500">
+              <CardHeader>
+                <CardTitle className="flex items-center text-base">
+                  <AlertCircle className="w-5 h-5 text-yellow-500 mr-2" />
+                  Active Alerts
+                </CardTitle>
+                <CardDescription>
+                  Thresholds crossed during this billing period. Dismiss once acknowledged.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {alertsData.alerts.map((alert) => (
+                  <div
+                    key={alert.id}
+                    className="flex items-center justify-between border rounded-md p-2 text-sm"
+                  >
+                    <div>
+                      <span className="font-medium">
+                        {METRIC_LABELS[alert.metric] ?? alert.metric}
+                      </span>{' '}
+                      <span className="text-muted-foreground">
+                        crossed {alert.threshold_pct}% of plan limit
+                      </span>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={dismissMutation.isPending}
+                      onClick={() => dismissMutation.mutate(alert.id)}
+                    >
+                      Dismiss
+                    </Button>
+                  </div>
+                ))}
+                <a
+                  href="/billing"
+                  className="inline-flex items-center mt-2 text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Upgrade plan
+                  <ArrowUpRight className="w-3 h-3 ml-1" />
+                </a>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Inline computed warning (instant, in-session, no dismissal) */}
           {highUsageMetrics.length > 0 && (
             <Card className="border-yellow-500">
               <CardContent className="p-4">
@@ -380,12 +508,15 @@ export function UsageDashboardPage() {
                           {formatBytes(period.storage_bytes)}
                         </div>
                       </div>
-                      <div>
-                        <div className="text-sm text-muted-foreground">Egress</div>
-                        <div className="text-lg font-semibold">
-                          {formatBytes(period.egress_bytes)}
+                      {/* Show egress in history only if there's non-zero usage OR a plan limit is defined */}
+                      {(period.egress_bytes > 0 || usage.usage.egress.limit > 0) && (
+                        <div>
+                          <div className="text-sm text-muted-foreground">Egress</div>
+                          <div className="text-lg font-semibold">
+                            {formatBytes(period.egress_bytes)}
+                          </div>
                         </div>
-                      </div>
+                      )}
                       {/* Show AI tokens in history if there's any non-zero usage OR current plan includes them */}
                       {(period.ai_tokens_used > 0 || usage.usage.ai_tokens.limit > 0) && (
                         <div>
@@ -444,7 +575,95 @@ export function UsageDashboardPage() {
             </Card>
           )}
         </TabsContent>
+
+        {/* Lifetime / All Time Tab */}
+        <TabsContent value="lifetime" className="space-y-4">
+          {lifetimeLoading ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              <UsageCardSkeleton />
+              <UsageCardSkeleton />
+            </div>
+          ) : lifetimeError || !lifetime ? (
+            <div className="text-center py-12 space-y-4">
+              <AlertCircle className="w-12 h-12 mx-auto text-red-500" />
+              <h2 className="text-lg font-semibold">Failed to load lifetime totals</h2>
+              <Button variant="outline" onClick={() => refetchLifetime()}>
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Lifetime Usage</CardTitle>
+                  <CardDescription>Cumulative across all billing periods</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <LifetimeStat
+                    icon={<TrendingUp className="w-4 h-4 mr-2" />}
+                    label="Total Requests"
+                    value={formatNumber(lifetime.total_requests)}
+                  />
+                  <LifetimeStat
+                    icon={<HardDrive className="w-4 h-4 mr-2" />}
+                    label="Total Storage"
+                    value={`${lifetime.total_storage_gb.toFixed(2)} GB`}
+                  />
+                  <LifetimeStat
+                    icon={<Zap className="w-4 h-4 mr-2" />}
+                    label="Total AI Tokens"
+                    value={formatNumber(lifetime.total_ai_tokens)}
+                  />
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Active Resources</CardTitle>
+                  <CardDescription>Current count across the org</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <LifetimeStat
+                    icon={<Server className="w-4 h-4 mr-2" />}
+                    label="Hosted Mocks"
+                    value={lifetime.hosted_mocks_count.toString()}
+                  />
+                  <LifetimeStat
+                    icon={<Package className="w-4 h-4 mr-2" />}
+                    label="Plugins Published"
+                    value={lifetime.plugins_published.toString()}
+                  />
+                  <LifetimeStat
+                    icon={<Key className="w-4 h-4 mr-2" />}
+                    label="API Tokens"
+                    value={lifetime.api_tokens_count.toString()}
+                  />
+                </CardContent>
+              </Card>
+            </div>
+          )}
+        </TabsContent>
       </Tabs>
+    </div>
+  );
+}
+
+function LifetimeStat({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="flex items-center text-muted-foreground">
+        {icon}
+        {label}
+      </span>
+      <span className="font-semibold">{value}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Bug fix:** `/api/v1/usage` and `/api/v1/billing/subscription` now merge `org_settings.quota` over `org.limits_json`, so admin-set custom quotas are actually reflected. Pure helper extracted (`merge_quota_overrides`) with 4 unit tests.
- **Round 1 polish:** egress card hides when there's no plan cap and no usage; `BillingPage` widened to render the four missing limit fields (`max_hosted_mocks`, `max_plugins_published`, `max_templates_published`, `max_scenarios_published`); badges for the three previously-unhandled `SubscriptionStatus` values (`unpaid`, `incomplete`, `incomplete_expired`); new "All Time" tab on `/usage` wired to `GET /api/v1/organizations/{org_id}/usage`.
- **In-app invoices:** new owner-only `GET /api/v1/billing/invoices` (live pass-through to Stripe), new "Invoices" tab on `BillingPage` with View / PDF links and color-coded status.
- **Threshold-alert system:** new `usage_alerts` table + idempotent `try_insert` model, new `usage_threshold_checker` worker (every 30 min, configurable) that emails the org owner on newly crossed 75 / 90 bands, new `GET/POST` alert endpoints, new "Active Alerts" card on `/usage` with per-row dismiss.

## Files
- New migration: `crates/mockforge-registry-server/migrations/20250101000054_usage_alerts.sql`
- New worker: `crates/mockforge-registry-server/src/workers/usage_threshold_checker.rs`
- 8 modified Rust files + 2 modified TS files (BillingPage, UsageDashboardPage)

## Deployment notes
- Migration auto-applies on registry-server boot (via `sqlx::migrate!`) before the worker spawn, so deploying this PR is one-step — no manual ordering required.
- New optional env var `USAGE_THRESHOLD_CHECK_INTERVAL_SECS` (default 1800, min 60).
- No new required config — Stripe credentials already present for checkout/portal are reused for invoices.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-core --all-targets -- -D warnings`
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-core --lib` — 242/242
- [x] `cargo test -p mockforge-registry-server --lib` — 274/274 (incl. 4 new worker + 4 new merge tests)
- [x] `pnpm type-check` (clean)
- [x] `pnpm lint` (0 errors in changed files)
- [ ] Smoke-test on staging once deployed: hit `/usage`, `/billing` (Invoices tab), set a custom quota and verify `/usage` shows the override
- [ ] Confirm threshold worker logs `Usage threshold checker started` after startup