### PR TITLE
docs(book): add observability, rate-limiting, and TUI-dashboard chapters

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -55,6 +55,9 @@
 
 - [Load Testing](user-guide/load-testing.md)
 - [Chaos Engineering](user-guide/chaos-engineering.md)
+- [Rate Limiting & Traffic Shaping](user-guide/rate-limiting.md)
+- [Observability & Metrics](user-guide/observability.md)
+- [TUI Dashboard](user-guide/tui-dashboard.md)
 
 ## Team and Cloud
 

--- a/book/src/user-guide/observability.md
+++ b/book/src/user-guide/observability.md
@@ -1,0 +1,201 @@
+# Observability & Metrics
+
+When MockForge is sitting in front of real client traffic — load tests, soak
+tests, integration test suites running for hours — you usually need three
+things:
+
+1. **Live numbers.** What's the server doing right now?
+2. **Structured metrics.** Pull into Grafana / Datadog / your dashboarding tool.
+3. **A persistent record.** When you come back tomorrow, what was the worst
+   case overnight?
+
+MockForge ships all three. Pick whichever fits your workflow.
+
+| Surface | Source of truth | When to use |
+|---|---|---|
+| TUI dashboard | In-process | Local dev, quick eyeballing |
+| Prometheus `/metrics` | In-process Prometheus registry | You already run Prometheus / Grafana |
+| OpenTelemetry / OTLP | OTLP exporter → collector | You already run Jaeger / Tempo / Honeycomb |
+| CSV metrics log | `MOCKFORGE_METRICS_LOG_FILE` env var | Multi-day soak tests; want a flat file |
+
+These aren't mutually exclusive — turn on whichever combination fits.
+
+## TUI dashboard
+
+```bash
+mockforge tui
+```
+
+Live dashboard in the terminal. Auto-refreshes every 2 s. Shows current and
+**lifetime peak** CPU / memory / error rate next to the live numbers, so
+you can leave it open during a soak test and glance at it later to see what
+the worst case was.
+
+For the full panel layout and keybindings, see the
+[TUI Dashboard chapter](./tui-dashboard.md).
+
+## Prometheus metrics
+
+Enable the metrics endpoint when starting the server:
+
+```bash
+mockforge serve --spec api.yaml --metrics --metrics-port 9090
+```
+
+Scrape `http://localhost:9090/metrics` from Prometheus. Default port is
+`9090`; change with `--metrics-port` or in config:
+
+```yaml
+observability:
+  metrics:
+    enabled: true
+    port: 9090
+    path: "/metrics"
+```
+
+### What gets exported
+
+Mock server core:
+- `http_requests_total` (counter, labels: `method`, `path`, `status`)
+- `http_request_duration_seconds` (histogram, labels: `method`, `path`)
+- `active_connections` (gauge, labels: `protocol`)
+- `mock_response_generations_total` (counter, labels: `template_type`)
+
+Chaos engine (when `--chaos` is on):
+- `chaos_faults_injected_total` (counter, labels: `kind`, `endpoint`) — kind ∈ `http_error`, `connection_error`, `timeout`, `partial_response`, `payload_corruption`
+- `chaos_latency_injected_seconds` (histogram, labels: `endpoint`)
+- `chaos_rate_limit_violations_total` (counter, labels: `kind`) — kind ∈ `global`, `per_ip`, `per_endpoint`
+- `chaos_circuit_breaker_state` (gauge: `0` closed, `1` half-open, `2` open)
+- `chaos_bulkhead_concurrent` (gauge)
+- `chaos_scenarios_total` (counter, labels: `scenario`, `event`)
+
+Resilience features:
+- `chaos_orchestration_step_duration_seconds` (histogram)
+- `chaos_orchestration_executions_total` (counter, labels: `status`)
+- `chaos_assertion_results_total` (counter, labels: `result`)
+
+### Grafana starter dashboard
+
+A starter Grafana dashboard JSON ships in the repo at
+`book/src/assets/mockforge-starter.json` (when present in your install).
+Import via Grafana **Dashboards → Import** and pick your Prometheus data
+source. The dashboard graphs request rate, p50/p95/p99 latency, error rate,
+and per-fault chaos counters by default.
+
+## OpenTelemetry / OTLP
+
+For distributed tracing, MockForge can export OTLP spans to any compatible
+collector (Jaeger, Tempo, Honeycomb, Datadog, etc.).
+
+```bash
+MOCKFORGE_OTLP_ENDPOINT=http://otel-collector:4317 \
+MOCKFORGE_OTLP_SERVICE_NAME=mockforge \
+MOCKFORGE_OTLP_SAMPLING_RATE=1.0 \
+  mockforge serve --spec api.yaml --tracing
+```
+
+YAML form:
+
+```yaml
+observability:
+  tracing:
+    enabled: true
+    exporter: otlp                    # otlp | jaeger
+    otlp:
+      endpoint: "http://otel-collector:4317"
+      service_name: "mockforge"
+      sampling_rate: 1.0              # 0.0–1.0, 1.0 = trace every request
+    # Or, for legacy Jaeger native:
+    jaeger:
+      endpoint: "http://jaeger:14268/api/traces"
+```
+
+### What gets traced
+
+Each incoming HTTP / gRPC / WebSocket request opens a top-level span with
+attributes: `http.method`, `http.route`, `http.status_code`, `mockforge.protocol`.
+Inner spans cover:
+
+- OpenAPI route matching
+- Template expansion
+- Plugin invocation (one span per plugin call)
+- Chaos middleware decisions (latency injected, faults injected)
+- Upstream proxy calls (if you're running in proxy mode)
+
+Sampling is head-based at `sampling_rate`. For chaos / load testing where
+you only care about the long tail, set `0.01` and have your collector
+upweight on `error=true` spans.
+
+### Pairing with metrics
+
+OTLP and Prometheus aren't either/or. A common pattern:
+
+- **Prometheus** for rate / error / duration RED metrics (cheap, always on).
+- **OTLP** for individual request traces (sampled, on for investigations).
+
+Both can run simultaneously. Run a combined demo with:
+
+```bash
+MOCKFORGE_OTLP_ENDPOINT=http://localhost:4317 \
+  mockforge serve --spec api.yaml \
+    --metrics --metrics-port 9090 \
+    --tracing
+```
+
+## CSV metrics log (multi-day soak)
+
+For long-running test scenarios where you want a flat record that survives
+a server restart and chart in any tool:
+
+```bash
+MOCKFORGE_METRICS_LOG_FILE=/var/log/mockforge-metrics.csv \
+  mockforge serve --spec api.yaml --admin
+```
+
+Appends one row every 10 s:
+
+```
+timestamp,cpu_pct,mem_mb,total_reqs,err_rate
+2026-05-02T12:00:00Z,3.45,412,12345,0.012
+2026-05-02T12:00:10Z,4.12,415,12567,0.013
+```
+
+Parse with anything (`pandas`, `awk`, Grafana CSV data source, Excel). Header
+is written when the file is empty/new; existing files just get appended to,
+so multiple runs accumulate.
+
+## Combining all four
+
+For a real chaos / load test you usually want everything at once:
+
+```bash
+# Server: chaos + metrics + tracing + CSV log
+MOCKFORGE_OTLP_ENDPOINT=http://otel-collector:4317 \
+MOCKFORGE_METRICS_LOG_FILE=/var/log/mockforge-soak.csv \
+  mockforge serve \
+    --spec api.yaml \
+    --chaos --chaos-scenario service_instability \
+    --metrics --metrics-port 9090 \
+    --tracing \
+    --admin --admin-port 9080
+
+# Watch live in one terminal
+mockforge tui
+
+# Drive load in another
+mockforge bench --spec api.yaml --target http://localhost:3000 \
+  --duration 6h --vus 50
+```
+
+Now you have:
+- **Live**: TUI shows current state + peak readouts.
+- **Streaming**: Prometheus `/metrics` for Grafana panels.
+- **Sampled deep-dives**: OTLP traces for individual problem requests.
+- **Persistent**: CSV log survives the run for next-day analysis.
+
+## Where to go next
+
+- [TUI Dashboard](./tui-dashboard.md) — full panel reference
+- [Rate Limiting & Traffic Shaping](./rate-limiting.md) — knobs that show up in chaos counters
+- [Chaos Engineering](./chaos-engineering.md) — what generates the metric movement
+- [Load Testing](./load-testing.md) — how to drive load past it

--- a/book/src/user-guide/rate-limiting.md
+++ b/book/src/user-guide/rate-limiting.md
@@ -1,0 +1,186 @@
+# Rate Limiting & Traffic Shaping
+
+Rate limiting and traffic shaping live in the chaos engine but they're
+useful well beyond chaos scenarios. This chapter covers them on their own
+because most teams reach for them outside of fault injection — to rehearse
+client-side backoff, throttle local dev environments, or simulate flaky
+backhaul during integration tests.
+
+## Rate Limiting
+
+Cap the request rate at the HTTP layer. Three scopes you can combine:
+
+| Scope | Use case |
+|---|---|
+| **Global** | "Cap everything at 100 RPS" — load shedding |
+| **Per-IP** | "Each client gets 10 RPS" — abuse mitigation |
+| **Per-endpoint** | "`/login` gets 5 RPS" — per-route policy |
+
+YAML config:
+
+```yaml
+observability:
+  chaos:
+    enabled: true
+    rate_limit:
+      enabled: true
+      requests_per_second: 100        # token-bucket refill rate
+      burst_size: 10                  # additional tokens for short spikes
+      per_ip: true                    # token bucket per source IP
+      per_endpoint: false             # token bucket per (method, path)
+```
+
+Quick CLI form:
+
+```bash
+mockforge serve --spec api.yaml --chaos --chaos-rate-limit 100
+```
+
+Rejected requests return `429 Too Many Requests` with body
+`Rate limit exceeded`. Counts as a `chaos_rate_limit_violations_total` metric
+labeled by scope (`global` / `per_ip` / `per_endpoint`) so dashboards can
+distinguish.
+
+### Disabling for trusted clients
+
+```bash
+# CLI flag
+mockforge serve --spec api.yaml --no-rate-limit
+
+# Or env var (preferred for SDK / Docker / k8s setups)
+MOCKFORGE_RATE_LIMIT_ENABLED=false mockforge serve --spec api.yaml
+```
+
+For a related case where requests still hit the limit middleware but get
+exempted, see the **per-request matchers** in
+[Chaos Engineering](./chaos-engineering.md) — you can scope rate limits to
+only requests with certain headers or source IPs.
+
+### Burst behavior
+
+Rate limiting uses token-bucket semantics, not a hard request-per-second
+cap:
+
+- `requests_per_second: 100, burst_size: 10` allows 110 requests in the
+  first second (refill + initial burst), then 100 RPS sustained.
+- Use a small burst (e.g. 10–20% of RPS) for "smooth client traffic with
+  occasional spikes." Use a large burst (e.g. 2× RPS) for "I want to
+  observe what happens when traffic spikes briefly."
+
+## Traffic Shaping
+
+Sub-application-layer constraints. Rate limiting throttles requests; traffic
+shaping throttles bytes and connections.
+
+```yaml
+observability:
+  chaos:
+    enabled: true
+    traffic_shaping:
+      enabled: true
+      bandwidth_limit_bps: 1000000     # 1 MB/s, 0 = unlimited
+      packet_loss_percent: 2.0         # randomly drop 2% of "packets"
+      max_connections: 100             # reject when accept queue > 100
+      connection_timeout_ms: 30000     # drop idle connections after 30s
+```
+
+### Bandwidth throttling
+
+Caps bytes/sec going through the HTTP layer. Useful for:
+
+- Simulating slow clients (3G, dial-up, satellite).
+- Pairing with `mockforge bench --duration 60` to see how the client
+  handles low-bandwidth conditions.
+- Stress-testing buffer / backpressure logic.
+
+CLI:
+
+```bash
+mockforge serve --spec api.yaml --chaos --chaos-bandwidth-limit 100000
+```
+
+(100 KB/s.)
+
+### Packet loss
+
+Randomly returns `408 Request Timeout` for the configured percentage of
+requests. Not real packet loss at the network layer — that requires `tc` or
+`iptables`. The HTTP-layer simulation is enough to test client-side retry /
+timeout logic in most cases.
+
+```bash
+mockforge serve --spec api.yaml --chaos --chaos-packet-loss 5
+```
+
+### Connection limits
+
+Caps the number of concurrent connections the listener accepts. New
+connections beyond `max_connections` get rejected with `503 Service
+Unavailable`. Useful for testing connection-pool exhaustion in clients.
+
+## Predefined network profiles
+
+For common real-world conditions, MockForge ships built-in network profiles
+that combine latency + bandwidth + connection-error rates:
+
+| Profile | Latency | Bandwidth | Notes |
+|---|---|---|---|
+| `slow_3g` | 400 ms | 400 KB/s | + 1% packet loss |
+| `fast_3g` | 150 ms | 1.5 MB/s | + 0.5% packet loss |
+| `flaky_wifi` | 50 ms | unlimited | + 5% packet loss + 3% disconnects |
+| `cable` | 20 ms | 10 MB/s | clean |
+| `dialup` | 2 s | 50 KB/s | + 2% packet loss |
+
+```bash
+mockforge serve --spec api.yaml --chaos-profile slow_3g
+```
+
+Or list and apply via the management API:
+
+```bash
+curl http://localhost:3000/api/chaos/profiles            # list
+curl -X POST http://localhost:3000/api/chaos/profiles/slow_3g/apply
+```
+
+## Example: rehearse client backoff
+
+Question you want to answer: *does my client handle 429s with exponential
+backoff?*
+
+```bash
+# Server: 10 RPS cap, return 429 above that
+mockforge serve --spec api.yaml --chaos --chaos-rate-limit 10
+
+# Drive 50 RPS at it
+mockforge bench --spec api.yaml --target http://localhost:3000 \
+  --vus 50 --duration 30 --scenario constant
+```
+
+Watch the bench output for `http_req_failed` rate. A correctly-implemented
+client with backoff will show error rate climbing initially then settling
+near 80% (40 RPS rejected). A client without backoff will show error rate
+flat at ~80% for the whole run.
+
+## Example: low-bandwidth soak
+
+```bash
+mockforge serve --spec api.yaml \
+  --chaos --chaos-bandwidth-limit 100000 \
+  --chaos --chaos-packet-loss 1.0 \
+  --metrics --metrics-port 9090
+
+mockforge bench --spec api.yaml --target http://localhost:3000 \
+  --vus 5 --duration 1h --scenario soak
+```
+
+Now scrape Prometheus / watch `mockforge tui` for memory growth — slow
+clients tend to surface buffering bugs.
+
+## Where to go next
+
+- [Chaos Engineering](./chaos-engineering.md) — full chaos config (combine
+  rate-limit / traffic-shaping with fault injection)
+- [Observability & Metrics](./observability.md) — `chaos_rate_limit_violations_total`
+  labels and dashboards
+- [Load Testing](./load-testing.md) — driving load through these limits
+- [Reference: full config schema](../reference/config-schema.md)

--- a/book/src/user-guide/tui-dashboard.md
+++ b/book/src/user-guide/tui-dashboard.md
@@ -1,0 +1,144 @@
+# TUI Dashboard
+
+`mockforge tui` is a terminal dashboard you point at a running MockForge
+admin server. It's the fastest way to see what's happening: live metrics,
+recent requests, chaos events, fixture inventory, error logs — all on one
+screen, no browser.
+
+```bash
+# Start the server with admin enabled
+mockforge serve --spec api.yaml --admin --admin-port 9080
+
+# In another terminal
+mockforge tui
+```
+
+The TUI talks to the admin server's HTTP API (default
+`http://localhost:9080`); set `MOCKFORGE_ADMIN_URL` if it's elsewhere.
+
+## Navigation
+
+| Key | Action |
+|---|---|
+| `Tab` / `Shift-Tab` | Next / previous panel |
+| `1`–`9`, `0` | Jump to panel by number |
+| `r` | Force refresh the current panel |
+| `q` / `Ctrl-C` | Quit |
+| `↑` `↓` `j` `k` | Scroll within a panel |
+| `Enter` | Drill into the highlighted row (where applicable) |
+
+Panels auto-refresh every 2 s; `r` forces an immediate fetch.
+
+## Dashboard panel (`1`)
+
+Four quadrants:
+
+```
+┌─ Server Status ─────────────────┬─ System Metrics ─────────────────┐
+│ ● HTTP    127.0.0.1:3000        │ CPU: 18% (peak 67%)              │
+│ ● WS      127.0.0.1:3001        │ Mem: 412 MB (peak 891 MB)        │
+│ ● Admin   127.0.0.1:9080        │ Threads: 8  Routes: 25  ...      │
+│                                 │                                  │
+├─ Request Stats ─────────────────┼─ Recent Logs ────────────────────┤
+│ Total: 12.5K  Err Rate: 0.4%    │ 14:23:01 GET    /api/users  200  │
+│ (peak 12.3%)                    │ 14:23:01 POST   /api/orders 201  │
+│ Avg RT: 34ms                    │ 14:23:00 GET    /api/users  200  │
+│ ┃▆█▇▅▆█▇▅▆█▇▅▆█▇▅▆█▇▅           │ ...                              │
+└─────────────────────────────────┴──────────────────────────────────┘
+```
+
+### What each cell shows
+
+**Server Status** — one row per protocol you've enabled. `●` = up, `○` =
+down. Address is what the listener actually bound to (so you see the real
+port when you started with `--http-port 0`).
+
+**System Metrics** — current value + lifetime peak (since server start, or
+since the last `reset_metric_peaks()` API call):
+
+- `CPU: <current>% (peak <peak>%)` — process CPU usage. Peak helps you
+  catch transient spikes during multi-hour soak tests.
+- `Mem: <current> MB (peak <peak> MB)` — process RSS. Peak is the
+  important number for memory-leak hunting.
+- `Threads: N` — count of OS threads in the runtime.
+- `Routes: N` — registered HTTP routes.
+- `Fixtures: N` — fixture files discovered.
+
+**Request Stats** — total requests served, error rate (5xx + 4xx / total),
+peak error rate, average response time, and a sparkline of request rate
+over the last 60 ticks (~2 minutes).
+
+**Recent Logs** — last 10 requests (or however many fit), newest at top.
+Color-coded by HTTP method and status code.
+
+### Resetting peaks
+
+Peaks accumulate from server start. To reset at the beginning of a new test
+run without restarting the server, hit the admin API:
+
+```bash
+curl -X POST http://localhost:9080/api/admin/metrics/reset-peaks
+```
+
+Or reset programmatically via the SDK.
+
+## Other panels
+
+| Panel | What it shows |
+|---|---|
+| `Routes` (`2`) | Every HTTP route registered, with hit count and last-request timestamp |
+| `Fixtures` (`3`) | Fixture files on disk, sizes, last-modified |
+| `Logs` (`4`) | Full request log with filter/search |
+| `Metrics` (`5`) | Detailed numeric metrics (response-time distribution, status code histogram) |
+| `Chaos` (`6`) | Live chaos engine state — current scenario, fault counters per kind, request matchers |
+| `Plugins` (`7`) | Loaded plugins, their status, recent invocations |
+| `Recorder` (`8`) | Traffic recordings — start/stop, file sizes, replay status |
+| `Health` (`9`) | Health checks, circuit breaker / bulkhead state, dependency status |
+
+Each is also reachable via the admin web UI at `http://localhost:9080`; the
+TUI is the same data over the same API, just rendered for the terminal.
+
+## When to use the TUI vs admin web UI
+
+| Use TUI when… | Use admin UI when… |
+|---|---|
+| You're SSH'd to a remote box | You want to edit fixtures interactively |
+| You want to leave it open during a soak test | You're sharing a screenshot |
+| Browser is too heavy | You need the visual config builder |
+| You want everything on one screen | You're walking someone through a feature |
+
+## CSV log alongside
+
+The TUI peak metrics are in-memory and reset on server restart. For a
+permanent record across restarts, set:
+
+```bash
+MOCKFORGE_METRICS_LOG_FILE=/var/log/mockforge.csv mockforge serve ...
+```
+
+The same numbers the TUI displays (CPU%, memory MB, total requests, error
+rate) get appended every 10 s to the CSV file. See the
+[Observability chapter](./observability.md#csv-metrics-log-multi-day-soak)
+for details.
+
+## Troubleshooting
+
+**"Failed to fetch dashboard"** — the admin server isn't running, or it's
+on a different host/port. Set `MOCKFORGE_ADMIN_URL=http://host:port` and
+retry. Make sure you started `mockforge serve` with `--admin`.
+
+**Metrics show all zeroes** — system monitoring runs in a background task
+that takes ~10 s to collect its first sample after server start. Wait a
+moment and hit `r` to refresh.
+
+**TUI feels sluggish** — the 2 s refresh fetches a lot. Switch to the
+admin web UI for low-traffic panels (Plugins, Fixtures); the TUI is most
+useful for high-velocity ones (Dashboard, Logs, Chaos, Metrics).
+
+## Where to go next
+
+- [Observability & Metrics](./observability.md) — Prometheus / OTLP / CSV
+  log all in one place
+- [Admin UI](./admin-ui.md) — the browser-based equivalent
+- [Chaos Engineering](./chaos-engineering.md) — what drives the chaos panel
+- [Load Testing](./load-testing.md) — drives the request-rate sparkline


### PR DESCRIPTION
## Summary

Closes audit follow-up tasks **16, 17, 18** in one PR — they share a user mental model so it makes sense to land together. Together with the Tier-2 chaos-engineering and load-testing chapters, the **Testing & Resilience** mdbook section is now first-class.

## New chapters

| File | What it covers |
|---|---|
| **`user-guide/observability.md`** | All four observability surfaces (TUI peaks, Prometheus `/metrics`, OpenTelemetry/OTLP, CSV log) and how to combine them for chaos / load test runs. Real exported metric names. OTLP env-var setup with worked Jaeger / Tempo / Honeycomb example. |
| **`user-guide/rate-limiting.md`** | Rate-limit + traffic-shaping in their own chapter (extracted from chaos config schema). Token-bucket semantics, predefined network profiles (slow_3g / fast_3g / flaky_wifi / cable / dialup), worked examples (429-retry rehearsal, low-bandwidth memory soak). |
| **`user-guide/tui-dashboard.md`** | Full panel reference for `mockforge tui`. All 9 panels, keybindings, peak-metrics + reset-peaks API, CSV log pairing, TUI-vs-admin-UI decision matrix. |

## SUMMARY.md

The three chapters land under the existing **Testing & Resilience** section, alongside Load Testing and Chaos Engineering. Five chapters now cross-link cleanly.

## Verification

- [x] `mdbook build book` — clean
- [x] `make docs-drift` — green
- [x] All inter-chapter links resolve

## Tracked separately

- Task 19 (AI/RAG generation chapter) — next
- Task 20 (Plugin system deep-dive) — after that
- Task 14 (Tier 3 long-tail docs sweep) — last

Refs: #79