### PR TITLE
fix(ui): repair pre-existing vitest failures across hooks and pages

### DIFF
--- a/crates/mockforge-ui/ui/src/components/__tests__/plugins/Plugins.test.tsx
+++ b/crates/mockforge-ui/ui/src/components/__tests__/plugins/Plugins.test.tsx
@@ -7,7 +7,16 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { PluginList } from '../../plugins/PluginList';
 
-// Mock fetch
+// PluginList calls `authenticatedFetch` from `@/utils/apiClient`, which
+// captures `globalThis.fetch` at module load — patching `global.fetch` from
+// the test never reaches the component. Mock the wrapper directly so we can
+// drive responses per-test.
+const authenticatedFetchMock = vi.fn();
+vi.mock('@/utils/apiClient', () => ({
+  authenticatedFetch: (...args: unknown[]) => authenticatedFetchMock(...args),
+}));
+
+// PluginList still uses raw `fetch` for enable/disable/reload calls.
 global.fetch = vi.fn();
 
 describe('PluginList', () => {
@@ -15,10 +24,11 @@ describe('PluginList', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    authenticatedFetchMock.mockReset();
   });
 
   it('renders loading state', () => {
-    (global.fetch as any).mockImplementationOnce(() =>
+    authenticatedFetchMock.mockImplementationOnce(() =>
       new Promise(() => {}) // Never resolves
     );
 
@@ -53,7 +63,7 @@ describe('PluginList', () => {
       },
     };
 
-    (global.fetch as any).mockResolvedValueOnce({
+    authenticatedFetchMock.mockResolvedValueOnce({
       json: async () => mockPlugins,
     });
 
@@ -71,7 +81,7 @@ describe('PluginList', () => {
   });
 
   it('handles errors', async () => {
-    (global.fetch as any).mockRejectedValueOnce(new Error('Failed to fetch'));
+    authenticatedFetchMock.mockRejectedValueOnce(new Error('Failed to fetch'));
 
     render(
       <PluginList
@@ -92,7 +102,7 @@ describe('PluginList', () => {
       data: { plugins: [] },
     };
 
-    (global.fetch as any).mockResolvedValueOnce({
+    authenticatedFetchMock.mockResolvedValueOnce({
       json: async () => mockPlugins,
     });
 
@@ -105,10 +115,10 @@ describe('PluginList', () => {
     );
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(authenticatedFetchMock).toHaveBeenCalledWith(
         expect.stringContaining('type=response')
       );
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(authenticatedFetchMock).toHaveBeenCalledWith(
         expect.stringContaining('status=enabled')
       );
     });

--- a/crates/mockforge-ui/ui/src/hooks/__tests__/useSSE.test.ts
+++ b/crates/mockforge-ui/ui/src/hooks/__tests__/useSSE.test.ts
@@ -7,9 +7,16 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { useSSE, useLogsSSE } from '../useSSE';
 
 // Mock EventSource
+//
+// Real `EventSource` opens asynchronously, but reproducing that with
+// `setTimeout` makes these tests flaky under React 19 — the effect cleanup
+// can race the open handler. Instead, fire `onopen` synchronously when the
+// consumer assigns the handler, so the hook's state setter lands inside
+// `renderHook`'s render window. The test contract is "handler runs, hook
+// reflects OPEN", which this still verifies.
 class MockEventSource {
   url: string;
-  onopen: ((event: Event) => void) | null = null;
+  private _onopen: ((event: Event) => void) | null = null;
   onmessage: ((event: MessageEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;
   readyState: number = 0;
@@ -22,14 +29,17 @@ class MockEventSource {
 
   constructor(url: string) {
     this.url = url;
-    this.readyState = MockEventSource.CONNECTING;
-    // Simulate connection opening
-    setTimeout(() => {
-      this.readyState = MockEventSource.OPEN;
-      if (this.onopen) {
-        this.onopen(new Event('open'));
-      }
-    }, 0);
+    this.readyState = MockEventSource.OPEN;
+  }
+
+  set onopen(handler: ((event: Event) => void) | null) {
+    this._onopen = handler;
+    if (handler && this.readyState === MockEventSource.OPEN) {
+      handler(new Event('open'));
+    }
+  }
+  get onopen(): ((event: Event) => void) | null {
+    return this._onopen;
   }
 
   addEventListener(event: string, handler: (event: MessageEvent) => void) {
@@ -67,9 +77,19 @@ class MockEventSource {
 describe('useSSE', () => {
   beforeEach(() => {
     (global as any).EventSource = MockEventSource;
+    (globalThis as any).EventSource = MockEventSource;
+    if (typeof window !== 'undefined') {
+      (window as any).EventSource = MockEventSource;
+    }
+    // The shared test setup (src/test/setup.ts) configures cloud mode, but
+    // useSSE intentionally refuses relative URLs in cloud mode. These tests
+    // exercise the local-mode connection path, so drop cloud mode here.
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('VITE_MOCKFORGE_MODE', '');
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.clearAllTimers();
   });
 
@@ -162,6 +182,16 @@ describe('useSSE', () => {
 describe('useLogsSSE', () => {
   beforeEach(() => {
     (global as any).EventSource = MockEventSource;
+    (globalThis as any).EventSource = MockEventSource;
+    if (typeof window !== 'undefined') {
+      (window as any).EventSource = MockEventSource;
+    }
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('VITE_MOCKFORGE_MODE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('connects to logs SSE endpoint', async () => {

--- a/crates/mockforge-ui/ui/src/hooks/__tests__/useWebSocket.test.ts
+++ b/crates/mockforge-ui/ui/src/hooks/__tests__/useWebSocket.test.ts
@@ -6,7 +6,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useWebSocket } from '../useWebSocket';
 
-// Mock WebSocket
+// Mock WebSocket — opens the moment `onopen` is assigned so the hook's
+// state setter lands inside the test's render window. A microtask-based
+// async open is racy under React 19's effect-cleanup timing.
 class MockWebSocket {
   static CONNECTING = 0;
   static OPEN = 1;
@@ -14,9 +16,9 @@ class MockWebSocket {
   static CLOSED = 3;
 
   static instances: MockWebSocket[] = [];
-  readyState = MockWebSocket.CONNECTING;
+  readyState = MockWebSocket.OPEN;
   url: string;
-  onopen: ((event: Event) => void) | null = null;
+  private _onopen: ((event: Event) => void) | null = null;
   onmessage: ((event: MessageEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;
   onclose: ((event: CloseEvent) => void) | null = null;
@@ -24,16 +26,19 @@ class MockWebSocket {
   constructor(url: string) {
     this.url = url;
     MockWebSocket.instances.push(this);
-    // Simulate connection after a short delay
-    Promise.resolve().then(() => {
-      this.readyState = MockWebSocket.OPEN;
-      if (this.onopen) {
-        this.onopen(new Event('open'));
-      }
-    });
   }
 
-  send(data: string | object) {
+  set onopen(handler: ((event: Event) => void) | null) {
+    this._onopen = handler;
+    if (handler && this.readyState === MockWebSocket.OPEN) {
+      handler(new Event('open'));
+    }
+  }
+  get onopen(): ((event: Event) => void) | null {
+    return this._onopen;
+  }
+
+  send(_data: string | object) {
     // Mock send
   }
 
@@ -49,21 +54,28 @@ describe('useWebSocket', () => {
   beforeEach(() => {
     MockWebSocket.instances = [];
     global.WebSocket = MockWebSocket as any;
-    window.WebSocket = MockWebSocket as any;
+    (globalThis as any).WebSocket = MockWebSocket;
+    if (typeof window !== 'undefined') {
+      window.WebSocket = MockWebSocket as any;
+    }
+    // The shared test setup configures cloud mode, but useWebSocket
+    // intentionally refuses relative paths in cloud mode. These tests
+    // exercise the local-mode connection path, so drop cloud mode here.
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('VITE_MOCKFORGE_MODE', '');
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('should create WebSocket connection', () => {
     const options = { autoConnect: true };
-    const { result } = renderHook(() =>
-      useWebSocket('/test', options)
-    );
+    renderHook(() => useWebSocket('/test', options));
 
-    // Initially not connected (connection happens asynchronously)
-    expect(result.current.connected).toBe(false);
+    // The hook should have constructed at least one underlying WebSocket.
+    expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(1);
   });
 
   it('should connect when autoConnect is true', async () => {

--- a/crates/mockforge-ui/ui/src/hooks/useSSE.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useSSE.ts
@@ -5,10 +5,12 @@ import { logger } from '@/utils/logger';
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 
-const isCloud = (() => {
+// Read at call time (not module load) so tests can drop cloud mode via
+// vi.stubEnv without stripping the value from every other consumer.
+function isCloudMode(): boolean {
   const apiBase = import.meta.env.VITE_API_BASE_URL;
   return !!apiBase && apiBase !== '';
-})();
+}
 
 /** Returns true if the URL is absolute (starts with http:// or https://). */
 function isAbsoluteUrl(url: string): boolean {
@@ -101,7 +103,7 @@ export function useSSE<T = unknown>(
   const connect = useCallback(() => {
     // Skip relative SSE paths in cloud mode — they don't exist on the registry
     // server. Absolute URLs targeting hosted mock deployments are still allowed.
-    if (isCloud && !isAbsoluteUrl(url)) return;
+    if (isCloudMode() && !isAbsoluteUrl(url)) return;
 
     // Prevent multiple connections
     if (eventSourceRef.current && eventSourceRef.current.readyState !== EventSource.CLOSED) {

--- a/crates/mockforge-ui/ui/src/hooks/useWebSocket.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useWebSocket.ts
@@ -9,11 +9,12 @@ import { logger } from '@/utils/logger';
 // Detect cloud mode — relative WebSocket paths don't work when the UI
 // is served by a static host (Cloudflare Pages) because /__mockforge/ws
 // doesn't exist on the registry server. Absolute URLs to hosted mock
-// deployments ARE allowed.
-const isCloud = (() => {
+// deployments ARE allowed. Read at call time so tests can drop cloud mode
+// via vi.stubEnv.
+function isCloudMode(): boolean {
   const apiBase = import.meta.env.VITE_API_BASE_URL;
   return !!apiBase && apiBase !== '';
-})();
+}
 
 /** Returns true if the URL is an absolute ws:// or wss:// URL (not a relative path). */
 function isAbsoluteWsUrl(url: string): boolean {
@@ -61,7 +62,7 @@ export function useWebSocket(
   const connect = useCallback(() => {
     // In cloud mode, skip relative WS paths (they don't exist on the registry
     // server). Absolute URLs targeting hosted mock deployments are still allowed.
-    if (isCloud && !isAbsoluteWsUrl(url)) return;
+    if (isCloudMode() && !isAbsoluteWsUrl(url)) return;
 
     shouldReconnectRef.current = true;
 

--- a/crates/mockforge-ui/ui/src/pages/__tests__/ConfigPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/ConfigPage.test.tsx
@@ -55,6 +55,7 @@ const mockUseApi = vi.hoisted(() => {
     useUpdateLatency: vi.fn(() => ({ mutateAsync: vi.fn() })),
     useUpdateFaults: vi.fn(() => ({ mutateAsync: vi.fn() })),
     useUpdateProxy: vi.fn(() => ({ mutateAsync: vi.fn() })),
+    useUpdateProtocols: vi.fn(() => ({ mutateAsync: vi.fn() })),
     useUpdateValidation: vi.fn(() => ({ mutateAsync: vi.fn() })),
     useRestartServers: vi.fn(() => ({ mutateAsync: vi.fn() })),
     useRestartStatus: vi.fn(() => ({ data: { restarting: false } })),
@@ -109,6 +110,7 @@ describe('ConfigPage', () => {
     mockUseApi.useUpdateLatency.mockReturnValue({ mutateAsync: vi.fn() });
     mockUseApi.useUpdateFaults.mockReturnValue({ mutateAsync: vi.fn() });
     mockUseApi.useUpdateProxy.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseApi.useUpdateProtocols.mockReturnValue({ mutateAsync: vi.fn() });
     mockUseApi.useUpdateValidation.mockReturnValue({ mutateAsync: vi.fn() });
     mockUseApi.useRestartServers.mockReturnValue({ mutateAsync: vi.fn() });
     mockUseApi.useRestartStatus.mockReturnValue({ data: { restarting: false } });
@@ -366,7 +368,10 @@ describe('ConfigPage', () => {
     });
   });
 
-  it('saves port config to localStorage', () => {
+  it('opens restart confirmation dialog before persisting port changes', () => {
+    // Port config is intentionally not persisted to localStorage until the
+    // restart is verified to have taken effect — clicking "Save & Restart
+    // Server" should only open the confirmation dialog.
     render(<ConfigPage />, { wrapper: createWrapper() });
 
     const httpPortInput = screen.getByDisplayValue('3000');
@@ -375,9 +380,8 @@ describe('ConfigPage', () => {
     const saveButton = screen.getByText('Save & Restart Server');
     fireEvent.click(saveButton);
 
-    const savedConfig = localStorage.getItem('mockforge_pending_port_config');
-    expect(savedConfig).toBeTruthy();
-    expect(JSON.parse(savedConfig!)).toMatchObject({ http_port: 8080 });
+    expect(screen.getByText('Restart Server Required')).toBeInTheDocument();
+    expect(localStorage.getItem('mockforge_pending_port_config')).toBeNull();
   });
 
   it('loads pending port config on mount', () => {

--- a/crates/mockforge-ui/ui/src/pages/__tests__/LogsPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/LogsPage.test.tsx
@@ -51,6 +51,25 @@ vi.mock('../../hooks/useApi', () => ({
   })),
 }));
 
+// LogsPage filters by `logPrefs.defaultTimeRange` (default 24h). The fixture
+// timestamps above sit in 2024, so the real store would silently drop every
+// log — pin the time-range filter off for tests so fixtures render.
+vi.mock('../../stores/usePreferencesStore', () => ({
+  usePreferencesStore: (selector: any) =>
+    selector({
+      preferences: {
+        logs: {
+          autoScroll: true,
+          pauseOnError: false,
+          defaultTimeRange: 0,
+          itemsPerPage: 100,
+          showTimestamps: true,
+          compactView: false,
+        },
+      },
+    }),
+}));
+
 describe('LogsPage', () => {
   const createWrapper = () => {
     const queryClient = new QueryClient({
@@ -234,8 +253,9 @@ describe('LogsPage', () => {
   });
 
   it('shows load more button when there are more logs', () => {
-    // Mock more logs than display limit
-    const manyLogs = Array.from({ length: 100 }, (_, i) => ({
+    // The default itemsPerPage is 100 — generate more so progressive
+    // loading kicks in.
+    const manyLogs = Array.from({ length: 150 }, (_, i) => ({
       id: `${i}`,
       timestamp: '2024-01-01T10:00:00Z',
       method: 'GET',
@@ -254,7 +274,7 @@ describe('LogsPage', () => {
   });
 
   it('loads more logs when button is clicked', () => {
-    const manyLogs = Array.from({ length: 100 }, (_, i) => ({
+    const manyLogs = Array.from({ length: 150 }, (_, i) => ({
       id: `${i}`,
       timestamp: '2024-01-01T10:00:00Z',
       method: 'GET',

--- a/crates/mockforge-ui/ui/src/pages/__tests__/PluginsPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/PluginsPage.test.tsx
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { PluginsPage } from '../PluginsPage';
 import { I18nProvider } from '../../i18n/I18nProvider';
 import { pluginsApi } from '../../services/api';
@@ -54,9 +55,11 @@ vi.mock('sonner', () => ({
 describe('PluginsPage', () => {
   const renderWithProviders = () =>
     render(
-      <I18nProvider>
-        <PluginsPage />
-      </I18nProvider>
+      <MemoryRouter>
+        <I18nProvider>
+          <PluginsPage />
+        </I18nProvider>
+      </MemoryRouter>
     );
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Six UI test files were red on `main` (65 / 851 tests failing) — each from drift between tests and the code under test. After this PR, **851 / 851 vitest tests pass.**

| File | Tests | Root cause | Fix |
|---|---|---|---|
| `ConfigPage.test.tsx` | 22 | Page added `useUpdateProtocols` hook (#289), but the `useApi` `vi.mock` didn't expose it — mounting threw. Also one test asserted a behavior that intentionally changed. | Add the missing hook to the mock map + `beforeEach` reset; rewrite the "saves port config to localStorage" test to match the new defer-until-verified-restart flow. |
| `PluginsPage.test.tsx` | 17 | Page now calls `useNavigate()`; test rendered without a Router. | Wrap with `<MemoryRouter>`. |
| `LogsPage.test.tsx` | 21 | Page started reading log preferences from `usePreferencesStore`, whose default `defaultTimeRange = 24h` silently filtered out the 2024-dated fixture logs. Two pagination tests also used exactly `length: 100`, which is `itemsPerPage` and therefore showed no "load more" button. | Mock `usePreferencesStore` with `defaultTimeRange = 0` so fixtures render; bump `manyLogs` to `length: 150` so progressive-load tests have something to load. |
| `Plugins.test.tsx` | 4 | `PluginList` switched from raw `fetch` to `authenticatedFetch` from `@/utils/apiClient`. `apiClient` captures `globalThis.fetch` at module load, so the test's `global.fetch = vi.fn()` never reached the component. | Mock `@/utils/apiClient` directly. |
| `useSSE.test.ts` | 9 | Hook added a cloud-mode guard that refuses relative URLs when `VITE_API_BASE_URL` is set, and the shared test setup (`src/test/setup.ts`) configures cloud mode globally. `isCloud` was evaluated at module load, so the inlined value couldn't be overridden. The `MockEventSource` also fired `onopen` via `setTimeout(0)` / microtask, which raced React 19's effect cleanup. | Convert `isCloud` to a runtime `isCloudMode()` function; tests drop cloud mode via `vi.stubEnv`. Switch the mock to fire `onopen` synchronously when the consumer assigns the handler — same observable behavior, no race. |
| `useWebSocket.test.ts` | 6 | Same cloud-mode and async-open issues as `useSSE`. | Same pattern of fixes. |

## Production-code touches
The only non-test changes are in `useSSE.ts` and `useWebSocket.ts`: replace the module-level `const isCloud = ...` with a `function isCloudMode()` that re-reads `import.meta.env` per call. Behavior identical in production; tests can now intercept via `vi.stubEnv`.

## Test plan
- [x] `pnpm test --run` — 72/72 files, 851/851 tests pass (was 66/72, 786/851)
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — 0 errors on changed files
- [ ] CI (self-hosted runner) — confirm vitest job is green