### PR TITLE
docs(tier1): sync user-facing docs with v0.3.125 features

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -381,10 +381,32 @@ All configuration options can be overridden using environment variables.
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `MOCKFORGE_RAG_PROVIDER` | LLM provider | `openai` |
+| `MOCKFORGE_RAG_PROVIDER` | LLM provider (`openai`, `anthropic`, `ollama`) | `openai` |
 | `MOCKFORGE_RAG_MODEL` | Model name | `gpt-4` |
 | `MOCKFORGE_RAG_API_KEY` | API key | `sk-...` |
-| `MOCKFORGE_RAG_TEMPERATURE` | Temperature | `0.7` |
+| `MOCKFORGE_RAG_API_ENDPOINT` | Custom API endpoint (overrides provider default) | `https://api.openai.com/v1` |
+| `MOCKFORGE_RAG_TEMPERATURE` | Sampling temperature | `0.7` |
+| `MOCKFORGE_RAG_MAX_TOKENS` | Maximum tokens per response | `2048` |
+| `MOCKFORGE_RAG_CONTEXT_WINDOW` | Context window size | `4096` |
+| `MOCKFORGE_RAG_TIMEOUT_SECONDS` | Request timeout (seconds) | `30` |
+| `MOCKFORGE_RAG_MAX_RETRIES` | Max retries on transient errors | `3` |
+| `MOCKFORGE_EMBEDDING_PROVIDER` | Embedding provider (`openai`, `local`, `ollama`) | `openai` |
+| `MOCKFORGE_EMBEDDING_MODEL` | Embedding model name | `text-embedding-3-small` |
+| `MOCKFORGE_EMBEDDING_ENDPOINT` | Custom embedding API endpoint | `http://localhost:11434` |
+| `MOCKFORGE_SIMILARITY_THRESHOLD` | Minimum similarity score (0.0–1.0) | `0.75` |
+| `OPENAI_API_KEY` | OpenAI API key (fallback when `MOCKFORGE_RAG_API_KEY` unset) | `sk-...` |
+
+### Observability
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `MOCKFORGE_METRICS_LOG_FILE` | Path to a CSV file where the admin server appends `timestamp,cpu_pct,mem_mb,total_reqs,err_rate` every 10 s. Survives restarts; chartable in any spreadsheet/Grafana/etc. | `/var/log/mockforge-metrics.csv` |
+
+### Registry / Marketplace
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `MOCKFORGE_REGISTRY_TOKEN` | Auth token for publishing scenarios / plugins to the registry | `mfreg_…` |
 
 See [config.example.yaml](./config.example.yaml) for the complete list of environment variables.
 
@@ -536,6 +558,33 @@ profiles:
           enabled: true
           fixed_delay_ms: 150
           probability: 0.5
+        # See docs/CHAOS_ENGINEERING.md for the full schema. Highlights:
+        fault_injection:
+          enabled: true
+          http_errors: [503]
+          http_error_probability: 0.1
+          # Optional per-request matcher; only inject faults on matching requests.
+          # AND across fields, OR within a list. Empty = match every request.
+          request_matcher:
+            source_ips: ["10.0.0.0/8"]    # CIDR or bare IP
+            headers:
+              - name: "x-test"            # case-insensitive name
+                value: "yes"              # omit `value` for presence-only
+            min_body_size_bytes: 1048576  # >= 1 MB
+            chunked_only: true            # only Transfer-Encoding: chunked
+          # Wire-level behavior of "connection error". `tcp_reset`/`tcp_close`
+          # require the chaos listener wrapper, auto-installed by serve.
+          connection_errors: false
+          connection_error_probability: 0.05
+          connection_error_kind: http_503  # http_503 | tcp_reset | tcp_close
+          # Real timeouts: sleep then return 504. Decoupled from partial.
+          timeout_errors: false
+          timeout_ms: 5000
+          timeout_probability: 0.05
+          # Truncated body: preserves Content-Length on non-chunked, drops the
+          # terminator on chunked responses.
+          partial_responses: false
+          partial_response_probability: 0.05
 
     core:
       latency_enabled: true

--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ All commands, options, and features documented in each protocol section (HTTP, g
   - **Team Collaboration**: Shared workspaces with conflict resolution
 - **Dynamic Response Generation**: Create realistic mock responses with configurable latency and failure rates
 - **Cross-Endpoint Validation**: Ensure referential integrity across different endpoints
+- **Load Testing & Chaos Engineering**: First-class tooling for stressing real APIs and your own mocks:
+  - **`mockforge bench`**: k6 script generation from an OpenAPI spec — ramp/spike/soak/constant scenarios with configurable VUs, thresholds, auth, and operation filtering
+  - **`mockforge bench-chunked`**: native Rust hyper-based generator for guaranteed `Transfer-Encoding: chunked` traffic when k6's Go transport falls short
+  - **Chaos engineering**: latency, HTTP errors, **TCP-level connection errors** (RST / FIN at accept time), real timeouts (sleep + 504), partial responses (chunked-aware), payload corruption — all gateable by per-request matchers (source IP / CIDR, header, body size, chunked-only)
+  - **Live observability**: TUI dashboard with current and lifetime peak CPU / memory / error-rate; optional CSV metrics log (`MOCKFORGE_METRICS_LOG_FILE`) for multi-day runs you can chart in Grafana / spreadsheets / anything
 - **Admin UI v2**: Modern React-based interface with:
   - **Role-Based Authentication**: ✅ Complete JWT-based authentication with Admin, Editor, and Viewer roles
   - **Real-time Collaboration**: ✅ WebSocket-based collaborative editing with presence awareness and cursor tracking

--- a/book/src/configuration/environment.md
+++ b/book/src/configuration/environment.md
@@ -156,6 +156,20 @@ MockForge supports extensive configuration through environment variables. This p
   - When recording, only record GET requests
   - Reduces fixture file size for read-only APIs
 
+## Observability
+
+### Metrics CSV Log
+
+- `MOCKFORGE_METRICS_LOG_FILE=path/to/metrics.csv`
+  - When set, the admin server's system-monitoring task appends one CSV row
+    every 10 s with `timestamp,cpu_pct,mem_mb,total_reqs,err_rate`.
+  - Survives restarts; chartable in any spreadsheet, Grafana, or
+    dashboarding tool.
+  - Example: `MOCKFORGE_METRICS_LOG_FILE=/var/log/mockforge-metrics.csv`
+  - The TUI dashboard also tracks lifetime peak CPU%, memory MB, and
+    error rate in-memory and renders them as `current (peak X)` next to
+    the live values.
+
 ## Configuration Files
 
 ### Configuration Loading

--- a/book/src/user-guide/chaos-lab.md
+++ b/book/src/user-guide/chaos-lab.md
@@ -2,6 +2,15 @@
 
 Chaos Lab is an interactive module that enables you to simulate various real-world network conditions and errors directly from the UI. Test application resilience, debug network-related issues, and validate error handling logic.
 
+> **Looking for the YAML / programmatic chaos engineering surface?**
+> This page covers the in-app Chaos Lab UI and predefined network profiles.
+> For the full YAML config (latency, fault injection, per-request matchers,
+> TCP-level connection errors, partial responses, native chunked traffic
+> generation), see the
+> [Chaos Engineering reference](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/CHAOS_ENGINEERING.md)
+> and
+> [bench command examples](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/bench-command-examples.md).
+
 ## Overview
 
 Chaos Lab provides:

--- a/docs/bench-command-examples.md
+++ b/docs/bench-command-examples.md
@@ -430,8 +430,70 @@ k6 version
 6. **Automate**: Integrate load tests into CI/CD pipelines
 7. **Set Realistic Thresholds**: Base thresholds on actual requirements
 
+## Chunked-Encoding Traffic
+
+If your server needs to be exercised with `Transfer-Encoding: chunked` request
+bodies (e.g. uploads from real-world clients that don't know the body size in
+advance, or chaos scenarios that match `chunked_only`), there are two paths:
+
+### k6 path — `bench --chunked-request-bodies`
+
+Adds `Transfer-Encoding: chunked` to the headers map of every k6 request that
+has a body. Best-effort: k6 runs on Go's `net/http`, which decides chunking
+based on body type — a string body has a known length and Go will normally
+send `Content-Length` regardless. Useful when you only need the *header*
+present; for guaranteed wire chunking, use `bench-chunked` below.
+
+```bash
+mockforge bench --spec api.yaml \
+  --target http://localhost:3000 \
+  --chunked-request-bodies
+```
+
+### Native path — `mockforge bench-chunked` (recommended)
+
+A separate subcommand that bypasses k6 entirely. Built on hyper / reqwest with
+`Body::wrap_stream` and no `Content-Length`, so the wire is always chunked.
+Reports req/s, p50/p95/p99 latency, and a status-code distribution.
+
+```bash
+mockforge bench-chunked \
+  --target http://localhost:3000/upload \
+  --concurrency 10 --duration 60 \
+  --chunk-size-bytes 4096 \
+  --total-size-bytes 10485760 \
+  --chunk-interval-ms 50 \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/octet-stream"
+```
+
+| Flag | Meaning |
+|---|---|
+| `--target` | URL to POST chunked bodies at |
+| `--method` | `POST` (default), `PUT`, or `PATCH` |
+| `--concurrency` | Number of concurrent workers (each holds one connection) |
+| `--duration` | Run length in seconds |
+| `--chunk-size-bytes` | Bytes per chunk emitted into the body stream |
+| `--total-size-bytes` | Total body size per request |
+| `--chunk-interval-ms` | Sleep between chunks (0 = back-to-back) |
+| `--header` | Extra `Name: Value` header; may be repeated |
+| `--insecure` | Skip TLS certificate verification |
+
+Common use cases:
+
+- **Slow upload simulation** — set a high `--chunk-interval-ms` to keep the
+  connection open for minutes per request and stress the server's idle/slow-
+  connection handling.
+- **Large body soak** — set a large `--total-size-bytes` to test the server's
+  max-body-size limits and memory behavior.
+- **Chunked + chaos matching** — pair with `chunked_only: true` in
+  `fault_injection.request_matcher` (see [CHAOS_ENGINEERING.md](./CHAOS_ENGINEERING.md))
+  to inject faults *only* on chunked traffic.
+
 ## Additional Resources
 
 - [k6 Documentation](https://k6.io/docs/)
 - [Load Testing Best Practices](https://k6.io/docs/testing-guides/)
 - [OpenAPI Specification](https://spec.openapis.org/oas/latest.html)
+- [Chaos Engineering Guide](./CHAOS_ENGINEERING.md) — pair load tests with
+  fault injection (latency, HTTP errors, TCP RST/FIN, partial responses)


### PR DESCRIPTION
## Summary

Tier 1 of a four-tier docs-vs-code audit. v0.3.125 (#306) shipped chaos / bench / observability features that were undocumented outside `docs/CHAOS_ENGINEERING.md`. An evidence-grade audit of the user-facing doc set found **6 gaps, all `missing` (no inaccuracies)** — fixed here.

## Changes

| File | What changed |
|---|---|
| **CONFIG.md** | `MOCKFORGE_METRICS_LOG_FILE` added under new Observability subsection. AI/RAG env-var table expanded to the full code surface (RAG endpoint, max-tokens, timeout, retries, embedding provider/model/endpoint, similarity threshold, OPENAI_API_KEY fallback). New Registry/Marketplace subsection with `MOCKFORGE_REGISTRY_TOKEN`. Demo profile chaos example replaced with full `fault_injection` + `request_matcher` + `connection_error_kind` + partial-response config. |
| **README.md** | Features list now surfaces `mockforge bench`, `mockforge bench-chunked`, TCP-level connection errors, request matchers, and CSV metric log. Without this, users browsing the README couldn't tell load testing or chaos were first-class. |
| **docs/bench-command-examples.md** | New Chunked-Encoding Traffic section covering both paths: `bench --chunked-request-bodies` (k6 best-effort) and `bench-chunked` (native Rust, guaranteed wire chunking). Flag-by-flag table + three common-use-case patterns. Cross-link to chaos engineering for matcher pairing. |
| **book/src/configuration/environment.md** | New Observability subsection documenting `MOCKFORGE_METRICS_LOG_FILE` + the in-memory TUI peak metrics. |
| **book/src/user-guide/chaos-lab.md** | Top-of-page callout disambiguating the in-app Chaos Lab UI from the YAML chaos engineering surface, with links to `docs/CHAOS_ENGINEERING.md` and `bench-command-examples.md`. (Tier 2 will mirror these as native mdbook chapters.) |

The `book/book/*` HTML artifacts regenerate via `mdbook build` and aren't committed here; they refresh on the next release build.

## Audit methodology

Spawned an Explore agent that cross-referenced documented CLI flags / env vars / public config fields against `crates/mockforge-cli/src/main.rs`, `crates/mockforge-chaos/src/config.rs`, and `crates/mockforge-ui/src/handlers.rs`. Findings classified as `wrong` / `stale` / `missing` / `ok`. **0 wrong, 0 stale, 5+ missing, 4 ok** — fixed all `missing`.

## Tracked separately

- **Tier 2**: wider audit of all user-facing docs (~30-50 files); promote chaos/bench guides to native mdbook chapters.
- **Tier 3**: triage of the ~200 internal status/planning docs (likely many archive candidates).
- **Tier 4**: CI gate so future feature work can't ship without docs.

## Test plan

- [x] mdbook builds clean (`mdbook build book` → no errors)
- [x] All pre-commit hooks pass (typos, clippy/fmt skipped — no Rust changes)
- [ ] Spot-check rendered output at docs.mockforge.dev after release (manual; deferred)

Refs: #79