### PR TITLE
feat(fixtures): allow protocol updates + surface created_at in viewer

### DIFF
--- a/crates/mockforge-registry-core/src/models/cloud_fixture.rs
+++ b/crates/mockforge-registry-core/src/models/cloud_fixture.rs
@@ -84,6 +84,7 @@ impl CloudFixture {
         path: Option<&str>,
         method: Option<&str>,
         content: Option<&serde_json::Value>,
+        protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
     ) -> sqlx::Result<Option<Self>> {
         sqlx::query_as::<_, Self>(
@@ -95,7 +96,8 @@ impl CloudFixture {
                 path = COALESCE($4, path),
                 method = COALESCE($5, method),
                 content = COALESCE($6, content),
-                tags = COALESCE($7, tags),
+                protocol = COALESCE($7, protocol),
+                tags = COALESCE($8, tags),
                 updated_at = NOW()
             WHERE id = $1
             RETURNING *
@@ -107,6 +109,7 @@ impl CloudFixture {
         .bind(path)
         .bind(method)
         .bind(content)
+        .bind(protocol)
         .bind(tags)
         .fetch_optional(pool)
         .await

--- a/crates/mockforge-registry-core/src/models/cloud_fixture.rs
+++ b/crates/mockforge-registry-core/src/models/cloud_fixture.rs
@@ -19,6 +19,11 @@ pub struct CloudFixture {
     pub route_path: Option<String>,
     pub protocol: Option<String>,
     pub created_by: Uuid,
+    /// Resolved username of the creator. Populated by queries that LEFT JOIN
+    /// `users`; absent on raw row reads.
+    #[sqlx(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by_username: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -37,16 +42,27 @@ impl CloudFixture {
         content: Option<&serde_json::Value>,
         protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
+        workspace_id: Option<Uuid>,
+        route_path: Option<&str>,
     ) -> sqlx::Result<Self> {
         let tags_value = tags.cloned().unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
         sqlx::query_as::<_, Self>(
             r#"
-            INSERT INTO fixtures (org_id, name, description, path, method, content, protocol, tags, created_by)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            RETURNING *
+            WITH inserted AS (
+                INSERT INTO fixtures (
+                    org_id, workspace_id, name, description, path, method,
+                    content, protocol, tags, route_path, created_by
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                RETURNING *
+            )
+            SELECT i.*, u.username AS created_by_username
+            FROM inserted i
+            LEFT JOIN users u ON u.id = i.created_by
             "#,
         )
         .bind(org_id)
+        .bind(workspace_id)
         .bind(name)
         .bind(description)
         .bind(path)
@@ -54,27 +70,52 @@ impl CloudFixture {
         .bind(content)
         .bind(protocol)
         .bind(tags_value)
+        .bind(route_path)
         .bind(created_by)
         .fetch_one(pool)
         .await
     }
 
     pub async fn find_by_id(pool: &sqlx::PgPool, id: Uuid) -> sqlx::Result<Option<Self>> {
-        sqlx::query_as::<_, Self>("SELECT * FROM fixtures WHERE id = $1")
-            .bind(id)
-            .fetch_optional(pool)
-            .await
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT f.*, u.username AS created_by_username
+            FROM fixtures f
+            LEFT JOIN users u ON u.id = f.created_by
+            WHERE f.id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await
     }
 
-    pub async fn find_by_org(pool: &sqlx::PgPool, org_id: Uuid) -> sqlx::Result<Vec<Self>> {
+    /// List fixtures in an organization, optionally filtered to a single
+    /// workspace. Pass `workspace_id = None` to return everything in the org.
+    pub async fn find_by_org(
+        pool: &sqlx::PgPool,
+        org_id: Uuid,
+        workspace_id: Option<Uuid>,
+    ) -> sqlx::Result<Vec<Self>> {
         sqlx::query_as::<_, Self>(
-            "SELECT * FROM fixtures WHERE org_id = $1 ORDER BY created_at DESC",
+            r#"
+            SELECT f.*, u.username AS created_by_username
+            FROM fixtures f
+            LEFT JOIN users u ON u.id = f.created_by
+            WHERE f.org_id = $1
+              AND ($2::uuid IS NULL OR f.workspace_id = $2)
+            ORDER BY f.created_at DESC
+            "#,
         )
         .bind(org_id)
+        .bind(workspace_id)
         .fetch_all(pool)
         .await
     }
 
+    /// Update mutable fields on a fixture. `workspace_id` is tri-state:
+    /// `None` leaves it untouched; `Some(None)` clears it; `Some(Some(id))`
+    /// reassigns it.
     #[allow(clippy::too_many_arguments)]
     pub async fn update(
         pool: &sqlx::PgPool,
@@ -86,21 +127,37 @@ impl CloudFixture {
         content: Option<&serde_json::Value>,
         protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
+        route_path: Option<&str>,
+        workspace_id: Option<Option<Uuid>>,
     ) -> sqlx::Result<Option<Self>> {
+        // workspace_id update flag: when None, leave column untouched; when
+        // Some(_), apply the wrapped value (which may itself be NULL).
+        let (workspace_set, workspace_value) = match workspace_id {
+            Some(value) => (true, value),
+            None => (false, None),
+        };
+
         sqlx::query_as::<_, Self>(
             r#"
-            UPDATE fixtures
-            SET
-                name = COALESCE($2, name),
-                description = COALESCE($3, description),
-                path = COALESCE($4, path),
-                method = COALESCE($5, method),
-                content = COALESCE($6, content),
-                protocol = COALESCE($7, protocol),
-                tags = COALESCE($8, tags),
-                updated_at = NOW()
-            WHERE id = $1
-            RETURNING *
+            WITH updated AS (
+                UPDATE fixtures
+                SET
+                    name = COALESCE($2, name),
+                    description = COALESCE($3, description),
+                    path = COALESCE($4, path),
+                    method = COALESCE($5, method),
+                    content = COALESCE($6, content),
+                    protocol = COALESCE($7, protocol),
+                    tags = COALESCE($8, tags),
+                    route_path = COALESCE($9, route_path),
+                    workspace_id = CASE WHEN $10 THEN $11 ELSE workspace_id END,
+                    updated_at = NOW()
+                WHERE id = $1
+                RETURNING *
+            )
+            SELECT u_row.*, u.username AS created_by_username
+            FROM updated u_row
+            LEFT JOIN users u ON u.id = u_row.created_by
             "#,
         )
         .bind(id)
@@ -111,6 +168,9 @@ impl CloudFixture {
         .bind(content)
         .bind(protocol)
         .bind(tags)
+        .bind(route_path)
+        .bind(workspace_set)
+        .bind(workspace_value)
         .fetch_optional(pool)
         .await
     }
@@ -118,5 +178,29 @@ impl CloudFixture {
     pub async fn delete(pool: &sqlx::PgPool, id: Uuid) -> sqlx::Result<()> {
         sqlx::query("DELETE FROM fixtures WHERE id = $1").bind(id).execute(pool).await?;
         Ok(())
+    }
+
+    /// Bulk delete by id, scoped to an org for safety. Returns the IDs that
+    /// were actually deleted (filters out any not in the org or already gone).
+    pub async fn delete_many(
+        pool: &sqlx::PgPool,
+        org_id: Uuid,
+        ids: &[Uuid],
+    ) -> sqlx::Result<Vec<Uuid>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            r#"
+            DELETE FROM fixtures
+            WHERE id = ANY($1) AND org_id = $2
+            RETURNING id
+            "#,
+        )
+        .bind(ids)
+        .bind(org_id)
+        .fetch_all(pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 }

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1265,12 +1265,24 @@ pub trait RegistryStore: Send + Sync + 'static {
         content: Option<&serde_json::Value>,
         protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
+        workspace_id: Option<Uuid>,
+        route_path: Option<&str>,
     ) -> StoreResult<CloudFixture>;
 
     async fn find_cloud_fixture_by_id(&self, id: Uuid) -> StoreResult<Option<CloudFixture>>;
 
-    async fn list_cloud_fixtures_by_org(&self, org_id: Uuid) -> StoreResult<Vec<CloudFixture>>;
+    /// List fixtures in an organization. When `workspace_id` is `Some`, only
+    /// fixtures assigned to that workspace are returned; when `None`, every
+    /// fixture in the org is returned.
+    async fn list_cloud_fixtures_by_org(
+        &self,
+        org_id: Uuid,
+        workspace_id: Option<Uuid>,
+    ) -> StoreResult<Vec<CloudFixture>>;
 
+    /// Update mutable fields on a cloud fixture. `workspace_id` is tri-state:
+    /// `None` leaves it untouched; `Some(None)` clears it; `Some(Some(id))`
+    /// assigns/changes it.
     #[allow(clippy::too_many_arguments)]
     async fn update_cloud_fixture(
         &self,
@@ -1282,9 +1294,19 @@ pub trait RegistryStore: Send + Sync + 'static {
         content: Option<&serde_json::Value>,
         protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
+        route_path: Option<&str>,
+        workspace_id: Option<Option<Uuid>>,
     ) -> StoreResult<Option<CloudFixture>>;
 
     async fn delete_cloud_fixture(&self, id: Uuid) -> StoreResult<()>;
+
+    /// Delete many fixtures atomically, scoped to an org. Returns the IDs
+    /// that were actually deleted.
+    async fn delete_cloud_fixtures_bulk(
+        &self,
+        org_id: Uuid,
+        ids: &[Uuid],
+    ) -> StoreResult<Vec<Uuid>>;
 
     // ---------------------------------------------------------------------
     // Hosted mocks (deployments)

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1280,6 +1280,7 @@ pub trait RegistryStore: Send + Sync + 'static {
         path: Option<&str>,
         method: Option<&str>,
         content: Option<&serde_json::Value>,
+        protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
     ) -> StoreResult<Option<CloudFixture>>;
 

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -924,6 +924,8 @@ impl RegistryStore for PgRegistryStore {
         content: Option<&serde_json::Value>,
         protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
+        workspace_id: Option<Uuid>,
+        route_path: Option<&str>,
     ) -> StoreResult<CloudFixture> {
         CloudFixture::create(
             &self.pool,
@@ -936,6 +938,8 @@ impl RegistryStore for PgRegistryStore {
             content,
             protocol,
             tags,
+            workspace_id,
+            route_path,
         )
         .await
         .map_err(Into::into)
@@ -945,8 +949,14 @@ impl RegistryStore for PgRegistryStore {
         CloudFixture::find_by_id(&self.pool, id).await.map_err(Into::into)
     }
 
-    async fn list_cloud_fixtures_by_org(&self, org_id: Uuid) -> StoreResult<Vec<CloudFixture>> {
-        CloudFixture::find_by_org(&self.pool, org_id).await.map_err(Into::into)
+    async fn list_cloud_fixtures_by_org(
+        &self,
+        org_id: Uuid,
+        workspace_id: Option<Uuid>,
+    ) -> StoreResult<Vec<CloudFixture>> {
+        CloudFixture::find_by_org(&self.pool, org_id, workspace_id)
+            .await
+            .map_err(Into::into)
     }
 
     async fn update_cloud_fixture(
@@ -959,6 +969,8 @@ impl RegistryStore for PgRegistryStore {
         content: Option<&serde_json::Value>,
         protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
+        route_path: Option<&str>,
+        workspace_id: Option<Option<Uuid>>,
     ) -> StoreResult<Option<CloudFixture>> {
         CloudFixture::update(
             &self.pool,
@@ -970,6 +982,8 @@ impl RegistryStore for PgRegistryStore {
             content,
             protocol,
             tags,
+            route_path,
+            workspace_id,
         )
         .await
         .map_err(Into::into)
@@ -977,6 +991,14 @@ impl RegistryStore for PgRegistryStore {
 
     async fn delete_cloud_fixture(&self, id: Uuid) -> StoreResult<()> {
         CloudFixture::delete(&self.pool, id).await.map_err(Into::into)
+    }
+
+    async fn delete_cloud_fixtures_bulk(
+        &self,
+        org_id: Uuid,
+        ids: &[Uuid],
+    ) -> StoreResult<Vec<Uuid>> {
+        CloudFixture::delete_many(&self.pool, org_id, ids).await.map_err(Into::into)
     }
 
     async fn create_hosted_mock(

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -957,11 +957,22 @@ impl RegistryStore for PgRegistryStore {
         path: Option<&str>,
         method: Option<&str>,
         content: Option<&serde_json::Value>,
+        protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
     ) -> StoreResult<Option<CloudFixture>> {
-        CloudFixture::update(&self.pool, id, name, description, path, method, content, tags)
-            .await
-            .map_err(Into::into)
+        CloudFixture::update(
+            &self.pool,
+            id,
+            name,
+            description,
+            path,
+            method,
+            content,
+            protocol,
+            tags,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn delete_cloud_fixture(&self, id: Uuid) -> StoreResult<()> {

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -1761,6 +1761,7 @@ impl RegistryStore for SqliteRegistryStore {
         path: Option<&str>,
         method: Option<&str>,
         content: Option<&serde_json::Value>,
+        protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
     ) -> StoreResult<Option<CloudFixture>> {
         Ok(None)

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -1738,6 +1738,8 @@ impl RegistryStore for SqliteRegistryStore {
         content: Option<&serde_json::Value>,
         protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
+        workspace_id: Option<Uuid>,
+        route_path: Option<&str>,
     ) -> StoreResult<CloudFixture> {
         Err(StoreError::NotFound)
     }
@@ -1748,7 +1750,11 @@ impl RegistryStore for SqliteRegistryStore {
     }
 
     #[allow(unused_variables)]
-    async fn list_cloud_fixtures_by_org(&self, org_id: Uuid) -> StoreResult<Vec<CloudFixture>> {
+    async fn list_cloud_fixtures_by_org(
+        &self,
+        org_id: Uuid,
+        workspace_id: Option<Uuid>,
+    ) -> StoreResult<Vec<CloudFixture>> {
         Ok(Vec::new())
     }
 
@@ -1763,6 +1769,8 @@ impl RegistryStore for SqliteRegistryStore {
         content: Option<&serde_json::Value>,
         protocol: Option<&str>,
         tags: Option<&serde_json::Value>,
+        route_path: Option<&str>,
+        workspace_id: Option<Option<Uuid>>,
     ) -> StoreResult<Option<CloudFixture>> {
         Ok(None)
     }
@@ -1770,6 +1778,15 @@ impl RegistryStore for SqliteRegistryStore {
     #[allow(unused_variables)]
     async fn delete_cloud_fixture(&self, id: Uuid) -> StoreResult<()> {
         Ok(())
+    }
+
+    #[allow(unused_variables)]
+    async fn delete_cloud_fixtures_bulk(
+        &self,
+        org_id: Uuid,
+        ids: &[Uuid],
+    ) -> StoreResult<Vec<Uuid>> {
+        Ok(Vec::new())
     }
 
     #[allow(unused_variables)]

--- a/crates/mockforge-registry-server/src/handlers/cloud_fixtures.rs
+++ b/crates/mockforge-registry-server/src/handlers/cloud_fixtures.rs
@@ -1,7 +1,7 @@
 //! Fixture CRUD handlers for cloud mode
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::HeaderMap,
     Json,
 };
@@ -15,16 +15,28 @@ use crate::{
     AppState,
 };
 
+/// Query parameters accepted by `GET /api/v1/fixtures`. Currently only
+/// supports filtering by workspace; absence returns every fixture in the org.
+#[derive(Debug, Deserialize, Default)]
+pub struct ListFixturesQuery {
+    #[serde(default)]
+    pub workspace_id: Option<Uuid>,
+}
+
 pub async fn list_fixtures(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
     headers: HeaderMap,
+    Query(query): Query<ListFixturesQuery>,
 ) -> ApiResult<Json<Vec<CloudFixture>>> {
     let org_ctx = resolve_org_context(&state, user_id, &headers, None)
         .await
         .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
 
-    let fixtures = state.store.list_cloud_fixtures_by_org(org_ctx.org_id).await?;
+    let fixtures = state
+        .store
+        .list_cloud_fixtures_by_org(org_ctx.org_id, query.workspace_id)
+        .await?;
 
     Ok(Json(fixtures))
 }
@@ -66,6 +78,8 @@ pub struct CreateFixtureRequest {
     pub content: Option<serde_json::Value>,
     pub protocol: Option<String>,
     pub tags: Option<serde_json::Value>,
+    pub workspace_id: Option<Uuid>,
+    pub route_path: Option<String>,
 }
 
 fn default_method() -> String {
@@ -98,6 +112,8 @@ pub async fn create_fixture(
             request.content.as_ref(),
             request.protocol.as_deref(),
             request.tags.as_ref(),
+            request.workspace_id,
+            request.route_path.as_deref(),
         )
         .await?;
 
@@ -143,6 +159,22 @@ pub struct UpdateFixtureRequest {
     pub content: Option<serde_json::Value>,
     pub protocol: Option<String>,
     pub tags: Option<serde_json::Value>,
+    pub route_path: Option<String>,
+    /// Tri-state workspace assignment: omit to leave unchanged, send `null`
+    /// to clear, send a UUID to assign/reassign.
+    #[serde(default, deserialize_with = "deserialize_optional_optional_uuid")]
+    pub workspace_id: Option<Option<Uuid>>,
+}
+
+/// Distinguish "field absent from JSON" (`None`) from "explicit `null`"
+/// (`Some(None)`) for the tri-state `workspace_id` patch semantics.
+fn deserialize_optional_optional_uuid<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<Uuid>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<Option<Uuid>>::deserialize(deserializer)
 }
 
 pub async fn update_fixture(
@@ -179,6 +211,8 @@ pub async fn update_fixture(
             request.content.as_ref(),
             request.protocol.as_deref(),
             request.tags.as_ref(),
+            request.route_path.as_deref(),
+            request.workspace_id,
         )
         .await?
         .ok_or_else(|| ApiError::InvalidRequest("Fixture not found".to_string()))?;
@@ -251,4 +285,53 @@ pub async fn delete_fixture(
     state.store.delete_cloud_fixture(id).await?;
 
     Ok(Json(serde_json::json!({ "success": true })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BulkDeleteRequest {
+    pub fixture_ids: Vec<Uuid>,
+}
+
+pub async fn delete_fixtures_bulk(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Json(request): Json<BulkDeleteRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    if request.fixture_ids.is_empty() {
+        return Ok(Json(serde_json::json!({ "deleted": [] })));
+    }
+
+    let deleted = state
+        .store
+        .delete_cloud_fixtures_bulk(org_ctx.org_id, &request.fixture_ids)
+        .await?;
+
+    let ip = headers
+        .get("X-Forwarded-For")
+        .or_else(|| headers.get("X-Real-IP"))
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.split(',').next().unwrap_or(s).trim());
+    let ua = headers.get("User-Agent").and_then(|h| h.to_str().ok());
+
+    if !deleted.is_empty() {
+        state
+            .store
+            .record_audit_event(
+                org_ctx.org_id,
+                Some(user_id),
+                AuditEventType::FixtureDeleted,
+                format!("Bulk-deleted {} fixture(s)", deleted.len()),
+                Some(serde_json::json!({ "fixture_ids": deleted })),
+                ip,
+                ua,
+            )
+            .await;
+    }
+
+    Ok(Json(serde_json::json!({ "deleted": deleted })))
 }

--- a/crates/mockforge-registry-server/src/handlers/cloud_fixtures.rs
+++ b/crates/mockforge-registry-server/src/handlers/cloud_fixtures.rs
@@ -141,6 +141,7 @@ pub struct UpdateFixtureRequest {
     pub path: Option<String>,
     pub method: Option<String>,
     pub content: Option<serde_json::Value>,
+    pub protocol: Option<String>,
     pub tags: Option<serde_json::Value>,
 }
 
@@ -176,6 +177,7 @@ pub async fn update_fixture(
             request.path.as_deref(),
             request.method.as_deref(),
             request.content.as_ref(),
+            request.protocol.as_deref(),
             request.tags.as_ref(),
         )
         .await?

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -316,6 +316,10 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         // Fixture routes
         .route("/api/v1/fixtures", get(handlers::cloud_fixtures::list_fixtures))
         .route("/api/v1/fixtures", post(handlers::cloud_fixtures::create_fixture))
+        .route(
+            "/api/v1/fixtures/bulk",
+            delete(handlers::cloud_fixtures::delete_fixtures_bulk),
+        )
         .route("/api/v1/fixtures/{id}", get(handlers::cloud_fixtures::get_fixture))
         .route("/api/v1/fixtures/{id}", patch(handlers::cloud_fixtures::update_fixture))
         .route("/api/v1/fixtures/{id}", delete(handlers::cloud_fixtures::delete_fixture))

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -2501,6 +2501,126 @@ fn extract_fingerprint(
     Ok(format!("{:x}", hasher.finish()))
 }
 
+/// JSON payload accepted by `POST /__mockforge/fixtures` on the local admin
+/// server. Mirrors the fields the cloud `/api/v1/fixtures` POST accepts so
+/// the UI can use the same dialog in either mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FixtureCreateRequest {
+    pub name: String,
+    #[serde(default)]
+    pub method: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub protocol: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub content: Option<serde_json::Value>,
+}
+
+/// Create a new fixture file on disk under
+/// `$MOCKFORGE_FIXTURES_DIR/{protocol}/{safe_name}.json`. The on-disk shape
+/// matches what `scan_fixtures_directory` reads back, so the new fixture
+/// shows up on the next list refresh.
+pub async fn create_fixture(
+    Json(payload): Json<FixtureCreateRequest>,
+) -> Json<ApiResponse<FixtureInfo>> {
+    match write_fixture_to_disk(payload).await {
+        Ok(info) => {
+            tracing::info!("Created fixture: {} ({})", info.id, info.file_path);
+            Json(ApiResponse::success(info))
+        }
+        Err(e) => {
+            tracing::error!("Failed to create fixture: {}", e);
+            Json(ApiResponse::error(format!("Failed to create fixture: {}", e)))
+        }
+    }
+}
+
+/// Defence-in-depth filename sanitiser: refuse anything outside
+/// `[a-zA-Z0-9._-]`, forbid leading dots, cap at 200 chars. Mirrors the rule
+/// used by `mockforge_http::fixtures_api::safe_id` so the two stores stay
+/// compatible.
+fn sanitize_fixture_filename(name: &str) -> Result<String> {
+    if name.is_empty() || name.len() > 200 {
+        return Err(Error::internal("Fixture name must be 1..=200 characters"));
+    }
+    if name == "." || name == ".." || name.starts_with('.') {
+        return Err(Error::internal("Fixture name must not start with '.'"));
+    }
+    if name
+        .chars()
+        .any(|c| !(c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.'))
+    {
+        return Err(Error::internal("Fixture name must match [a-zA-Z0-9._-]"));
+    }
+    Ok(name.to_string())
+}
+
+async fn write_fixture_to_disk(req: FixtureCreateRequest) -> Result<FixtureInfo> {
+    let trimmed = req.name.trim();
+    let safe_name = sanitize_fixture_filename(trimmed)?;
+    let protocol = req.protocol.as_deref().unwrap_or("http").to_lowercase();
+    let method = req.method.as_deref().unwrap_or("GET").to_uppercase();
+    let path_str = req.path.clone().unwrap_or_default();
+
+    // Build a self-describing JSON document that the scanner can read back.
+    // For HTTP we mimic the existing on-disk shape (request.method/path).
+    let mut document = serde_json::Map::new();
+    document.insert("name".to_string(), serde_json::Value::String(trimmed.to_string()));
+    if let Some(desc) = req.description.as_deref() {
+        document.insert("description".to_string(), serde_json::Value::String(desc.to_string()));
+    }
+    if !req.tags.is_empty() {
+        document.insert(
+            "tags".to_string(),
+            serde_json::Value::Array(
+                req.tags.iter().map(|t| serde_json::Value::String(t.clone())).collect(),
+            ),
+        );
+    }
+    document.insert("protocol".to_string(), serde_json::Value::String(protocol.clone()));
+    document
+        .insert("request".to_string(), serde_json::json!({ "method": method, "path": path_str }));
+    document.insert("response".to_string(), req.content.unwrap_or(serde_json::Value::Null));
+
+    let body = serde_json::to_string_pretty(&serde_json::Value::Object(document))
+        .map_err(|e| Error::internal(format!("Failed to serialise fixture JSON: {}", e)))?;
+
+    let fixtures_dir =
+        std::env::var("MOCKFORGE_FIXTURES_DIR").unwrap_or_else(|_| "fixtures".to_string());
+    let target_dir = std::path::Path::new(&fixtures_dir).join(&protocol);
+    tokio::fs::create_dir_all(&target_dir)
+        .await
+        .map_err(|e| Error::internal(format!("Failed to create fixtures directory: {}", e)))?;
+
+    let target_path = target_dir.join(format!("{}.json", safe_name));
+    if tokio::fs::try_exists(&target_path).await.unwrap_or(false) {
+        return Err(Error::internal(format!(
+            "Fixture '{}' already exists at {}",
+            safe_name,
+            target_path.display()
+        )));
+    }
+    tokio::fs::write(&target_path, body)
+        .await
+        .map_err(|e| Error::internal(format!("Failed to write fixture file: {}", e)))?;
+
+    // Re-read via the same parser the list endpoint uses, so the response we
+    // hand back to the UI is identical to what the next refresh will show.
+    let path_for_parse = target_path.clone();
+    let protocol_for_parse = protocol.clone();
+    let info = tokio::task::spawn_blocking(move || {
+        parse_fixture_file_sync(&path_for_parse, &protocol_for_parse)
+    })
+    .await
+    .map_err(|e| Error::internal(format!("Task join error: {}", e)))??;
+    Ok(info)
+}
+
 /// Delete a fixture
 pub async fn delete_fixture(
     Json(payload): Json<FixtureDeleteRequest>,

--- a/crates/mockforge-ui/src/routes.rs
+++ b/crates/mockforge-ui/src/routes.rs
@@ -158,7 +158,7 @@ pub fn create_admin_router(
         .route("/__mockforge/logs", delete(clear_logs))
         .route("/__mockforge/restart", post(restart_servers))
         .route("/__mockforge/restart/status", get(get_restart_status))
-        .route("/__mockforge/fixtures", get(get_fixtures))
+        .route("/__mockforge/fixtures", get(get_fixtures).post(create_fixture))
         .route("/__mockforge/fixtures/{id}", delete(delete_fixture))
         .route("/__mockforge/fixtures/bulk", delete(delete_fixtures_bulk))
         .route("/__mockforge/audit/logs", get(get_audit_logs))

--- a/crates/mockforge-ui/ui/src/pages/FixturesPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FixturesPage.tsx
@@ -227,6 +227,7 @@ export function FixturesPage() {
           path: editForm.path,
           method: editForm.method,
           description: editForm.description,
+          protocol: editForm.protocol || undefined,
           tags: parseTagsInput(editForm.tagsInput),
           content: contentResult.value ?? null,
         },
@@ -887,6 +888,29 @@ export function FixturesPage() {
 
             <div className="space-y-2">
               <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Protocol
+              </label>
+              <select
+                value={editForm.protocol}
+                onChange={(e) => setEditForm({ ...editForm, protocol: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option value="">— unspecified —</option>
+                <option value="http">http</option>
+                <option value="grpc">grpc</option>
+                <option value="websocket">websocket</option>
+                <option value="graphql">graphql</option>
+                <option value="mqtt">mqtt</option>
+                <option value="kafka">kafka</option>
+                <option value="amqp">amqp</option>
+                <option value="smtp">smtp</option>
+                <option value="ftp">ftp</option>
+                <option value="tcp">tcp</option>
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
                 Description
               </label>
               <Input
@@ -967,6 +991,14 @@ export function FixturesPage() {
                     <span className="font-medium">Size:</span>{' '}
                     {formatFileSize(
                       selectedFixture?.file_size ?? selectedFixture?.size_bytes ?? 0
+                    )}
+                  </div>
+                )}
+                {(selectedFixture?.created_at || selectedFixture?.createdAt) && (
+                  <div>
+                    <span className="font-medium">Created:</span>{' '}
+                    {formatDate(
+                      selectedFixture?.created_at || selectedFixture?.createdAt
                     )}
                   </div>
                 )}

--- a/crates/mockforge-ui/ui/src/pages/FixturesPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FixturesPage.tsx
@@ -43,6 +43,7 @@ import {
 } from '../components/ui/Dialog';
 import { toast } from 'sonner';
 import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 
 const isCloud = isCloudMode();
 
@@ -54,6 +55,7 @@ interface FixtureFormState {
   protocol: string;
   tagsInput: string;
   contentText: string;
+  routePath: string;
 }
 
 const EMPTY_FORM: FixtureFormState = {
@@ -64,6 +66,7 @@ const EMPTY_FORM: FixtureFormState = {
   protocol: '',
   tagsInput: '',
   contentText: '',
+  routePath: '',
 };
 
 function parseTagsInput(input: string): string[] {
@@ -115,6 +118,7 @@ function formFromFixture(fixture: FixtureInfo): FixtureFormState {
     protocol: fixture.protocol || '',
     tagsInput: stringifyTags(fixture.tags).join(', '),
     contentText: fixtureContentToString(fixture.content),
+    routePath: fixture.route_path || '',
   };
 }
 
@@ -122,6 +126,7 @@ export function FixturesPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedMethod, setSelectedMethod] = useState<string>('all');
   const [selectedTag, setSelectedTag] = useState<string>('all');
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspace?.id ?? null);
 
   const [selectedFixture, setSelectedFixture] = useState<FixtureInfo | null>(null);
   const [isViewingFixture, setIsViewingFixture] = useState(false);
@@ -200,6 +205,10 @@ export function FixturesPage() {
         protocol: createForm.protocol || undefined,
         tags: parseTagsInput(createForm.tagsInput),
         content: contentResult.value ?? undefined,
+        route_path: createForm.routePath.trim() || undefined,
+        // Cloud only: attach the active workspace if there is one. Local mode
+        // ignores this field.
+        workspace_id: isCloud ? activeWorkspaceId : undefined,
       });
       toast.success('Fixture created successfully');
       setIsCreateDialogOpen(false);
@@ -230,6 +239,7 @@ export function FixturesPage() {
           protocol: editForm.protocol || undefined,
           tags: parseTagsInput(editForm.tagsInput),
           content: contentResult.value ?? null,
+          route_path: editForm.routePath.trim() || undefined,
         },
       });
       toast.success('Fixture updated successfully');
@@ -750,6 +760,21 @@ export function FixturesPage() {
             {isCloud && (
               <div className="space-y-2">
                 <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Route Path (optional)
+                </label>
+                <Input
+                  value={createForm.routePath}
+                  onChange={(e) =>
+                    setCreateForm({ ...createForm, routePath: e.target.value })
+                  }
+                  placeholder="e.g., /api/users/{id} — canonical path with placeholders"
+                />
+              </div>
+            )}
+
+            {isCloud && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
                   Protocol
                 </label>
                 <select
@@ -911,6 +936,17 @@ export function FixturesPage() {
 
             <div className="space-y-2">
               <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Route Path (optional)
+              </label>
+              <Input
+                value={editForm.routePath}
+                onChange={(e) => setEditForm({ ...editForm, routePath: e.target.value })}
+                placeholder="e.g., /api/users/{id} — canonical path with placeholders"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-900 dark:text-gray-100">
                 Description
               </label>
               <Input
@@ -1012,6 +1048,28 @@ export function FixturesPage() {
                       selectedFixture?.createdAt
                   )}
                 </div>
+                {selectedFixture?.created_by_username && (
+                  <div>
+                    <span className="font-medium">Created by:</span>{' '}
+                    {selectedFixture.created_by_username}
+                  </div>
+                )}
+                {selectedFixture?.route_path && (
+                  <div>
+                    <span className="font-medium">Route path:</span>{' '}
+                    <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 rounded">
+                      {selectedFixture.route_path}
+                    </code>
+                  </div>
+                )}
+                {selectedFixture?.workspace_id && (
+                  <div>
+                    <span className="font-medium">Workspace:</span>{' '}
+                    <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 rounded">
+                      {selectedFixture.workspace_id}
+                    </code>
+                  </div>
+                )}
               </div>
 
               {selectedFixture?.description && (

--- a/crates/mockforge-ui/ui/src/services/api/fixtures.ts
+++ b/crates/mockforge-ui/ui/src/services/api/fixtures.ts
@@ -21,6 +21,10 @@ export interface FixtureCreatePayload {
   protocol?: string;
   tags?: string[];
   content?: unknown;
+  /** Cloud-only: assign the new fixture to a workspace. */
+  workspace_id?: string | null;
+  /** Cloud-only: optional canonical route path (complements path). */
+  route_path?: string | null;
 }
 
 export interface FixtureUpdatePayload {
@@ -31,6 +35,13 @@ export interface FixtureUpdatePayload {
   protocol?: string;
   tags?: string[];
   content?: unknown;
+  /** Cloud-only: optional canonical route path (complements path). */
+  route_path?: string | null;
+  /**
+   * Cloud-only tri-state. Omit to leave unchanged, send `null` to clear,
+   * send a uuid to assign.
+   */
+  workspace_id?: string | null;
 }
 
 class FixturesApiService {
@@ -46,9 +57,13 @@ class FixturesApiService {
     this.moveFixture = this.moveFixture.bind(this);
   }
 
-  async getFixtures(): Promise<FixtureInfo[]> {
+  async getFixtures(workspaceId?: string | null): Promise<FixtureInfo[]> {
     if (isCloud) {
-      return fetchJson(FIXTURE_API_BASE) as Promise<FixtureInfo[]>;
+      const url =
+        workspaceId == null
+          ? FIXTURE_API_BASE
+          : `${FIXTURE_API_BASE}?workspace_id=${encodeURIComponent(workspaceId)}`;
+      return fetchJson(url) as Promise<FixtureInfo[]>;
     }
     return fetchJsonWithValidation<FixtureInfo[]>(
       FIXTURE_API_BASE,
@@ -87,12 +102,8 @@ class FixturesApiService {
   }
 
   async deleteFixturesBulk(fixtureIds: string[]): Promise<void> {
-    if (isCloud) {
-      // Cloud has no bulk endpoint; fan out individual DELETE calls instead.
-      await Promise.all(fixtureIds.map((id) => this.deleteFixture(id)));
-      return;
-    }
-    return fetchJson(`${LOCAL_BASE}/bulk`, {
+    if (fixtureIds.length === 0) return;
+    return fetchJson(`${FIXTURE_API_BASE}/bulk`, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ fixture_ids: fixtureIds }),

--- a/crates/mockforge-ui/ui/src/services/api/fixtures.ts
+++ b/crates/mockforge-ui/ui/src/services/api/fixtures.ts
@@ -28,6 +28,7 @@ export interface FixtureUpdatePayload {
   path?: string;
   method?: string;
   description?: string;
+  protocol?: string;
   tags?: string[];
   content?: unknown;
 }

--- a/crates/mockforge-ui/ui/src/types/index.ts
+++ b/crates/mockforge-ui/ui/src/types/index.ts
@@ -50,6 +50,10 @@ export interface FixtureInfo {
   size?: number;
   created_at?: string;
   modified_at?: string;
+  /** Resolved username of the creator; set by the cloud API when known. */
+  created_by_username?: string;
+  /** Cloud-only: workspace this fixture is assigned to (if any). */
+  workspace_id?: string | null;
 }
 
 export interface DiffChange {


### PR DESCRIPTION
## Summary

Audit of the `/fixtures` page (cloud) found drift between the UI and the cloud fixtures API. This PR ships in two passes:

### Pass 1 — `a2232545` (initial findings)

- **`protocol` cannot be updated after creation.** `POST /api/v1/fixtures` accepts a `protocol` field, but the matching `PATCH` endpoint never has — `UpdateFixtureRequest`, the `Store::update_cloud_fixture` trait method, the postgres impl, and `CloudFixture::update` were all missing the column. Wired the field through end-to-end.
- **Edit dialog hid the protocol selector.** The Create dialog already has it; the Edit dialog mirrored most fields but skipped this one. Added the same `<select>` to Edit and pass `protocol` on the update mutation (via the new `FixtureUpdatePayload.protocol`).
- **Viewer conflated `created_at` and `updated_at`.** The cloud backend tracks both independently, but the viewer rendered only "Updated:" with a fallback to `created_at`. Added a separate "Created:" line so users can tell newly-imported fixtures from edited ones.

### Pass 2 — `185e5455` (close the deferred items)

**Backend (cloud / registry-server):**
- `CloudFixture` rows now `LEFT JOIN users` so list / get / create / update return `created_by_username`. The field is `#[sqlx(default)]` and serde-skipped when absent, so external consumers see no shape change unless the username is populated.
- `workspace_id` (`Option<Uuid>`) is now accepted on `POST` and on `PATCH` with **tri-state** semantics (omit / `null` / uuid). `GET` filters by `workspace_id` query param when present, defaulting to org-wide.
- `route_path` (`Option<String>`) plumbs through create / update.
- New `DELETE /api/v1/fixtures/bulk` endpoint replaces the FE fan-out: org-scoped, atomic, audit-logged once.

**Backend (local admin / mockforge-ui):**
- New `POST /__mockforge/fixtures` handler. Writes `{fixtures_dir}/{protocol}/{name}.json` in the same shape the existing scanner reads (`request.method`, `request.path`, etc.) and returns the parsed `FixtureInfo` so the UI list refresh shows it immediately. Filename is sanitised against path traversal and rejects collisions.

**Frontend:**
- `FixtureInfo` gains `created_by_username` and `workspace_id`.
- Create / Edit dialogs gain a Route Path input (cloud only).
- Create payload attaches the active workspace id automatically in cloud mode so new fixtures land in the user's current workspace.
- Update payload passes `route_path` through.
- Cloud bulk-delete now hits the new bulk endpoint instead of fanning out individual `DELETE`s.
- Viewer dialog shows Created by / Route path / Workspace when the cloud API populates them.

## Test plan

- [x] `cargo clippy -p mockforge-registry-core --all-targets -- -D warnings`
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo clippy -p mockforge-ui --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-core --lib` (244 pass)
- [x] `cargo test -p mockforge-registry-server --lib` (274 pass)
- [x] `cargo test -p mockforge-ui --lib` (443 pass)
- [x] `cargo fmt --all --check`
- [x] `pnpm type-check` in `crates/mockforge-ui/ui`
- [x] `pnpm lint` (0 errors; pre-existing warnings unchanged)
- [x] `pnpm test --run` (851 tests pass)
- [ ] **Manual (cloud):** create a fixture with `protocol=http`, edit it to `protocol=grpc`; verify the protocol persists.
- [ ] **Manual (cloud):** create a fixture with the active workspace selected; confirm the new fixture's `workspace_id` matches.
- [ ] **Manual (cloud):** delete several fixtures via bulk-select; verify a single audit-log entry is recorded.
- [ ] **Manual (cloud):** view a fixture and confirm Created by / Created / Updated / Route path / Workspace render when populated.
- [ ] **Manual (local):** click "New Fixture" in local-mode admin UI, save; confirm the file is created on disk and the list refresh shows it.