### PR TITLE
docs(tier2): expand mdbook coverage of v0.3.125 surface

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -51,6 +51,11 @@
 - [Admin UI](user-guide/admin-ui.md)
 - [IDE Integration](user-guide/ide-integration.md)
 
+## Testing & Resilience
+
+- [Load Testing](user-guide/load-testing.md)
+- [Chaos Engineering](user-guide/chaos-engineering.md)
+
 ## Team and Cloud
 
 - [Cloud Workspaces](user-guide/cloud-workspaces.md)

--- a/book/src/api/cli.md
+++ b/book/src/api/cli.md
@@ -343,6 +343,75 @@ mockforge-cli admin
 mockforge-cli admin --port 9090
 ```
 
+### `bench` - OpenAPI-driven Load Testing
+
+Generate and run a k6 load test from an OpenAPI spec.
+
+```bash
+mockforge bench --spec api.yaml --target http://localhost:3000 [OPTIONS]
+```
+
+#### Common Options
+
+- `-s, --spec <PATH>` — OpenAPI spec file (repeatable for multi-spec mode).
+- `--spec-dir <DIR>` — Directory of specs (auto-discovered).
+- `-t, --target <URL>` — Target server URL.
+- `-d, --duration <SECS>` — Run length (default: 60).
+- `--vus <N>` — Virtual users (default: 10).
+- `--scenario <NAME>` — `constant` | `ramp-up` | `spike` | `stress` | `soak`.
+- `--operations <FILTER>` — Comma-separated operation filter (e.g. `"GET /users,POST /orders"`).
+- `--auth <HEADER>` — Authorization header value (e.g. `"Bearer $TOKEN"`).
+- `--headers <KV>` — Comma-separated extra headers (e.g. `"X-Tenant: a,X-Region: b"`).
+- `--threshold-percentile <P>` / `--threshold-ms <N>` — Latency SLO.
+- `--max-error-rate <RATE>` — Error-rate SLO (`0.01` = 1%).
+- `--generate-only` — Write the k6 script without running it.
+- `--script-output <PATH>` — Where to write the generated script.
+- `--targets-file <PATH>` — Multi-target mode (one URL per line).
+- `--max-concurrency <N>` — Parallel target limit (default: 10).
+- `--insecure` — Skip TLS verification (test self-signed certs).
+- `--chunked-request-bodies` — Add `Transfer-Encoding: chunked` to every k6 request body. NOTE: k6 runs on Go's `net/http`, which may still send `Content-Length` based on body type. For guaranteed wire chunking use [`bench-chunked`](#bench-chunked---native-chunked-traffic-generator) instead.
+
+See the [Load Testing chapter](../user-guide/load-testing.md) for the full
+options surface (security testing, OWASP API top 10, conformance mode,
+data-driven testing) and end-to-end examples.
+
+### `bench-chunked` - Native Chunked Traffic Generator
+
+Send guaranteed `Transfer-Encoding: chunked` request bodies via hyper. Useful
+when `bench --chunked-request-bodies` falls back to `Content-Length` (Go's
+transport heuristics) and you need real chunked traffic on the wire.
+
+```bash
+mockforge bench-chunked --target http://localhost:3000/upload [OPTIONS]
+```
+
+#### Options
+
+- `--target <URL>` — Target URL (required).
+- `--method <METHOD>` — `POST` (default), `PUT`, or `PATCH`.
+- `-c, --concurrency <N>` — Concurrent workers (default: 10).
+- `-d, --duration <SECS>` — Run length (default: 30).
+- `--chunk-size-bytes <N>` — Bytes per chunk (default: 1024).
+- `--total-size-bytes <N>` — Total body size per request (default: 1048576 = 1 MiB).
+- `--chunk-interval-ms <MS>` — Sleep between chunks (default: 0 = back-to-back).
+- `--header <NAME: VALUE>` — Extra header (repeatable).
+- `--insecure` — Skip TLS verification.
+
+Reports req/s, p50/p95/p99 latency, and a status-code distribution at the end.
+
+### `tui` - Terminal Dashboard
+
+Live dashboard in the terminal showing server status, system metrics
+(current and lifetime peak CPU / memory / error rate), request stats, and
+recent logs. Auto-refreshes every 2 s.
+
+```bash
+mockforge tui
+```
+
+Optionally pair with `MOCKFORGE_METRICS_LOG_FILE=path.csv` to also append a
+persistent CSV record while the server runs.
+
 ### `sync` - Workspace Synchronization Daemon
 
 Start a background daemon that monitors a workspace directory for file changes and automatically syncs them to MockForge workspaces.

--- a/book/src/configuration/environment.md
+++ b/book/src/configuration/environment.md
@@ -144,6 +144,31 @@ MockForge supports extensive configuration through environment variables. This p
   - Enable/disable faker token expansion
   - Controls whether `{{faker.email}}` etc. work
 
+### RAG / LLM Provider
+
+- `MOCKFORGE_RAG_PROVIDER=openai|anthropic|ollama` (default: `openai`)
+  - LLM provider for retrieval-augmented generation.
+- `MOCKFORGE_RAG_API_KEY=<key>` — provider API key (falls back to `OPENAI_API_KEY` when unset).
+- `MOCKFORGE_RAG_API_ENDPOINT=<url>` — custom endpoint, overrides the provider default.
+- `MOCKFORGE_RAG_MODEL=<name>` — e.g. `gpt-4`, `claude-3-5-sonnet`, `llama3`.
+- `MOCKFORGE_RAG_TEMPERATURE=<float>` (default: `0.7`).
+- `MOCKFORGE_RAG_MAX_TOKENS=<int>` (default: `2048`).
+- `MOCKFORGE_RAG_CONTEXT_WINDOW=<int>` (default: `4096`).
+- `MOCKFORGE_RAG_TIMEOUT_SECONDS=<int>` (default: `30`).
+- `MOCKFORGE_RAG_MAX_RETRIES=<int>` (default: `3`).
+- `OPENAI_API_KEY=<key>` — fallback when `MOCKFORGE_RAG_API_KEY` is unset.
+
+### Embedding (vector search)
+
+- `MOCKFORGE_EMBEDDING_PROVIDER=openai|local|ollama` — provider for embeddings used by RAG.
+- `MOCKFORGE_EMBEDDING_MODEL=<name>` — e.g. `text-embedding-3-small`.
+- `MOCKFORGE_EMBEDDING_ENDPOINT=<url>` — custom endpoint.
+- `MOCKFORGE_SIMILARITY_THRESHOLD=<float>` (`0.0`–`1.0`) — minimum match score.
+
+## Registry / Marketplace
+
+- `MOCKFORGE_REGISTRY_TOKEN=<token>` — auth token for publishing scenarios or plugins to the registry. Required for `mockforge scenario publish` and similar commands.
+
 ## Fixtures and Testing
 
 ### Fixtures Configuration

--- a/book/src/development/architecture.md
+++ b/book/src/development/architecture.md
@@ -76,19 +76,95 @@ graph TB
 
 ## Crate Structure
 
-MockForge is organized as a Cargo workspace with the following crates:
+MockForge is organized as a Cargo workspace with **56 crates** grouped by
+concern. The current authoritative list is in the root `Cargo.toml`'s
+`[workspace.members]`; the table below summarizes the major groupings.
 
-```
-mockforge/
-  crates/
-    mockforge-cli/     # Command-line interface
-    mockforge-core/    # Shared functionality
-    mockforge-http/    # HTTP REST API mocking
-    mockforge-ws/      # WebSocket connection mocking
-    mockforge-grpc/    # gRPC service mocking
-    mockforge-data/   # Synthetic data generation
-    mockforge-ui/      # Web-based admin interface
-```
+### Foundation
+
+| Crate | Purpose |
+|---|---|
+| `mockforge-foundation` | Shared error types, encryption primitives |
+| `mockforge-core` | Server, routing, OpenAPI parsing, middleware |
+| `mockforge-config` | Configuration types and loading |
+| `mockforge-security-core` | Auth/security primitives |
+| `mockforge-template-expansion` | Handlebars rendering |
+| `mockforge-data` | Data models, synthesis, RAG |
+| `mockforge-world-state` | Stateful mock behavior |
+| `mockforge-scenarios` | Test scenario management |
+
+### Protocol implementations
+
+| Crate | Purpose |
+|---|---|
+| `mockforge-http` | HTTP REST (primary protocol) |
+| `mockforge-grpc` | gRPC services |
+| `mockforge-ws` | WebSocket connections |
+| `mockforge-graphql` | GraphQL |
+| `mockforge-kafka` | Kafka event streaming |
+| `mockforge-mqtt` | MQTT pub/sub |
+| `mockforge-amqp` | AMQP message queuing |
+| `mockforge-smtp` | SMTP email |
+| `mockforge-ftp` | FTP |
+| `mockforge-tcp` | Raw TCP |
+
+### Plugin & extension layer
+
+| Crate | Purpose |
+|---|---|
+| `mockforge-plugin-core` | Plugin trait definitions |
+| `mockforge-plugin-sdk` | SDK for plugin authors |
+| `mockforge-plugin-loader` | WASM dynamic loading |
+| `mockforge-plugin-cli` | Plugin management CLI |
+| `mockforge-plugin-registry` | Local plugin registry |
+| `mockforge-registry-server` | Multi-tenant marketplace API |
+| `mockforge-registry-core` | Shared registry types |
+
+### Bench, test & observability
+
+| Crate | Purpose |
+|---|---|
+| `mockforge-bench` | k6 generation, OWASP testing, native chunked bench |
+| `mockforge-chaos` | Chaos engineering (latency, faults, TCP-level errors) |
+| `mockforge-chaos-orchestration` | Multi-step chaos scenarios |
+| `mockforge-chaos-ml` | ML-driven chaos analysis |
+| `mockforge-route-chaos` | Per-route chaos injection |
+| `mockforge-recorder` | Traffic recording |
+| `mockforge-test` | Test framework utilities |
+| `mockforge-observability` | Metrics, OTLP, dashboards |
+| `mockforge-tracing` | Distributed tracing |
+| `mockforge-analytics` | Usage analytics |
+| `mockforge-reporting` | Report generation |
+| `mockforge-performance` | Performance profiling |
+| `mockforge-pipelines` | Request/response pipelines |
+
+### User-facing
+
+| Crate | Purpose |
+|---|---|
+| `mockforge-cli` | Main `mockforge` binary |
+| `mockforge-ui` | React admin UI (Vite + React 19) |
+| `mockforge-tui` | Terminal UI dashboard |
+| `mockforge-sdk` | Client SDK |
+
+### Infrastructure / extension
+
+| Crate | Purpose |
+|---|---|
+| `mockforge-proxy` | Pass-through / record-replay proxy |
+| `mockforge-tunnel` | Tunnel support |
+| `mockforge-vbr` | Virtual branch resilience |
+| `mockforge-collab` | Collaborative features (SQLite/SQLx) |
+| `mockforge-federation` | Cross-instance federation |
+| `mockforge-k8s-operator` | Kubernetes operator |
+| `mockforge-runtime-daemon` | Runtime daemon |
+| `mockforge-import` | Spec import (HAR, Postman, etc.) |
+| `mockforge-intelligence` | AI-driven mocking |
+| `mockforge-ai-core` | AI primitives |
+| `mockforge-behavioral-cloning` | Record real traffic, replay synthetically |
+| `mockforge-contracts` | Contract testing |
+| `mockforge-openapi` | OpenAPI types and helpers |
+| `mockforge-workspace` | Workspace persistence |
 
 ### Crate Responsibilities
 

--- a/book/src/reference/config-schema.md
+++ b/book/src/reference/config-schema.md
@@ -253,6 +253,103 @@ chaos:
   failure_status_codes: [500, 502, 503, 504]
 ```
 
+### Full Chaos Engineering Surface (v0.3.125+)
+
+The simple flat fields above are kept for back-compat. The richer chaos
+surface is configured under `observability.chaos` with these blocks:
+
+#### `observability.chaos.fault_injection`
+
+```yaml
+observability:
+  chaos:
+    enabled: true
+    fault_injection:
+      enabled: true
+
+      # HTTP errors
+      http_errors: [500, 502, 503, 504]
+      http_error_probability: 0.1
+      error_pattern:               # optional, takes precedence over flat probability
+        type: burst                # burst | random | sequential
+        count: 3
+        interval_ms: 1000
+
+      # Connection errors
+      connection_errors: false
+      connection_error_probability: 0.05
+      connection_error_kind: http_503   # http_503 | tcp_reset | tcp_close
+
+      # Real timeouts (sleep then 504)
+      timeout_errors: false
+      timeout_ms: 5000
+      timeout_probability: 0.05
+
+      # Truncated responses (chunked-aware)
+      partial_responses: false
+      partial_response_probability: 0.05
+
+      # Body corruption
+      payload_corruption: false
+      payload_corruption_probability: 0.05
+      corruption_type: none        # none | random_bytes | truncate | bit_flip
+
+      # Per-request matcher: gate fault injection on request properties.
+      # AND across fields, OR within a list. Empty matcher = match all.
+      request_matcher:
+        source_ips:
+          - "10.0.0.0/8"
+          - "192.168.1.42"
+        headers:
+          - name: "x-test"
+            value: "yes"            # omit `value` for presence-only
+        min_body_size_bytes: 1048576
+        chunked_only: true
+```
+
+#### `observability.chaos.rate_limit`
+
+```yaml
+rate_limit:
+  enabled: true
+  requests_per_second: 100
+  burst_size: 10
+  per_ip: true
+  per_endpoint: false
+```
+
+#### `observability.chaos.traffic_shaping`
+
+```yaml
+traffic_shaping:
+  enabled: true
+  bandwidth_limit_bps: 1000000   # 1 MB/s
+  packet_loss_percent: 2.0
+  max_connections: 100
+  connection_timeout_ms: 30000
+```
+
+#### `observability.chaos.circuit_breaker` and `bulkhead`
+
+```yaml
+circuit_breaker:
+  enabled: true
+  failure_threshold: 5
+  success_threshold: 2
+  timeout_ms: 60000
+
+bulkhead:
+  enabled: true
+  max_concurrent_requests: 100
+  max_queue_size: 10
+```
+
+For a tour of the resulting behavior — including which faults get injected
+per-request vs per-connection, and how `connection_error_kind` interacts
+with the chaos listener wrapper — see the
+[Chaos Engineering chapter](../user-guide/chaos-engineering.md) and the
+[reference doc](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/CHAOS_ENGINEERING.md).
+
 ## gRPC Configuration
 
 ### `grpc.proto_dir` (string, default: "proto/")

--- a/book/src/user-guide/advanced-behavior.md
+++ b/book/src/user-guide/advanced-behavior.md
@@ -156,10 +156,65 @@ core:
 ### Fault Types
 
 - **HTTP Error**: Return specific status codes
-- **Connection Error**: Simulate connection failures
-- **Timeout**: Simulate request timeouts
-- **Partial Response**: Truncate responses
+- **Connection Error**: Simulate connection failures (HTTP-503 by default; see below for TCP-level)
+- **Timeout**: Real `tokio::sleep(timeout_ms)` then `504 Gateway Timeout`
+- **Partial Response**: Truncate responses (chunked-aware: keeps Content-Length on non-chunked, drops the terminator on chunked)
 - **Payload Corruption**: Corrupt response payloads
+
+### Per-Request Matchers (v0.3.125+)
+
+By default, fault probabilities apply to every request. To gate fault injection
+on properties of the incoming request — useful for targeting specific clients,
+headers, body sizes, or `Transfer-Encoding: chunked` traffic without affecting
+baseline traffic — add a `request_matcher` block:
+
+```yaml
+fault_injection:
+  enabled: true
+  http_errors: [503]
+  http_error_probability: 0.5     # 50% of *matching* requests get 503
+  request_matcher:
+    source_ips:
+      - "10.0.0.0/8"              # CIDR or bare IP
+      - "192.168.1.42"
+    headers:
+      - name: "x-test"            # case-insensitive name
+        value: "yes"              # omit `value` for presence-only
+    min_body_size_bytes: 1048576  # only requests with body >= 1 MB
+    chunked_only: true            # only Transfer-Encoding: chunked
+```
+
+Semantics: AND across fields, OR within a list. Empty matcher matches every
+request. Applies to all five fault paths (HTTP errors, timeouts, partial
+responses, payload corruption, connection errors).
+
+### Connection Error Wire-Level Behavior (v0.3.125+)
+
+The `connection_error_kind` knob picks what "connection error" means at the
+TCP level:
+
+| Kind | What clients see |
+|---|---|
+| `http_503` (default) | HTTP 503 on a healthy connection — application layer only |
+| `tcp_reset` | TCP RST sent at accept time. Clients see `ECONNRESET`. |
+| `tcp_close` | TCP FIN at accept time. Clients see EOF before any HTTP response. |
+
+```yaml
+fault_injection:
+  enabled: true
+  connection_errors: true
+  connection_error_probability: 0.05
+  connection_error_kind: tcp_reset    # http_503 | tcp_reset | tcp_close
+```
+
+The TCP-level kinds wrap the listener with a chaos accept loop, so the fault
+is per-connection (every request that would have pipelined onto that socket
+is affected). Auto-installed by `mockforge serve` when chaos is enabled and
+the kind is not `http_503`. Plain HTTP only — TLS path doesn't yet support
+TCP-level injection.
+
+For the full reference (every fault config field, hot-reload API, predefined
+scenarios), see the [Chaos Engineering chapter](./chaos-engineering.md).
 
 ## Per-Route Latency Simulation
 

--- a/book/src/user-guide/chaos-engineering.md
+++ b/book/src/user-guide/chaos-engineering.md
@@ -1,0 +1,210 @@
+# Chaos Engineering
+
+MockForge ships a runtime chaos engineering surface that injects controlled
+failures, delays, and resource constraints into your mock or proxy server.
+Use it to test how clients behave when the real backend gets slow, returns
+errors, drops the connection, sends partial responses, or rate-limits you.
+
+> **Two related but distinct features:** this chapter covers the **YAML /
+> runtime config** (loaded by `mockforge serve`). For the in-app
+> [Chaos Lab](./chaos-lab.md) UI and predefined network profiles, see the
+> separate page. Many users want both — the YAML config for headless test
+> runs and the UI for interactive exploration.
+
+The full reference (every config knob, every API endpoint, every predefined
+scenario) lives at
+[docs/CHAOS_ENGINEERING.md](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/CHAOS_ENGINEERING.md).
+This chapter focuses on the patterns most teams reach for first.
+
+## What you can inject
+
+| Category | Examples |
+|---|---|
+| **Latency** | Fixed delay, random range, jitter, probability-based |
+| **HTTP errors** | Any status code, configurable probability, error pattern (burst / random / sequential) |
+| **Connection errors** | HTTP 503 (default), TCP RST, TCP FIN — at the wire level |
+| **Timeouts** | Real `tokio::sleep` then `504 Gateway Timeout` |
+| **Partial responses** | Body truncation; preserves Content-Length on non-chunked, drops the terminator on chunked |
+| **Payload corruption** | Random bytes, bit-flips, truncation |
+| **Rate limiting** | Global, per-IP, per-endpoint with burst |
+| **Traffic shaping** | Bandwidth throttle, packet loss, max connections |
+
+Every fault path can be gated on a per-request matcher (source IP / CIDR,
+header, body size, `Transfer-Encoding: chunked`).
+
+## Quick start
+
+### Enable from the CLI
+
+```bash
+mockforge serve --chaos --chaos-scenario service_instability
+```
+
+`service_instability` is one of five predefined scenarios. The others are
+`network_degradation`, `cascading_failure`, `peak_traffic`, `slow_backend`.
+
+### Enable from a config profile
+
+```yaml
+profiles:
+  flaky:
+    observability:
+      chaos:
+        enabled: true
+        latency:
+          enabled: true
+          fixed_delay_ms: 250
+          jitter_percent: 20
+          probability: 0.5
+        fault_injection:
+          enabled: true
+          http_errors: [500, 503]
+          http_error_probability: 0.1
+```
+
+Run with `mockforge serve --profile flaky`.
+
+## Per-request fault matchers
+
+By default, fault probabilities apply to every request. Add a `request_matcher`
+to gate fault injection on properties of the incoming request — useful for
+targeting specific clients, headers, body sizes, or chunked-encoded traffic
+without affecting baseline traffic.
+
+```yaml
+fault_injection:
+  enabled: true
+  http_errors: [503]
+  http_error_probability: 0.5     # 50% of *matching* requests get 503
+  request_matcher:
+    source_ips:
+      - "10.0.0.0/8"              # CIDR range; bare IP works too
+      - "192.168.1.42"
+    headers:
+      - name: "x-test"            # case-insensitive
+        value: "yes"              # exact value; omit `value` for presence-only
+    min_body_size_bytes: 1048576  # only requests with body >= 1 MB
+    chunked_only: true            # only Transfer-Encoding: chunked requests
+```
+
+Semantics: AND across fields, OR within a list. Empty matcher matches every
+request (preserves prior behavior). Applies to all five fault paths
+(HTTP errors, timeouts, partial responses, payload corruption,
+connection errors).
+
+## TCP-level connection errors
+
+The `connection_error_kind` knob picks the wire-level behavior:
+
+| Kind | What clients see |
+|---|---|
+| `http_503` (default) | HTTP 503 on a healthy connection — application-layer only |
+| `tcp_reset` | TCP RST sent at accept time. Clients see `ECONNRESET`. |
+| `tcp_close` | TCP FIN at accept time. Clients see EOF before any HTTP response. |
+
+```yaml
+fault_injection:
+  enabled: true
+  connection_errors: true
+  connection_error_probability: 0.05
+  connection_error_kind: tcp_reset    # http_503 | tcp_reset | tcp_close
+```
+
+The TCP-level kinds (`tcp_reset`, `tcp_close`) wrap the listener with a chaos
+accept loop, so the fault is per-connection (every request that would have
+pipelined onto that socket is affected). The wrapper installs automatically
+when chaos is enabled and the kind is not `http_503`. Plain HTTP only — TLS
+path doesn't yet support TCP-level injection.
+
+## Timeouts and partial responses
+
+When `timeout_errors: true` fires, MockForge sleeps for `timeout_ms` and then
+returns `504 Gateway Timeout`. The sleep happens *before* the upstream
+handler runs, so the client experiences a true server-side hang followed
+by a 504. Applies uniformly to chunked and non-chunked requests.
+
+When `partial_responses: true` fires, MockForge truncates the response body:
+
+- **Non-chunked response** — preserves the original `Content-Length` header,
+  so clients perceive an unexpected EOF (they expect N bytes, receive fewer).
+- **Chunked response** — cuts before the terminating chunk, surfacing as a
+  real protocol violation (`IncompleteMessage` / `ChunkedDecoderError` in
+  most HTTP clients).
+
+```yaml
+fault_injection:
+  enabled: true
+  timeout_errors: true
+  timeout_ms: 5000
+  timeout_probability: 0.05      # 5% of matching requests hang then 504
+  partial_responses: true
+  partial_response_probability: 0.05  # 5% get a truncated body
+```
+
+## Predefined scenarios
+
+| Scenario | Profile |
+|---|---|
+| `network_degradation` | High latency + packet loss |
+| `service_instability` | Random 5xx errors + timeouts |
+| `cascading_failure` | Combined latency, errors, connection drops, rate limits |
+| `peak_traffic` | Aggressive rate limiting (per-endpoint) |
+| `slow_backend` | Consistent 2 s latency on every request |
+
+```bash
+mockforge serve --chaos --chaos-scenario cascading_failure
+```
+
+You can also start, stop, and combine scenarios at runtime via the management
+API (`POST /api/chaos/scenarios/{name}`, `DELETE /api/chaos/scenarios/{name}`).
+See the [reference doc](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/CHAOS_ENGINEERING.md#management-api)
+for the full API surface.
+
+## Hot-reload
+
+The chaos config is read on every request. Update it via `PUT /api/chaos/config`
+and changes apply immediately to subsequent requests — no restart needed.
+
+## Observability while testing
+
+When chaos is on, you usually want to watch what's happening:
+
+- **TUI dashboard** (in `mockforge-tui`): shows current and lifetime peak CPU,
+  memory, and error rate. The error-rate peak is especially useful for
+  multi-hour soak tests where you might miss a spike.
+- **CSV metrics log**: set `MOCKFORGE_METRICS_LOG_FILE=/var/log/mockforge.csv`
+  to append `timestamp,cpu_pct,mem_mb,total_reqs,err_rate` every 10 s.
+  Survives restarts; chartable in Grafana / spreadsheets / anything.
+- **Prometheus metrics**: expose `/metrics` and scrape with your usual
+  observability stack (`mockforge serve --metrics --metrics-port 9090`).
+
+## Pairing with load testing
+
+Chaos is most useful when you're driving real traffic at the server. Combine
+with [`mockforge bench`](./load-testing.md) to generate that traffic:
+
+```bash
+# Terminal 1 — server with chaos
+mockforge serve --spec api.yaml --chaos --chaos-scenario service_instability
+
+# Terminal 2 — drive load
+mockforge bench --spec api.yaml --target http://localhost:3000 \
+  --vus 50 --duration 5m
+```
+
+For chunked-encoding traffic specifically (e.g. to exercise the
+`chunked_only: true` matcher), use the native generator:
+
+```bash
+mockforge bench-chunked \
+  --target http://localhost:3000/upload \
+  --concurrency 10 --duration 60 \
+  --total-size-bytes 10485760
+```
+
+## Where to go next
+
+- [Reference: full chaos config schema](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/CHAOS_ENGINEERING.md)
+- [Chaos Lab UI](./chaos-lab.md) — the in-app interactive view
+- [Load Testing](./load-testing.md) — generate traffic to exercise chaos
+- [Configuration reference](../configuration/files.md) — every config field

--- a/book/src/user-guide/load-testing.md
+++ b/book/src/user-guide/load-testing.md
@@ -1,0 +1,229 @@
+# Load Testing
+
+MockForge ships first-class load-testing tools that work against any HTTP API
+— your real backend, a MockForge mock, or a hosted test environment. Two
+commands, two purposes:
+
+| Command | When to use |
+|---|---|
+| **`mockforge bench`** | OpenAPI-driven k6 script generation. Best for ramp/spike/soak/constant scenarios across realistic, schema-aware traffic. |
+| **`mockforge bench-chunked`** | Native Rust generator for guaranteed `Transfer-Encoding: chunked` request bodies — chunk size, total size, inter-chunk delay all controllable. |
+
+The full reference lives at
+[docs/bench-command-examples.md](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/bench-command-examples.md)
+and
+[docs/LOAD_TESTING_GUIDE.md](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/LOAD_TESTING_GUIDE.md).
+This chapter covers the patterns most teams reach for first.
+
+## `mockforge bench` — OpenAPI-driven k6
+
+### Quick start
+
+```bash
+mockforge bench \
+  --spec api.yaml \
+  --target http://localhost:3000 \
+  --duration 60 --vus 10 \
+  --scenario ramp-up
+```
+
+That generates a k6 script from `api.yaml`, writes it to `bench-results/`,
+and runs it. The script:
+
+- Walks every operation in the spec
+- Generates realistic placeholder bodies / headers / path params
+- Tracks `http_req_duration` and `http_req_failed` thresholds
+- Prints a summary at the end (and writes `summary.json`)
+
+### Load scenarios
+
+| Scenario | Shape | Use case |
+|---|---|---|
+| `constant` | Flat at `--vus` | Steady-state throughput |
+| `ramp-up` | 0 → vus → 0 | Find capacity ceiling |
+| `spike` | Sudden burst | Test autoscaling response |
+| `stress` | Aggressive ramp past vus | Find breaking point |
+| `soak` | Long duration at moderate load | Memory leaks / degradation |
+
+### Auth and custom headers
+
+```bash
+mockforge bench --spec api.yaml --target https://api.example.com \
+  --auth "Bearer $TOKEN" \
+  --headers "X-Tenant: acme,X-Region: us-east-1"
+```
+
+### Operation filtering
+
+Test only specific endpoints:
+
+```bash
+# Specific operation
+mockforge bench --spec api.yaml --target ... \
+  --operations "GET /users,POST /orders"
+
+# By method
+mockforge bench --spec api.yaml --target ... \
+  --operations "GET"
+
+# Wildcards
+mockforge bench --spec api.yaml --target ... \
+  --operations "* /api/v1/*"
+```
+
+### Generate-only (don't run)
+
+```bash
+mockforge bench --spec api.yaml --target ... \
+  --generate-only --script-output my-load-test.js
+```
+
+Edit the script by hand, then run with k6 directly. Useful for CI/CD where
+the test infrastructure runs k6 on its own.
+
+### Multi-target
+
+```bash
+mockforge bench --spec api.yaml --targets-file targets.txt \
+  --max-concurrency 5 --results-format both
+```
+
+`targets.txt` lists one URL per line; bench runs against all of them in
+parallel and produces per-target + aggregated reports.
+
+## `mockforge bench-chunked` — native chunked traffic
+
+When you need real `Transfer-Encoding: chunked` request bodies on the wire,
+`mockforge bench` (k6/Go-based) may fall back to `Content-Length` because
+Go's HTTP transport decides chunking from body type. `bench-chunked` bypasses
+that — it builds a streaming body via hyper's `Body::wrap_stream` with no
+declared length, so the wire is **always** chunked.
+
+```bash
+mockforge bench-chunked \
+  --target http://localhost:3000/upload \
+  --concurrency 10 --duration 60 \
+  --chunk-size-bytes 4096 \
+  --total-size-bytes 10485760 \
+  --chunk-interval-ms 50 \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+| Flag | Meaning |
+|---|---|
+| `--target` | URL to POST chunked bodies at |
+| `--method` | `POST` (default), `PUT`, or `PATCH` |
+| `--concurrency` | Number of concurrent workers (each holds one connection) |
+| `--duration` | Run length in seconds |
+| `--chunk-size-bytes` | Bytes per chunk emitted into the body stream |
+| `--total-size-bytes` | Total body size per request |
+| `--chunk-interval-ms` | Sleep between chunks (0 = back-to-back) |
+| `--header` | Extra `Name: Value` header; may be repeated |
+| `--insecure` | Skip TLS certificate verification |
+
+### Common patterns
+
+**Slow upload simulation** — high `--chunk-interval-ms` keeps the connection
+open for minutes per request, stressing the server's idle/slow-connection
+handling:
+
+```bash
+mockforge bench-chunked --target http://server/upload \
+  --concurrency 50 --duration 300 \
+  --chunk-size-bytes 256 --total-size-bytes 65536 \
+  --chunk-interval-ms 500
+```
+
+**Large body soak** — find the server's max-body-size limits and memory
+behavior:
+
+```bash
+mockforge bench-chunked --target http://server/upload \
+  --concurrency 5 --duration 180 \
+  --chunk-size-bytes 1048576 --total-size-bytes 1073741824
+```
+
+**Chunked + chaos matching** — pair with `chunked_only: true` in
+`fault_injection.request_matcher` (see
+[Chaos Engineering](./chaos-engineering.md)) to inject faults *only* on
+chunked traffic:
+
+```yaml
+# server config
+fault_injection:
+  enabled: true
+  http_errors: [503]
+  http_error_probability: 0.5
+  request_matcher:
+    chunked_only: true
+```
+
+```bash
+# in another terminal
+mockforge bench-chunked --target http://localhost:3000/upload \
+  --concurrency 10 --duration 60 \
+  --total-size-bytes 1048576
+```
+
+## Pairing with chaos
+
+Load testing alone tells you the *throughput* your server handles. Pair it
+with [chaos engineering](./chaos-engineering.md) to test how it behaves
+when things go wrong:
+
+```bash
+# Terminal 1
+mockforge serve --spec api.yaml --chaos --chaos-scenario cascading_failure
+
+# Terminal 2
+mockforge bench --spec api.yaml --target http://localhost:3000 \
+  --duration 5m --vus 50
+```
+
+Watch the TUI dashboard to see CPU / memory / error-rate spike as chaos
+fires. Set `MOCKFORGE_METRICS_LOG_FILE=metrics.csv` for a persistent record
+of multi-hour runs.
+
+## Watching the run
+
+While a bench is running, you usually want to monitor:
+
+- **`mockforge tui`** — live dashboard with current and peak CPU, memory,
+  error rate. Auto-refreshes every 2 s.
+- **CSV metrics log** — `MOCKFORGE_METRICS_LOG_FILE=path` appends a row per
+  10 s. Persistent record for soak tests.
+- **k6 stdout / `summary.json`** — at the end of the bench run.
+- **Prometheus** — `mockforge serve --metrics --metrics-port 9090`, scrape
+  with your usual stack.
+
+## CI/CD
+
+```bash
+#!/bin/bash
+set -e
+
+# Start MockForge against staging
+mockforge serve --spec api.yaml &
+SERVER=$!
+trap "kill $SERVER" EXIT
+
+# Wait for ready
+until curl -sf http://localhost:3000/__health > /dev/null; do sleep 1; done
+
+# Run bench with thresholds enforced
+mockforge bench --spec api.yaml \
+  --target http://localhost:3000 \
+  --duration 30 --vus 20 \
+  --threshold-percentile 95 \
+  --threshold-ms 250 \
+  --max-error-rate 0.01
+
+# Exit code propagates from k6 — fails the build if thresholds break
+```
+
+## Where to go next
+
+- [Reference: bench command examples](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/bench-command-examples.md)
+- [Reference: load testing guide](https://github.com/SaaSy-Solutions/mockforge/blob/main/docs/LOAD_TESTING_GUIDE.md)
+- [Chaos Engineering](./chaos-engineering.md) — pair load tests with fault injection
+- [k6 Documentation](https://k6.io/docs/) — k6 itself


### PR DESCRIPTION
## Summary

Tier 2 of the docs-vs-code audit. An Explore agent cross-referenced the ~114 mdbook chapters against the current code; this PR fixes the highest-impact findings and adds two native chapters that previously lived only in `docs/`.

## New mdbook chapters

| File | What it covers |
|---|---|
| **`book/src/user-guide/chaos-engineering.md`** | Native coverage of the YAML chaos surface — `request_matcher`, `connection_error_kind`, partial responses, real timeouts, predefined scenarios, hot-reload. Distinct from `chaos-lab.md` (UI feature); both cross-link. |
| **`book/src/user-guide/load-testing.md`** | Native coverage of `mockforge bench` (k6) and `mockforge bench-chunked` (hyper). Common-pattern recipes + CI/CD example + chunked-traffic patterns. |
| **`book/src/SUMMARY.md`** | New "Testing & Resilience" section listing both. |

## Architecture page rewrite (the audit's only `WRONG` finding)

`development/architecture.md` listed 7 crates; the workspace has **56**. Replaced with grouped tables (Foundation / Protocols / Plugin Layer / Bench-Test-Observability / User-Facing / Infrastructure) so future drift is easier to spot.

## Per-chapter fixes

| Chapter | Added |
|---|---|
| `configuration/environment.md` | Full RAG/LLM env vars (`MOCKFORGE_RAG_API_ENDPOINT`, `MAX_TOKENS`, `CONTEXT_WINDOW`, `TIMEOUT_SECONDS`, `MAX_RETRIES`); embedding vars; `MOCKFORGE_REGISTRY_TOKEN`. Mirrors Tier 1's CONFIG.md additions. |
| `user-guide/advanced-behavior.md` | Per-route fault injection now documents `request_matcher` (IP/header/body-size/chunked filtering), `connection_error_kind` (`http_503`/`tcp_reset`/`tcp_close`), and the fixed timeout semantics (sleep+504, decoupled from partial). |
| `api/cli.md` | New `bench`, `bench-chunked`, and `tui` sections with full flag documentation. |
| `reference/config-schema.md` | New "Full Chaos Engineering Surface" section — `fault_injection` (incl. `error_pattern` and `request_matcher`), `rate_limit`, `traffic_shaping`, `circuit_breaker`, `bulkhead`. Legacy flat fields stay for back-compat. |

## Verification

- [x] `mdbook build book` — clean
- [x] All pre-commit hooks pass (typos, etc.)
- [x] No new public API; pure docs

## Tracked separately

- **Tier 3**: triage of ~200 internal status/planning docs in `docs/` (most likely archive candidates).
- **Tier 4**: CI gate so docs can't silently rot between releases.
- **Audit follow-ups not in this PR** (each ~30-90 min, worth their own PR): observability/metrics chapter, rate-limiting chapter, TUI dashboard chapter, AI/RAG generation chapter, plugin system deep-dive.

Refs: #79