### PR TITLE
chore(ci): guard against migration version-prefix collisions across concurrent PRs

### DIFF
--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
 
@@ -53,21 +54,39 @@ jobs:
           fi
 
           # New migrations must use unique version prefixes (the YYYYMMDDHHMMSS timestamp).
-          # Catches the orphan-branch renumbering pattern from #261.
+          # Catches the orphan-branch renumbering pattern from #261 *and* the
+          # concurrent-PR race that crashed the registry on 2026-04-30 (#297 +
+          # #298 both added 20250101000057): we union the working tree with the
+          # target branch's current tip so a prefix that landed there *after*
+          # this PR forked is still flagged.
+          target_ref="origin/${BASE_REF:-main}"
+          git fetch --quiet origin "${BASE_REF:-main}"
+
           new_files=$(echo "$changed" | awk '$1 == "A" {print $2}' | grep -E 'crates/.*/migrations/[0-9]+_.+\.sql$' || true)
           if [ -n "$new_files" ]; then
             for crate_dir in $(echo "$new_files" | xargs -n1 dirname | sort -u); do
-              # All version prefixes in this dir on HEAD.
-              dupes=$(ls "$crate_dir" 2>/dev/null \
+              # Prefixes in this dir on HEAD (PR's working tree).
+              head_prefixes=$(ls "$crate_dir" 2>/dev/null \
                 | grep -E '^[0-9]+_' \
-                | awk -F_ '{print $1}' \
+                | awk -F_ '{print $1}')
+              # Prefixes in this dir on the target branch's tip — catches
+              # collisions with migrations that merged after this PR was opened
+              # but before it lands. Empty if the dir doesn't exist there.
+              main_prefixes=$(git ls-tree --name-only "$target_ref" -- "$crate_dir/" 2>/dev/null \
+                | xargs -n1 -I{} basename {} 2>/dev/null \
+                | grep -E '^[0-9]+_' \
+                | awk -F_ '{print $1}' || true)
+              dupes=$(printf '%s\n%s\n' "$head_prefixes" "$main_prefixes" \
+                | grep -v '^$' \
                 | sort | uniq -d)
               if [ -n "$dupes" ]; then
                 echo "::error::Duplicate migration version prefix in $crate_dir:"
                 echo "$dupes"
+                echo "::error::A migration with this prefix exists on $target_ref or in this PR."
+                echo "::error::Bump your new migration to the next free prefix and rebase."
                 exit 1
               fi
             done
           fi
 
-          echo "Migration changes are append-only and version-unique."
+          echo "Migration changes are append-only and version-unique vs $target_ref."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,16 @@ repos:
     name: check-shebang-scripts-are-executable
     entry: python3 scripts/precommit/offline_checks.py check-shebang-scripts-are-executable
     language: system
+  - id: check-migration-collisions
+    name: check-migration-collisions
+    # Catches the failure mode that crashed the registry server on 2026-04-30:
+    # PR #297 and PR #298 both added migrations at version 20250101000057,
+    # neither CI run saw the other, sqlx refused the second on first deploy.
+    # Local guard for the same-commit case; CI (.github/workflows/migration-guard.yml)
+    # catches the cross-PR race.
+    entry: python3 scripts/precommit/check_migration_collisions.py
+    language: system
+    files: ^crates/[^/]+/migrations/.+\.sql$
   - id: clippy
     name: clippy
     entry: cargo clippy --all-targets --all-features --workspace --exclude mockforge-desktop

--- a/scripts/precommit/check_migration_collisions.py
+++ b/scripts/precommit/check_migration_collisions.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Pre-commit guard against migration version-prefix collisions.
+
+sqlx records each migration by `(version_prefix, content_checksum)`. Two
+migration files in the same directory that share a version prefix are an
+unrunnable schema state — whichever sqlx applies first wins, the second
+errors `migration N was previously applied but has been modified`, and the
+registry server crash-loops on the next deploy.
+
+This catches the *local* case: a developer stages a file whose version
+prefix already exists in `crates/<crate>/migrations/` (either committed or
+also staged in the same commit). The harder case — two PRs adding the same
+prefix concurrently — is caught by `.github/workflows/migration-guard.yml`,
+which checks the rebased state against `origin/main`.
+
+Pre-commit invokes this with the staged paths as positional args (we only
+care about `crates/*/migrations/*.sql`; everything else is filtered out).
+Works whether or not pre-commit was set up with `pass_filenames`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Migration filenames are `<digits>_<name>.sql`. The digit prefix is sqlx's
+# version. Anything else in the dir (READMEs, gitkeeps) is ignored.
+MIGRATION_RE = re.compile(r"^(?P<version>\d+)_.+\.sql$")
+MIGRATION_PATH_RE = re.compile(r"^crates/[^/]+/migrations/.+\.sql$")
+
+
+def staged_migration_paths(argv: list[str]) -> list[Path]:
+    """Filter argv down to staged migration .sql files. argv comes from
+    pre-commit, which passes paths as forward-slash strings even on Windows."""
+    out = []
+    for arg in argv:
+        if MIGRATION_PATH_RE.match(arg):
+            p = Path(arg)
+            if p.is_file():
+                out.append(p)
+    return out
+
+
+def collisions_in(dir_path: Path) -> dict[str, list[str]]:
+    """Group every migration file in `dir_path` by version prefix; return
+    the groups with more than one file. Operates on the working tree, so it
+    sees both committed migrations and ones being staged in this commit."""
+    by_version: dict[str, list[str]] = defaultdict(list)
+    if not dir_path.is_dir():
+        return {}
+    for entry in os.listdir(dir_path):
+        m = MIGRATION_RE.match(entry)
+        if m:
+            by_version[m.group("version")].append(entry)
+    return {v: sorted(files) for v, files in by_version.items() if len(files) > 1}
+
+
+def main(argv: list[str]) -> int:
+    staged = staged_migration_paths(argv)
+    if not staged:
+        return 0
+
+    # We only need to inspect each migration directory once, even if the
+    # commit touches several files in it.
+    dirs_touched = {p.parent for p in staged}
+
+    failed = False
+    for d in sorted(dirs_touched):
+        dupes = collisions_in(d)
+        if not dupes:
+            continue
+        failed = True
+        print(f"error: duplicate migration version prefix in {d}:", file=sys.stderr)
+        for version, files in sorted(dupes.items()):
+            print(f"  version {version}:", file=sys.stderr)
+            for f in files:
+                print(f"    - {f}", file=sys.stderr)
+        print(
+            "\nsqlx tracks (version, checksum) per migration; two files at the "
+            "same version are an unrunnable schema state. Bump the version on "
+            "your new migration to the next free prefix.",
+            file=sys.stderr,
+        )
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
PR #297 (scenario_stars) and PR #298 (plugin_takedown_review_response) both added migrations at version `20250101000057` (Postgres) / `20260101000014` (SQLite). Each PR's CI ran against its own base sha and saw no collision; after both merged, sqlx applied whichever sorted first and refused the second on first deploy (`migration N was previously applied but has been modified`), crash-looping the registry on Fly v66. PR #300 unblocked deploy by bumping `scenario_stars` to a free prefix.

This adds two layers of defence so it can't happen again:

### 1. Pre-commit hook
`scripts/precommit/check_migration_collisions.py` walks every staged migration's directory and fails if any version prefix appears on more than one file. Catches the same-commit case locally and the just-pulled-main case before push. Wired into `.pre-commit-config.yaml` after the existing `check-shebang-scripts-are-executable` hook with a `files:` filter so it only runs when migrations change.

### 2. Strengthened `migration-guard.yml`
Previously, the duplicate-prefix check ran `ls $crate_dir` on the PR's working tree, which by definition only contained that PR's files (against the PR's base sha). The cross-PR race was invisible.

Now we union the working tree with the **target branch's current tip** (`origin/<base_ref>`) via `git ls-tree`. If another PR's migration with the same prefix lands on main while this PR is open, the next CI run on this PR catches the collision and blocks the merge.

The "modified/deleted/renamed" branch of the guard (the original #261 protection) is unchanged.

## Test plan
- [x] `python3 scripts/precommit/check_migration_collisions.py <real_migration>` — pass
- [x] Same script with two crafted same-prefix files — exit 1, prints which versions collide
- [x] `pre-commit run check-migration-collisions --all-files` — pass on the current repo
- [x] Pre-commit ran clean during this PR's commit (existing hooks plus the new one)
- [ ] On merge: confirm next migration-touching PR runs the new CI logic (the workflow only triggers on PRs with `crates/*/migrations/**` paths)