### PR TITLE
feat(ui): wire scenario marketplace gaps — reviews, metadata, snackbar, authenticatedFetch

### DIFF
--- a/crates/mockforge-ui/ui/src/components/marketplace/PublishScenarioModal.tsx
+++ b/crates/mockforge-ui/ui/src/components/marketplace/PublishScenarioModal.tsx
@@ -6,6 +6,8 @@
 
 import React, { useState } from 'react';
 import { apiErrorMessage } from '@/utils/errorHandling';
+import { authenticatedFetch } from '@/utils/apiClient';
+import { useAuthStore } from '@/stores/useAuthStore';
 import {
   Dialog,
   DialogTitle,
@@ -35,6 +37,7 @@ export const PublishScenarioModal: React.FC<PublishScenarioModalProps> = ({
   onClose,
   onSuccess,
 }) => {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const [manifest, setManifest] = useState(`{
   "name": "",
   "version": "1.0.0",
@@ -100,19 +103,14 @@ export const PublishScenarioModal: React.FC<PublishScenarioModalProps> = ({
         size: fileBuffer.byteLength,
       };
 
-      // Get auth token
-      const token = localStorage.getItem('auth_token');
-      if (!token) {
+      if (!isAuthenticated) {
         throw new Error('Not authenticated. Please log in.');
       }
 
-      // Submit to API
-      const response = await fetch('/api/v1/marketplace/scenarios/publish', {
+      // Submit to API (authenticatedFetch attaches the JWT and refreshes on 401)
+      const response = await authenticatedFetch('/api/v1/marketplace/scenarios/publish', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(request),
       });
 
@@ -121,9 +119,8 @@ export const PublishScenarioModal: React.FC<PublishScenarioModalProps> = ({
         throw new Error(apiErrorMessage(response, errorData, `Failed to publish: ${response.statusText}`));
       }
 
-      const result = await response.json();
+      await response.json().catch(() => ({}));
 
-      // Success
       if (onSuccess) {
         onSuccess();
       }

--- a/crates/mockforge-ui/ui/src/pages/ScenarioMarketplacePage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ScenarioMarketplacePage.tsx
@@ -16,7 +16,6 @@ import {
   Button,
   Chip,
   Rating,
-  IconButton,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -27,24 +26,23 @@ import {
   MenuItem,
   List,
   ListItem,
-  ListItemText,
   Divider,
   Alert,
-  Avatar,
+  Snackbar,
+  Link,
 } from '@mui/material';
 import {
   Search as SearchIcon,
-  Star as StarIcon,
   Download as DownloadIcon,
   Visibility as ViewIcon,
-  Category as CategoryIcon,
-  TrendingUp as TrendingIcon,
-  NewReleases as NewIcon,
-  FilterList as FilterIcon,
   Upload as UploadIcon,
+  Launch as LaunchIcon,
 } from '@mui/icons-material';
 import { PublishScenarioModal } from '../components/marketplace/PublishScenarioModal';
 import { MarketplaceTabs } from '../components/marketplace/MarketplaceTabs';
+import { authenticatedFetch } from '../utils/apiClient';
+import { useAuthStore } from '../stores/useAuthStore';
+import { apiErrorMessage } from '../utils/errorHandling';
 
 interface Scenario {
   name: string;
@@ -87,7 +85,11 @@ interface Review {
   verified_purchase: boolean;
 }
 
+type Snack = { severity: 'success' | 'error' | 'info'; message: string } | null;
+
 export const ScenarioMarketplacePage: React.FC = () => {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
   const [scenarios, setScenarios] = useState<Scenario[]>([]);
   const [filteredScenarios, setFilteredScenarios] = useState<Scenario[]>([]);
   const [selectedScenario, setSelectedScenario] = useState<Scenario | null>(null);
@@ -95,6 +97,13 @@ export const ScenarioMarketplacePage: React.FC = () => {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [publishModalOpen, setPublishModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [snack, setSnack] = useState<Snack>(null);
+
+  // Review form
+  const [reviewRating, setReviewRating] = useState<number>(5);
+  const [reviewComment, setReviewComment] = useState('');
+  const [reviewTitle, setReviewTitle] = useState('');
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
 
   // Filters
   const [searchQuery, setSearchQuery] = useState('');
@@ -154,10 +163,19 @@ export const ScenarioMarketplacePage: React.FC = () => {
         const data = await response.json();
         setScenarios(data.scenarios || []);
       } else {
-        console.error('Failed to load scenarios:', response.statusText);
+        const errorData = await response.json().catch(() => ({}));
+        setSnack({
+          severity: 'error',
+          message: apiErrorMessage(response, errorData, 'Failed to load scenarios'),
+        });
+        setScenarios([]);
       }
     } catch (error) {
-      console.error('Failed to load scenarios:', error);
+      setSnack({
+        severity: 'error',
+        message: error instanceof Error ? error.message : 'Failed to load scenarios',
+      });
+      setScenarios([]);
     } finally {
       setLoading(false);
     }
@@ -190,35 +208,102 @@ export const ScenarioMarketplacePage: React.FC = () => {
     setFilteredScenarios(filtered);
   };
 
-  const handleViewDetails = async (scenario: Scenario) => {
-    setSelectedScenario(scenario);
-    setDetailsOpen(true);
-
-    // Load reviews
+  const loadReviews = async (scenarioName: string) => {
     try {
-      const response = await fetch(`/api/v1/marketplace/scenarios/${encodeURIComponent(scenario.name)}/reviews?page=0&per_page=10`);
+      const response = await fetch(
+        `/api/v1/marketplace/scenarios/${encodeURIComponent(scenarioName)}/reviews?page=0&per_page=20`
+      );
       if (response.ok) {
         const data = await response.json();
         setReviews(data.reviews || []);
+      } else {
+        setReviews([]);
       }
-    } catch (error) {
-      console.error('Failed to load reviews:', error);
+    } catch {
+      setReviews([]);
     }
+  };
+
+  const handleViewDetails = async (scenario: Scenario) => {
+    setSelectedScenario(scenario);
+    setReviews([]);
+    setReviewRating(5);
+    setReviewTitle('');
+    setReviewComment('');
+    setDetailsOpen(true);
+    await loadReviews(scenario.name);
   };
 
   const handleDownload = async (scenarioName: string, version?: string) => {
     try {
       const targetVersion = version || selectedScenario?.version || 'latest';
-      const response = await fetch(`/api/v1/marketplace/scenarios/${encodeURIComponent(scenarioName)}/versions/${encodeURIComponent(targetVersion)}`);
+      const response = await fetch(
+        `/api/v1/marketplace/scenarios/${encodeURIComponent(scenarioName)}/versions/${encodeURIComponent(targetVersion)}`
+      );
 
       if (response.ok) {
         const data = await response.json();
-        // Trigger download
         window.open(data.download_url, '_blank');
-        loadScenarios(); // Refresh to update download count
+        setSnack({
+          severity: 'success',
+          message: `Downloading ${scenarioName}@${targetVersion}`,
+        });
+        loadScenarios();
+      } else {
+        const errorData = await response.json().catch(() => ({}));
+        setSnack({
+          severity: 'error',
+          message: apiErrorMessage(response, errorData, 'Failed to download scenario'),
+        });
       }
     } catch (error) {
-      console.error('Failed to download scenario:', error);
+      setSnack({
+        severity: 'error',
+        message: error instanceof Error ? error.message : 'Failed to download scenario',
+      });
+    }
+  };
+
+  const handleSubmitReview = async () => {
+    if (!selectedScenario) return;
+    if (reviewComment.trim().length < 10) {
+      setSnack({ severity: 'error', message: 'Comment must be at least 10 characters' });
+      return;
+    }
+    setReviewSubmitting(true);
+    try {
+      const response = await authenticatedFetch(
+        `/api/v1/marketplace/scenarios/${encodeURIComponent(selectedScenario.name)}/reviews`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            rating: reviewRating,
+            title: reviewTitle.trim() ? reviewTitle.trim() : undefined,
+            comment: reviewComment.trim(),
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(apiErrorMessage(response, errorData, 'Failed to submit review'));
+      }
+
+      setSnack({ severity: 'success', message: 'Review submitted' });
+      setReviewTitle('');
+      setReviewComment('');
+      setReviewRating(5);
+      await loadReviews(selectedScenario.name);
+      // Reload scenarios so updated rating is reflected in the grid
+      loadScenarios();
+    } catch (error) {
+      setSnack({
+        severity: 'error',
+        message: error instanceof Error ? error.message : 'Failed to submit review',
+      });
+    } finally {
+      setReviewSubmitting(false);
     }
   };
 
@@ -466,7 +551,7 @@ export const ScenarioMarketplacePage: React.FC = () => {
                           Rating
                         </Typography>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <Rating value={selectedScenario.rating} readOnly />
+                          <Rating value={selectedScenario.rating} readOnly precision={0.5} />
                           <Typography variant="body2">
                             ({selectedScenario.reviews_count} reviews)
                           </Typography>
@@ -475,6 +560,40 @@ export const ScenarioMarketplacePage: React.FC = () => {
                     </Card>
                   </Grid>
                 </Grid>
+
+                {(selectedScenario.repository ||
+                  selectedScenario.homepage ||
+                  selectedScenario.license) && (
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 3 }}>
+                    {selectedScenario.license && (
+                      <Chip
+                        label={`License: ${selectedScenario.license}`}
+                        size="small"
+                        variant="outlined"
+                      />
+                    )}
+                    {selectedScenario.repository && (
+                      <Link
+                        href={selectedScenario.repository}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                      >
+                        <LaunchIcon fontSize="inherit" /> Repository
+                      </Link>
+                    )}
+                    {selectedScenario.homepage && (
+                      <Link
+                        href={selectedScenario.homepage}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                      >
+                        <LaunchIcon fontSize="inherit" /> Homepage
+                      </Link>
+                    )}
+                  </Box>
+                )}
 
                 {selectedScenario.versions.length > 0 && (
                   <Box sx={{ mb: 2 }}>
@@ -508,6 +627,52 @@ export const ScenarioMarketplacePage: React.FC = () => {
               <Typography variant="h6" gutterBottom>
                 Reviews
               </Typography>
+
+              {isAuthenticated ? (
+                <Card variant="outlined" sx={{ mb: 2 }}>
+                  <CardContent>
+                    <Typography variant="subtitle2" gutterBottom>
+                      Leave a review
+                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+                      <Typography variant="body2">Your rating:</Typography>
+                      <Rating
+                        value={reviewRating}
+                        onChange={(_, value) => setReviewRating(value || 1)}
+                      />
+                    </Box>
+                    <TextField
+                      fullWidth
+                      placeholder="Title (optional)"
+                      value={reviewTitle}
+                      onChange={(e) => setReviewTitle(e.target.value)}
+                      sx={{ mb: 2 }}
+                      inputProps={{ maxLength: 200 }}
+                    />
+                    <TextField
+                      fullWidth
+                      multiline
+                      minRows={2}
+                      placeholder="Share your experience (min 10 characters)"
+                      value={reviewComment}
+                      onChange={(e) => setReviewComment(e.target.value)}
+                      sx={{ mb: 2 }}
+                    />
+                    <Button
+                      variant="contained"
+                      size="small"
+                      disabled={reviewSubmitting || reviewComment.trim().length < 10}
+                      onClick={handleSubmitReview}
+                    >
+                      {reviewSubmitting ? 'Submitting…' : 'Submit review'}
+                    </Button>
+                  </CardContent>
+                </Card>
+              ) : (
+                <Alert severity="info" sx={{ mb: 2 }}>
+                  Sign in to leave a review.
+                </Alert>
+              )}
 
               {reviews.length === 0 ? (
                 <Alert severity="info">No reviews yet</Alert>
@@ -565,8 +730,22 @@ export const ScenarioMarketplacePage: React.FC = () => {
         onSuccess={() => {
           loadScenarios();
           setPublishModalOpen(false);
+          setSnack({ severity: 'success', message: 'Scenario published successfully' });
         }}
       />
+
+      <Snackbar
+        open={!!snack}
+        autoHideDuration={4000}
+        onClose={() => setSnack(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {snack ? (
+          <Alert severity={snack.severity} onClose={() => setSnack(null)} sx={{ width: '100%' }}>
+            {snack.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
Audit of `app.mockforge.dev/scenario-marketplace` against the registry-server backend turned up four wiring gaps. All addressed in `ScenarioMarketplacePage.tsx` + `PublishScenarioModal.tsx` (no backend changes needed):

- **Submit reviews** — `POST /api/v1/marketplace/scenarios/{name}/reviews` exists in the backend (`handlers/scenario_reviews.rs::submit_scenario_review`) but the page only loaded reviews. Added a rating + optional title + comment form inside the details dialog, gated on `useAuthStore.isAuthenticated`. Mirrors the pattern already used by `TemplateMarketplacePage`.
- **Show repository / homepage / license** — backend returns these on every `ScenarioRegistryEntry`; the UI declared the fields in its TS interface but never rendered them. Now shown in the details dialog as a license chip + linkified Repo/Homepage links.
- **Snackbar feedback** — load/download/publish/review errors were previously logged to `console.error` only. Replaced with a MUI Snackbar + `apiErrorMessage` so users actually see what went wrong, plus a success toast on download/publish/review.
- **`authenticatedFetch` for publish** — `PublishScenarioModal` was reaching into `localStorage.getItem('auth_token')` and using raw `fetch`, bypassing the project's JWT-refresh path. Switched to `authenticatedFetch` + `useAuthStore`, matching the rest of the app.

Out of scope: scenario yank / star / review-helpfulness voting — these don't exist in the backend for scenarios (only for plugins / templates), so there's nothing to wire up. Scenario promotions already have their own `WorkspacePromotions` UI on the workspaces page.

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (no new warnings or errors in changed files; pre-existing useEffect-deps warnings unchanged)
- [x] `pnpm test --run` — 851 tests pass
- [x] `pnpm build` succeeds
- [x] Page renders with no console errors at `/scenario-marketplace` (verified via Playwright on local dev server)
- [ ] Smoke-test review submission against staging registry once deployed