### PR TITLE
feat(ui,registry-server): wire api-tokens — fix expires_at, expose scopes, rotation banner

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/tokens.rs
+++ b/crates/mockforge-registry-server/src/handlers/tokens.rs
@@ -205,6 +205,54 @@ pub async fn list_tokens(
     Ok(Json(items))
 }
 
+/// Available token scope, including human-readable label and description.
+#[derive(Debug, Serialize)]
+pub struct TokenScopeInfo {
+    pub value: String,
+    pub label: String,
+    pub description: String,
+}
+
+/// Return the canonical list of token scopes.
+///
+/// Returns static metadata derived from the `TokenScope` enum so the UI
+/// doesn't have to hardcode the list. Lives behind the auth middleware along
+/// with the other token routes.
+pub async fn list_scopes() -> Json<Vec<TokenScopeInfo>> {
+    Json(vec![
+        TokenScopeInfo {
+            value: TokenScope::ReadPackages.to_string(),
+            label: "Read Packages".to_string(),
+            description: "Read and search packages".to_string(),
+        },
+        TokenScopeInfo {
+            value: TokenScope::PublishPackages.to_string(),
+            label: "Publish Packages".to_string(),
+            description: "Publish new package versions".to_string(),
+        },
+        TokenScopeInfo {
+            value: TokenScope::DeployMocks.to_string(),
+            label: "Deploy Mocks".to_string(),
+            description: "Deploy hosted mock services".to_string(),
+        },
+        TokenScopeInfo {
+            value: TokenScope::AdminOrg.to_string(),
+            label: "Admin Organization".to_string(),
+            description: "Full organization administration".to_string(),
+        },
+        TokenScopeInfo {
+            value: TokenScope::ReadUsage.to_string(),
+            label: "Read Usage".to_string(),
+            description: "Read usage analytics and metrics".to_string(),
+        },
+        TokenScopeInfo {
+            value: TokenScope::ManageBilling.to_string(),
+            label: "Manage Billing".to_string(),
+            description: "Manage billing and subscription".to_string(),
+        },
+    ])
+}
+
 /// Delete an API token
 pub async fn delete_token(
     State(state): State<AppState>,

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -209,6 +209,8 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         // API token management routes
         .route("/api/v1/tokens", post(handlers::tokens::create_token))
         .route("/api/v1/tokens", get(handlers::tokens::list_tokens))
+        // Static path — must be registered before `{token_id}` matchers.
+        .route("/api/v1/tokens/scopes", get(handlers::tokens::list_scopes))
         .route("/api/v1/tokens/{token_id}", delete(handlers::tokens::delete_token))
         // Usage tracking routes
         .route("/api/v1/usage", get(handlers::usage::get_usage))

--- a/crates/mockforge-ui/ui/src/pages/ApiTokensPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ApiTokensPage.tsx
@@ -42,12 +42,17 @@ interface ApiToken {
 interface CreateTokenRequest {
   name: string;
   scopes: string[];
-  expires_days?: number;
+  expires_at?: string; // ISO 8601 timestamp
 }
 
 interface CreateTokenResponse {
   token: string; // Full token (only shown once)
-  token_info: ApiToken;
+  token_id: string;
+  token_prefix: string;
+  name: string;
+  scopes: string[];
+  expires_at?: string;
+  created_at: string;
 }
 
 interface RotateTokenResponse {
@@ -57,6 +62,27 @@ interface RotateTokenResponse {
   new_token_prefix: string;
   old_token_deleted: boolean;
   message: string;
+}
+
+interface TokenScopeInfo {
+  value: string;
+  label: string;
+  description: string;
+}
+
+interface TokenRotationStatus {
+  token_id: string;
+  name: string;
+  token_prefix: string;
+  age_days: number;
+  needs_rotation: boolean;
+  last_used_at?: string;
+  created_at: string;
+}
+
+interface TokenRotationStatusResponse {
+  tokens_needing_rotation: TokenRotationStatus[];
+  rotation_threshold_days: number;
 }
 
 // API base URL
@@ -107,6 +133,34 @@ async function deleteToken(tokenId: string): Promise<void> {
   }
 }
 
+async function fetchRotationStatus(): Promise<TokenRotationStatusResponse> {
+  const token = localStorage.getItem('auth_token');
+  const response = await fetch(`${API_BASE}/tokens/rotation-status`, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error('Failed to fetch rotation status');
+  }
+  return response.json();
+}
+
+async function fetchScopes(): Promise<TokenScopeInfo[]> {
+  const token = localStorage.getItem('auth_token');
+  const response = await fetch(`${API_BASE}/tokens/scopes`, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error('Failed to fetch scopes');
+  }
+  return response.json();
+}
+
 async function rotateToken(tokenId: string, newName?: string, deleteOld?: boolean): Promise<RotateTokenResponse> {
   const token = localStorage.getItem('auth_token');
   const response = await fetch(`${API_BASE}/tokens/${tokenId}/rotate`, {
@@ -124,7 +178,8 @@ async function rotateToken(tokenId: string, newName?: string, deleteOld?: boolea
   return response.json();
 }
 
-const AVAILABLE_SCOPES = [
+// Fallback if the scopes endpoint is unavailable (e.g. older backend).
+const FALLBACK_SCOPES: TokenScopeInfo[] = [
   { value: 'read:packages', label: 'Read Packages', description: 'Read and search packages' },
   { value: 'publish:packages', label: 'Publish Packages', description: 'Publish new package versions' },
   { value: 'deploy:mocks', label: 'Deploy Mocks', description: 'Deploy hosted mock services' },
@@ -152,12 +207,30 @@ export function ApiTokensPage() {
     queryFn: fetchTokens,
   });
 
+  // Fetch the scope catalogue from the backend (falls back if unavailable).
+  const { data: scopesFromApi } = useQuery({
+    queryKey: ['api-token-scopes'],
+    queryFn: fetchScopes,
+    staleTime: 60 * 60 * 1000, // 1 hour
+    retry: false,
+  });
+  const availableScopes: TokenScopeInfo[] =
+    scopesFromApi && scopesFromApi.length > 0 ? scopesFromApi : FALLBACK_SCOPES;
+
+  // Server-side rotation status (powers the summary banner).
+  const { data: rotationStatus } = useQuery({
+    queryKey: ['api-token-rotation-status'],
+    queryFn: fetchRotationStatus,
+    retry: false,
+  });
+
   // Create token mutation
   const createTokenMutation = useMutation({
     mutationFn: createToken,
     onSuccess: (data) => {
       setNewToken(data.token);
       queryClient.invalidateQueries({ queryKey: ['api-tokens'] });
+      queryClient.invalidateQueries({ queryKey: ['api-token-rotation-status'] });
       setIsCreateDialogOpen(false);
       // Reset form
       setNewTokenName('');
@@ -174,6 +247,7 @@ export function ApiTokensPage() {
     mutationFn: deleteToken,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['api-tokens'] });
+      queryClient.invalidateQueries({ queryKey: ['api-token-rotation-status'] });
       showToast('success', 'Success', 'Token deleted successfully');
     },
     onError: (error: Error) => {
@@ -191,6 +265,7 @@ export function ApiTokensPage() {
       setRotateNewName('');
       setRotateDeleteOld(false);
       queryClient.invalidateQueries({ queryKey: ['api-tokens'] });
+      queryClient.invalidateQueries({ queryKey: ['api-token-rotation-status'] });
       showToast('success', 'Success', data.message);
     },
     onError: (error: Error) => {
@@ -216,10 +291,14 @@ export function ApiTokensPage() {
       showToast('error', 'Error', 'At least one scope is required');
       return;
     }
+    const expiresAt =
+      expiresDays && expiresDays > 0
+        ? new Date(Date.now() + expiresDays * 24 * 60 * 60 * 1000).toISOString()
+        : undefined;
     createTokenMutation.mutate({
       name: newTokenName,
       scopes: selectedScopes,
-      expires_days: expiresDays,
+      expires_at: expiresAt,
     });
   };
 
@@ -258,6 +337,30 @@ export function ApiTokensPage() {
           Create Token
         </Button>
       </div>
+
+      {/* Rotation Reminder Banner */}
+      {rotationStatus && rotationStatus.tokens_needing_rotation.length > 0 && (
+        <div
+          className="rounded-lg border border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20 p-4"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex items-start space-x-3">
+            <AlertTriangle className="w-5 h-5 mt-0.5 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm font-medium text-yellow-900 dark:text-yellow-100">
+                {rotationStatus.tokens_needing_rotation.length === 1
+                  ? '1 token is older than '
+                  : `${rotationStatus.tokens_needing_rotation.length} tokens are older than `}
+                {rotationStatus.rotation_threshold_days} days and should be rotated.
+              </p>
+              <p className="text-sm text-yellow-800 dark:text-yellow-200 mt-1">
+                Rotating long-lived tokens reduces the blast radius of leaked credentials.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* New Token Display Dialog */}
       {newToken && (
@@ -336,7 +439,7 @@ export function ApiTokensPage() {
             <div>
               <Label>Scopes</Label>
               <div className="mt-2 space-y-2 max-h-64 overflow-y-auto">
-                {AVAILABLE_SCOPES.map((scope) => (
+                {availableScopes.map((scope) => (
                   <div
                     key={scope.value}
                     className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-accent cursor-pointer"
@@ -478,7 +581,7 @@ export function ApiTokensPage() {
                     </div>
                     <div className="flex flex-wrap gap-2">
                       {token.scopes.map((scope) => {
-                        const scopeInfo = AVAILABLE_SCOPES.find((s) => s.value === scope);
+                        const scopeInfo = availableScopes.find((s) => s.value === scope);
                         return (
                           <Badge key={scope} variant="outline">
                             {scopeInfo?.label || scope}


### PR DESCRIPTION
## Summary

Audit of the `/api-tokens` page found one silently-broken contract, one type-only mismatch, and two backend endpoints with no UI consumer. This PR addresses all four.

- **Bug — expirations were silently dropped.** Frontend was sending `expires_days` while the backend `CreateTokenRequest` expects `expires_at` (ISO 8601). Serde ignored the unknown field, so every token was created with no expiration regardless of what the user picked. UI now converts `expires_days → expires_at` (`new Date(now + days*86400000).toISOString()`) before POSTing.
- **Type mismatch.** `CreateTokenResponse` declared a non-existent `token_info` wrapper. Runtime worked because only `data.token` was read, but the type was lying. Updated the interface to match the actual flat backend shape (`token`, `token_id`, `token_prefix`, `name`, `scopes`, `expires_at`, `created_at`).
- **New endpoint `GET /api/v1/tokens/scopes`.** Returns the canonical scope catalogue (`{value, label, description}`) derived from the `TokenScope` enum so the UI no longer hardcodes a parallel list. The page falls back to a hardcoded list if the endpoint is unavailable (older backends).
- **Rotation summary banner.** `GET /api/v1/tokens/rotation-status` already existed but had no UI consumer. Added a banner at the top of the page that surfaces "N tokens are older than X days and should be rotated" using the server-side threshold. Mutations now invalidate the rotation-status query alongside the tokens list.

What I checked but intentionally **did not** include in this PR:
- Audit-log surface for token events — already wired in `OrganizationPage` via `AuditLogTab`.
- Suspicious-activity surface — separate page concern, not part of api-tokens.
- Email rotation reminders — backend cron job, not a UI feature.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-server --lib` (274 passed)
- [x] `pnpm type-check`
- [x] `pnpm lint` (no new warnings on `ApiTokensPage.tsx`)
- [ ] Manual: create a token with a 30-day expiry on a deployed env, confirm `expires_at` is populated and the badge shows the correct date
- [ ] Manual: confirm rotation banner renders only when ≥1 token is older than 90 days