### PR TITLE
feat(registry,ui): plugin moderation admin page

### DIFF
--- a/crates/mockforge-registry-core/src/models/plugin.rs
+++ b/crates/mockforge-registry-core/src/models/plugin.rs
@@ -360,6 +360,18 @@ impl Plugin {
         .await?;
         Ok(())
     }
+
+    /// Returns every plugin currently flagged as taken-down, newest first.
+    /// Powers the admin moderation page; the public search filters these
+    /// out, so this is the only path to find them once a takedown has
+    /// happened (apart from the per-action audit row).
+    pub async fn list_taken_down(pool: &sqlx::PgPool) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>(
+            "SELECT * FROM plugins WHERE taken_down_at IS NOT NULL ORDER BY taken_down_at DESC",
+        )
+        .fetch_all(pool)
+        .await
+    }
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1814,6 +1814,11 @@ pub trait RegistryStore: Send + Sync + 'static {
 
     async fn restore_plugin(&self, plugin_id: Uuid) -> StoreResult<()>;
 
+    /// All currently taken-down plugins, newest takedown first. Powers
+    /// the admin moderation page; the public search excludes these so
+    /// this is the only programmatic way to enumerate them.
+    async fn list_taken_down_plugins(&self) -> StoreResult<Vec<crate::models::Plugin>>;
+
     /// Look up a single review by id, scoped to the plugin path param so the
     /// author-response endpoint can return 404 (not 403) when the path/body
     /// disagree.

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -2126,6 +2126,10 @@ impl RegistryStore for PgRegistryStore {
         Plugin::restore(&self.pool, plugin_id).await.map_err(Into::into)
     }
 
+    async fn list_taken_down_plugins(&self) -> StoreResult<Vec<Plugin>> {
+        Plugin::list_taken_down(&self.pool).await.map_err(Into::into)
+    }
+
     async fn find_review_in_plugin(
         &self,
         plugin_id: Uuid,

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -3327,6 +3327,13 @@ impl RegistryStore for SqliteRegistryStore {
         Ok(())
     }
 
+    async fn list_taken_down_plugins(&self) -> StoreResult<Vec<Plugin>> {
+        // SQLite is the in-memory test backend; the plugin search/list
+        // surface is stubbed (see `search_plugins` above), so the
+        // moderation list mirrors that and stays empty.
+        Ok(Vec::new())
+    }
+
     async fn find_review_in_plugin(
         &self,
         plugin_id: Uuid,

--- a/crates/mockforge-registry-server/src/handlers/admin.rs
+++ b/crates/mockforge-registry-server/src/handlers/admin.rs
@@ -235,6 +235,88 @@ pub async fn restore_plugin(
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TakenDownPluginEntry {
+    pub name: String,
+    pub description: String,
+    pub category: String,
+    pub current_version: String,
+    pub author: TakenDownAuthorInfo,
+    pub taken_down_at: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TakenDownAuthorInfo {
+    pub id: String,
+    pub username: String,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListTakenDownResponse {
+    pub plugins: Vec<TakenDownPluginEntry>,
+    pub total: usize,
+}
+
+/// Admin moderation: list every plugin that's currently taken-down.
+/// `Plugin::search` filters these out, so this is the only programmatic
+/// path for the moderation UI to find them after the post-takedown
+/// snackbar window closes.
+pub async fn list_taken_down_plugins(
+    State(state): State<AppState>,
+    Extension(user_id): Extension<String>,
+) -> ApiResult<Json<ListTakenDownResponse>> {
+    let pool = state.db.pool();
+
+    let user_uuid = Uuid::parse_str(&user_id)
+        .map_err(|_| ApiError::InvalidRequest("Invalid user ID".to_string()))?;
+
+    let user = sqlx::query_as::<_, (bool,)>("SELECT is_admin FROM users WHERE id = $1")
+        .bind(user_uuid)
+        .fetch_one(pool)
+        .await
+        .map_err(ApiError::Database)?;
+    if !user.0 {
+        return Err(ApiError::PermissionDenied);
+    }
+
+    let plugins = state.store.list_taken_down_plugins().await?;
+    let mut entries = Vec::with_capacity(plugins.len());
+    for plugin in plugins {
+        let author = state
+            .store
+            .find_user_by_id(plugin.author_id)
+            .await?
+            .unwrap_or_else(|| crate::models::User::placeholder(plugin.author_id));
+        entries.push(TakenDownPluginEntry {
+            name: plugin.name,
+            description: plugin.description,
+            category: plugin.category,
+            current_version: plugin.current_version,
+            author: TakenDownAuthorInfo {
+                id: author.id.to_string(),
+                username: author.username,
+                email: Some(author.email),
+            },
+            // taken_down_at is guaranteed Some by the SQL filter, but
+            // keep a defensive fallback so a clock-skew or column
+            // regression can't crash the page.
+            taken_down_at: plugin.taken_down_at.map(|dt| dt.to_rfc3339()).unwrap_or_default(),
+            reason: plugin.taken_down_reason,
+        });
+    }
+
+    let total = entries.len();
+    Ok(Json(ListTakenDownResponse {
+        plugins: entries,
+        total,
+    }))
+}
+
+#[derive(Debug, Serialize)]
 pub struct PluginWithBadges {
     pub name: String,
     pub version: String,

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -393,6 +393,10 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/admin/plugins/{name}/verify", post(handlers::admin::verify_plugin))
         .route("/api/v1/admin/plugins/{name}/takedown", post(handlers::admin::takedown_plugin))
         .route("/api/v1/admin/plugins/{name}/restore", post(handlers::admin::restore_plugin))
+        .route(
+            "/api/v1/admin/plugins/taken-down",
+            get(handlers::admin::list_taken_down_plugins),
+        )
         .route("/api/v1/admin/stats", get(handlers::admin::get_admin_stats))
         .route("/api/v1/admin/analytics", get(handlers::analytics::get_analytics))
         .route(
@@ -487,6 +491,7 @@ mod tests {
             "/api/v1/admin/plugins/{name}/verify",
             "/api/v1/admin/plugins/{name}/takedown",
             "/api/v1/admin/plugins/{name}/restore",
+            "/api/v1/admin/plugins/taken-down",
             "/api/v1/admin/stats",
             "/api/v1/admin/analytics",
             "/api/v1/admin/analytics/funnel",

--- a/crates/mockforge-ui/ui/src/pages/PluginModerationPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PluginModerationPage.tsx
@@ -1,0 +1,246 @@
+/**
+ * Plugin Moderation (admin)
+ *
+ * Lists plugins that have been taken down via the admin "Take down" button
+ * on `/plugin-registry`. Public search filters these out, so this page is
+ * the only UI surface for finding them again and restoring them once the
+ * post-takedown undo snackbar has expired.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  ArrowBack as ArrowBackIcon,
+  Refresh as RefreshIcon,
+  Restore as RestoreIcon,
+} from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { authenticatedFetch } from '../utils/apiClient';
+import { useAuthStore } from '../stores/useAuthStore';
+
+interface TakenDownPlugin {
+  name: string;
+  description: string;
+  category: string;
+  currentVersion: string;
+  author: { id: string; username: string; email?: string | null };
+  takenDownAt: string;
+  reason?: string | null;
+}
+
+interface ListResponse {
+  plugins: TakenDownPlugin[];
+  total: number;
+}
+
+export const PluginModerationPage: React.FC = () => {
+  const navigate = useNavigate();
+  const currentUser = useAuthStore((s) => s.user);
+  const isAdmin = currentUser?.role === 'admin';
+
+  const [plugins, setPlugins] = useState<TakenDownPlugin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [restoring, setRestoring] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await authenticatedFetch('/api/v1/admin/plugins/taken-down');
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}));
+        throw new Error(body?.error || body?.message || `HTTP ${resp.status}`);
+      }
+      const data: ListResponse = await resp.json();
+      setPlugins(data.plugins || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load taken-down plugins');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isAdmin) {
+      load();
+    } else {
+      setLoading(false);
+    }
+  }, [isAdmin]);
+
+  const handleRestore = async (name: string) => {
+    if (!window.confirm(`Restore ${name}? It will reappear in search and detail views immediately.`)) {
+      return;
+    }
+    setRestoring(name);
+    try {
+      const resp = await authenticatedFetch(
+        `/api/v1/admin/plugins/${encodeURIComponent(name)}/restore`,
+        { method: 'POST' }
+      );
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}));
+        throw new Error(body?.error || body?.message || `HTTP ${resp.status}`);
+      }
+      setFeedback(`Restored ${name}`);
+      setPlugins((prev) => prev.filter((p) => p.name !== name));
+    } catch (err) {
+      setFeedback(err instanceof Error ? err.message : 'Restore failed');
+    } finally {
+      setRestoring(null);
+      setTimeout(() => setFeedback(null), 4000);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="error">
+          Plugin moderation is restricted to administrators.
+        </Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <Tooltip title="Back to plugin registry">
+          <IconButton onClick={() => navigate('/plugin-registry')} size="small">
+            <ArrowBackIcon />
+          </IconButton>
+        </Tooltip>
+        <Typography variant="h4" sx={{ flexGrow: 1 }}>
+          Plugin Moderation
+        </Typography>
+        <Tooltip title="Reload">
+          <span>
+            <IconButton onClick={load} disabled={loading}>
+              <RefreshIcon />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Plugins currently hidden from public search. Restoring a plugin makes
+        it discoverable and installable again immediately.
+      </Typography>
+
+      {feedback && (
+        <Alert severity="info" sx={{ mb: 2 }} onClose={() => setFeedback(null)}>
+          {feedback}
+        </Alert>
+      )}
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} action={
+          <Button color="inherit" size="small" onClick={load}>Retry</Button>
+        }>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : plugins.length === 0 ? (
+        <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="text.secondary">
+            No plugins are currently taken down.
+          </Typography>
+        </Paper>
+      ) : (
+        <TableContainer component={Paper} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Plugin</TableCell>
+                <TableCell>Author</TableCell>
+                <TableCell>Reason</TableCell>
+                <TableCell>Taken down</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {plugins.map((plugin) => (
+                <TableRow key={plugin.name} hover>
+                  <TableCell>
+                    <Stack spacing={0.5}>
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Typography variant="subtitle2">{plugin.name}</Typography>
+                        <Chip label={plugin.category} size="small" variant="outlined" />
+                        <Chip label={`v${plugin.currentVersion}`} size="small" variant="outlined" />
+                      </Stack>
+                      <Typography variant="caption" color="text.secondary">
+                        {plugin.description}
+                      </Typography>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">{plugin.author.username}</Typography>
+                    {plugin.author.email && (
+                      <Typography variant="caption" color="text.secondary">
+                        {plugin.author.email}
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ maxWidth: 280 }}>
+                    {plugin.reason ? (
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                        {plugin.reason}
+                      </Typography>
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">
+                        (no reason recorded)
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Tooltip title={new Date(plugin.takenDownAt).toLocaleString()}>
+                      <Typography variant="caption">
+                        {new Date(plugin.takenDownAt).toLocaleDateString()}
+                      </Typography>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell align="right">
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<RestoreIcon />}
+                      disabled={restoring === plugin.name}
+                      onClick={() => handleRestore(plugin.name)}
+                    >
+                      {restoring === plugin.name ? 'Restoring…' : 'Restore'}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+export default PluginModerationPage;

--- a/crates/mockforge-ui/ui/src/pages/PluginRegistryPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PluginRegistryPage.tsx
@@ -56,6 +56,7 @@ import {
   ThumbUp as ThumbUpIcon,
   ThumbDown as ThumbDownIcon,
 } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
 import { authenticatedFetch } from '../utils/apiClient';
 import { useAuthStore } from '../stores/useAuthStore';
 import { PublishPluginModal } from '../components/marketplace/PublishPluginModal';
@@ -143,6 +144,7 @@ interface SecurityFinding {
 }
 
 export const PluginRegistryPage: React.FC = () => {
+  const navigate = useNavigate();
   const currentUser = useAuthStore((s) => s.user);
   const isAdmin = currentUser?.role === 'admin';
 
@@ -645,11 +647,22 @@ export const PluginRegistryPage: React.FC = () => {
             Discover and install plugins from the MockForge ecosystem
           </Typography>
         </Box>
-        {currentUser && (
-          <Button variant="contained" onClick={() => setPublishOpen(true)}>
-            Publish Plugin
-          </Button>
-        )}
+        <Stack direction="row" spacing={1} alignItems="center">
+          {isAdmin && (
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => navigate('/plugin-registry/moderation')}
+            >
+              Moderation
+            </Button>
+          )}
+          {currentUser && (
+            <Button variant="contained" onClick={() => setPublishOpen(true)}>
+              Publish Plugin
+            </Button>
+          )}
+        </Stack>
       </Box>
 
       {/* Filters */}

--- a/crates/mockforge-ui/ui/src/routes/index.tsx
+++ b/crates/mockforge-ui/ui/src/routes/index.tsx
@@ -64,6 +64,7 @@ const OrchestrationExecutionView = lazy(() => import('../pages/OrchestrationExec
 
 // Plugins & Templates
 const PluginRegistryPage = lazy(() => import('../pages/PluginRegistryPage'));
+const PluginModerationPage = lazy(() => import('../pages/PluginModerationPage'));
 const TemplateMarketplacePage = lazy(() => import('../pages/TemplateMarketplacePage'));
 const ScenarioMarketplacePage = lazy(() => import('../pages/ScenarioMarketplacePage'));
 
@@ -194,6 +195,7 @@ export const routes: RouteConfig[] = [
   // Plugins
   { path: '/plugins', element: <PluginsPage /> },
   { path: '/plugin-registry', element: <PluginRegistryPage /> },
+  { path: '/plugin-registry/moderation', element: <PluginModerationPage /> },
 
   // User Management
   { path: '/user-management', element: <UserManagementPage /> },


### PR DESCRIPTION
## Summary

Follow-up to #298 — adds the missing UI surface for finding and restoring taken-down plugins after the post-takedown undo snackbar window has expired. Until now restoration required hitting `/api/v1/admin/plugins/{name}/restore` with curl because the public search filters taken-down plugins out.

## Backend

- `Plugin::list_taken_down` — `SELECT * FROM plugins WHERE taken_down_at IS NOT NULL ORDER BY taken_down_at DESC`.
- `Store::list_taken_down_plugins` — plumbs that through both backends. SQLite stays an empty stub (matching `search_plugins`).
- `GET /api/v1/admin/plugins/taken-down` (admin-only) — returns name, description, category, current version, author info (id/username/email), takedown timestamp, and reason.

## UI

- New `PluginModerationPage` at `/plugin-registry/moderation` — sortable-style table with name + category + version chips, author column, reason column (preserves whitespace), takedown date, and a per-row Restore button. Restore confirms, hits the existing endpoint, and drops the row from local state.
- Admin-only "Moderation" button next to "Publish Plugin" on the plugin registry header for discovery.
- Non-admins see an access-denied alert.

## Test plan

- [x] `cargo clippy -p mockforge-registry-core -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-core` (244 passed)
- [x] `cargo test -p mockforge-registry-server` (274 passed, 6 ignored)
- [x] `pnpm type-check`, `pnpm lint` (no new warnings), `pnpm test --run` (851 passed)
- [x] `cargo fmt --all --check`
- [ ] Manual: take down a plugin, navigate via the new "Moderation" button, verify it appears with the correct reason/timestamp, click Restore, confirm it leaves the table and reappears in the public search.