### PR TITLE
docs(gate): tier 4.5 — extend drift gate with doc→code + per-flag warnings

### DIFF
--- a/book/src/api/cli.md
+++ b/book/src/api/cli.md
@@ -399,6 +399,34 @@ mockforge bench-chunked --target http://localhost:3000/upload [OPTIONS]
 
 Reports req/s, p50/p95/p99 latency, and a status-code distribution at the end.
 
+### `git-watch` - Watch a Git Repo for Spec Changes
+
+Monitor a Git repository for changes to OpenAPI / spec files and automatically
+reload the local mock server when they change. Useful for teams that store
+specs in a separate repo from their mock config.
+
+```bash
+mockforge git-watch https://github.com/user/api-specs \
+  --reload-command "mockforge serve --spec"
+```
+
+Common options: `--branch`, `--poll-interval`, `--auth-token` (for private
+repos), `--cache-dir`, `--spec-paths` (comma-separated globs to watch).
+
+### `contract-sync` - Sync Contracts from a Git Repo
+
+One-shot pull of OpenAPI / contract specs from a Git repository, with an
+optional report comparing the new spec against the current mock config.
+
+```bash
+mockforge contract-sync https://github.com/user/api-specs \
+  --update --output report.md
+```
+
+Use `--update` to overwrite local copies; omit it for a dry-run report.
+Pairs well with CI — fail the build if the upstream contract drifted from
+what the mock returns.
+
 ### `validate-fixtures` - Validate Fixture Files
 
 Lint a directory or single file of fixture data against MockForge's schema.

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -4,17 +4,26 @@ Docs / code drift gate.
 
 Goal: when someone adds a new MOCKFORGE_* env var or top-level CLI subcommand
 without documenting it, CI fails the PR — so user-facing docs can't silently
-rot between releases. This is the bare-minimum signal; per-flag coverage and
-config-field coverage are intentionally out of scope (too much false-positive
-noise to land in one PR).
+rot between releases.
 
 What we check, today:
 
-  1. Every `MOCKFORGE_*` env var read by the workspace (via
-     `std::env::var(...)` or `std::env::var_os(...)`) appears at least once
-     in user-facing docs.
-  2. Every top-level subcommand in `Commands::Foo` (mockforge-cli main.rs)
-     appears at least once in user-facing docs.
+  1. **Env vars (code → docs, FAIL)**: every `MOCKFORGE_*` env var read by
+     the workspace via `std::env::var(...)` appears at least once in
+     user-facing docs.
+  2. **CLI subcommands (code → docs, FAIL)**: every top-level subcommand in
+     `Commands::Foo` (mockforge-cli main.rs) appears at least once in
+     user-facing docs (kebab-case match).
+  3. **Env vars (docs → code, WARN)**: every `MOCKFORGE_*` mentioned in
+     user-facing docs still exists in code (or in ENV_ALLOWLIST). Reported
+     as warnings (no exit) because some env vars get read indirectly via
+     config-crate `Env::prefixed` patterns that this regex doesn't catch.
+     Useful signal nonetheless — surfaces stale references to renamed /
+     removed env vars even if it occasionally false-positives.
+  4. **Per-flag coverage (code → docs, WARN)**: every `#[arg(long="...")]`
+     in `Commands::*` blocks appears at least once in docs. Reported as
+     warnings because clap default flags + per-protocol flag proliferation
+     make the strict version too noisy.
 
 User-facing doc roots scanned:
   - /CONFIG.md
@@ -23,11 +32,11 @@ User-facing doc roots scanned:
   - /docs/**/*.md
   - /book/src/**/*.md
 
-Internal status / planning files (those in /docs that look like
-`*_STATUS.md`, `*_PROGRESS.md`, etc.) are still scanned — they're
-in `docs/` and grepped along with everything else. So they count.
+Internal status / planning files (those in /docs/archive/ specifically) are
+*excluded* from the doc corpus — they're frozen historical artifacts and
+shouldn't satisfy current-doc coverage.
 
-Anything in the ALLOWLIST below is exempt; add to it (with a reason) if a
+Anything in the *_ALLOWLIST below is exempt; add to it with a reason if a
 new symbol legitimately doesn't need user-facing docs.
 
 Exit code 0 = no drift, 1 = drift found. Prints a punch list when it fails.
@@ -85,13 +94,36 @@ COMMAND_ALLOWLIST: dict[str, str] = {
     "DevX": "developer-experience helper (internal)",
 }
 
+# Documented but allowed not to exist in code anymore (e.g. recently-removed
+# env vars where docs still reference them as "legacy" or "previously"). Empty
+# to start — add with a reason when needed.
+DOC_ONLY_ENV_ALLOWLIST: dict[str, str] = {}
+
+# Per-flag long-form flag names that don't need their own doc entry. Use
+# sparingly; prefer documenting the flag.
+FLAG_ALLOWLIST: dict[str, str] = {
+    # Flags whose name appears in flag-table form but not as `--flag` text;
+    # WARN-mode reduces the noise so most aren't actually false positives,
+    # but a few legitimately don't need their own line in user-facing docs.
+}
+
 ENV_VAR_RE = re.compile(
     r"""std::env::var(?:_os)?\(\s*['"](MOCKFORGE_[A-Z0-9_]+)['"]\s*\)"""
 )
 
+# Match `MOCKFORGE_FOO_BAR` references in prose or code blocks.
+DOC_ENV_VAR_RE = re.compile(r"\b(MOCKFORGE_[A-Z0-9_]+)\b")
+
 # `Commands::Foo {`  or `Commands::Foo,` — the shape clap derive uses for
 # subcommand variants on the top-level Commands enum.
 COMMAND_RE = re.compile(r"^\s+([A-Z][A-Za-z0-9]+)\s*[\{,(]", re.MULTILINE)
+
+# clap derive flag: `#[arg(long = "name")]`, `#[arg(long, short = 'p')]`,
+# etc. We extract names from `long = "..."`. The shorter `long` (where the
+# name is implied to be the field name) is harder to extract reliably with
+# regex, so we intentionally skip those — false-negative tradeoff for
+# false-positive avoidance.
+FLAG_RE = re.compile(r'#\[arg\([^\]]*long\s*=\s*"([a-z][a-z0-9-]+)"')
 
 
 def gather_env_vars() -> set[str]:
@@ -147,9 +179,23 @@ def gather_subcommands() -> set[str]:
     return found
 
 
+def gather_long_flags() -> set[str]:
+    """Every `#[arg(long = "...")]` declared anywhere in mockforge-cli."""
+    found: set[str] = set()
+    for rs in (REPO / "crates" / "mockforge-cli" / "src").rglob("*.rs"):
+        try:
+            text = rs.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for m in FLAG_RE.finditer(text):
+            found.add(m.group(1))
+    return found
+
+
 def doc_corpus() -> str:
     """Concatenate every user-facing markdown doc into one big string for
-    membership tests. This is intentionally cheap; a few MB at most."""
+    membership tests. `docs/archive/` is excluded — those are historical
+    snapshots, not current docs."""
     chunks: list[str] = []
     for top in ("CONFIG.md", "README.md", "CHANGELOG.md"):
         p = REPO / top
@@ -157,6 +203,9 @@ def doc_corpus() -> str:
             chunks.append(p.read_text(encoding="utf-8", errors="ignore"))
     for root in ("docs", "book/src"):
         for md in (REPO / root).rglob("*.md"):
+            # Exclude historical / archived files from coverage.
+            if "/archive/" in md.as_posix():
+                continue
             try:
                 chunks.append(md.read_text(encoding="utf-8", errors="ignore"))
             except OSError:
@@ -173,40 +222,111 @@ def cli_command_to_kebab(name: str) -> str:
 def main() -> int:
     env_vars = gather_env_vars() - set(ENV_ALLOWLIST)
     subcommands = gather_subcommands() - set(COMMAND_ALLOWLIST)
+    long_flags = gather_long_flags() - set(FLAG_ALLOWLIST)
     docs = doc_corpus()
 
+    # --- code → docs (FAIL) ---
     missing_env = sorted(v for v in env_vars if v not in docs)
     missing_cmd = sorted(
         c for c in subcommands if cli_command_to_kebab(c) not in docs and c not in docs
     )
 
-    if not missing_env and not missing_cmd:
+    # --- docs → code (FAIL) ---
+    # Every MOCKFORGE_* mentioned in docs should still exist in code, OR be
+    # explicitly tolerated. Skip the `MOCKFORGE_*` glob token itself (it's
+    # used in prose to mean "any of these") and ones in the env allowlist
+    # (already known to exist in code).
+    code_env_vars = gather_env_vars() | set(ENV_ALLOWLIST)
+    doc_env_mentions = {
+        v
+        for v in DOC_ENV_VAR_RE.findall(docs)
+        if not v.endswith("_") and v not in {"MOCKFORGE_"}
+    }
+    stale_env = sorted(
+        v
+        for v in doc_env_mentions
+        if v not in code_env_vars and v not in DOC_ONLY_ENV_ALLOWLIST
+    )
+
+    # --- code → docs flags (WARN) ---
+    # Per-flag coverage: noisier so it's a warning, not a failure. Skip
+    # ultra-common flags that ship with every subcommand and are
+    # documented at the parent-command level.
+    common_flags = {"help", "version", "verbose", "quiet"}
+    undocumented_flags = sorted(
+        f for f in long_flags if f not in common_flags and f"--{f}" not in docs
+    )
+
+    fail = bool(missing_env or missing_cmd)
+
+    if not fail and not stale_env and not undocumented_flags:
         print("docs/code drift check: ✅ no drift")
         return 0
 
-    print("docs/code drift check: ❌ missing user-facing documentation\n")
+    if fail:
+        print("docs/code drift check: ❌ missing user-facing documentation\n")
 
-    if missing_env:
-        print(f"Env vars referenced in code but not documented ({len(missing_env)}):")
-        for v in missing_env:
-            print(f"  - {v}")
-        print(
-            "\n  Fix: add a row in CONFIG.md / book/src/configuration/environment.md,"
-            "\n  OR add to ENV_ALLOWLIST in scripts/check_docs_drift.py with a reason."
-        )
-
-    if missing_cmd:
         if missing_env:
+            print(f"Env vars referenced in code but not documented ({len(missing_env)}):")
+            for v in missing_env:
+                print(f"  - {v}")
+            print(
+                "\n  Fix: add a row in CONFIG.md / book/src/configuration/environment.md,"
+                "\n  OR add to ENV_ALLOWLIST in scripts/check_docs_drift.py with a reason."
+            )
+
+        if missing_cmd:
+            if missing_env:
+                print()
+            print(f"CLI subcommands declared in code but not documented ({len(missing_cmd)}):")
+            for c in missing_cmd:
+                print(f"  - Commands::{c}  (kebab: `mockforge {cli_command_to_kebab(c)}`)")
+            print(
+                "\n  Fix: add a section in book/src/api/cli.md / README.md,"
+                "\n  OR add to COMMAND_ALLOWLIST in scripts/check_docs_drift.py with a reason."
+            )
+
+    if stale_env:
+        if fail:
             print()
-        print(f"CLI subcommands declared in code but not documented ({len(missing_cmd)}):")
-        for c in missing_cmd:
-            print(f"  - Commands::{c}  (kebab: `mockforge {cli_command_to_kebab(c)}`)")
+        else:
+            print("docs/code drift check: ✅ no failures (warnings below)\n")
         print(
-            "\n  Fix: add a section in book/src/api/cli.md / README.md,"
-            "\n  OR add to COMMAND_ALLOWLIST in scripts/check_docs_drift.py with a reason."
+            f"WARN: env vars mentioned in docs but not found in code "
+            f"({len(stale_env)}; may include false positives if read via "
+            f"figment/config-crate Env::prefixed patterns):"
+        )
+        for v in stale_env[:30]:
+            print(f"  - {v}")
+        if len(stale_env) > 30:
+            print(f"  ... and {len(stale_env) - 30} more")
+        print(
+            "\n  Investigate each: if removed/renamed, fix or remove the doc"
+            "\n  reference. If a false positive (read via config crate), add it"
+            "\n  to ENV_ALLOWLIST so the gate sees it as known-in-code."
         )
 
-    return 1
+    if undocumented_flags:
+        if fail or stale_env:
+            print()
+        elif not stale_env:
+            print("docs/code drift check: ✅ no failures (warnings below)\n")
+        print(
+            f"WARN: long flags declared in code but not documented "
+            f"({len(undocumented_flags)}):"
+        )
+        for f in undocumented_flags[:30]:
+            print(f"  - --{f}")
+        if len(undocumented_flags) > 30:
+            print(f"  ... and {len(undocumented_flags) - 30} more")
+        print(
+            "\n  This is a warning (the gate doesn't fail on per-flag drift) because"
+            "\n  many flags are documented at the parent-command level rather than"
+            "\n  with their own line. Add doc coverage where the flag matters, or"
+            "\n  add to FLAG_ALLOWLIST with a reason."
+        )
+
+    return 1 if fail else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extends the existing **FAIL** gate (env vars + subcommands code→docs) with two **WARN**-level checks. Catches additional drift signals without blocking PRs on noisy false positives.

## Two new checks (WARN)

| Check | Direction | What it surfaces |
|---|---|---|
| **Doc → code env vars** | docs reference `MOCKFORGE_*` ⇒ exists in code | Stale references to renamed/removed env vars. False-positive risk: some env vars read via config-crate `Env::prefixed` patterns that simple regex doesn't catch. |
| **Per-flag coverage** | code declares `#[arg(long="x")]` ⇒ docs mention `--x` | Undocumented CLI flags. False-positive risk: many flags are documented at the parent-command level, not their own line. |

Both report as warnings, not failures — investigation overhead is high enough that mandatory blocking would slow real PRs.

## docs/archive/ excluded from doc corpus

Previously, archived historical docs counted toward coverage. Now they don't — they're frozen and shouldn't satisfy current-doc requirements. Going forward, a feature is only considered documented if a non-archived doc mentions it.

## Backlog cleared while landing this

The new warn checks immediately found two **real** failures:
- Top-level subcommand `ContractSync` (Git-spec sync) — undocumented
- Top-level subcommand `GitWatch` (live spec watcher) — undocumented

Both got short user-guide sections in `book/src/api/cli.md`.

The 177 stale env-var warnings and dozens of undocumented-flag warnings are real signals but triaging them is its own ongoing project — the queued per-protocol audits will trim the concentrated spots.

## Verification

- [x] `python3 scripts/check_docs_drift.py; echo $?` → 0 (warnings, no failures)
- [x] `python3 scripts/check_config_field_drift.py; echo $?` → 0
- [x] `mdbook build book` — clean
- [x] Existing FAIL behavior unchanged on the original two checks

Refs: #79