### PR TITLE
docs(gate): config-field drift gate + document max_body_size_bytes

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -58,3 +58,11 @@ jobs:
         # exists in code without a single mention in user-facing docs.
         # See scripts/check_docs_drift.py for the allowlist.
         run: python3 scripts/check_docs_drift.py
+
+      - name: Config-field drift gate
+        # Fails if any public field on a serde-derived config struct in
+        # crates/mockforge-chaos/src/config.rs (and its companions) is
+        # not mentioned anywhere in user-facing docs. See
+        # scripts/check_config_field_drift.py for the target list and
+        # allowlist.
+        run: python3 scripts/check_config_field_drift.py

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -571,6 +571,7 @@ profiles:
               - name: "x-test"            # case-insensitive name
                 value: "yes"              # omit `value` for presence-only
             min_body_size_bytes: 1048576  # >= 1 MB
+            max_body_size_bytes: 10485760 # AND <= 10 MB (omit either side)
             chunked_only: true            # only Transfer-Encoding: chunked
           # Wire-level behavior of "connection error". `tcp_reset`/`tcp_close`
           # require the chaos listener wrapper, auto-installed by serve.

--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,13 @@ spellcheck: ## Check for typos
 docs-drift: ## Verify every MOCKFORGE_* env var and CLI subcommand has docs
 	python3 scripts/check_docs_drift.py
 
+# Config-field drift gate (also runs in docs-check.yml on PRs)
+config-field-drift: ## Verify every public serde-config field has docs
+	python3 scripts/check_config_field_drift.py
+
+# Run both drift gates
+docs-drift-all: docs-drift config-field-drift ## Run all docs / code drift gates
+
 # Workspace sync targets
 sync-git: ## Sync workspaces to a git repository directory
 	@echo "Syncing workspaces to git repository..."

--- a/book/src/reference/config-schema.md
+++ b/book/src/reference/config-schema.md
@@ -304,6 +304,7 @@ observability:
           - name: "x-test"
             value: "yes"            # omit `value` for presence-only
         min_body_size_bytes: 1048576
+        max_body_size_bytes: 10485760
         chunked_only: true
 ```
 

--- a/book/src/user-guide/advanced-behavior.md
+++ b/book/src/user-guide/advanced-behavior.md
@@ -181,6 +181,7 @@ fault_injection:
       - name: "x-test"            # case-insensitive name
         value: "yes"              # omit `value` for presence-only
     min_body_size_bytes: 1048576  # only requests with body >= 1 MB
+    max_body_size_bytes: 10485760 # AND <= 10 MB (omit either side)
     chunked_only: true            # only Transfer-Encoding: chunked
 ```
 

--- a/book/src/user-guide/chaos-engineering.md
+++ b/book/src/user-guide/chaos-engineering.md
@@ -84,6 +84,7 @@ fault_injection:
       - name: "x-test"            # case-insensitive
         value: "yes"              # exact value; omit `value` for presence-only
     min_body_size_bytes: 1048576  # only requests with body >= 1 MB
+    max_body_size_bytes: 10485760 # AND <= 10 MB (omit either side)
     chunked_only: true            # only Transfer-Encoding: chunked requests
 ```
 

--- a/docs/CHAOS_ENGINEERING.md
+++ b/docs/CHAOS_ENGINEERING.md
@@ -685,6 +685,7 @@ fault_injection:
       - name: "x-test"            # required header (case-insensitive name)
         value: "yes"              # exact value; omit `value` to match presence only
     min_body_size_bytes: 1048576  # only requests with body >= 1 MB
+    max_body_size_bytes: 10485760 # AND <= 10 MB (omit either side)
     chunked_only: true            # only requests with Transfer-Encoding: chunked
 ```
 

--- a/scripts/check_config_field_drift.py
+++ b/scripts/check_config_field_drift.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Config-field drift gate.
+
+Companion to scripts/check_docs_drift.py. That script catches missing env-var
+and CLI-subcommand docs; this one catches **missing config-field docs** —
+public fields on serde-derived configuration structs that users set in
+mockforge.yaml / config files.
+
+What it checks
+--------------
+
+For each (file, struct) pair in `TARGETS`, parse the struct definition,
+extract `pub` field names, and require each field name to appear at least
+once in user-facing docs (top-level *.md, docs/, book/src/).
+
+What it doesn't check (yet)
+---------------------------
+- Nested type fields (e.g. `pub latency: LatencyConfig` is checked at the
+  field name `latency`, but the LatencyConfig fields are checked separately
+  if LatencyConfig is in TARGETS).
+- Variant fields on enums (we only care about struct fields).
+- `#[serde(skip)]`-annotated fields are skipped (correct behavior — they're
+  not user-set).
+
+Allowlist
+---------
+`FIELD_ALLOWLIST` exempts fields that are public for cross-crate access but
+not user-facing. Add an entry only with a clear reason.
+
+Run from the repo root:
+    python3 scripts/check_config_field_drift.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class Target:
+    file: str  # repo-relative
+    struct: str  # struct name to parse
+
+
+# Structs whose public fields users set in YAML/JSON config. Order doesn't
+# matter — each is checked independently.
+TARGETS: list[Target] = [
+    # Chaos engine
+    Target("crates/mockforge-chaos/src/config.rs", "ChaosConfig"),
+    Target("crates/mockforge-chaos/src/config.rs", "FaultInjectionConfig"),
+    Target("crates/mockforge-chaos/src/config.rs", "LatencyConfig"),
+    Target("crates/mockforge-chaos/src/config.rs", "RateLimitConfig"),
+    Target("crates/mockforge-chaos/src/config.rs", "TrafficShapingConfig"),
+    Target("crates/mockforge-chaos/src/config.rs", "CircuitBreakerConfig"),
+    Target("crates/mockforge-chaos/src/config.rs", "BulkheadConfig"),
+    Target("crates/mockforge-chaos/src/request_matcher.rs", "RequestMatcher"),
+    Target("crates/mockforge-chaos/src/request_matcher.rs", "HeaderMatch"),
+]
+
+
+# Per-(struct, field) allowlist. Use sparingly with a reason.
+# The key is "<StructName>.<field_name>".
+FIELD_ALLOWLIST: dict[str, str] = {
+    # Internal Prometheus metric labels / debug knobs that aren't user-set.
+    # (Currently empty — populate as we add structs that have non-user fields.)
+}
+
+
+# Match `pub struct Foo {` allowing arbitrary attributes / docs above it.
+def find_struct_block(text: str, struct: str) -> str | None:
+    """Return the body (between `{` and matching `}`) of `pub struct <name>`,
+    or None if not found. Handles only struct-with-named-fields form."""
+    pattern = re.compile(
+        rf"pub\s+struct\s+{re.escape(struct)}\s*(?:<[^>]*>)?\s*\{{", re.MULTILINE
+    )
+    m = pattern.search(text)
+    if m is None:
+        return None
+    start = m.end() - 1  # position of `{`
+    depth = 0
+    for i, ch in enumerate(text[start:], start=start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1 : i]
+    return None
+
+
+def extract_pub_fields(block: str) -> list[str]:
+    """Walk the struct body line-by-line and return each `pub <name>:` field
+    name. Skips fields whose nearest preceding non-blank attribute line
+    contains `#[serde(skip)]` or `skip_serializing` (fields that won't be
+    set by users)."""
+    out: list[str] = []
+    pending_attrs: list[str] = []
+    for raw in block.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("//"):
+            continue
+        if line.startswith("#["):
+            pending_attrs.append(line)
+            continue
+        m = re.match(r"pub\s+(\w+)\s*:", line)
+        if m:
+            field = m.group(1)
+            skip = any(
+                "skip)" in a or "skip_serializing" in a or 'skip,' in a
+                for a in pending_attrs
+            )
+            if not skip:
+                out.append(field)
+        # Reset pending attrs after any non-attribute line.
+        pending_attrs = []
+    return out
+
+
+def doc_corpus() -> str:
+    """Same corpus as the env-var drift gate. Concatenated for one membership
+    test pass."""
+    chunks: list[str] = []
+    for top in ("CONFIG.md", "README.md", "CHANGELOG.md"):
+        p = REPO / top
+        if p.is_file():
+            chunks.append(p.read_text(encoding="utf-8", errors="ignore"))
+    for root in ("docs", "book/src"):
+        for md in (REPO / root).rglob("*.md"):
+            try:
+                chunks.append(md.read_text(encoding="utf-8", errors="ignore"))
+            except OSError:
+                continue
+    return "\n".join(chunks)
+
+
+def main() -> int:
+    docs = doc_corpus()
+    missing: list[tuple[str, str, str]] = []  # (struct, field, file)
+    parsed = 0
+
+    for t in TARGETS:
+        path = REPO / t.file
+        if not path.is_file():
+            print(f"WARN: target file missing: {t.file}", file=sys.stderr)
+            continue
+        text = path.read_text(encoding="utf-8")
+        block = find_struct_block(text, t.struct)
+        if block is None:
+            print(f"WARN: struct {t.struct!r} not found in {t.file}", file=sys.stderr)
+            continue
+        parsed += 1
+        for field in extract_pub_fields(block):
+            key = f"{t.struct}.{field}"
+            if key in FIELD_ALLOWLIST:
+                continue
+            if field not in docs:
+                missing.append((t.struct, field, t.file))
+
+    if not missing:
+        print(f"config-field drift check: ✅ no drift ({parsed} structs parsed)")
+        return 0
+
+    print("config-field drift check: ❌ undocumented public config fields\n")
+    by_struct: dict[str, list[tuple[str, str]]] = {}
+    for struct, field, file in missing:
+        by_struct.setdefault(struct, []).append((field, file))
+
+    for struct in sorted(by_struct):
+        items = by_struct[struct]
+        print(f"  {struct} ({len(items)} field(s) in {items[0][1]}):")
+        for field, _ in items:
+            print(f"    - {field}")
+
+    print(
+        "\n  Fix: document each field in CONFIG.md, "
+        "book/src/configuration/*.md, or the chapter where the struct's"
+        "\n  feature lives. OR add to FIELD_ALLOWLIST in"
+        "\n  scripts/check_config_field_drift.py with a reason."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a second drift gate covering **public fields on serde-derived configuration structs** (`ChaosConfig`, `FaultInjectionConfig`, `RequestMatcher`, etc.). The existing `check_docs_drift.py` covers env vars + CLI subcommands; this one covers config-field coverage that the original gate explicitly skipped (regex isn't reliable for arbitrary Rust structs, but a brace-depth-aware parser is sufficient for the well-defined targets).

## What it catches

For each (file, struct) in `TARGETS`, parses pub field names (skipping `#[serde(skip)]`) and requires each to appear at least once in user-facing docs (top-level `*.md`, `docs/`, `book/src/`).

Initial target set: 9 structs across `mockforge-chaos` covering the entire user-facing chaos surface. Expandable via the `TARGETS` list.

## Real drift caught while landing this

Running the gate immediately surfaced one real gap: `max_body_size_bytes` on `RequestMatcher` was undocumented across **all five** doc surfaces (`CONFIG.md`, the chaos engineering chapter, advanced-behavior, config-schema reference, and `docs/CHAOS_ENGINEERING.md`). Only `min_body_size_bytes` was shown — readers had no way to know they could specify a max bound. Fixed in this PR.

## Sanity tested

Injected `pub test_fake_field_xyzzy_not_documented: bool,` into `RequestMatcher` → gate fails with a clear punch list. Removed → green.

## Wiring

- `Makefile`: `make config-field-drift` (and `make docs-drift-all` for both gates).
- `.github/workflows/docs-check.yml`: runs alongside the env-var gate on every PR touching code or docs.

## What it doesn't (yet) check

- Structs in `mockforge-core/src/config/`, `mockforge-tracing`, `mockforge-recorder`, etc. The `TARGETS` list starts conservative with the chaos engine; expand by adding entries as each crate gets audited.
- Enum variants (only struct fields).
- Non-serde-derived public structs.

## Verification

- [x] `make docs-drift-all` — green
- [x] `mdbook build book` — clean
- [x] Sanity-tested gate in both directions

Refs: #79