### PR TITLE
feat(registry,ui): wire publisher-keys gaps — revoked history, usage counts, signed badge, CLI ref

### DIFF
--- a/crates/mockforge-registry-core/src/models/attestation.rs
+++ b/crates/mockforge-registry-core/src/models/attestation.rs
@@ -36,6 +36,19 @@ impl UserPublicKey {
     }
 }
 
+/// A publisher key paired with the count of plugin versions whose
+/// attestation it has verified. Returned by the user-facing list path
+/// so the UI can show "this key has signed N versions" without an
+/// extra round-trip per key.
+#[derive(Debug, Clone)]
+pub struct UserPublicKeyWithUsage {
+    pub key: UserPublicKey,
+    /// Number of `plugin_versions` rows where `sbom_signed_key_id` equals
+    /// this key's id. Computed by a `LEFT JOIN ... GROUP BY` so revoked
+    /// keys still show their historical usage.
+    pub usage_count: i64,
+}
+
 /// Input passed to [`verify_sbom_attestation`]. Kept as a named struct
 /// rather than a long argument list so each field can be documented
 /// independently.

--- a/crates/mockforge-registry-core/src/models/mod.rs
+++ b/crates/mockforge-registry-core/src/models/mod.rs
@@ -41,6 +41,7 @@ pub use verification_token::VerificationToken;
 pub use api_token::{ApiToken, TokenScope};
 pub use attestation::{
     verify_sbom_attestation, SbomAttestationInput, SbomVerifyOutcome, UserPublicKey,
+    UserPublicKeyWithUsage,
 };
 #[cfg(feature = "postgres")]
 pub use audit_log::record_audit_event;

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::models::api_token::{ApiToken, TokenScope};
-use crate::models::attestation::UserPublicKey;
+use crate::models::attestation::{UserPublicKey, UserPublicKeyWithUsage};
 use crate::models::audit_log::{AuditEventType, AuditLog};
 use crate::models::cloud_fixture::CloudFixture;
 use crate::models::cloud_service::CloudService;
@@ -1654,6 +1654,21 @@ pub trait RegistryStore: Send + Sync + 'static {
     /// List every non-revoked public key registered against a user. The
     /// attestation verifier tries each one at publish time.
     async fn list_user_public_keys(&self, user_id: Uuid) -> StoreResult<Vec<UserPublicKey>>;
+
+    /// List a user's keys for the user-facing settings page. Unlike
+    /// [`Self::list_user_public_keys`] (which is the verifier hot path
+    /// and only ever returns active keys), this variant:
+    ///
+    /// * optionally includes revoked keys when `include_revoked` is true,
+    ///   so the UI can render a revocation history;
+    /// * joins `plugin_versions.sbom_signed_key_id` so each row carries
+    ///   the count of versions it has verified — a single round-trip
+    ///   instead of N+1 per-key counts.
+    async fn list_user_public_keys_with_usage(
+        &self,
+        user_id: Uuid,
+        include_revoked: bool,
+    ) -> StoreResult<Vec<UserPublicKeyWithUsage>>;
 
     /// Register a new public key on a user's account. The caller has
     /// already validated that `public_key_b64` decodes to the right

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -16,7 +16,7 @@ use super::{
     StoreResult, SubscriptionRow, UserSettingRow,
 };
 use crate::models::api_token::{ApiToken, TokenScope};
-use crate::models::attestation::UserPublicKey;
+use crate::models::attestation::{UserPublicKey, UserPublicKeyWithUsage};
 use crate::models::audit_log::{record_audit_event, AuditEventType, AuditLog};
 use crate::models::cloud_fixture::CloudFixture;
 use crate::models::cloud_service::CloudService;
@@ -1650,6 +1650,72 @@ impl RegistryStore for PgRegistryStore {
         .fetch_all(&self.pool)
         .await
         .map_err(Into::into)
+    }
+
+    async fn list_user_public_keys_with_usage(
+        &self,
+        user_id: Uuid,
+        include_revoked: bool,
+    ) -> StoreResult<Vec<UserPublicKeyWithUsage>> {
+        // The same query for both modes; the WHERE clause toggles on the
+        // boolean so we don't keep two near-identical SQL strings in sync.
+        // The LEFT JOIN means revoked keys still get usage_count=N if
+        // they signed something before revocation.
+        let rows: Vec<(
+            Uuid,
+            Uuid,
+            String,
+            String,
+            String,
+            DateTime<Utc>,
+            Option<DateTime<Utc>>,
+            i64,
+        )> = sqlx::query_as(
+            r#"
+                SELECT k.id, k.user_id, k.algorithm, k.public_key_b64, k.label,
+                       k.created_at, k.revoked_at,
+                       COUNT(pv.id) AS usage_count
+                FROM user_public_keys k
+                LEFT JOIN plugin_versions pv ON pv.sbom_signed_key_id = k.id
+                WHERE k.user_id = $1 AND ($2 OR k.revoked_at IS NULL)
+                GROUP BY k.id, k.user_id, k.algorithm, k.public_key_b64,
+                         k.label, k.created_at, k.revoked_at
+                ORDER BY k.created_at ASC
+                "#,
+        )
+        .bind(user_id)
+        .bind(include_revoked)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    uid,
+                    algorithm,
+                    public_key_b64,
+                    label,
+                    created_at,
+                    revoked_at,
+                    usage_count,
+                )| {
+                    UserPublicKeyWithUsage {
+                        key: UserPublicKey {
+                            id,
+                            user_id: uid,
+                            algorithm,
+                            public_key_b64,
+                            label,
+                            created_at,
+                            revoked_at,
+                        },
+                        usage_count,
+                    }
+                },
+            )
+            .collect())
     }
 
     async fn create_user_public_key(

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -30,7 +30,7 @@ use super::{
 };
 use crate::error::{StoreError, StoreResult};
 use crate::models::api_token::{ApiToken, TokenScope};
-use crate::models::attestation::UserPublicKey;
+use crate::models::attestation::{UserPublicKey, UserPublicKeyWithUsage};
 use crate::models::audit_log::{AuditEventType, AuditLog};
 use crate::models::cloud_fixture::CloudFixture;
 use crate::models::cloud_service::CloudService;
@@ -2687,6 +2687,59 @@ impl RegistryStore for SqliteRegistryStore {
         Ok(out)
     }
 
+    async fn list_user_public_keys_with_usage(
+        &self,
+        user_id: Uuid,
+        include_revoked: bool,
+    ) -> StoreResult<Vec<UserPublicKeyWithUsage>> {
+        use sqlx::Row;
+        // SQLite doesn't take a boolean bind cleanly through query(); use
+        // the literal integer in the predicate instead and key the second
+        // half off of `revoked_at IS NULL` so the active-only path keeps
+        // hitting the partial index.
+        let revoked_predicate = if include_revoked {
+            "1=1"
+        } else {
+            "k.revoked_at IS NULL"
+        };
+        let sql = format!(
+            r#"
+            SELECT k.id, k.user_id, k.algorithm, k.public_key_b64, k.label,
+                   k.created_at, k.revoked_at,
+                   COUNT(pv.id) AS usage_count
+            FROM user_public_keys k
+            LEFT JOIN plugin_versions pv ON pv.sbom_signed_key_id = k.id
+            WHERE k.user_id = ? AND {revoked_predicate}
+            GROUP BY k.id
+            ORDER BY k.created_at ASC
+            "#
+        );
+        let rows = sqlx::query(&sql).bind(user_id.to_string()).fetch_all(&self.pool).await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id_str: String = row.try_get("id")?;
+            let user_id_str: String = row.try_get("user_id")?;
+            let created_at_str: String = row.try_get("created_at")?;
+            let revoked_at_str: Option<String> = row.try_get("revoked_at")?;
+            // SQLite returns COUNT() as INTEGER; sqlx maps it to i64 here.
+            let usage_count: i64 = row.try_get("usage_count")?;
+            out.push(UserPublicKeyWithUsage {
+                key: UserPublicKey {
+                    id: parse_uuid(&id_str)?,
+                    user_id: parse_uuid(&user_id_str)?,
+                    algorithm: row.try_get("algorithm")?,
+                    public_key_b64: row.try_get("public_key_b64")?,
+                    label: row.try_get("label")?,
+                    created_at: parse_dt(&created_at_str)?,
+                    revoked_at: revoked_at_str.as_deref().map(parse_dt).transpose()?,
+                },
+                usage_count,
+            });
+        }
+        Ok(out)
+    }
+
     async fn create_user_public_key(
         &self,
         user_id: Uuid,
@@ -4407,6 +4460,95 @@ mod tests {
         // Trying to revoke someone else's key (or a random id) returns false.
         let someone_else = Uuid::new_v4();
         assert!(!store.revoke_user_public_key(someone_else, b.id).await.unwrap());
+    }
+
+    /// `list_user_public_keys_with_usage` is the user-facing list path.
+    /// It must (a) include revoked keys when asked and (b) return the
+    /// count of plugin versions whose attestation each key verified.
+    /// Without this, the UI's "you have signed N versions with this
+    /// key" pill silently shows zero.
+    #[tokio::test]
+    async fn test_list_user_public_keys_with_usage() {
+        use base64::Engine;
+        let store = memory_store().await;
+        let pool = store.pool();
+
+        let user_id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO users (id, username, email, password_hash, created_at, updated_at)
+               VALUES (?, 'usage-user', 'u@example.com', 'x', datetime('now'), datetime('now'))"#,
+        )
+        .bind(user_id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Register two keys.
+        let b64 = |b: &[u8]| base64::engine::general_purpose::STANDARD.encode(b);
+        let key_a = store
+            .create_user_public_key(user_id, "ed25519", &b64(&[0x11u8; 32]), "laptop")
+            .await
+            .unwrap();
+        let key_b = store
+            .create_user_public_key(user_id, "ed25519", &b64(&[0x22u8; 32]), "ci")
+            .await
+            .unwrap();
+
+        // Seed a plugin + two versions, attribute one signature to key_a.
+        let plugin_id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO plugins (id, name, description, current_version, category,
+                                    license, author_id)
+               VALUES (?, 'usage-plugin', 'd', '1.0.0', 'other', 'MIT', ?)"#,
+        )
+        .bind(plugin_id.to_string())
+        .bind(user_id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+        for v in ["1.0.0", "1.0.1"] {
+            let version_id = Uuid::new_v4();
+            sqlx::query(
+                r#"INSERT INTO plugin_versions
+                       (id, plugin_id, version, download_url, checksum, file_size)
+                   VALUES (?, ?, ?, 'https://example.invalid', 'cs', 0)"#,
+            )
+            .bind(version_id.to_string())
+            .bind(plugin_id.to_string())
+            .bind(v)
+            .execute(pool)
+            .await
+            .unwrap();
+            // Only the first version gets attributed to key_a.
+            if v == "1.0.0" {
+                store
+                    .record_plugin_version_attestation(version_id, Some(key_a.id))
+                    .await
+                    .unwrap();
+            }
+        }
+
+        // include_revoked=false returns both active keys, key_a counts 1.
+        let active_listing = store.list_user_public_keys_with_usage(user_id, false).await.unwrap();
+        assert_eq!(active_listing.len(), 2);
+        let a = active_listing.iter().find(|k| k.key.id == key_a.id).unwrap();
+        let b = active_listing.iter().find(|k| k.key.id == key_b.id).unwrap();
+        assert_eq!(a.usage_count, 1);
+        assert_eq!(b.usage_count, 0);
+
+        // Revoke key_a — active-only listing drops it.
+        assert!(store.revoke_user_public_key(user_id, key_a.id).await.unwrap());
+        let after_revoke = store.list_user_public_keys_with_usage(user_id, false).await.unwrap();
+        assert_eq!(after_revoke.len(), 1);
+        assert_eq!(after_revoke[0].key.id, key_b.id);
+
+        // include_revoked=true brings it back, with its historical
+        // usage_count preserved so users can audit revoked keys.
+        let history = store.list_user_public_keys_with_usage(user_id, true).await.unwrap();
+        assert_eq!(history.len(), 2);
+        let revoked = history.iter().find(|k| k.key.id == key_a.id).unwrap();
+        assert!(revoked.key.revoked_at.is_some());
+        assert_eq!(revoked.usage_count, 1);
     }
 
     /// End-to-end scenarios CRUD on SQLite. Seeds a user + org, creates

--- a/crates/mockforge-registry-server/src/handlers/admin.rs
+++ b/crates/mockforge-registry-server/src/handlers/admin.rs
@@ -167,6 +167,28 @@ pub async fn get_plugin_badges(
         badges.push("trending".to_string());
     }
 
+    // "Signed" badge — set when the plugin's current version was
+    // published with a verified Ed25519 SBOM attestation. The scanner
+    // also surfaces this inside security findings, but the badge here
+    // makes it visible at the marketplace card level so users can spot
+    // signed plugins without opening the security tab.
+    let signed: Option<bool> = sqlx::query_scalar(
+        r#"
+        SELECT (sbom_signed_key_id IS NOT NULL) AS signed
+        FROM plugin_versions
+        WHERE plugin_id = $1 AND version = $2
+        LIMIT 1
+        "#,
+    )
+    .bind(plugin.id)
+    .bind(&plugin.current_version)
+    .fetch_optional(pool)
+    .await
+    .map_err(ApiError::Database)?;
+    if matches!(signed, Some(true)) {
+        badges.push("signed".to_string());
+    }
+
     Ok(Json(PluginWithBadges {
         name: plugin.name,
         version: plugin.current_version,

--- a/crates/mockforge-registry-server/src/handlers/public_keys.rs
+++ b/crates/mockforge-registry-server/src/handlers/public_keys.rs
@@ -11,7 +11,7 @@
 //! owns the user-facing CRUD.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     Json,
 };
 use base64::Engine;
@@ -33,17 +33,22 @@ pub struct PublicKeyResponse {
     pub label: String,
     pub created_at: String,
     pub revoked_at: Option<String>,
+    /// Number of plugin versions whose SBOM signature was verified by
+    /// this key. Lets the UI show a "signed N versions" pill so a user
+    /// can decide whether a key is safe to revoke before doing it.
+    pub usage_count: i64,
 }
 
-impl From<mockforge_registry_core::models::UserPublicKey> for PublicKeyResponse {
-    fn from(k: mockforge_registry_core::models::UserPublicKey) -> Self {
+impl From<mockforge_registry_core::models::UserPublicKeyWithUsage> for PublicKeyResponse {
+    fn from(k: mockforge_registry_core::models::UserPublicKeyWithUsage) -> Self {
         Self {
-            id: k.id,
-            algorithm: k.algorithm,
-            public_key_b64: k.public_key_b64,
-            label: k.label,
-            created_at: k.created_at.to_rfc3339(),
-            revoked_at: k.revoked_at.map(|dt| dt.to_rfc3339()),
+            id: k.key.id,
+            algorithm: k.key.algorithm,
+            public_key_b64: k.key.public_key_b64,
+            label: k.key.label,
+            created_at: k.key.created_at.to_rfc3339(),
+            revoked_at: k.key.revoked_at.map(|dt| dt.to_rfc3339()),
+            usage_count: k.usage_count,
         }
     }
 }
@@ -54,11 +59,21 @@ pub struct ListPublicKeysResponse {
     pub keys: Vec<PublicKeyResponse>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListPublicKeysQuery {
+    /// When `true`, the response also includes soft-revoked keys so the
+    /// UI can render a revocation history. Defaults to `false`.
+    #[serde(default)]
+    pub include_revoked: bool,
+}
+
 pub async fn list_my_public_keys(
     AuthUser(user_id): AuthUser,
     State(state): State<AppState>,
+    Query(q): Query<ListPublicKeysQuery>,
 ) -> ApiResult<Json<ListPublicKeysResponse>> {
-    let keys = state.store.list_user_public_keys(user_id).await?;
+    let keys = state.store.list_user_public_keys_with_usage(user_id, q.include_revoked).await?;
     Ok(Json(ListPublicKeysResponse {
         keys: keys.into_iter().map(Into::into).collect(),
     }))
@@ -119,7 +134,17 @@ pub async fn create_my_public_key(
     }
 
     let saved = state.store.create_user_public_key(user_id, &algorithm, key_b64, label).await?;
-    Ok(Json(saved.into()))
+    // Freshly registered keys have signed nothing yet — short-circuit
+    // the count rather than re-querying.
+    Ok(Json(PublicKeyResponse {
+        id: saved.id,
+        algorithm: saved.algorithm,
+        public_key_b64: saved.public_key_b64,
+        label: saved.label,
+        created_at: saved.created_at.to_rfc3339(),
+        revoked_at: saved.revoked_at.map(|dt| dt.to_rfc3339()),
+        usage_count: 0,
+    }))
 }
 
 pub async fn revoke_my_public_key(

--- a/crates/mockforge-ui/ui/src/pages/PluginRegistryPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PluginRegistryPage.tsx
@@ -700,7 +700,7 @@ export const PluginRegistryPage: React.FC = () => {
                           label={badge.replace(/-/g, ' ')}
                           size="small"
                           color={
-                            badge === 'official' || badge === 'verified'
+                            badge === 'official' || badge === 'verified' || badge === 'signed'
                               ? 'success'
                               : badge === 'popular' || badge === 'trending'
                               ? 'info'

--- a/crates/mockforge-ui/ui/src/pages/PublisherKeysPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PublisherKeysPage.tsx
@@ -14,6 +14,9 @@
 import React, { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Button,
   Card,
   CardContent,
@@ -23,10 +26,12 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  FormControlLabel,
   IconButton,
   LinearProgress,
   Paper,
   Stack,
+  Switch,
   TextField,
   Tooltip,
   Typography,
@@ -34,8 +39,10 @@ import {
 import {
   Add as AddIcon,
   Delete as DeleteIcon,
+  ExpandMore as ExpandMoreIcon,
   Key as KeyIcon,
   ContentCopy as CopyIcon,
+  Terminal as TerminalIcon,
   VerifiedUser as VerifiedIcon,
 } from '@mui/icons-material';
 import { authenticatedFetch } from '../utils/apiClient';
@@ -47,14 +54,21 @@ interface PublicKey {
   label: string;
   createdAt: string;
   revokedAt?: string | null;
+  /// Number of plugin versions whose SBOM signature was verified by
+  /// this key. Server-computed via a JOIN on `plugin_versions` so we
+  /// don't ship N+1 queries from the browser.
+  usageCount: number;
 }
 
 interface ListResponse {
   keys: PublicKey[];
 }
 
-async function fetchKeys(): Promise<PublicKey[]> {
-  const resp = await authenticatedFetch('/api/v1/users/me/public-keys');
+async function fetchKeys(includeRevoked: boolean): Promise<PublicKey[]> {
+  const url = includeRevoked
+    ? '/api/v1/users/me/public-keys?includeRevoked=true'
+    : '/api/v1/users/me/public-keys';
+  const resp = await authenticatedFetch(url);
   if (!resp.ok) {
     const body = await resp.text().catch(() => '');
     throw new Error(`Failed to load keys (${resp.status}): ${body}`);
@@ -226,6 +240,95 @@ function sha256Fallback(bytes: Uint8Array): Uint8Array {
 // Exported for unit tests.
 export const __testing__ = { sha256, sha256Fallback, normalizeBase64 };
 
+/// Copy-to-clipboard CLI snippet. Plain element instead of a heavier
+/// dependency (no syntax highlighter pulled in for a four-snippet
+/// reference) — the CLI strings are short and the dialog text already
+/// uses `<code>` for the same purpose, so this stays consistent.
+const CliSnippet: React.FC<{ command: string; description: string }> = ({
+  command,
+  description,
+}) => {
+  const [copied, setCopied] = useState(false);
+  const onCopy = () => {
+    navigator.clipboard
+      .writeText(command)
+      .then(() => {
+        setCopied(true);
+        // Reset after a beat so a second copy still shows feedback.
+        window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* clipboard permission denied — silently no-op */
+      });
+  };
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
+        {description}
+      </Typography>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        sx={{
+          backgroundColor: 'action.hover',
+          borderRadius: 1,
+          px: 1.5,
+          py: 0.75,
+          fontFamily: 'monospace',
+          fontSize: '0.85rem',
+        }}
+      >
+        <span style={{ color: 'var(--mui-palette-text-secondary, #888)' }}>$</span>
+        <span style={{ flexGrow: 1, overflowX: 'auto', whiteSpace: 'nowrap' }}>{command}</span>
+        <Tooltip title={copied ? 'Copied!' : 'Copy command'}>
+          <IconButton size="small" onClick={onCopy} aria-label="copy command">
+            <CopyIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+    </div>
+  );
+};
+
+/// CLI quick-reference accordion. Until now the page only mentioned
+/// `mockforge-plugin key gen` inline; the rest of the publishing
+/// workflow (sign, rotate, publish --sign) was undiscoverable from
+/// the UI even though the server depends on it. Collapsed by default
+/// so users who already know the flow aren't visually taxed.
+const CliQuickReference: React.FC = () => (
+  <Accordion variant="outlined" sx={{ mb: 3 }}>
+    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <TerminalIcon fontSize="small" color="action" />
+        <Typography variant="subtitle2">CLI quick reference</Typography>
+      </Stack>
+    </AccordionSummary>
+    <AccordionDetails>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        These commands run locally with the <code>mockforge-plugin</code>{' '}
+        binary. Your private key never leaves your machine.
+      </Typography>
+      <CliSnippet
+        description="Generate a fresh Ed25519 keypair (PKCS#8 PEM). Output the public half to register on this page."
+        command="mockforge-plugin key gen --out ~/.mockforge/publisher.pem"
+      />
+      <CliSnippet
+        description="Sign an SBOM detached, e.g. as a separate CI step before upload."
+        command="mockforge-plugin key sign --key-file ~/.mockforge/publisher.pem --checksum <hex> --sbom sbom.json"
+      />
+      <CliSnippet
+        description="Publish a plugin with an attested SBOM in one shot."
+        command="mockforge-plugin publish --sign --key-file ~/.mockforge/publisher.pem --sbom sbom.json"
+      />
+      <CliSnippet
+        description="Rotate: register a new key and revoke an old one atomically."
+        command="mockforge-plugin key rotate --out ~/.mockforge/publisher-new.pem --label ci-2026 --revoke <old-key-id>"
+      />
+    </AccordionDetails>
+  </Accordion>
+);
+
 const PublisherKeysPage: React.FC = () => {
   const queryClient = useQueryClient();
   const [showAdd, setShowAdd] = useState(false);
@@ -234,6 +337,10 @@ const PublisherKeysPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [confirmRevoke, setConfirmRevoke] = useState<PublicKey | null>(null);
   const [fingerprints, setFingerprints] = useState<Record<string, string>>({});
+  // Off by default — most of the time users care about active keys.
+  // Flipping this on makes the server return revoked rows too so the
+  // user can audit who signed what before it was retired.
+  const [includeRevoked, setIncludeRevoked] = useState(false);
 
   const {
     data: keys,
@@ -241,8 +348,8 @@ const PublisherKeysPage: React.FC = () => {
     isError,
     error: queryError,
   } = useQuery({
-    queryKey: ['publisher-public-keys'],
-    queryFn: fetchKeys,
+    queryKey: ['publisher-public-keys', includeRevoked],
+    queryFn: () => fetchKeys(includeRevoked),
   });
 
   // Derive fingerprints whenever the key list changes. Done in an
@@ -320,17 +427,29 @@ const PublisherKeysPage: React.FC = () => {
           <KeyIcon color="primary" />
           <Typography variant="h5">Publisher Attestation Keys</Typography>
         </Stack>
-        <Button
-          variant="contained"
-          startIcon={<AddIcon />}
-          onClick={() => setShowAdd(true)}
-          disabled={addMutation.isPending}
-        >
-          Add key
-        </Button>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={includeRevoked}
+                onChange={(e) => setIncludeRevoked(e.target.checked)}
+                size="small"
+              />
+            }
+            label="Show revoked"
+          />
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => setShowAdd(true)}
+            disabled={addMutation.isPending}
+          >
+            Add key
+          </Button>
+        </Stack>
       </Stack>
 
-      <Typography variant="body2" color="text.secondary" mb={3}>
+      <Typography variant="body2" color="text.secondary" mb={2}>
         Register an Ed25519 public key to sign SBOMs at publish time. The
         registry verifies signatures against any of your active keys and
         surfaces a <b>verified publisher attestation</b> finding on each
@@ -338,6 +457,8 @@ const PublisherKeysPage: React.FC = () => {
         <code>mockforge-plugin key gen</code> — the private half never
         leaves your machine.
       </Typography>
+
+      <CliQuickReference />
 
       {isLoading && <LinearProgress />}
       {isError && (
@@ -377,6 +498,26 @@ const PublisherKeysPage: React.FC = () => {
                       color="primary"
                       variant="outlined"
                     />
+                    {/* Usage badge — surfaces the per-key signed-version
+                        count returned from the server's JOIN. Hidden at
+                        zero so a brand-new key isn't shouting "signed 0".
+                        Worth showing on revoked keys too: that's the
+                        whole point of "show revoked" — auditors want to
+                        see what a key did before being retired. */}
+                    {key.usageCount > 0 && (
+                      <Tooltip
+                        title={`${key.usageCount} plugin version${
+                          key.usageCount === 1 ? '' : 's'
+                        } verified by this key`}
+                      >
+                        <Chip
+                          label={`signed ${key.usageCount}`}
+                          size="small"
+                          color="success"
+                          variant="outlined"
+                        />
+                      </Tooltip>
+                    )}
                     {key.revokedAt && (
                       <Chip label="Revoked" color="default" size="small" />
                     )}


### PR DESCRIPTION
## Summary
Surfaced backend functionality that the publisher-keys page wasn't exposing yet.

- **Revoked-key history.** `GET /api/v1/users/me/public-keys` now accepts `?includeRevoked=true`. New page toggle "Show revoked" surfaces the revocation timeline so users can audit what a retired key signed.
- **Per-key usage counts.** Same endpoint joins `plugin_versions.sbom_signed_key_id` and returns `usageCount` per row (single round-trip; covered for Postgres + SQLite). The page renders a `signed N` pill, helping users decide whether revoking a key is safe.
- **Signed badge in the marketplace.** `GET /api/v1/plugins/{name}/badges` now returns `signed` when the current version has a verified attestation; PluginRegistryPage colors it as success. Previously the only signal was buried in the Security tab finding emitted by the scanner.
- **CLI quick reference.** Collapsible accordion on PublisherKeysPage with copyable snippets for `key gen`, `key sign`, `publish --sign`, and `key rotate`. The page used to only mention `key gen` inline; the rest of the workflow was undiscoverable from the UI even though the server depends on it.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-core --all-targets -- -D warnings`
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-core --lib` (242 passed, includes new `test_list_user_public_keys_with_usage`)
- [x] `cargo test -p mockforge-registry-server --lib` (274 passed)
- [x] `pnpm type-check` and `pnpm lint` (no new warnings on touched files)
- [x] `pnpm test --run src/pages/__tests__/PublisherKeysPage.test.tsx` (5 passed)