### PR TITLE
feat(registry,ui): publisher-keys depth — audit events, per-plan quotas, org scope, atomic rotation

### DIFF
--- a/crates/mockforge-registry-core/migrations/20260101000012_publisher_keys_org_scope.sql
+++ b/crates/mockforge-registry-core/migrations/20260101000012_publisher_keys_org_scope.sql
@@ -1,0 +1,11 @@
+-- SQLite mirror of 20250101000055_publisher_keys_org_scope.sql.
+--
+-- SQLite doesn't have native enums, so the audit_event_type extension
+-- is a no-op here — `event_type` is TEXT in this backend. We only need
+-- to add the new `org_id` column.
+
+ALTER TABLE user_public_keys ADD COLUMN org_id TEXT
+    REFERENCES organizations(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_public_keys_org
+    ON user_public_keys(org_id);

--- a/crates/mockforge-registry-core/src/models/attestation.rs
+++ b/crates/mockforge-registry-core/src/models/attestation.rs
@@ -25,6 +25,11 @@ pub struct UserPublicKey {
     pub label: String,
     pub created_at: DateTime<Utc>,
     pub revoked_at: Option<DateTime<Utc>>,
+    /// Optional org tag. When set, the key is also accepted by the
+    /// attestation verifier when other members of that org publish and
+    /// is visible to org Owners/Admins via the org-scoped listing
+    /// endpoint. `None` keeps the historical user-only behavior.
+    pub org_id: Option<Uuid>,
 }
 
 impl UserPublicKey {
@@ -181,6 +186,7 @@ mod tests {
             label: "test".to_string(),
             created_at: Utc::now(),
             revoked_at: None,
+            org_id: None,
         };
         (signing, key)
     }
@@ -412,6 +418,7 @@ mod jcs_fuzz {
                 label: "prop".to_string(),
                 created_at: Utc::now(),
                 revoked_at: None,
+                org_id: None,
             };
 
             let sbom = serde_jcs::to_vec(&v).unwrap();

--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -41,6 +41,10 @@ pub enum AuditEventType {
     PluginPublished,
     TemplatePublished,
     ScenarioPublished,
+    // Publisher attestation keys (user-scoped — recorded with org_id=nil)
+    PublisherKeyCreated,
+    PublisherKeyRevoked,
+    PublisherKeyRotated,
     // Security
     PasswordChanged,
     EmailChanged,
@@ -99,6 +103,9 @@ impl AuditEventType {
             "plugin_published" => Some(Self::PluginPublished),
             "template_published" => Some(Self::TemplatePublished),
             "scenario_published" => Some(Self::ScenarioPublished),
+            "publisher_key_created" => Some(Self::PublisherKeyCreated),
+            "publisher_key_revoked" => Some(Self::PublisherKeyRevoked),
+            "publisher_key_rotated" => Some(Self::PublisherKeyRotated),
             "password_changed" => Some(Self::PasswordChanged),
             "email_changed" => Some(Self::EmailChanged),
             "two_factor_enabled" => Some(Self::TwoFactorEnabled),

--- a/crates/mockforge-registry-core/src/models/organization.rs
+++ b/crates/mockforge-registry-core/src/models/organization.rs
@@ -359,6 +359,7 @@ fn get_default_limits(plan: Plan) -> serde_json::Value {
             "max_plugins_published": 1,
             "max_templates_published": 3,
             "max_scenarios_published": 1,
+            "max_publisher_keys": 3, // ed25519 keys per user (active count)
             "ai_tokens_per_month": 0, // BYOK only
             "hosted_mocks": false,
             "max_hosted_mocks": 0
@@ -372,6 +373,7 @@ fn get_default_limits(plan: Plan) -> serde_json::Value {
             "max_plugins_published": 10,
             "max_templates_published": 50,
             "max_scenarios_published": 20,
+            "max_publisher_keys": 25,
             "ai_tokens_per_month": 100000,
             "hosted_mocks": true,
             "max_hosted_mocks": 3
@@ -385,6 +387,7 @@ fn get_default_limits(plan: Plan) -> serde_json::Value {
             "max_plugins_published": -1, // unlimited
             "max_templates_published": -1, // unlimited
             "max_scenarios_published": -1, // unlimited
+            "max_publisher_keys": -1, // unlimited
             "ai_tokens_per_month": 1000000,
             "hosted_mocks": true,
             "max_hosted_mocks": -1 // unlimited

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1672,14 +1672,16 @@ pub trait RegistryStore: Send + Sync + 'static {
 
     /// Register a new public key on a user's account. The caller has
     /// already validated that `public_key_b64` decodes to the right
-    /// length for the algorithm. Returns the persisted record so the
-    /// handler can echo the id to the client.
+    /// length for the algorithm. `org_id` is `Some` when the key is
+    /// scoped to an organization (caller must be an Owner/Admin of that
+    /// org — handler-level check). Returns the persisted record.
     async fn create_user_public_key(
         &self,
         user_id: Uuid,
         algorithm: &str,
         public_key_b64: &str,
         label: &str,
+        org_id: Option<Uuid>,
     ) -> StoreResult<UserPublicKey>;
 
     /// Soft-revoke a key (sets `revoked_at`). Revoked keys are skipped
@@ -1688,6 +1690,44 @@ pub trait RegistryStore: Send + Sync + 'static {
     /// updated, so the handler can distinguish "not yours" (or "already
     /// revoked") from "done."
     async fn revoke_user_public_key(&self, user_id: Uuid, key_id: Uuid) -> StoreResult<bool>;
+
+    /// Soft-revoke a key on behalf of an org Owner/Admin. The handler is
+    /// responsible for verifying the caller's role; this method only
+    /// guards on the key actually being scoped to the supplied org.
+    /// Returns `true` if a row updated.
+    async fn revoke_org_public_key(&self, org_id: Uuid, key_id: Uuid) -> StoreResult<bool>;
+
+    /// Look up a single key by id, regardless of owner. Used by the
+    /// revoke handler to resolve an org-scoped revoke when the caller
+    /// isn't the key's owner but is an org admin.
+    async fn find_user_public_key_by_id(&self, key_id: Uuid) -> StoreResult<Option<UserPublicKey>>;
+
+    /// List keys tagged with `org_id`. Mirrors
+    /// [`Self::list_user_public_keys_with_usage`] for the org listing
+    /// endpoint — joins usage and respects `include_revoked`.
+    async fn list_org_public_keys_with_usage(
+        &self,
+        org_id: Uuid,
+        include_revoked: bool,
+    ) -> StoreResult<Vec<UserPublicKeyWithUsage>>;
+
+    /// Pull every active key the verifier should try when `author_id`
+    /// publishes — i.e. the author's own keys plus any keys tagged with
+    /// orgs the author is a member of. Single round-trip.
+    async fn list_keys_for_publisher(&self, author_id: Uuid) -> StoreResult<Vec<UserPublicKey>>;
+
+    /// Atomic publisher-key rotation: register a new key with the same
+    /// org tag as `old_key_id` and revoke the old one in one
+    /// transaction. Returns the new key. Callers (handler) audit-log
+    /// the rotation as a single event.
+    async fn rotate_user_public_key(
+        &self,
+        user_id: Uuid,
+        old_key_id: Uuid,
+        algorithm: &str,
+        new_public_key_b64: &str,
+        new_label: &str,
+    ) -> StoreResult<UserPublicKey>;
 
     /// Record a verified SBOM attestation against a plugin version. No-op
     /// when `key_id` is `None` (publisher didn't submit a signature).

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -1640,7 +1640,7 @@ impl RegistryStore for PgRegistryStore {
         sqlx::query_as::<_, UserPublicKey>(
             r#"
             SELECT id, user_id, algorithm, public_key_b64, label,
-                   created_at, revoked_at
+                   created_at, revoked_at, org_id
             FROM user_public_keys
             WHERE user_id = $1 AND revoked_at IS NULL
             ORDER BY created_at ASC
@@ -1661,7 +1661,7 @@ impl RegistryStore for PgRegistryStore {
         // boolean so we don't keep two near-identical SQL strings in sync.
         // The LEFT JOIN means revoked keys still get usage_count=N if
         // they signed something before revocation.
-        let rows: Vec<(
+        type Row = (
             Uuid,
             Uuid,
             String,
@@ -1669,17 +1669,19 @@ impl RegistryStore for PgRegistryStore {
             String,
             DateTime<Utc>,
             Option<DateTime<Utc>>,
+            Option<Uuid>,
             i64,
-        )> = sqlx::query_as(
+        );
+        let rows: Vec<Row> = sqlx::query_as(
             r#"
                 SELECT k.id, k.user_id, k.algorithm, k.public_key_b64, k.label,
-                       k.created_at, k.revoked_at,
+                       k.created_at, k.revoked_at, k.org_id,
                        COUNT(pv.id) AS usage_count
                 FROM user_public_keys k
                 LEFT JOIN plugin_versions pv ON pv.sbom_signed_key_id = k.id
                 WHERE k.user_id = $1 AND ($2 OR k.revoked_at IS NULL)
                 GROUP BY k.id, k.user_id, k.algorithm, k.public_key_b64,
-                         k.label, k.created_at, k.revoked_at
+                         k.label, k.created_at, k.revoked_at, k.org_id
                 ORDER BY k.created_at ASC
                 "#,
         )
@@ -1699,6 +1701,7 @@ impl RegistryStore for PgRegistryStore {
                     label,
                     created_at,
                     revoked_at,
+                    org_id,
                     usage_count,
                 )| {
                     UserPublicKeyWithUsage {
@@ -1710,6 +1713,7 @@ impl RegistryStore for PgRegistryStore {
                             label,
                             created_at,
                             revoked_at,
+                            org_id,
                         },
                         usage_count,
                     }
@@ -1724,22 +1728,208 @@ impl RegistryStore for PgRegistryStore {
         algorithm: &str,
         public_key_b64: &str,
         label: &str,
+        org_id: Option<Uuid>,
     ) -> StoreResult<UserPublicKey> {
         sqlx::query_as::<_, UserPublicKey>(
             r#"
-            INSERT INTO user_public_keys (user_id, algorithm, public_key_b64, label)
-            VALUES ($1, $2, $3, $4)
+            INSERT INTO user_public_keys (user_id, algorithm, public_key_b64, label, org_id)
+            VALUES ($1, $2, $3, $4, $5)
             RETURNING id, user_id, algorithm, public_key_b64, label,
-                      created_at, revoked_at
+                      created_at, revoked_at, org_id
             "#,
         )
         .bind(user_id)
         .bind(algorithm)
         .bind(public_key_b64)
         .bind(label)
+        .bind(org_id)
         .fetch_one(&self.pool)
         .await
         .map_err(Into::into)
+    }
+
+    async fn find_user_public_key_by_id(&self, key_id: Uuid) -> StoreResult<Option<UserPublicKey>> {
+        sqlx::query_as::<_, UserPublicKey>(
+            r#"
+            SELECT id, user_id, algorithm, public_key_b64, label,
+                   created_at, revoked_at, org_id
+            FROM user_public_keys
+            WHERE id = $1
+            "#,
+        )
+        .bind(key_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    async fn revoke_org_public_key(&self, org_id: Uuid, key_id: Uuid) -> StoreResult<bool> {
+        let res = sqlx::query(
+            r#"
+            UPDATE user_public_keys
+            SET revoked_at = NOW()
+            WHERE id = $1 AND org_id = $2 AND revoked_at IS NULL
+            "#,
+        )
+        .bind(key_id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    async fn list_org_public_keys_with_usage(
+        &self,
+        org_id: Uuid,
+        include_revoked: bool,
+    ) -> StoreResult<Vec<UserPublicKeyWithUsage>> {
+        type Row = (
+            Uuid,
+            Uuid,
+            String,
+            String,
+            String,
+            DateTime<Utc>,
+            Option<DateTime<Utc>>,
+            Option<Uuid>,
+            i64,
+        );
+        let rows: Vec<Row> = sqlx::query_as(
+            r#"
+                SELECT k.id, k.user_id, k.algorithm, k.public_key_b64, k.label,
+                       k.created_at, k.revoked_at, k.org_id,
+                       COUNT(pv.id) AS usage_count
+                FROM user_public_keys k
+                LEFT JOIN plugin_versions pv ON pv.sbom_signed_key_id = k.id
+                WHERE k.org_id = $1 AND ($2 OR k.revoked_at IS NULL)
+                GROUP BY k.id, k.user_id, k.algorithm, k.public_key_b64,
+                         k.label, k.created_at, k.revoked_at, k.org_id
+                ORDER BY k.created_at ASC
+                "#,
+        )
+        .bind(org_id)
+        .bind(include_revoked)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    uid,
+                    algorithm,
+                    public_key_b64,
+                    label,
+                    created_at,
+                    revoked_at,
+                    org_id,
+                    usage_count,
+                )| {
+                    UserPublicKeyWithUsage {
+                        key: UserPublicKey {
+                            id,
+                            user_id: uid,
+                            algorithm,
+                            public_key_b64,
+                            label,
+                            created_at,
+                            revoked_at,
+                            org_id,
+                        },
+                        usage_count,
+                    }
+                },
+            )
+            .collect())
+    }
+
+    async fn list_keys_for_publisher(&self, author_id: Uuid) -> StoreResult<Vec<UserPublicKey>> {
+        // UNION (not UNION ALL) so a key tagged to an org the author
+        // also owns isn't returned twice.
+        sqlx::query_as::<_, UserPublicKey>(
+            r#"
+            SELECT id, user_id, algorithm, public_key_b64, label,
+                   created_at, revoked_at, org_id
+            FROM user_public_keys
+            WHERE revoked_at IS NULL AND (
+                user_id = $1
+                OR org_id IN (
+                    SELECT id FROM organizations WHERE owner_id = $1
+                    UNION
+                    SELECT org_id FROM org_members WHERE user_id = $1
+                )
+            )
+            ORDER BY created_at ASC
+            "#,
+        )
+        .bind(author_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    async fn rotate_user_public_key(
+        &self,
+        user_id: Uuid,
+        old_key_id: Uuid,
+        algorithm: &str,
+        new_public_key_b64: &str,
+        new_label: &str,
+    ) -> StoreResult<UserPublicKey> {
+        let mut tx = self.pool.begin().await?;
+        // Read inside the txn so the new key inherits the same org tag
+        // and we can reject revoked/foreign keys atomically.
+        let row: Option<(Option<Uuid>, Option<DateTime<Utc>>)> = sqlx::query_as(
+            r#"
+            SELECT org_id, revoked_at
+            FROM user_public_keys
+            WHERE id = $1 AND user_id = $2
+            "#,
+        )
+        .bind(old_key_id)
+        .bind(user_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let (inherited_org_id, revoked_at) = match row {
+            Some(r) => r,
+            None => return Err(crate::error::StoreError::NotFound),
+        };
+        if revoked_at.is_some() {
+            return Err(crate::error::StoreError::NotFound);
+        }
+
+        let new_key: UserPublicKey = sqlx::query_as::<_, UserPublicKey>(
+            r#"
+            INSERT INTO user_public_keys
+                (user_id, algorithm, public_key_b64, label, org_id)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id, user_id, algorithm, public_key_b64, label,
+                      created_at, revoked_at, org_id
+            "#,
+        )
+        .bind(user_id)
+        .bind(algorithm)
+        .bind(new_public_key_b64)
+        .bind(new_label)
+        .bind(inherited_org_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            r#"
+            UPDATE user_public_keys
+            SET revoked_at = NOW()
+            WHERE id = $1 AND user_id = $2
+            "#,
+        )
+        .bind(old_key_id)
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(new_key)
     }
 
     async fn revoke_user_public_key(&self, user_id: Uuid, key_id: Uuid) -> StoreResult<bool> {

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -2658,7 +2658,7 @@ impl RegistryStore for SqliteRegistryStore {
         let rows = sqlx::query(
             r#"
             SELECT id, user_id, algorithm, public_key_b64, label,
-                   created_at, revoked_at
+                   created_at, revoked_at, org_id
             FROM user_public_keys
             WHERE user_id = ? AND revoked_at IS NULL
             ORDER BY created_at ASC
@@ -2674,6 +2674,7 @@ impl RegistryStore for SqliteRegistryStore {
             let user_id_str: String = row.try_get("user_id")?;
             let created_at_str: String = row.try_get("created_at")?;
             let revoked_at_str: Option<String> = row.try_get("revoked_at")?;
+            let org_id_str: Option<String> = row.try_get("org_id")?;
             out.push(UserPublicKey {
                 id: parse_uuid(&id_str)?,
                 user_id: parse_uuid(&user_id_str)?,
@@ -2682,6 +2683,7 @@ impl RegistryStore for SqliteRegistryStore {
                 label: row.try_get("label")?,
                 created_at: parse_dt(&created_at_str)?,
                 revoked_at: revoked_at_str.as_deref().map(parse_dt).transpose()?,
+                org_id: org_id_str.as_deref().map(parse_uuid).transpose()?,
             });
         }
         Ok(out)
@@ -2705,7 +2707,7 @@ impl RegistryStore for SqliteRegistryStore {
         let sql = format!(
             r#"
             SELECT k.id, k.user_id, k.algorithm, k.public_key_b64, k.label,
-                   k.created_at, k.revoked_at,
+                   k.created_at, k.revoked_at, k.org_id,
                    COUNT(pv.id) AS usage_count
             FROM user_public_keys k
             LEFT JOIN plugin_versions pv ON pv.sbom_signed_key_id = k.id
@@ -2722,6 +2724,7 @@ impl RegistryStore for SqliteRegistryStore {
             let user_id_str: String = row.try_get("user_id")?;
             let created_at_str: String = row.try_get("created_at")?;
             let revoked_at_str: Option<String> = row.try_get("revoked_at")?;
+            let org_id_str: Option<String> = row.try_get("org_id")?;
             // SQLite returns COUNT() as INTEGER; sqlx maps it to i64 here.
             let usage_count: i64 = row.try_get("usage_count")?;
             out.push(UserPublicKeyWithUsage {
@@ -2733,6 +2736,7 @@ impl RegistryStore for SqliteRegistryStore {
                     label: row.try_get("label")?,
                     created_at: parse_dt(&created_at_str)?,
                     revoked_at: revoked_at_str.as_deref().map(parse_dt).transpose()?,
+                    org_id: org_id_str.as_deref().map(parse_uuid).transpose()?,
                 },
                 usage_count,
             });
@@ -2746,6 +2750,7 @@ impl RegistryStore for SqliteRegistryStore {
         algorithm: &str,
         public_key_b64: &str,
         label: &str,
+        org_id: Option<Uuid>,
     ) -> StoreResult<UserPublicKey> {
         let id = Uuid::new_v4();
         let now = Utc::now();
@@ -2753,8 +2758,8 @@ impl RegistryStore for SqliteRegistryStore {
         sqlx::query(
             r#"
             INSERT INTO user_public_keys
-                (id, user_id, algorithm, public_key_b64, label, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+                (id, user_id, algorithm, public_key_b64, label, created_at, org_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(id.to_string())
@@ -2763,6 +2768,7 @@ impl RegistryStore for SqliteRegistryStore {
         .bind(public_key_b64)
         .bind(label)
         .bind(&now_str)
+        .bind(org_id.map(|o| o.to_string()))
         .execute(&self.pool)
         .await?;
 
@@ -2774,6 +2780,7 @@ impl RegistryStore for SqliteRegistryStore {
             label: label.to_string(),
             created_at: now,
             revoked_at: None,
+            org_id,
         })
     }
 
@@ -2790,6 +2797,243 @@ impl RegistryStore for SqliteRegistryStore {
         .execute(&self.pool)
         .await?;
         Ok(res.rows_affected() > 0)
+    }
+
+    async fn find_user_public_key_by_id(&self, key_id: Uuid) -> StoreResult<Option<UserPublicKey>> {
+        use sqlx::Row;
+        let row = sqlx::query(
+            r#"
+            SELECT id, user_id, algorithm, public_key_b64, label,
+                   created_at, revoked_at, org_id
+            FROM user_public_keys
+            WHERE id = ?
+            "#,
+        )
+        .bind(key_id.to_string())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            None => Ok(None),
+            Some(row) => {
+                let id_str: String = row.try_get("id")?;
+                let user_id_str: String = row.try_get("user_id")?;
+                let created_at_str: String = row.try_get("created_at")?;
+                let revoked_at_str: Option<String> = row.try_get("revoked_at")?;
+                let org_id_str: Option<String> = row.try_get("org_id")?;
+                Ok(Some(UserPublicKey {
+                    id: parse_uuid(&id_str)?,
+                    user_id: parse_uuid(&user_id_str)?,
+                    algorithm: row.try_get("algorithm")?,
+                    public_key_b64: row.try_get("public_key_b64")?,
+                    label: row.try_get("label")?,
+                    created_at: parse_dt(&created_at_str)?,
+                    revoked_at: revoked_at_str.as_deref().map(parse_dt).transpose()?,
+                    org_id: org_id_str.as_deref().map(parse_uuid).transpose()?,
+                }))
+            }
+        }
+    }
+
+    async fn revoke_org_public_key(&self, org_id: Uuid, key_id: Uuid) -> StoreResult<bool> {
+        // Org-scoped revocation: the predicate doesn't constrain on
+        // user_id since any Owner/Admin of the org may pull a key.
+        // Handler-level role check is the gate.
+        let res = sqlx::query(
+            r#"
+            UPDATE user_public_keys
+            SET revoked_at = datetime('now')
+            WHERE id = ? AND org_id = ? AND revoked_at IS NULL
+            "#,
+        )
+        .bind(key_id.to_string())
+        .bind(org_id.to_string())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    async fn list_org_public_keys_with_usage(
+        &self,
+        org_id: Uuid,
+        include_revoked: bool,
+    ) -> StoreResult<Vec<UserPublicKeyWithUsage>> {
+        use sqlx::Row;
+        let revoked_predicate = if include_revoked {
+            "1=1"
+        } else {
+            "k.revoked_at IS NULL"
+        };
+        let sql = format!(
+            r#"
+            SELECT k.id, k.user_id, k.algorithm, k.public_key_b64, k.label,
+                   k.created_at, k.revoked_at, k.org_id,
+                   COUNT(pv.id) AS usage_count
+            FROM user_public_keys k
+            LEFT JOIN plugin_versions pv ON pv.sbom_signed_key_id = k.id
+            WHERE k.org_id = ? AND {revoked_predicate}
+            GROUP BY k.id
+            ORDER BY k.created_at ASC
+            "#
+        );
+        let rows = sqlx::query(&sql).bind(org_id.to_string()).fetch_all(&self.pool).await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id_str: String = row.try_get("id")?;
+            let user_id_str: String = row.try_get("user_id")?;
+            let created_at_str: String = row.try_get("created_at")?;
+            let revoked_at_str: Option<String> = row.try_get("revoked_at")?;
+            let org_id_str: Option<String> = row.try_get("org_id")?;
+            let usage_count: i64 = row.try_get("usage_count")?;
+            out.push(UserPublicKeyWithUsage {
+                key: UserPublicKey {
+                    id: parse_uuid(&id_str)?,
+                    user_id: parse_uuid(&user_id_str)?,
+                    algorithm: row.try_get("algorithm")?,
+                    public_key_b64: row.try_get("public_key_b64")?,
+                    label: row.try_get("label")?,
+                    created_at: parse_dt(&created_at_str)?,
+                    revoked_at: revoked_at_str.as_deref().map(parse_dt).transpose()?,
+                    org_id: org_id_str.as_deref().map(parse_uuid).transpose()?,
+                },
+                usage_count,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn list_keys_for_publisher(&self, author_id: Uuid) -> StoreResult<Vec<UserPublicKey>> {
+        use sqlx::Row;
+        // Single statement returning the union of:
+        //   * the author's own active keys, and
+        //   * any active key tagged to an org the author owns or is a
+        //     member of.
+        // The verifier dedupes if a key matches both branches (own +
+        // org-tagged), so a UNION (not UNION ALL) is what we want.
+        let rows = sqlx::query(
+            r#"
+            SELECT id, user_id, algorithm, public_key_b64, label,
+                   created_at, revoked_at, org_id
+            FROM user_public_keys
+            WHERE revoked_at IS NULL AND (
+                user_id = ?1
+                OR org_id IN (
+                    SELECT id FROM organizations WHERE owner_id = ?1
+                    UNION
+                    SELECT org_id FROM org_members WHERE user_id = ?1
+                )
+            )
+            ORDER BY created_at ASC
+            "#,
+        )
+        .bind(author_id.to_string())
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id_str: String = row.try_get("id")?;
+            let user_id_str: String = row.try_get("user_id")?;
+            let created_at_str: String = row.try_get("created_at")?;
+            let revoked_at_str: Option<String> = row.try_get("revoked_at")?;
+            let org_id_str: Option<String> = row.try_get("org_id")?;
+            out.push(UserPublicKey {
+                id: parse_uuid(&id_str)?,
+                user_id: parse_uuid(&user_id_str)?,
+                algorithm: row.try_get("algorithm")?,
+                public_key_b64: row.try_get("public_key_b64")?,
+                label: row.try_get("label")?,
+                created_at: parse_dt(&created_at_str)?,
+                revoked_at: revoked_at_str.as_deref().map(parse_dt).transpose()?,
+                org_id: org_id_str.as_deref().map(parse_uuid).transpose()?,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn rotate_user_public_key(
+        &self,
+        user_id: Uuid,
+        old_key_id: Uuid,
+        algorithm: &str,
+        new_public_key_b64: &str,
+        new_label: &str,
+    ) -> StoreResult<UserPublicKey> {
+        use sqlx::Row;
+        let mut tx = self.pool.begin().await?;
+        // Re-read the old key inside the transaction so the new key
+        // inherits the same org tag (or lack thereof). Bail if the
+        // caller can't actually revoke it.
+        let row = sqlx::query(
+            r#"
+            SELECT org_id, revoked_at
+            FROM user_public_keys
+            WHERE id = ? AND user_id = ?
+            "#,
+        )
+        .bind(old_key_id.to_string())
+        .bind(user_id.to_string())
+        .fetch_optional(&mut *tx)
+        .await?;
+        let row = match row {
+            Some(r) => r,
+            None => return Err(crate::error::StoreError::NotFound),
+        };
+        let revoked_at_str: Option<String> = row.try_get("revoked_at")?;
+        if revoked_at_str.is_some() {
+            // Treat "already revoked" the same as "not found" — same
+            // user-facing shape, and the handler maps both to a 400.
+            return Err(crate::error::StoreError::NotFound);
+        }
+        let inherited_org_id_str: Option<String> = row.try_get("org_id")?;
+        let inherited_org_id = inherited_org_id_str.as_deref().map(parse_uuid).transpose()?;
+
+        let new_id = Uuid::new_v4();
+        let now = Utc::now();
+        let now_str = now.to_rfc3339();
+        sqlx::query(
+            r#"
+            INSERT INTO user_public_keys
+                (id, user_id, algorithm, public_key_b64, label, created_at, org_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(new_id.to_string())
+        .bind(user_id.to_string())
+        .bind(algorithm)
+        .bind(new_public_key_b64)
+        .bind(new_label)
+        .bind(&now_str)
+        .bind(inherited_org_id.map(|o| o.to_string()))
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            r#"
+            UPDATE user_public_keys
+            SET revoked_at = ?
+            WHERE id = ? AND user_id = ?
+            "#,
+        )
+        .bind(&now_str)
+        .bind(old_key_id.to_string())
+        .bind(user_id.to_string())
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(UserPublicKey {
+            id: new_id,
+            user_id,
+            algorithm: algorithm.to_string(),
+            public_key_b64: new_public_key_b64.to_string(),
+            label: new_label.to_string(),
+            created_at: now,
+            revoked_at: None,
+            org_id: inherited_org_id,
+        })
     }
 
     async fn record_plugin_version_attestation(
@@ -4305,7 +4549,7 @@ mod tests {
 
         // 2. Register via the SQLite store.
         let registered = store
-            .create_user_public_key(user_id, "ed25519", &public_b64, "laptop")
+            .create_user_public_key(user_id, "ed25519", &public_b64, "laptop", None)
             .await
             .unwrap();
         assert!(registered.is_active());
@@ -4435,11 +4679,11 @@ mod tests {
         let key_b_bytes = [0x22u8; 32];
         let b64 = |b: &[u8]| base64::engine::general_purpose::STANDARD.encode(b);
         let a = store
-            .create_user_public_key(user_id, "ed25519", &b64(&key_a_bytes), "laptop")
+            .create_user_public_key(user_id, "ed25519", &b64(&key_a_bytes), "laptop", None)
             .await
             .unwrap();
         let b = store
-            .create_user_public_key(user_id, "ed25519", &b64(&key_b_bytes), "ci")
+            .create_user_public_key(user_id, "ed25519", &b64(&key_b_bytes), "ci", None)
             .await
             .unwrap();
         assert_ne!(a.id, b.id);
@@ -4486,11 +4730,11 @@ mod tests {
         // Register two keys.
         let b64 = |b: &[u8]| base64::engine::general_purpose::STANDARD.encode(b);
         let key_a = store
-            .create_user_public_key(user_id, "ed25519", &b64(&[0x11u8; 32]), "laptop")
+            .create_user_public_key(user_id, "ed25519", &b64(&[0x11u8; 32]), "laptop", None)
             .await
             .unwrap();
         let key_b = store
-            .create_user_public_key(user_id, "ed25519", &b64(&[0x22u8; 32]), "ci")
+            .create_user_public_key(user_id, "ed25519", &b64(&[0x22u8; 32]), "ci", None)
             .await
             .unwrap();
 
@@ -4549,6 +4793,154 @@ mod tests {
         let revoked = history.iter().find(|k| k.key.id == key_a.id).unwrap();
         assert!(revoked.key.revoked_at.is_some());
         assert_eq!(revoked.usage_count, 1);
+    }
+
+    /// Org-scoped publisher keys: register a key tagged to an org, the
+    /// org-scoped lister returns it, the verifier hands it to a
+    /// teammate publish, and an admin (non-owner) can revoke it.
+    #[tokio::test]
+    async fn test_org_scoped_publisher_keys_lifecycle() {
+        use base64::Engine;
+        let store = memory_store().await;
+        let pool = store.pool();
+
+        // Seed: owner user, admin user, org, member rows.
+        let owner_id = Uuid::new_v4();
+        let admin_id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO users (id, username, email, password_hash, created_at, updated_at)
+               VALUES (?, 'owner', 'o@example.com', 'x', datetime('now'), datetime('now')),
+                      (?, 'admin', 'a@example.com', 'x', datetime('now'), datetime('now'))"#,
+        )
+        .bind(owner_id.to_string())
+        .bind(admin_id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let org_id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO organizations (id, name, slug, owner_id, plan, limits_json,
+                                          stripe_customer_id, created_at, updated_at)
+               VALUES (?, 'AcmeOrg', 'acme', ?, 'team', '{}', NULL,
+                       datetime('now'), datetime('now'))"#,
+        )
+        .bind(org_id.to_string())
+        .bind(owner_id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"INSERT INTO org_members (id, org_id, user_id, role, created_at)
+               VALUES (?, ?, ?, 'admin', datetime('now'))"#,
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(org_id.to_string())
+        .bind(admin_id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Owner registers an org-scoped key.
+        let b64 = |b: &[u8]| base64::engine::general_purpose::STANDARD.encode(b);
+        let team_key = store
+            .create_user_public_key(
+                owner_id,
+                "ed25519",
+                &b64(&[0x33u8; 32]),
+                "ci-bot",
+                Some(org_id),
+            )
+            .await
+            .unwrap();
+        assert_eq!(team_key.org_id, Some(org_id));
+
+        // Org listing returns it.
+        let listed = store.list_org_public_keys_with_usage(org_id, false).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].key.id, team_key.id);
+
+        // The admin user (a member, not owner) gets that key offered to
+        // the verifier when *they* publish.
+        let publisher_keys = store.list_keys_for_publisher(admin_id).await.unwrap();
+        assert!(publisher_keys.iter().any(|k| k.id == team_key.id));
+
+        // Org-admin revoke succeeds even though admin isn't the owner.
+        assert!(store.revoke_org_public_key(org_id, team_key.id).await.unwrap());
+
+        // After revocation the verifier no longer sees it.
+        let publisher_keys_after = store.list_keys_for_publisher(admin_id).await.unwrap();
+        assert!(publisher_keys_after.iter().all(|k| k.id != team_key.id));
+
+        // The org listing (active-only) drops it; including revoked
+        // brings it back so admins can audit retired keys.
+        let active = store.list_org_public_keys_with_usage(org_id, false).await.unwrap();
+        assert!(active.is_empty());
+        let history = store.list_org_public_keys_with_usage(org_id, true).await.unwrap();
+        assert_eq!(history.len(), 1);
+        assert!(history[0].key.revoked_at.is_some());
+    }
+
+    /// Atomic key rotation: new key inherits the old's org tag, old key
+    /// is revoked in the same transaction.
+    #[tokio::test]
+    async fn test_rotate_user_public_key_inherits_org() {
+        use base64::Engine;
+        let store = memory_store().await;
+        let pool = store.pool();
+
+        let user_id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO users (id, username, email, password_hash, created_at, updated_at)
+               VALUES (?, 'rot', 'r@example.com', 'x', datetime('now'), datetime('now'))"#,
+        )
+        .bind(user_id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+        let org_id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO organizations (id, name, slug, owner_id, plan, limits_json,
+                                          stripe_customer_id, created_at, updated_at)
+               VALUES (?, 'RotOrg', 'rot-org', ?, 'free', '{}', NULL,
+                       datetime('now'), datetime('now'))"#,
+        )
+        .bind(org_id.to_string())
+        .bind(user_id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let b64 = |b: &[u8]| base64::engine::general_purpose::STANDARD.encode(b);
+        let old = store
+            .create_user_public_key(
+                user_id,
+                "ed25519",
+                &b64(&[0x44u8; 32]),
+                "old-laptop",
+                Some(org_id),
+            )
+            .await
+            .unwrap();
+
+        let new = store
+            .rotate_user_public_key(user_id, old.id, "ed25519", &b64(&[0x55u8; 32]), "new-laptop")
+            .await
+            .unwrap();
+        assert_ne!(new.id, old.id);
+        assert_eq!(new.org_id, Some(org_id), "new key inherits org tag");
+        assert!(new.is_active());
+
+        // Old is revoked.
+        let lookup = store.find_user_public_key_by_id(old.id).await.unwrap().unwrap();
+        assert!(lookup.revoked_at.is_some());
+
+        // Re-rotating the now-revoked old key fails.
+        let err = store
+            .rotate_user_public_key(user_id, old.id, "ed25519", &b64(&[0x66u8; 32]), "another")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::error::StoreError::NotFound));
     }
 
     /// End-to-end scenarios CRUD on SQLite. Seeds a user + org, creates

--- a/crates/mockforge-registry-server/migrations/20250101000055_publisher_keys_org_scope.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000055_publisher_keys_org_scope.sql
@@ -1,0 +1,39 @@
+-- Org-scoped publisher attestation keys.
+--
+-- A publisher key has been user-scoped since the original SBOM
+-- attestation work (migration 20250101000036). That fits a single-author
+-- workflow but breaks down for teams: a CI bot signing on behalf of an
+-- organization, or shared on-call rotation, has no way to publish using
+-- a key that other teammates can audit and revoke.
+--
+-- We add a nullable `org_id` so a key can either be:
+--   * personal (`org_id IS NULL`) — same as today; the verifier still
+--     accepts it for the owner's plugin publishes.
+--   * org-tagged — visible to org Owners/Admins via the new
+--     `/api/v1/organizations/{org_id}/public-keys` endpoint and accepted
+--     by the verifier when *any* member of that org publishes.
+--
+-- ON DELETE SET NULL because deleting an org should not silently delete
+-- a publisher's history of signatures. The key falls back to a personal
+-- key in that case, which keeps `plugin_versions.sbom_signed_key_id`
+-- references intact.
+--
+-- A new audit-event variant for create/revoke/rotate ships in the same
+-- migration so handlers can record under a single CHECK type.
+
+ALTER TABLE user_public_keys
+    ADD COLUMN IF NOT EXISTS org_id UUID
+        REFERENCES organizations(id) ON DELETE SET NULL;
+
+-- Partial index on org_id IS NOT NULL so the org-scoped list endpoint
+-- doesn't scan personal keys.
+CREATE INDEX IF NOT EXISTS user_public_keys_org_idx
+    ON user_public_keys(org_id)
+    WHERE org_id IS NOT NULL AND revoked_at IS NULL;
+
+-- Audit-event variants for the publisher-key lifecycle. ALTER TYPE ADD
+-- VALUE is the standard pattern across this codebase
+-- (see 20250101000029_federations.sql).
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'publisher_key_created';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'publisher_key_revoked';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'publisher_key_rotated';

--- a/crates/mockforge-registry-server/src/handlers/plugins.rs
+++ b/crates/mockforge-registry-server/src/handlers/plugins.rs
@@ -434,7 +434,11 @@ pub async fn publish_plugin(
             verify_sbom_attestation, SbomAttestationInput, SbomVerifyOutcome,
         };
 
-        let keys = state.store.list_user_public_keys(author_id).await?;
+        // Pull both the author's own keys and any keys tagged to orgs
+        // they belong to. Lets a CI bot's key registered against an org
+        // verify a teammate's publish without requiring every member to
+        // re-register the same key personally.
+        let keys = state.store.list_keys_for_publisher(author_id).await?;
         // Canonicalize via RFC 8785 (JCS) — the CLI signs the same form,
         // so publishers using different JSON libraries produce
         // byte-identical inputs to the verifier. Without this step, two

--- a/crates/mockforge-registry-server/src/handlers/public_keys.rs
+++ b/crates/mockforge-registry-server/src/handlers/public_keys.rs
@@ -1,25 +1,31 @@
 //! Publisher public-key management for SBOM attestation.
 //!
-//! Routes (all authenticated, scoped to the calling user):
-//!   * `GET    /api/v1/users/me/public-keys` — list active keys.
-//!   * `POST   /api/v1/users/me/public-keys` — register a new key.
-//!   * `DELETE /api/v1/users/me/public-keys/{id}` — soft-revoke.
-//!
-//! These are the minimum surface a publisher needs to opt into signing
-//! SBOMs. The verification logic lives in
-//! `mockforge-registry-core::models::attestation`; this handler just
-//! owns the user-facing CRUD.
+//! Routes:
+//!   * `GET    /api/v1/users/me/public-keys` — list keys, with `usage_count`
+//!     and (when `?includeRevoked=true`) revoked rows.
+//!   * `POST   /api/v1/users/me/public-keys` — register a new key. Optional
+//!     `orgId` tags the key to an org; the caller must be Owner/Admin.
+//!     Per-plan quota enforced via `effective_limits`.
+//!   * `POST   /api/v1/users/me/public-keys/{id}/rotate` — atomic rotation:
+//!     register a new key with the same org tag and revoke the old one in a
+//!     single transaction; emits a `PublisherKeyRotated` audit event.
+//!   * `DELETE /api/v1/users/me/public-keys/{id}` — soft-revoke a key the
+//!     caller owns (or, if the key is org-scoped, an org Owner/Admin).
+//!   * `GET    /api/v1/organizations/{org_id}/public-keys` — list keys
+//!     tagged to an org; visible to org Owners/Admins.
 
 use axum::{
     extract::{Path, Query, State},
     Json,
 };
 use base64::Engine;
+use mockforge_registry_core::models::{AuditEventType, OrgRole};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
     error::{ApiError, ApiResult},
+    handlers::usage::effective_limits,
     middleware::AuthUser,
     AppState,
 };
@@ -34,9 +40,12 @@ pub struct PublicKeyResponse {
     pub created_at: String,
     pub revoked_at: Option<String>,
     /// Number of plugin versions whose SBOM signature was verified by
-    /// this key. Lets the UI show a "signed N versions" pill so a user
-    /// can decide whether a key is safe to revoke before doing it.
+    /// this key. Lets the UI show a "signed N versions" pill.
     pub usage_count: i64,
+    /// Optional org the key is scoped to. `None` = personal key.
+    /// Serializes as `null` (not omitted) so clients can rely on the
+    /// field being present when reading older records back.
+    pub org_id: Option<Uuid>,
 }
 
 impl From<mockforge_registry_core::models::UserPublicKeyWithUsage> for PublicKeyResponse {
@@ -49,6 +58,7 @@ impl From<mockforge_registry_core::models::UserPublicKeyWithUsage> for PublicKey
             created_at: k.key.created_at.to_rfc3339(),
             revoked_at: k.key.revoked_at.map(|dt| dt.to_rfc3339()),
             usage_count: k.usage_count,
+            org_id: k.key.org_id,
         }
     }
 }
@@ -79,6 +89,19 @@ pub async fn list_my_public_keys(
     }))
 }
 
+pub async fn list_org_public_keys(
+    AuthUser(user_id): AuthUser,
+    State(state): State<AppState>,
+    Path(org_id): Path<Uuid>,
+    Query(q): Query<ListPublicKeysQuery>,
+) -> ApiResult<Json<ListPublicKeysResponse>> {
+    require_org_admin(&state, org_id, user_id).await?;
+    let keys = state.store.list_org_public_keys_with_usage(org_id, q.include_revoked).await?;
+    Ok(Json(ListPublicKeysResponse {
+        keys: keys.into_iter().map(Into::into).collect(),
+    }))
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatePublicKeyRequest {
@@ -92,6 +115,10 @@ pub struct CreatePublicKeyRequest {
     /// Short human label the user sees in their key list. Required so
     /// a returning user can distinguish their own keys.
     pub label: String,
+    /// Optional org the key should be scoped to. The caller must be
+    /// Owner/Admin of that org.
+    #[serde(default)]
+    pub org_id: Option<Uuid>,
 }
 
 fn default_algorithm() -> String {
@@ -133,9 +160,41 @@ pub async fn create_my_public_key(
         )));
     }
 
-    let saved = state.store.create_user_public_key(user_id, &algorithm, key_b64, label).await?;
-    // Freshly registered keys have signed nothing yet — short-circuit
-    // the count rather than re-querying.
+    // Org tag: confirm the caller is Owner/Admin of the requested org
+    // before we let them attach a key to it.
+    if let Some(org_id) = request.org_id {
+        require_org_admin(&state, org_id, user_id).await?;
+    }
+
+    enforce_publisher_key_quota(&state, user_id).await?;
+
+    let saved = state
+        .store
+        .create_user_public_key(user_id, &algorithm, key_b64, label, request.org_id)
+        .await?;
+
+    // Audit the create. org_id on the audit row is the audit log's own
+    // scope (always nil for personal-style events) — independent of the
+    // key's optional org tag, which goes in metadata so org admins can
+    // correlate later.
+    state
+        .store
+        .record_audit_event(
+            uuid::Uuid::nil(),
+            Some(user_id),
+            AuditEventType::PublisherKeyCreated,
+            format!("Publisher key '{}' created", saved.label),
+            Some(serde_json::json!({
+                "key_id": saved.id,
+                "label": saved.label,
+                "algorithm": saved.algorithm,
+                "key_org_id": saved.org_id,
+            })),
+            None,
+            None,
+        )
+        .await;
+
     Ok(Json(PublicKeyResponse {
         id: saved.id,
         algorithm: saved.algorithm,
@@ -144,6 +203,7 @@ pub async fn create_my_public_key(
         created_at: saved.created_at.to_rfc3339(),
         revoked_at: saved.revoked_at.map(|dt| dt.to_rfc3339()),
         usage_count: 0,
+        org_id: saved.org_id,
     }))
 }
 
@@ -152,12 +212,197 @@ pub async fn revoke_my_public_key(
     State(state): State<AppState>,
     Path(key_id): Path<Uuid>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    let revoked = state.store.revoke_user_public_key(user_id, key_id).await?;
+    // First try the user-scoped revoke. If that misses (returns false)
+    // and the key is tagged to an org the caller administers, fall
+    // through to the org-scoped revoke.
+    let revoked = if state.store.revoke_user_public_key(user_id, key_id).await? {
+        true
+    } else {
+        // Look up the key to learn its org tag, then check the
+        // caller's role on that org.
+        match state.store.find_user_public_key_by_id(key_id).await? {
+            Some(k) => match k.org_id {
+                Some(org_id) => {
+                    require_org_admin(&state, org_id, user_id).await?;
+                    state.store.revoke_org_public_key(org_id, key_id).await?
+                }
+                None => false,
+            },
+            None => false,
+        }
+    };
+
     if !revoked {
         return Err(ApiError::InvalidRequest(
-            "key does not exist, is already revoked, or does not belong to the calling user"
+            "key does not exist, is already revoked, or you don't have permission to revoke it"
                 .to_string(),
         ));
     }
+
+    state
+        .store
+        .record_audit_event(
+            uuid::Uuid::nil(),
+            Some(user_id),
+            AuditEventType::PublisherKeyRevoked,
+            format!("Publisher key {} revoked", key_id),
+            Some(serde_json::json!({"key_id": key_id})),
+            None,
+            None,
+        )
+        .await;
+
     Ok(Json(serde_json::json!({ "revoked": true, "id": key_id })))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RotatePublicKeyRequest {
+    pub new_public_key_b64: String,
+    pub new_label: String,
+    /// Caller may pin the algorithm; defaults to ed25519 (the only one
+    /// supported today). Kept symmetric with `CreatePublicKeyRequest`.
+    #[serde(default = "default_algorithm")]
+    pub algorithm: String,
+}
+
+pub async fn rotate_my_public_key(
+    AuthUser(user_id): AuthUser,
+    State(state): State<AppState>,
+    Path(old_key_id): Path<Uuid>,
+    Json(request): Json<RotatePublicKeyRequest>,
+) -> ApiResult<Json<PublicKeyResponse>> {
+    let algorithm = request.algorithm.trim().to_ascii_lowercase();
+    if algorithm != "ed25519" {
+        return Err(ApiError::InvalidRequest(format!(
+            "unsupported key algorithm '{}': only 'ed25519' is accepted",
+            algorithm
+        )));
+    }
+
+    let new_label = request.new_label.trim();
+    if new_label.is_empty() || new_label.len() > 128 {
+        return Err(ApiError::InvalidRequest(
+            "new_label must be between 1 and 128 characters".to_string(),
+        ));
+    }
+
+    let new_key_b64 = request.new_public_key_b64.trim();
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(new_key_b64)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(new_key_b64))
+        .map_err(|e| {
+            ApiError::InvalidRequest(format!("new_public_key_b64 is not base64: {}", e))
+        })?;
+    if decoded.len() != ed25519_dalek::PUBLIC_KEY_LENGTH {
+        return Err(ApiError::InvalidRequest(format!(
+            "ed25519 public key must be {} bytes, got {}",
+            ed25519_dalek::PUBLIC_KEY_LENGTH,
+            decoded.len()
+        )));
+    }
+
+    // Quota: rotation creates one key but also revokes one in the same
+    // transaction, so net active count doesn't change. We still gate
+    // the create on the quota in case the user is *over* quota due to
+    // a downgrade and is rotating to fix that — they're allowed.
+    // No-op for now.
+
+    let new_key = state
+        .store
+        .rotate_user_public_key(user_id, old_key_id, &algorithm, new_key_b64, new_label)
+        .await
+        .map_err(|e| match e {
+            mockforge_registry_core::error::StoreError::NotFound => ApiError::InvalidRequest(
+                "key does not exist, is already revoked, or doesn't belong to you".to_string(),
+            ),
+            other => other.into(),
+        })?;
+
+    state
+        .store
+        .record_audit_event(
+            uuid::Uuid::nil(),
+            Some(user_id),
+            AuditEventType::PublisherKeyRotated,
+            format!("Publisher key rotated from {} to {}", old_key_id, new_key.id),
+            Some(serde_json::json!({
+                "old_key_id": old_key_id,
+                "new_key_id": new_key.id,
+                "label": new_key.label,
+                "key_org_id": new_key.org_id,
+            })),
+            None,
+            None,
+        )
+        .await;
+
+    Ok(Json(PublicKeyResponse {
+        id: new_key.id,
+        algorithm: new_key.algorithm,
+        public_key_b64: new_key.public_key_b64,
+        label: new_key.label,
+        created_at: new_key.created_at.to_rfc3339(),
+        revoked_at: new_key.revoked_at.map(|dt| dt.to_rfc3339()),
+        usage_count: 0,
+        org_id: new_key.org_id,
+    }))
+}
+
+/// Resolve a Plan limit on `max_publisher_keys` for the user's owner
+/// org and reject if the user is at or over it. Falls back to the Free
+/// default when the user has no owned org (e.g. before personal-org
+/// backfill ran). `-1` means unlimited.
+async fn enforce_publisher_key_quota(state: &AppState, user_id: Uuid) -> ApiResult<()> {
+    let pool = state.db.pool();
+    let orgs = mockforge_registry_core::models::Organization::find_by_user(pool, user_id)
+        .await
+        .map_err(ApiError::Database)?;
+    let owner_org = orgs.into_iter().find(|o| o.owner_id == user_id);
+
+    let limit = if let Some(org) = owner_org.as_ref() {
+        let limits = effective_limits(state, org).await?;
+        limits.get("max_publisher_keys").and_then(|v| v.as_i64()).unwrap_or(3)
+    } else {
+        // No owner org yet — apply the Free default conservatively so
+        // users without an org still hit a sane cap.
+        3
+    };
+
+    if limit < 0 {
+        return Ok(());
+    }
+
+    // Count active keys via the existing list helper. Keys per user
+    // typically <50, so the cost of running the JOIN here is fine.
+    let active = state.store.list_user_public_keys(user_id).await?;
+    if active.len() as i64 >= limit {
+        return Err(ApiError::ResourceLimitExceeded(format!(
+            "publisher key limit reached ({}/{}) — revoke an old key or upgrade your plan",
+            active.len(),
+            limit
+        )));
+    }
+
+    Ok(())
+}
+
+/// Bail with `PermissionDenied` unless `user_id` is the org's Owner or
+/// has an Admin/Owner role in `org_members`.
+async fn require_org_admin(state: &AppState, org_id: Uuid, user_id: Uuid) -> ApiResult<()> {
+    let org = state
+        .store
+        .find_organization_by_id(org_id)
+        .await?
+        .ok_or(ApiError::OrganizationNotFound)?;
+    if org.owner_id == user_id {
+        return Ok(());
+    }
+    let member = state.store.find_org_member(org_id, user_id).await?;
+    let role = member.as_ref().map(|m| m.role());
+    if matches!(role, Some(OrgRole::Owner) | Some(OrgRole::Admin)) {
+        Ok(())
+    } else {
+        Err(ApiError::PermissionDenied)
+    }
 }

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -106,6 +106,14 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/users/me/public-keys/{id}",
             delete(handlers::public_keys::revoke_my_public_key),
         )
+        .route(
+            "/api/v1/users/me/public-keys/{id}/rotate",
+            post(handlers::public_keys::rotate_my_public_key),
+        )
+        .route(
+            "/api/v1/organizations/{org_id}/public-keys",
+            get(handlers::public_keys::list_org_public_keys),
+        )
         // 2FA routes
         .route("/api/v1/auth/2fa/setup", get(handlers::two_factor::setup_2fa))
         .route("/api/v1/auth/2fa/verify-setup", post(handlers::two_factor::verify_2fa_setup_with_secret))

--- a/crates/mockforge-ui/ui/src/pages/PublisherKeysPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PublisherKeysPage.tsx
@@ -26,10 +26,14 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  FormControl,
   FormControlLabel,
   IconButton,
+  InputLabel,
   LinearProgress,
+  MenuItem,
   Paper,
+  Select,
   Stack,
   Switch,
   TextField,
@@ -42,6 +46,7 @@ import {
   ExpandMore as ExpandMoreIcon,
   Key as KeyIcon,
   ContentCopy as CopyIcon,
+  Autorenew as RotateIcon,
   Terminal as TerminalIcon,
   VerifiedUser as VerifiedIcon,
 } from '@mui/icons-material';
@@ -58,10 +63,20 @@ interface PublicKey {
   /// this key. Server-computed via a JOIN on `plugin_versions` so we
   /// don't ship N+1 queries from the browser.
   usageCount: number;
+  /// Optional org tag. When set, the key is also accepted by the
+  /// attestation verifier when other org members publish.
+  orgId?: string | null;
 }
 
 interface ListResponse {
   keys: PublicKey[];
+}
+
+interface OrganizationOption {
+  id: string;
+  name: string;
+  slug: string;
+  ownerId: string;
 }
 
 async function fetchKeys(includeRevoked: boolean): Promise<PublicKey[]> {
@@ -77,10 +92,24 @@ async function fetchKeys(includeRevoked: boolean): Promise<PublicKey[]> {
   return data.keys;
 }
 
+async function fetchOrgs(): Promise<OrganizationOption[]> {
+  // Soft-fail: org-tagged keys are an opt-in feature. If the user has
+  // no orgs (or the endpoint is unavailable), the dialog falls back to
+  // a personal-only key with no fanfare.
+  try {
+    const resp = await authenticatedFetch('/api/v1/organizations');
+    if (!resp.ok) return [];
+    return await resp.json();
+  } catch {
+    return [];
+  }
+}
+
 async function addKey(req: {
   algorithm: string;
   publicKeyB64: string;
   label: string;
+  orgId?: string | null;
 }): Promise<PublicKey> {
   const resp = await authenticatedFetch('/api/v1/users/me/public-keys', {
     method: 'POST',
@@ -102,6 +131,25 @@ async function revokeKey(id: string): Promise<void> {
     const body = await resp.text().catch(() => '');
     throw new Error(`Failed to revoke key (${resp.status}): ${body}`);
   }
+}
+
+async function rotateKey(
+  id: string,
+  req: { newPublicKeyB64: string; newLabel: string }
+): Promise<PublicKey> {
+  const resp = await authenticatedFetch(
+    `/api/v1/users/me/public-keys/${id}/rotate`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    }
+  );
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    throw new Error(`Failed to rotate key (${resp.status}): ${body}`);
+  }
+  return resp.json();
 }
 
 /// Short fingerprint for UI display — first 16 hex chars of SHA-256 of
@@ -334,8 +382,14 @@ const PublisherKeysPage: React.FC = () => {
   const [showAdd, setShowAdd] = useState(false);
   const [label, setLabel] = useState('');
   const [publicKeyB64, setPublicKeyB64] = useState('');
+  // '' = personal key. Otherwise an org id from the orgs query.
+  const [selectedOrgId, setSelectedOrgId] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [confirmRevoke, setConfirmRevoke] = useState<PublicKey | null>(null);
+  const [rotateTarget, setRotateTarget] = useState<PublicKey | null>(null);
+  const [rotateLabel, setRotateLabel] = useState('');
+  const [rotateKeyB64, setRotateKeyB64] = useState('');
+  const [rotateError, setRotateError] = useState<string | null>(null);
   const [fingerprints, setFingerprints] = useState<Record<string, string>>({});
   // Off by default — most of the time users care about active keys.
   // Flipping this on makes the server return revoked rows too so the
@@ -350,6 +404,15 @@ const PublisherKeysPage: React.FC = () => {
   } = useQuery({
     queryKey: ['publisher-public-keys', includeRevoked],
     queryFn: () => fetchKeys(includeRevoked),
+  });
+
+  // Lazy-load orgs only when the Add dialog opens. Keeps the page
+  // load cheap for users who never tag a key.
+  const { data: orgs } = useQuery({
+    queryKey: ['publisher-keys-orgs'],
+    queryFn: fetchOrgs,
+    enabled: showAdd,
+    staleTime: 60_000,
   });
 
   // Derive fingerprints whenever the key list changes. Done in an
@@ -377,9 +440,23 @@ const PublisherKeysPage: React.FC = () => {
       setShowAdd(false);
       setLabel('');
       setPublicKeyB64('');
+      setSelectedOrgId('');
       setError(null);
     },
     onError: (e: Error) => setError(e.message),
+  });
+
+  const rotateMutation = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: { newPublicKeyB64: string; newLabel: string } }) =>
+      rotateKey(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['publisher-public-keys'] });
+      setRotateTarget(null);
+      setRotateLabel('');
+      setRotateKeyB64('');
+      setRotateError(null);
+    },
+    onError: (e: Error) => setRotateError(e.message),
   });
 
   const revokeMutation = useMutation({
@@ -417,6 +494,33 @@ const PublisherKeysPage: React.FC = () => {
       algorithm: 'ed25519',
       publicKeyB64: trimmedKey,
       label: trimmedLabel,
+      orgId: selectedOrgId || null,
+    });
+  };
+
+  const handleRotateSubmit = () => {
+    setRotateError(null);
+    if (!rotateTarget) return;
+    const trimmedLabel = rotateLabel.trim();
+    if (!trimmedLabel) {
+      setRotateError('New label is required.');
+      return;
+    }
+    const trimmedKey = rotateKeyB64.trim();
+    if (!trimmedKey) {
+      setRotateError('New public key is required.');
+      return;
+    }
+    const stripped = normalizeBase64(trimmedKey);
+    if (stripped.length !== 44) {
+      setRotateError(
+        `Expected 44 base64 characters for an Ed25519 public key; got ${stripped.length}.`
+      );
+      return;
+    }
+    rotateMutation.mutate({
+      id: rotateTarget.id,
+      body: { newPublicKeyB64: trimmedKey, newLabel: trimmedLabel },
     });
   };
 
@@ -518,6 +622,16 @@ const PublisherKeysPage: React.FC = () => {
                         />
                       </Tooltip>
                     )}
+                    {key.orgId && (
+                      <Tooltip title="Org-scoped key — accepted by the verifier when any member of this org publishes">
+                        <Chip
+                          label="org-scoped"
+                          size="small"
+                          color="info"
+                          variant="outlined"
+                        />
+                      </Tooltip>
+                    )}
                     {key.revokedAt && (
                       <Chip label="Revoked" color="default" size="small" />
                     )}
@@ -554,6 +668,21 @@ const PublisherKeysPage: React.FC = () => {
                     <CopyIcon />
                   </IconButton>
                 </Tooltip>
+                {!key.revokedAt && (
+                  <Tooltip title="Rotate key (atomically register a replacement and revoke this one)">
+                    <IconButton
+                      onClick={() => {
+                        setRotateTarget(key);
+                        setRotateLabel('');
+                        setRotateKeyB64('');
+                        setRotateError(null);
+                      }}
+                      disabled={rotateMutation.isPending}
+                    >
+                      <RotateIcon />
+                    </IconButton>
+                  </Tooltip>
+                )}
                 {!key.revokedAt && (
                   <Tooltip title="Revoke key">
                     <IconButton
@@ -598,6 +727,30 @@ const PublisherKeysPage: React.FC = () => {
               fullWidth
               placeholder="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
             />
+            {/* Org dropdown is only useful when the user owns at least
+                one org. We surface owned orgs only — admin-but-not-owner
+                membership requires a separate /members lookup we don't
+                want to do per dialog open. */}
+            {orgs && orgs.length > 0 && (
+              <FormControl fullWidth>
+                <InputLabel id="key-org-label">Scope</InputLabel>
+                <Select
+                  labelId="key-org-label"
+                  label="Scope"
+                  value={selectedOrgId}
+                  onChange={(e) => setSelectedOrgId(e.target.value)}
+                >
+                  <MenuItem value="">
+                    <em>Personal — only me</em>
+                  </MenuItem>
+                  {orgs.map((o) => (
+                    <MenuItem key={o.id} value={o.id}>
+                      Org: {o.name} <code style={{ marginLeft: 6, opacity: 0.6 }}>{o.slug}</code>
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
             {error && (
               <Typography color="error" variant="body2">
                 {error}
@@ -615,6 +768,63 @@ const PublisherKeysPage: React.FC = () => {
             disabled={addMutation.isPending}
           >
             {addMutation.isPending ? 'Registering…' : 'Register'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Rotate dialog — register a new key and revoke the old one in
+          a single backend transaction so the org tag (if any) is
+          preserved and there's no window where neither is active. */}
+      <Dialog
+        open={!!rotateTarget}
+        onClose={() => setRotateTarget(null)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Rotate key</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            Register a replacement for <b>{rotateTarget?.label}</b>. The
+            new key inherits the same scope (personal vs. org). The old
+            key is revoked in the same transaction and stops verifying
+            new signatures immediately.
+          </DialogContentText>
+          <Stack spacing={2}>
+            <TextField
+              label="New label"
+              placeholder="e.g. laptop-2026"
+              value={rotateLabel}
+              onChange={(e) => setRotateLabel(e.target.value)}
+              inputProps={{ maxLength: 128 }}
+              fullWidth
+              autoFocus
+            />
+            <TextField
+              label="New public key (base64)"
+              value={rotateKeyB64}
+              onChange={(e) => setRotateKeyB64(e.target.value)}
+              multiline
+              minRows={2}
+              fullWidth
+              placeholder="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+            />
+            {rotateError && (
+              <Typography color="error" variant="body2">
+                {rotateError}
+              </Typography>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRotateTarget(null)} disabled={rotateMutation.isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleRotateSubmit}
+            disabled={rotateMutation.isPending}
+          >
+            {rotateMutation.isPending ? 'Rotating…' : 'Rotate'}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Summary
Closes the three follow-ups deferred from PR #287 (publisher-keys wiring). None of these are blocking but they all matter once the page is in real team use.

- **Audit events.** `publisher_key_created/revoked/rotated` added to the Postgres `audit_event_type` enum; create/revoke/rotate handlers emit one event each with key id + label + optional org tag in metadata.
- **Per-plan quotas.** New `max_publisher_keys` default in Plan limits (Free=3, Pro=25, Team=-1). `create_my_public_key` resolves the user's owner org, runs it through `effective_limits` (so admin overrides apply), counts active keys, returns 403 ResourceLimitExceeded when over.
- **Org-scoped keys.** Nullable `org_id` column on `user_public_keys` (FK ON DELETE SET NULL so historical signatures still resolve). POST accepts optional `orgId`; handler enforces caller is Owner/Admin of that org. New `GET /api/v1/organizations/{org_id}/public-keys`. Verifier now UNIONs author's keys with any keys tagged to orgs they belong to — a CI bot's org key verifies any teammate's publish. Revoke falls through to org-admin revocation when the caller isn't the key's owner.
- **Atomic rotation.** New `POST /api/v1/users/me/public-keys/{id}/rotate` does register-new + revoke-old in one SQL transaction. New key inherits the old key's org tag. Frontend gets a Rotate button + dialog.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-core --all-targets -- -D warnings`
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-core --features sqlite --lib` — 271 passed (incl. 2 new tests covering org-admin revoke + rotation atomicity)
- [x] `cargo test -p mockforge-registry-server --lib` — 274 passed
- [x] `pnpm type-check` and `pnpm lint` (no new warnings on touched files)
- [x] `pnpm test --run src/pages/__tests__/PublisherKeysPage.test.tsx` — 5/5