### PR TITLE
feat(registry-server,ui): audit-log filter, rotation reminder cron, api-tokens CTA

### DIFF
--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -121,6 +121,58 @@ impl AuditEventType {
             _ => None,
         }
     }
+
+    /// Canonical snake_case wire form. Round-trips with [`Self::from_str`].
+    ///
+    /// Use this when serializing for HTTP responses; the `Debug` form
+    /// produces PascalCase like `OrgUpdated` which doesn't match the input
+    /// the filter accepts.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MemberAdded => "member_added",
+            Self::MemberRemoved => "member_removed",
+            Self::MemberRoleChanged => "member_role_changed",
+            Self::OrgCreated => "org_created",
+            Self::OrgUpdated => "org_updated",
+            Self::OrgDeleted => "org_deleted",
+            Self::OrgPlanChanged => "org_plan_changed",
+            Self::BillingCheckout => "billing_checkout",
+            Self::BillingUpgrade => "billing_upgrade",
+            Self::BillingDowngrade => "billing_downgrade",
+            Self::BillingCanceled => "billing_canceled",
+            Self::ApiTokenCreated => "api_token_created",
+            Self::ApiTokenDeleted => "api_token_deleted",
+            Self::ApiTokenRotated => "api_token_rotated",
+            Self::SettingsUpdated => "settings_updated",
+            Self::ByokConfigUpdated => "byok_config_updated",
+            Self::ByokConfigDeleted => "byok_config_deleted",
+            Self::DeploymentCreated => "deployment_created",
+            Self::DeploymentDeleted => "deployment_deleted",
+            Self::DeploymentUpdated => "deployment_updated",
+            Self::PluginPublished => "plugin_published",
+            Self::TemplatePublished => "template_published",
+            Self::ScenarioPublished => "scenario_published",
+            Self::PasswordChanged => "password_changed",
+            Self::EmailChanged => "email_changed",
+            Self::TwoFactorEnabled => "two_factor_enabled",
+            Self::TwoFactorDisabled => "two_factor_disabled",
+            Self::FederationCreated => "federation_created",
+            Self::FederationUpdated => "federation_updated",
+            Self::FederationDeleted => "federation_deleted",
+            Self::FederationScenarioActivated => "federation_scenario_activated",
+            Self::FederationScenarioDeactivated => "federation_scenario_deactivated",
+            Self::WorkspaceCreated => "workspace_created",
+            Self::WorkspaceUpdated => "workspace_updated",
+            Self::WorkspaceDeleted => "workspace_deleted",
+            Self::ServiceCreated => "service_created",
+            Self::ServiceUpdated => "service_updated",
+            Self::ServiceDeleted => "service_deleted",
+            Self::FixtureCreated => "fixture_created",
+            Self::FixtureUpdated => "fixture_updated",
+            Self::FixtureDeleted => "fixture_deleted",
+            Self::AdminImpersonation => "admin_impersonation",
+        }
+    }
 }
 
 /// Audit log entry
@@ -263,5 +315,75 @@ pub async fn record_audit_event(
     .await
     {
         tracing::warn!("Failed to record audit event: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant must round-trip through as_str → from_str. A new variant
+    /// added without updating either method will fail this test.
+    #[test]
+    fn audit_event_type_round_trips_via_as_str() {
+        let variants = [
+            AuditEventType::MemberAdded,
+            AuditEventType::MemberRemoved,
+            AuditEventType::MemberRoleChanged,
+            AuditEventType::OrgCreated,
+            AuditEventType::OrgUpdated,
+            AuditEventType::OrgDeleted,
+            AuditEventType::OrgPlanChanged,
+            AuditEventType::BillingCheckout,
+            AuditEventType::BillingUpgrade,
+            AuditEventType::BillingDowngrade,
+            AuditEventType::BillingCanceled,
+            AuditEventType::ApiTokenCreated,
+            AuditEventType::ApiTokenDeleted,
+            AuditEventType::ApiTokenRotated,
+            AuditEventType::SettingsUpdated,
+            AuditEventType::ByokConfigUpdated,
+            AuditEventType::ByokConfigDeleted,
+            AuditEventType::DeploymentCreated,
+            AuditEventType::DeploymentDeleted,
+            AuditEventType::DeploymentUpdated,
+            AuditEventType::PluginPublished,
+            AuditEventType::TemplatePublished,
+            AuditEventType::ScenarioPublished,
+            AuditEventType::PasswordChanged,
+            AuditEventType::EmailChanged,
+            AuditEventType::TwoFactorEnabled,
+            AuditEventType::TwoFactorDisabled,
+            AuditEventType::FederationCreated,
+            AuditEventType::FederationUpdated,
+            AuditEventType::FederationDeleted,
+            AuditEventType::FederationScenarioActivated,
+            AuditEventType::FederationScenarioDeactivated,
+            AuditEventType::WorkspaceCreated,
+            AuditEventType::WorkspaceUpdated,
+            AuditEventType::WorkspaceDeleted,
+            AuditEventType::ServiceCreated,
+            AuditEventType::ServiceUpdated,
+            AuditEventType::ServiceDeleted,
+            AuditEventType::FixtureCreated,
+            AuditEventType::FixtureUpdated,
+            AuditEventType::FixtureDeleted,
+            AuditEventType::AdminImpersonation,
+        ];
+        for variant in variants {
+            let s = variant.as_str();
+            assert_eq!(
+                AuditEventType::from_str(s),
+                Some(variant),
+                "round-trip failed for {variant:?} (got {s:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn audit_event_type_as_str_examples() {
+        assert_eq!(AuditEventType::ApiTokenCreated.as_str(), "api_token_created");
+        assert_eq!(AuditEventType::OrgUpdated.as_str(), "org_updated");
+        assert_eq!(AuditEventType::MemberRoleChanged.as_str(), "member_role_changed");
     }
 }

--- a/crates/mockforge-registry-server/src/handlers/audit.rs
+++ b/crates/mockforge-registry-server/src/handlers/audit.rs
@@ -102,7 +102,7 @@ pub async fn get_audit_logs(
             id: log.id,
             org_id: log.org_id,
             user_id: log.user_id,
-            event_type: format!("{:?}", log.event_type),
+            event_type: log.event_type.as_str().to_string(),
             description: log.description,
             metadata: log.metadata,
             ip_address: log.ip_address,

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -178,6 +178,7 @@ async fn main() -> Result<()> {
         db.pool().clone(),
     );
     workers::usage_threshold_checker::start_usage_threshold_checker(state.clone());
+    workers::token_rotation_reminders::start_token_rotation_reminders_worker(db.pool().clone());
 
     // Start deployment orchestrator for hosted mocks
     let flyio_token = std::env::var("FLYIO_API_TOKEN").ok();

--- a/crates/mockforge-registry-server/src/workers/mod.rs
+++ b/crates/mockforge-registry-server/src/workers/mod.rs
@@ -5,4 +5,5 @@ pub mod plugin_scanner;
 pub mod runtime_logs_retention;
 pub mod runtime_observability_retention;
 pub mod saml_cleanup;
+pub mod token_rotation_reminders;
 pub mod usage_threshold_checker;

--- a/crates/mockforge-registry-server/src/workers/token_rotation_reminders.rs
+++ b/crates/mockforge-registry-server/src/workers/token_rotation_reminders.rs
@@ -1,0 +1,70 @@
+//! Background worker that emails reminders for API tokens older than the
+//! rotation threshold.
+//!
+//! Wraps `handlers::token_rotation::send_rotation_reminders`, which on its own
+//! is just an async function — without this worker it would never run.
+//!
+//! The worker tolerates a missing email provider: `EmailService::from_env()`
+//! defaults to a `Disabled` provider that logs instead of sending, so on dev
+//! environments without SMTP the worker just iterates and produces info logs
+//! rather than failing.
+
+use sqlx::PgPool;
+use std::time::Duration;
+use tracing::{error, info};
+
+use crate::handlers::token_rotation::send_rotation_reminders;
+
+/// One day. Long-lived tokens don't need a tighter cadence than this — even a
+/// week would be defensible — but daily keeps the per-tick work small and
+/// makes the reminder land within 24h of crossing the threshold.
+const REMINDER_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Default rotation age threshold. Matches the value baked into
+/// `tokens.rs::list_tokens` and the `needs_rotation` helper so that the
+/// "needs rotation" badge in the UI and the reminder email agree.
+const DEFAULT_THRESHOLD_DAYS: i64 = 90;
+
+/// Spawn the rotation-reminder worker. Runs the first sweep one tick in (so
+/// startup isn't blocked by an SMTP round-trip storm) and every 24h after.
+pub fn start_token_rotation_reminders_worker(pool: PgPool) {
+    let threshold_days = std::env::var("TOKEN_ROTATION_THRESHOLD_DAYS")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or(DEFAULT_THRESHOLD_DAYS);
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(REMINDER_INTERVAL);
+        // First tick fires immediately; skip it so the worker doesn't blast
+        // every old token the moment the server boots (especially after a
+        // crash-loop restart).
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+
+            match send_rotation_reminders(&pool, threshold_days).await {
+                Ok(count) if count > 0 => {
+                    info!(
+                        "Token rotation reminders: sent {} reminder(s) for tokens older than {} days",
+                        count, threshold_days
+                    );
+                }
+                Ok(_) => {
+                    tracing::debug!(
+                        "Token rotation reminders: no tokens needed reminding (threshold {} days)",
+                        threshold_days
+                    );
+                }
+                Err(e) => {
+                    error!("Token rotation reminders failed: {:?}", e);
+                }
+            }
+        }
+    });
+
+    info!(
+        "Token rotation reminder worker started (runs every 24h, threshold {} days)",
+        threshold_days
+    );
+}

--- a/crates/mockforge-ui/ui/src/pages/ApiTokensPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ApiTokensPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
@@ -23,6 +24,7 @@ import {
   EyeOff,
   Calendar,
   AlertTriangle,
+  ScrollText,
 } from 'lucide-react';
 import { useToast } from '@/components/ui/ToastProvider';
 
@@ -332,10 +334,20 @@ export function ApiTokensPage() {
             Manage personal access tokens for CLI and API access
           </p>
         </div>
-        <Button onClick={() => setIsCreateDialogOpen(true)}>
-          <Plus className="w-4 h-4 mr-2" />
-          Create Token
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" asChild>
+            <RouterLink
+              to="/organization?tab=audit&event_type=api_token_created,api_token_deleted,api_token_rotated"
+            >
+              <ScrollText className="w-4 h-4 mr-2" />
+              View Audit Log
+            </RouterLink>
+          </Button>
+          <Button onClick={() => setIsCreateDialogOpen(true)}>
+            <Plus className="w-4 h-4 mr-2" />
+            Create Token
+          </Button>
+        </div>
       </div>
 
       {/* Rotation Reminder Banner */}

--- a/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
@@ -709,9 +710,50 @@ function SettingsTab({ org }: { org: Organization }) {
   );
 }
 
+// Format a snake_case audit event type into a human-readable label.
+// Special-cases acronyms ("api", "sso", "byok") so we get "API Token Created"
+// rather than "Api Token Created".
+const ACRONYMS = new Set(['api', 'sso', 'byok', 'ip']);
+function humanizeEventType(eventType: string): string {
+  return eventType
+    .split('_')
+    .map((part) =>
+      ACRONYMS.has(part) ? part.toUpperCase() : part.charAt(0).toUpperCase() + part.slice(1),
+    )
+    .join(' ');
+}
+
+// Filter dropdown options. Values must match the backend's snake_case
+// `AuditEventType::from_str` mapping or the filter is silently a no-op.
+// The backend accepts a comma-separated list, so a "group" option (e.g. all
+// API token events) is just a CSV value.
+const AUDIT_EVENT_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'api_token_created,api_token_deleted,api_token_rotated', label: 'API Token (any)' },
+  { value: 'api_token_created', label: 'API Token Created' },
+  { value: 'api_token_deleted', label: 'API Token Deleted' },
+  { value: 'api_token_rotated', label: 'API Token Rotated' },
+  { value: 'org_updated', label: 'Organization Updated' },
+  { value: 'org_deleted', label: 'Organization Deleted' },
+  { value: 'member_added', label: 'Member Added' },
+  { value: 'member_removed', label: 'Member Removed' },
+  { value: 'member_role_changed', label: 'Role Changed' },
+  { value: 'settings_updated', label: 'Settings Updated' },
+  { value: 'org_plan_changed', label: 'Plan Changed' },
+  { value: 'byok_config_updated', label: 'BYOK Config Updated' },
+  { value: 'byok_config_deleted', label: 'BYOK Config Deleted' },
+  { value: 'deployment_created', label: 'Deployment Created' },
+  { value: 'deployment_deleted', label: 'Deployment Deleted' },
+  { value: 'password_changed', label: 'Password Changed' },
+  { value: 'two_factor_enabled', label: 'Two-Factor Enabled' },
+  { value: 'two_factor_disabled', label: 'Two-Factor Disabled' },
+];
+
 function AuditLogTab({ org }: { org: Organization }) {
+  const [searchParams] = useSearchParams();
   const [offset, setOffset] = useState(0);
-  const [eventTypeFilter, setEventTypeFilter] = useState('');
+  const [eventTypeFilter, setEventTypeFilter] = useState(
+    () => searchParams.get('event_type') ?? '',
+  );
   const limit = 20;
 
   const { data, isLoading } = useQuery({
@@ -729,14 +771,9 @@ function AuditLogTab({ org }: { org: Organization }) {
           onChange={(e) => { setEventTypeFilter(e.target.value); setOffset(0); }}
         >
           <option value="">All events</option>
-          <option value="org.updated">Organization Updated</option>
-          <option value="org.deleted">Organization Deleted</option>
-          <option value="member.added">Member Added</option>
-          <option value="member.removed">Member Removed</option>
-          <option value="member.role_changed">Role Changed</option>
-          <option value="settings.updated">Settings Updated</option>
-          <option value="sso.configured">SSO Configured</option>
-          <option value="plan.changed">Plan Changed</option>
+          {AUDIT_EVENT_TYPE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
         </select>
       </div>
 
@@ -748,7 +785,9 @@ function AuditLogTab({ org }: { org: Organization }) {
             {data.logs.map((log) => (
               <div key={log.id} className="p-3 border rounded-lg text-sm">
                 <div className="flex items-center justify-between mb-1">
-                  <Badge variant="secondary" className="text-xs">{log.event_type}</Badge>
+                  <Badge variant="secondary" className="text-xs" title={log.event_type}>
+                    {humanizeEventType(log.event_type)}
+                  </Badge>
                   <span className="text-xs text-muted-foreground">
                     {new Date(log.created_at).toLocaleString()}
                   </span>
@@ -1553,13 +1592,36 @@ function AISettingsTab({ org }: { org: Organization }) {
 
 // ─── Main Page Component ─────────────────────────────────────────────────────
 
+// Tab values that the OrganizationPage will honor via the `?tab=` URL param
+// (e.g. when ApiTokensPage deep-links into the audit log).
+const VALID_TABS = new Set([
+  'members', 'settings', 'invitations', 'audit', 'templates',
+  'sso', 'usage', 'ai', 'security',
+]);
+
 export function OrganizationPage() {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(null);
   const [showCreateOrg, setShowCreateOrg] = useState(false);
   const [newOrgName, setNewOrgName] = useState('');
   const [newOrgSlug, setNewOrgSlug] = useState('');
+
+  const tabParam = searchParams.get('tab');
+  const activeTab = tabParam && VALID_TABS.has(tabParam) ? tabParam : 'members';
+  const handleTabChange = (next: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (next === 'members') {
+      params.delete('tab');
+    } else {
+      params.set('tab', next);
+    }
+    // Don't preserve a stale event_type filter when the user manually
+    // navigates away from the audit log tab.
+    if (next !== 'audit') params.delete('event_type');
+    setSearchParams(params, { replace: true });
+  };
 
   const { data: organizations, isLoading: orgsLoading } = useQuery({
     queryKey: ['organizations'],
@@ -1667,7 +1729,7 @@ export function OrganizationPage() {
               <CardDescription>@{selectedOrg.slug}</CardDescription>
             </CardHeader>
             <CardContent>
-              <Tabs defaultValue="members" className="w-full">
+              <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
                 <TabsList className="flex w-full overflow-x-auto">
                   <TabsTrigger value="members">
                     <Users className="w-4 h-4 mr-1" />


### PR DESCRIPTION
## Summary

Follow-up to #288 addressing the three items I previously marked out of scope. Each turned out to have an actual gap once I dug in.

### Audit log
- **Bug:** the backend was returning `event_type` via `format!("{:?}", ..)` (PascalCase \"OrgUpdated\"), the frontend dropdown was sending dotted values (\"org.updated\"), and the `from_str` parser only accepts snake_case (\"org_updated\"). The filter was a silent no-op and the badge rendered an enum dump.
- **Fix:** added `AuditEventType::as_str()` (snake_case, round-trip-tested against `from_str`), switched the handler to use it, and updated the dropdown values to match. Added missing event types (token events, BYOK, deployments, password/2FA).
- **Display:** badge is now humanized (\"API Token Created\") with the raw value preserved in `title=` for power users.
- **Deep linking:** `OrganizationPage` tabs are now URL-driven (`?tab=audit`), and the audit tab honors `?event_type=` so external pages can pre-filter.

### ApiTokensPage
- Added a \"View Audit Log\" button that deep-links to `/organization?tab=audit&event_type=api_token_created,api_token_deleted,api_token_rotated`. The dropdown has a matching \"API Token (any)\" CSV option so the deep link reflects in the UI state.

### Rotation reminder cron
- `send_rotation_reminders` was orphaned code — defined but never invoked. Added `workers::token_rotation_reminders` that spawns a tokio interval (24h, configurable threshold via `TOKEN_ROTATION_THRESHOLD_DAYS`, default 90 to match the badge logic). Wired it into `main.rs` alongside the other workers.
- Tolerates a missing email provider: `EmailService::from_env()` already defaults to the `Disabled` provider that logs instead of sending, so dev environments stay quiet.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-core -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-core --lib audit_log` (round-trip + example tests pass)
- [x] `cargo test -p mockforge-registry-server --lib` (274 passed)
- [x] `pnpm type-check`
- [x] `pnpm lint` (no new warnings on the touched files)
- [x] `pnpm build` (production bundle compiles)
- [ ] Manual: from `/api-tokens`, click \"View Audit Log\" → lands on `/organization` with the Audit tab open and \"API Token (any)\" pre-selected
- [ ] Manual: in audit log, change the dropdown to \"All events\" → URL drops the `event_type` param; switch tabs → `event_type` clears
- [ ] Manual: confirm rotation worker logs at startup (`Token rotation reminder worker started ...`)