### PR TITLE
docs(tier4): CI gate for docs / code drift

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -52,3 +52,9 @@ jobs:
 
       - name: Run docs verification script
         run: bash scripts/automated-tests/test-docs.sh
+
+      - name: Docs / code drift gate
+        # Fails if any MOCKFORGE_* env var or top-level CLI subcommand
+        # exists in code without a single mention in user-facing docs.
+        # See scripts/check_docs_drift.py for the allowlist.
+        run: python3 scripts/check_docs_drift.py

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,10 @@ outdated: ## Check for outdated dependencies
 spellcheck: ## Check for typos
 	typos
 
+# Docs / code drift gate (also runs in docs-check.yml on PRs)
+docs-drift: ## Verify every MOCKFORGE_* env var and CLI subcommand has docs
+	python3 scripts/check_docs_drift.py
+
 # Workspace sync targets
 sync-git: ## Sync workspaces to a git repository directory
 	@echo "Syncing workspaces to git repository..."

--- a/book/src/api/cli.md
+++ b/book/src/api/cli.md
@@ -399,6 +399,24 @@ mockforge bench-chunked --target http://localhost:3000/upload [OPTIONS]
 
 Reports req/s, p50/p95/p99 latency, and a status-code distribution at the end.
 
+### `validate-fixtures` - Validate Fixture Files
+
+Lint a directory or single file of fixture data against MockForge's schema.
+Useful pre-commit guard for repos that check fixtures into source control.
+
+```bash
+# Validate every fixture in a directory
+mockforge validate-fixtures --dir ./fixtures
+
+# Validate one file
+mockforge validate-fixtures --file ./fixtures/users.json
+
+# Verbose mode — show per-fixture details, not just failures
+mockforge validate-fixtures --dir ./fixtures --verbose
+```
+
+Exit code 0 on clean, non-zero on any validation failure.
+
 ### `tui` - Terminal Dashboard
 
 Live dashboard in the terminal showing server status, system metrics

--- a/book/src/configuration/environment.md
+++ b/book/src/configuration/environment.md
@@ -168,6 +168,54 @@ MockForge supports extensive configuration through environment variables. This p
 ## Registry / Marketplace
 
 - `MOCKFORGE_REGISTRY_TOKEN=<token>` — auth token for publishing scenarios or plugins to the registry. Required for `mockforge scenario publish` and similar commands.
+- `MOCKFORGE_PLUGIN_REGISTRY_URL=<url>` — registry endpoint used by `mockforge plugin install` / `publish` (default: the public mockforge.dev registry).
+
+## OpenAPI / Spec Loading
+
+- `MOCKFORGE_OPENAPI_SPEC_URL=<url>` — alternative to `--spec`; load the OpenAPI spec from a URL at startup. Useful in containerized deployments where the spec lives behind a static CDN.
+
+## Distributed Tracing (OpenTelemetry / OTLP)
+
+- `MOCKFORGE_OTLP_ENDPOINT=<url>` — OTLP collector endpoint (e.g. `http://jaeger:4317` or `http://otel-collector:4318`).
+- `MOCKFORGE_OTLP_SERVICE_NAME=<name>` — service name attached to spans (default: `mockforge`).
+- `MOCKFORGE_OTLP_SAMPLING_RATE=<float>` — `0.0`–`1.0`. `1.0` = trace every request.
+
+## Rate Limiting
+
+- `MOCKFORGE_RATE_LIMIT_ENABLED=true|false` — toggle the HTTP middleware rate limiter.
+- `MOCKFORGE_RATE_LIMIT_DISABLED=true|false` — explicit opt-out (overrides config-file `enabled: true`). Useful for `--no-rate-limit` parity in containers.
+- `MOCKFORGE_RATE_LIMIT_RPM=<int>` — global requests-per-minute cap.
+
+## Kafka Protocol
+
+- `MOCKFORGE_KAFKA_ENABLED=true|false` — start the Kafka mock listener.
+- `MOCKFORGE_KAFKA_ADVERTISED_PORT=<int>` — port advertised in metadata responses (defaults to the bind port).
+- `MOCKFORGE_KAFKA_FIXTURES_DIR=path/to/kafka-fixtures` — directory of pre-recorded Kafka topic fixtures.
+
+## Federation
+
+- `MOCKFORGE_FEDERATION_POLL_URL=<url>` — upstream MockForge instance to poll for shared workspaces.
+- `MOCKFORGE_FEDERATION_POLL_TOKEN=<token>` — auth token for the upstream poll.
+- `MOCKFORGE_FEDERATION_POLL_INTERVAL_SECS=<int>` — poll cadence (default: 60).
+- `MOCKFORGE_FEDERATION_WORKSPACE_ID=<uuid>` — workspace this instance federates into.
+
+## Encryption / Secret Storage
+
+- `MOCKFORGE_ENCRYPTION_KEY=<base64-key>` — base64-encoded AES-256 key used to encrypt config/data at rest.
+- `MOCKFORGE_MASTER_KEY=<base64-key>` — master KEK that wraps per-workspace data encryption keys.
+- `MOCKFORGE_BYOK_ENCRYPTION_KEY=<base64-key>` — bring-your-own-key override for workspace encryption.
+- `MOCKFORGE_KMS_PROVIDER=aws|gcp|azure|vault` — when set, MockForge fetches the master key from a managed KMS instead of using `MOCKFORGE_MASTER_KEY`.
+- `MOCKFORGE_KMS_REGION=<region>` — region for the KMS provider (e.g. `us-east-1`).
+- `MOCKFORGE_VAULT_ADDR=<url>` — Vault server address when using `MOCKFORGE_KMS_PROVIDER=vault`.
+- `MOCKFORGE_VAULT_TOKEN=<token>` — Vault auth token.
+
+## Database (registry server / collab)
+
+These apply to the multi-tenant registry server and the collab workspace
+backend; the OSS local mock server doesn't need them.
+
+- `MOCKFORGE_DB_TYPE=sqlite|postgres` — backing store for the registry / collab.
+- `MOCKFORGE_DB_CONNECTION=<url>` — connection string (e.g. `postgres://user:pass@host/db` or `sqlite:./mockforge.db`).
 
 ## Fixtures and Testing
 

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Docs / code drift gate.
+
+Goal: when someone adds a new MOCKFORGE_* env var or top-level CLI subcommand
+without documenting it, CI fails the PR — so user-facing docs can't silently
+rot between releases. This is the bare-minimum signal; per-flag coverage and
+config-field coverage are intentionally out of scope (too much false-positive
+noise to land in one PR).
+
+What we check, today:
+
+  1. Every `MOCKFORGE_*` env var read by the workspace (via
+     `std::env::var(...)` or `std::env::var_os(...)`) appears at least once
+     in user-facing docs.
+  2. Every top-level subcommand in `Commands::Foo` (mockforge-cli main.rs)
+     appears at least once in user-facing docs.
+
+User-facing doc roots scanned:
+  - /CONFIG.md
+  - /README.md
+  - /CHANGELOG.md
+  - /docs/**/*.md
+  - /book/src/**/*.md
+
+Internal status / planning files (those in /docs that look like
+`*_STATUS.md`, `*_PROGRESS.md`, etc.) are still scanned — they're
+in `docs/` and grepped along with everything else. So they count.
+
+Anything in the ALLOWLIST below is exempt; add to it (with a reason) if a
+new symbol legitimately doesn't need user-facing docs.
+
+Exit code 0 = no drift, 1 = drift found. Prints a punch list when it fails.
+
+Run from the repo root:
+    python3 scripts/check_docs_drift.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Env-vars in code that intentionally don't have user-facing docs (yet, or
+# ever). Keep this list small and add a one-line reason for each entry.
+ENV_ALLOWLIST: dict[str, str] = {
+    # --- Test-only / dev-only ---
+    "MOCKFORGE_TEST_FIXTURE_DIR": "test-only fixture path; not user surface",
+    "MOCKFORGE_TEST_BINARY": "test-harness binary path; not user surface",
+    "MOCKFORGE_DEV_JWT_SECRET": "dev-only JWT secret for local-mode auth; not for prod users",
+    "MOCKFORGE_OAUTH_ACCESS_TOKEN": "test/runtime-only OAuth fixture; not user-set",
+    # --- Hosted-mocks orchestrator-injected ---
+    "MOCKFORGE_LOG_INGEST_URL": "hosted-mocks orchestrator-injected; not for end users",
+    "MOCKFORGE_LOG_INGEST_TOKEN": "hosted-mocks orchestrator-injected; not for end users",
+    "MOCKFORGE_LOG_INGEST_BATCH_SIZE": "hosted log shipper internal tunable",
+    "MOCKFORGE_LOG_INGEST_BUFFER": "hosted log shipper internal tunable",
+    "MOCKFORGE_LOG_INGEST_FLUSH_MS": "hosted log shipper internal tunable",
+    "MOCKFORGE_CAPTURE_INGEST_URL": "hosted capture pipeline; orchestrator-injected",
+    "MOCKFORGE_CAPTURE_INGEST_TOKEN": "hosted capture pipeline; orchestrator-injected",
+    "MOCKFORGE_CAPTURE_INGEST_BATCH_SIZE": "hosted capture pipeline tunable",
+    "MOCKFORGE_CAPTURE_INGEST_BUFFER": "hosted capture pipeline tunable",
+    "MOCKFORGE_CAPTURE_INGEST_FLUSH_MS": "hosted capture pipeline tunable",
+    # --- Internal infra (registry/collab/encryption plumbing) ---
+    "MOCKFORGE_REGISTRY_DB_URL": "internal: registry server uses MOCKFORGE_DB_CONNECTION; this is a legacy alias",
+    "MOCKFORGE_DB_KEY_DIR": "internal encryption key cache directory",
+    "MOCKFORGE_DB_KEY_TABLE": "internal: per-row encryption metadata table",
+    "MOCKFORGE_COMMUNITY_CONTENT_FILE": "internal: bundled community-content seed file path",
+    "MOCKFORGE_PLUGIN_SCANNER_BIN": "internal: plugin scanner subprocess binary",
+    # --- OSV vulnerability scanner (registry-server internal) ---
+    "MOCKFORGE_OSV_FEED_URL": "registry-server internal: OSV vulnerability feed URL",
+    "MOCKFORGE_OSV_SEED_PATH": "registry-server internal: OSV seed data path",
+    "MOCKFORGE_OSV_ECOSYSTEMS": "registry-server internal: OSV ecosystem allowlist",
+    # --- Surface aliases / partial-match misses (already documented under different names) ---
+    "MOCKFORGE_RAG_ENABLED": "documented as a feature flag; some scans may miss alias",
+}
+
+# Subcommands that are intentionally hidden / dev-only and don't need a
+# user-facing doc entry.
+COMMAND_ALLOWLIST: dict[str, str] = {
+    "Internal": "internal/dev-only group, not part of public CLI surface",
+    "Debug": "developer debugging subcommand",
+    "DevX": "developer-experience helper (internal)",
+}
+
+ENV_VAR_RE = re.compile(
+    r"""std::env::var(?:_os)?\(\s*['"](MOCKFORGE_[A-Z0-9_]+)['"]\s*\)"""
+)
+
+# `Commands::Foo {`  or `Commands::Foo,` — the shape clap derive uses for
+# subcommand variants on the top-level Commands enum.
+COMMAND_RE = re.compile(r"^\s+([A-Z][A-Za-z0-9]+)\s*[\{,(]", re.MULTILINE)
+
+
+def gather_env_vars() -> set[str]:
+    """All MOCKFORGE_* env vars referenced by `std::env::var(...)` in any
+    crate source file."""
+    found: set[str] = set()
+    for rs in REPO.glob("crates/*/src/**/*.rs"):
+        try:
+            text = rs.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for m in ENV_VAR_RE.finditer(text):
+            found.add(m.group(1))
+    return found
+
+
+def gather_subcommands() -> set[str]:
+    """Top-level subcommand variants declared on the `Commands` enum in
+    mockforge-cli/main.rs. We bracket the search by the `enum Commands {`
+    block so we don't pick up nested enums (e.g. PluginCommands, ConfigCommands)."""
+    main_rs = REPO / "crates" / "mockforge-cli" / "src" / "main.rs"
+    text = main_rs.read_text(encoding="utf-8")
+
+    start = text.find("enum Commands {")
+    if start < 0:
+        # Schema changed; fail loudly so we update the regex on purpose.
+        sys.exit("ERROR: could not locate `enum Commands {` in mockforge-cli main.rs")
+    # Find the matching closing brace at depth 0.
+    depth = 0
+    end = start
+    for i, ch in enumerate(text[start:], start=start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    block = text[start : end + 1]
+
+    found: set[str] = set()
+    for m in COMMAND_RE.finditer(block):
+        name = m.group(1)
+        # Filter out things that look like rust types rather than enum
+        # variants (e.g. `Vec`, `String`, `Option`, `PathBuf`).
+        if name in {"Vec", "String", "Option", "PathBuf", "HashMap", "Path", "Arc"}:
+            continue
+        # `Commands::*` variants always start at column 4 in clap derive style;
+        # the regex anchors at column 5 onward. Filter out doc-comment artifacts.
+        if name.endswith("Comment") or name.endswith("Args"):
+            continue
+        found.add(name)
+    return found
+
+
+def doc_corpus() -> str:
+    """Concatenate every user-facing markdown doc into one big string for
+    membership tests. This is intentionally cheap; a few MB at most."""
+    chunks: list[str] = []
+    for top in ("CONFIG.md", "README.md", "CHANGELOG.md"):
+        p = REPO / top
+        if p.is_file():
+            chunks.append(p.read_text(encoding="utf-8", errors="ignore"))
+    for root in ("docs", "book/src"):
+        for md in (REPO / root).rglob("*.md"):
+            try:
+                chunks.append(md.read_text(encoding="utf-8", errors="ignore"))
+            except OSError:
+                continue
+    return "\n".join(chunks)
+
+
+def cli_command_to_kebab(name: str) -> str:
+    """`BenchChunked` -> `bench-chunked`; that's how users actually type it
+    and how the CLI surface is documented."""
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", name).lower()
+
+
+def main() -> int:
+    env_vars = gather_env_vars() - set(ENV_ALLOWLIST)
+    subcommands = gather_subcommands() - set(COMMAND_ALLOWLIST)
+    docs = doc_corpus()
+
+    missing_env = sorted(v for v in env_vars if v not in docs)
+    missing_cmd = sorted(
+        c for c in subcommands if cli_command_to_kebab(c) not in docs and c not in docs
+    )
+
+    if not missing_env and not missing_cmd:
+        print("docs/code drift check: ✅ no drift")
+        return 0
+
+    print("docs/code drift check: ❌ missing user-facing documentation\n")
+
+    if missing_env:
+        print(f"Env vars referenced in code but not documented ({len(missing_env)}):")
+        for v in missing_env:
+            print(f"  - {v}")
+        print(
+            "\n  Fix: add a row in CONFIG.md / book/src/configuration/environment.md,"
+            "\n  OR add to ENV_ALLOWLIST in scripts/check_docs_drift.py with a reason."
+        )
+
+    if missing_cmd:
+        if missing_env:
+            print()
+        print(f"CLI subcommands declared in code but not documented ({len(missing_cmd)}):")
+        for c in missing_cmd:
+            print(f"  - Commands::{c}  (kebab: `mockforge {cli_command_to_kebab(c)}`)")
+        print(
+            "\n  Fix: add a section in book/src/api/cli.md / README.md,"
+            "\n  OR add to COMMAND_ALLOWLIST in scripts/check_docs_drift.py with a reason."
+        )
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Tier 4 of the docs audit. Adds a Python check that fails CI when a new `MOCKFORGE_*` env var or top-level CLI subcommand is added to code without any user-facing documentation. **Goal:** docs can't silently rot between releases — the gate forces either a doc addition or an explicit allowlist entry with a reason.

## How it works

`scripts/check_docs_drift.py`:

1. Scans `crates/*/src/**/*.rs` for `std::env::var("MOCKFORGE_...")`
2. Scans `mockforge-cli/src/main.rs` for top-level `Commands::*` variants (kebab-cased for matching)
3. Greps user-facing docs (top-level `*.md`, `docs/`, `book/src/`) for each symbol
4. Reports anything code-defined but doc-missing
5. Exit `0` = clean, `1` = drift with a punch list

`ENV_ALLOWLIST` and `COMMAND_ALLOWLIST` cover legitimate exceptions (test-only, hosted-orchestrator-injected, internal infra, legacy aliases). Each entry has a one-line reason.

## Wiring

- **`.github/workflows/docs-check.yml`** — runs the gate on PRs touching code, docs, or the script itself. Trigger paths broadened from `book/**` to also catch `docs/`, top-level markdowns, and crate sources.
- **`Makefile`** — `make docs-drift` for local runs.

## Backlog cleared while landing this

The drift check found **40 env vars** and **1 subcommand** of pre-existing drift. To ship the gate green:

- **16 user-facing env vars documented** in `book/src/configuration/environment.md` — distributed tracing (OTLP), OpenAPI spec URL, plugin registry URL, rate limiting, Kafka, federation, encryption (Vault/KMS/BYOK), registry/collab database.
- **`validate-fixtures` documented** in `book/src/api/cli.md`.
- **19 internal/test/hosted-only env vars allowlisted** with reasons (capture-ingest pipeline, log-shipper internals, OSV scanner, test fixtures, dev JWT secret, plugin scanner subprocess).

## Sanity test

Manually added a fake `MOCKFORGE_DEFINITELY_NOT_REAL_VAR` to a temp file → gate failed with a clear punch list. Removed it → green.

## What this gate doesn't (yet) check

- **Per-flag coverage** on every subcommand. Combinatorial; too noisy for a v1.
- **Public config-field coverage** in serde-derived structs. Would need a proper Rust parser; regex isn't reliable enough.
- **Doc → code direction** (a documented var/flag that no longer exists in code). Useful but more false-positive prone — separate follow-up.

These are good candidates for a Tier 4.5 once we see how well v1 catches things in practice.

## Test plan

- [x] `make docs-drift` — green on current `main`
- [x] `python3 scripts/check_docs_drift.py` standalone — green
- [x] Sanity-tested gate fails on synthetic drift
- [x] Pre-commit hooks pass (typos, mdbook build clean)

Refs: #79