### PR TITLE
feat(registry,ui): wire plugin-registry gaps — server-side search, version metadata, sort modes

### DIFF
--- a/crates/mockforge-plugin-registry/src/index.rs
+++ b/crates/mockforge-plugin-registry/src/index.rs
@@ -70,8 +70,8 @@ fn matches_category(entry_cat: &crate::PluginCategory, query_cat: &crate::Plugin
 /// Sort results by the specified order
 fn sort_results(results: &mut [RegistryEntry], sort: &SortOrder) {
     results.sort_by(|a, b| match sort {
-        SortOrder::Relevance => {
-            // For relevance, prioritize by downloads and rating
+        SortOrder::Relevance | SortOrder::Popular => {
+            // For relevance/popularity, prioritize by downloads and rating.
             let score_a = a.downloads as f64 + a.rating * 1000.0;
             let score_b = b.downloads as f64 + b.rating * 1000.0;
             score_b.partial_cmp(&score_a).unwrap_or(CmpOrdering::Equal)
@@ -80,6 +80,10 @@ fn sort_results(results: &mut [RegistryEntry], sort: &SortOrder) {
         SortOrder::Rating => b.rating.partial_cmp(&a.rating).unwrap_or(CmpOrdering::Equal),
         SortOrder::Recent => b.updated_at.cmp(&a.updated_at),
         SortOrder::Name => a.name.cmp(&b.name),
+        SortOrder::Security => b
+            .security_score
+            .cmp(&a.security_score)
+            .then_with(|| b.downloads.cmp(&a.downloads)),
     });
 }
 

--- a/crates/mockforge-plugin-registry/src/lib.rs
+++ b/crates/mockforge-plugin-registry/src/lib.rs
@@ -213,6 +213,12 @@ pub enum SortOrder {
     Rating,
     Recent,
     Name,
+    /// Combined score of downloads + rating — backed by `downloads_total`
+    /// since rating_count alone produces noisy ranking for new plugins.
+    Popular,
+    /// Order by `verified_at IS NOT NULL` then downloads — best proxy for
+    /// the heuristic security score derived in `derive_security_score`.
+    Security,
 }
 
 /// Search results
@@ -453,6 +459,8 @@ mod tests {
         assert_eq!(serde_json::to_string(&SortOrder::Rating).unwrap(), "\"rating\"");
         assert_eq!(serde_json::to_string(&SortOrder::Recent).unwrap(), "\"recent\"");
         assert_eq!(serde_json::to_string(&SortOrder::Name).unwrap(), "\"name\"");
+        assert_eq!(serde_json::to_string(&SortOrder::Popular).unwrap(), "\"popular\"");
+        assert_eq!(serde_json::to_string(&SortOrder::Security).unwrap(), "\"security\"");
     }
 
     #[test]

--- a/crates/mockforge-registry-core/src/models/plugin.rs
+++ b/crates/mockforge-registry-core/src/models/plugin.rs
@@ -140,12 +140,22 @@ impl Plugin {
             sql.push_str(&conditions.join(" AND "));
         }
 
-        // Add sorting
+        // Add sorting. "popular" weights ratings into the ranking so
+        // well-loved-but-less-downloaded plugins surface above silently
+        // popular ones; "security" floats verified plugins to the top
+        // (matching how `derive_security_score` boosts verified entries
+        // by 35 points).
         match sort_by {
             "downloads" => sql.push_str(" ORDER BY p.downloads_total DESC"),
-            "rating" => sql.push_str(" ORDER BY p.rating_avg DESC"),
-            "recent" => sql.push_str(" ORDER BY p.created_at DESC"),
+            "rating" => sql.push_str(" ORDER BY p.rating_avg DESC, p.rating_count DESC"),
+            "recent" => sql.push_str(" ORDER BY p.updated_at DESC"),
             "name" => sql.push_str(" ORDER BY p.name ASC"),
+            "popular" => sql.push_str(
+                " ORDER BY (p.downloads_total + (p.rating_avg * p.rating_count * 100)::bigint) DESC",
+            ),
+            "security" => sql.push_str(
+                " ORDER BY (p.verified_at IS NOT NULL) DESC, p.rating_avg DESC, p.downloads_total DESC",
+            ),
             _ => sql.push_str(" ORDER BY p.downloads_total DESC"),
         }
 

--- a/crates/mockforge-registry-server/src/handlers/plugins.rs
+++ b/crates/mockforge-registry-server/src/handlers/plugins.rs
@@ -29,6 +29,8 @@ pub async fn search_plugins(
         SortOrder::Rating => "rating",
         SortOrder::Recent => "recent",
         SortOrder::Name => "name",
+        SortOrder::Popular => "popular",
+        SortOrder::Security => "security",
         _ => "downloads",
     };
 

--- a/crates/mockforge-ui/ui/src/pages/PluginRegistryPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PluginRegistryPage.tsx
@@ -99,7 +99,17 @@ interface VersionInfo {
   yanked: boolean;
   downloadUrl: string;
   checksum: string;
+  size?: number;
+  minMockforgeVersion?: string | null;
+  dependencies?: Record<string, string>;
 }
+
+const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+};
 
 interface Review {
   id: string;
@@ -112,10 +122,6 @@ interface Review {
   helpfulCount: number;
   unhelpfulCount: number;
   verified: boolean;
-  authorResponse?: {
-    text: string;
-    createdAt: string;
-  };
 }
 
 interface SecurityScanResult {
@@ -198,25 +204,36 @@ export const PluginRegistryPage: React.FC = () => {
   ];
 
   useEffect(() => {
-    // Reset paging whenever the server-side sort or language filter changes.
+    // Reset paging whenever a server-side filter changes. Search query is
+    // debounced separately below so each keystroke doesn't fire a request.
     setPage(0);
     loadPlugins(0, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortBy, selectedLanguage]);
+  }, [sortBy, selectedLanguage, selectedCategory]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setPage(0);
+      loadPlugins(0, false);
+    }, 300);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery]);
 
   useEffect(() => {
     filterPlugins();
-  }, [plugins, searchQuery, selectedCategory, selectedLanguage, sortBy, minRating, minSecurityScore]);
+  }, [plugins, minRating, minSecurityScore]);
 
   const loadPlugins = async (nextPage: number, append: boolean) => {
     setPageLoading(true);
     try {
+      const trimmedQuery = searchQuery.trim();
       const response = await authenticatedFetch('/api/v1/plugins/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          query: null,
-          category: null,
+          query: trimmedQuery.length > 0 ? trimmedQuery : null,
+          category: selectedCategory === 'all' ? null : selectedCategory,
           language: selectedLanguage === 'all' ? null : selectedLanguage,
           tags: [],
           sort: sortBy,
@@ -263,63 +280,18 @@ export const PluginRegistryPage: React.FC = () => {
   };
 
   const filterPlugins = () => {
+    // Search query, category, language, and sort are applied server-side via
+    // /api/v1/plugins/search so they reflect the entire catalog rather than
+    // just the currently-loaded page. Min-rating and min-security are applied
+    // here because the backend search API doesn't accept those filters yet.
     let filtered = [...plugins];
 
-    // Search filter
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (p) =>
-          p.name.toLowerCase().includes(query) ||
-          p.description.toLowerCase().includes(query) ||
-          p.author.name.toLowerCase().includes(query) ||
-          p.tags.some((tag) => tag.toLowerCase().includes(query))
-      );
-    }
-
-    // Category filter
-    if (selectedCategory !== 'all') {
-      filtered = filtered.filter((p) => p.category === selectedCategory);
-    }
-
-    // Language filter
-    if (selectedLanguage !== 'all') {
-      filtered = filtered.filter((p) => p.language === selectedLanguage);
-    }
-
-    // Rating filter
     if (minRating > 0) {
       filtered = filtered.filter((p) => p.rating >= minRating);
     }
 
-    // Security score filter
     if (minSecurityScore > 0) {
       filtered = filtered.filter((p) => p.securityScore >= minSecurityScore);
-    }
-
-    // Sort
-    switch (sortBy) {
-      case 'popular':
-        filtered.sort((a, b) => {
-          const scoreA = a.downloads + a.rating * 100;
-          const scoreB = b.downloads + b.rating * 100;
-          return scoreB - scoreA;
-        });
-        break;
-      case 'downloads':
-        filtered.sort((a, b) => b.downloads - a.downloads);
-        break;
-      case 'rating':
-        filtered.sort((a, b) => b.rating - a.rating);
-        break;
-      case 'recent':
-        filtered.sort(
-          (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-        );
-        break;
-      case 'security':
-        filtered.sort((a, b) => b.securityScore - a.securityScore);
-        break;
     }
 
     setFilteredPlugins(filtered);
@@ -1004,14 +976,6 @@ export const PluginRegistryPage: React.FC = () => {
                                   Not helpful ({review.unhelpfulCount})
                                 </Button>
                               </Box>
-                              {review.authorResponse && (
-                                <Box sx={{ mt: 2, ml: 4, p: 2, bgcolor: 'action.hover', borderRadius: 1 }}>
-                                  <Typography variant="caption" color="primary" fontWeight="bold">
-                                    Author Response
-                                  </Typography>
-                                  <Typography variant="body2">{review.authorResponse.text}</Typography>
-                                </Box>
-                              )}
                             </Box>
                           </ListItem>
                           <Divider component="li" />
@@ -1115,15 +1079,59 @@ export const PluginRegistryPage: React.FC = () => {
                         >
                           <ListItemText
                             primary={
-                              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
                                 <Typography variant="subtitle1">{version.version}</Typography>
                                 {version.version === selectedPlugin.version && (
                                   <Chip label="Latest" size="small" color="primary" />
                                 )}
                                 {version.yanked && <Chip label="Yanked" size="small" color="error" />}
+                                {version.minMockforgeVersion && (
+                                  <Tooltip title="Minimum MockForge version required to run this plugin">
+                                    <Chip
+                                      label={`MockForge ≥ ${version.minMockforgeVersion}`}
+                                      size="small"
+                                      variant="outlined"
+                                    />
+                                  </Tooltip>
+                                )}
+                                {typeof version.size === 'number' && version.size > 0 && (
+                                  <Chip label={formatFileSize(version.size)} size="small" variant="outlined" />
+                                )}
                               </Box>
                             }
-                            secondary={`Published: ${new Date(version.publishedAt).toLocaleDateString()}`}
+                            secondary={
+                              <Box component="span" sx={{ display: 'block' }}>
+                                <Typography variant="caption" color="text.secondary" component="span">
+                                  Published {new Date(version.publishedAt).toLocaleDateString()}
+                                </Typography>
+                                {version.checksum && (
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    component="span"
+                                    sx={{ display: 'block', fontFamily: 'monospace', mt: 0.25, wordBreak: 'break-all' }}
+                                  >
+                                    sha256: {version.checksum}
+                                  </Typography>
+                                )}
+                                {version.dependencies && Object.keys(version.dependencies).length > 0 && (
+                                  <Box component="span" sx={{ display: 'block', mt: 0.5 }}>
+                                    <Typography variant="caption" color="text.secondary" component="span">
+                                      Depends on:{' '}
+                                    </Typography>
+                                    {Object.entries(version.dependencies).map(([dep, range]) => (
+                                      <Chip
+                                        key={dep}
+                                        label={`${dep} ${range}`}
+                                        size="small"
+                                        variant="outlined"
+                                        sx={{ mr: 0.5, mt: 0.25 }}
+                                      />
+                                    ))}
+                                  </Box>
+                                )}
+                              </Box>
+                            }
                           />
                         </ListItem>
                       );


### PR DESCRIPTION
## Summary

Audited `/plugin-registry` (and the inner Overview / Reviews / Security / Versions tabs) for backend functionality the UI didn't expose, UI elements with no backend, and broken wiring. Three real gaps:

- **Server-side search/category were silently broken past page 1.** UI was sending `query: null, category: null` and filtering client-side after fetching one page of 24 plugins. The backend search API already accepted both — it was just never asked.
- **Sort dropdown values `popular` and `security` weren't valid `SortOrder` variants on the backend**, so those modes returned a deserialization error and the catalog showed nothing. (Default sort is `popular`, so this affected the first paint.)
- **VersionEntry returned `size`, `checksum`, `minMockforgeVersion`, and `dependencies`** but the Versions tab only showed version + published date. All four are now displayed.
- **Dead `authorResponse` UI code** rendered conditionally for a field that doesn't exist in the `reviews` table and has no endpoint to write or read it. Removed.

## Changes

**UI (`PluginRegistryPage.tsx`):**
- Pass `searchQuery` (300ms debounced) and `selectedCategory` to `/api/v1/plugins/search`.
- Reset paging on filter change; keep min-rating / min-security as client-side filters since the backend search API doesn't accept them yet.
- Versions tab: add file-size chip (KB/MB/GB), `MockForge ≥ x.y.z` compatibility chip, SHA-256 checksum row, and a dependencies chip list when non-empty.
- Drop dead `authorResponse` interface field + render block.

**Backend (`mockforge-plugin-registry`, `mockforge-registry-core`, `mockforge-registry-server`):**
- Add `SortOrder::Popular` and `SortOrder::Security` so existing UI sort values deserialize successfully.
- Postgres `Plugin::search` ORDER BY now handles `popular` (downloads + rating × count × 100) and `security` (verified plugins first, then rating, then downloads — matches `derive_security_score`'s 35-point verified boost). Switched `recent` from `created_at` to `updated_at` so re-published plugins surface as recently updated.
- Update in-memory `sort_results` (used in tests / non-Postgres paths) to handle the new variants.

## Test plan

- [x] `cargo clippy -p mockforge-plugin-registry -p mockforge-registry-core -p mockforge-registry-server --all-targets -- -D warnings` — clean
- [x] `cargo test -p mockforge-plugin-registry` (140 passed)
- [x] `cargo test -p mockforge-registry-core` (244 passed)
- [x] `cargo test -p mockforge-registry-server` (274 passed)
- [x] `pnpm type-check` (no errors), `pnpm lint` (0 errors), `pnpm test --run` (851 passed)
- [x] `cargo fmt --all --check`
- [ ] Manual: search the catalog by name across pages and confirm hits beyond the first page are reflected; switch the category dropdown and verify the count + grid update; open a plugin's Versions tab and confirm size, checksum, MockForge minimum, and dependencies render when present.