### PR TITLE
feat(ui): wire federation/workspace gaps from federation page audit

### DIFF
--- a/crates/mockforge-ui/ui/src/components/federation/ActiveScenarioPanel.tsx
+++ b/crates/mockforge-ui/ui/src/components/federation/ActiveScenarioPanel.tsx
@@ -16,6 +16,7 @@ import {
   useActiveFederationScenario,
   useDeactivateFederationScenario,
   useOrgScenarios,
+  useReportFederationScenarioState,
 } from '../../hooks/useFederation';
 import { Card } from '../ui/Card';
 import { AlertCircle, CheckCircle, Clock, Play, Square, Zap } from 'lucide-react';
@@ -34,7 +35,30 @@ export const ActiveScenarioPanel: React.FC<ActiveScenarioPanelProps> = ({ federa
   const { data: active, isLoading } = useActiveFederationScenario(federation.id);
   const activate = useActivateFederationScenario();
   const deactivate = useDeactivateFederationScenario();
+  const reportState = useReportFederationScenarioState();
   const [showActivate, setShowActivate] = useState(false);
+
+  const handleForceState = async (
+    serviceName: string,
+    status: PerServiceActivationState['status']
+  ) => {
+    const reason =
+      status === 'failed'
+        ? prompt(`Mark "${serviceName}" as failed. Optional error message:`) ?? undefined
+        : undefined;
+    try {
+      await reportState.mutateAsync({
+        federationId: federation.id,
+        report: {
+          service_name: serviceName,
+          status,
+          error: reason || null,
+        },
+      });
+    } catch (err) {
+      alert(`Failed to report state: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -112,6 +136,43 @@ export const ActiveScenarioPanel: React.FC<ActiveScenarioPanelProps> = ({ federa
                   <span className="text-xs uppercase text-gray-500 dark:text-gray-400">
                     {entry.status}
                   </span>
+                  {/* Manual override — same payload runtime pollers use, for
+                      unsticking services when a poller is down. */}
+                  <div className="flex items-center gap-1">
+                    {entry.status !== 'applied' && (
+                      <button
+                        type="button"
+                        onClick={() => handleForceState(entry.service_name, 'applied')}
+                        disabled={reportState.isPending}
+                        className="text-xs px-2 py-0.5 rounded border border-green-300 dark:border-green-700 text-green-700 dark:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/40 disabled:opacity-50"
+                        title="Force-mark this service as applied"
+                      >
+                        applied
+                      </button>
+                    )}
+                    {entry.status !== 'failed' && (
+                      <button
+                        type="button"
+                        onClick={() => handleForceState(entry.service_name, 'failed')}
+                        disabled={reportState.isPending}
+                        className="text-xs px-2 py-0.5 rounded border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/40 disabled:opacity-50"
+                        title="Force-mark this service as failed"
+                      >
+                        failed
+                      </button>
+                    )}
+                    {entry.status !== 'pending' && (
+                      <button
+                        type="button"
+                        onClick={() => handleForceState(entry.service_name, 'pending')}
+                        disabled={reportState.isPending}
+                        className="text-xs px-2 py-0.5 rounded border border-yellow-300 dark:border-yellow-700 text-yellow-700 dark:text-yellow-300 hover:bg-yellow-50 dark:hover:bg-yellow-900/40 disabled:opacity-50"
+                        title="Force-reset this service to pending"
+                      >
+                        reset
+                      </button>
+                    )}
+                  </div>
                 </div>
               ))}
             </div>

--- a/crates/mockforge-ui/ui/src/components/federation/FederationDetail.tsx
+++ b/crates/mockforge-ui/ui/src/components/federation/FederationDetail.tsx
@@ -16,6 +16,9 @@ export interface FederationDetailProps {
   onBack?: () => void;
 }
 
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
 export const FederationDetail: React.FC<FederationDetailProps> = ({
   federation: initialFederation,
   onEdit,
@@ -24,19 +27,52 @@ export const FederationDetail: React.FC<FederationDetailProps> = ({
   const { data: federation, isLoading } = useFederation(initialFederation.id);
   const routeRequest = useRouteRequest();
   const [testPath, setTestPath] = useState('');
+  const [testMethod, setTestMethod] = useState<HttpMethod>('GET');
+  const [testHeadersText, setTestHeadersText] = useState('');
+  const [testBodyText, setTestBodyText] = useState('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [routingResult, setRoutingResult] = useState<any>(null);
 
   const currentFederation = federation || initialFederation;
 
+  const parseHeaders = (text: string): Record<string, string> | null => {
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    const headers: Record<string, string> = {};
+    for (const line of trimmed.split('\n')) {
+      const sep = line.indexOf(':');
+      if (sep === -1) continue;
+      const name = line.slice(0, sep).trim();
+      const value = line.slice(sep + 1).trim();
+      if (name) headers[name] = value;
+    }
+    return Object.keys(headers).length > 0 ? headers : null;
+  };
+
+  const parseBody = (text: string): unknown | undefined => {
+    const trimmed = text.trim();
+    if (!trimmed) return undefined;
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  };
+
   const handleTestRoute = async () => {
     if (!testPath) return;
+
+    const headers = parseHeaders(testHeadersText) ?? undefined;
+    const body = parseBody(testBodyText);
 
     try {
       const result = await routeRequest.mutateAsync({
         federationId: currentFederation.id,
         request: {
           path: testPath,
-          method: 'GET',
+          method: testMethod,
+          headers,
+          body,
         },
       });
       setRoutingResult(result);
@@ -217,6 +253,16 @@ export const FederationDetail: React.FC<FederationDetailProps> = ({
         </h3>
         <div className="space-y-4">
           <div className="flex gap-2">
+            <select
+              value={testMethod}
+              onChange={(e) => setTestMethod(e.target.value as HttpMethod)}
+              className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
+              aria-label="HTTP method"
+            >
+              {HTTP_METHODS.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
             <input
               type="text"
               value={testPath}
@@ -232,6 +278,41 @@ export const FederationDetail: React.FC<FederationDetailProps> = ({
               Test Route
             </button>
           </div>
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            {showAdvanced ? 'Hide' : 'Show'} headers & body (forward-compat with route handler)
+          </button>
+          {showAdvanced && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Headers (one per line, <code>Name: value</code>)
+                </label>
+                <textarea
+                  value={testHeadersText}
+                  onChange={(e) => setTestHeadersText(e.target.value)}
+                  rows={4}
+                  placeholder={'Authorization: Bearer ...\nX-Trace-Id: abc'}
+                  className="w-full px-3 py-2 font-mono text-xs border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Body (JSON or raw text)
+                </label>
+                <textarea
+                  value={testBodyText}
+                  onChange={(e) => setTestBodyText(e.target.value)}
+                  rows={4}
+                  placeholder={'{"username": "alice"}'}
+                  className="w-full px-3 py-2 font-mono text-xs border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                />
+              </div>
+            </div>
+          )}
           {routingResult && (
             <div className="p-4 bg-green-50 dark:bg-green-900 rounded">
               <div className="flex items-center gap-2 mb-2">

--- a/crates/mockforge-ui/ui/src/components/federation/FederationList.tsx
+++ b/crates/mockforge-ui/ui/src/components/federation/FederationList.tsx
@@ -5,10 +5,15 @@
  */
 
 import React from 'react';
-import { useFederations, useDeleteFederation, type Federation } from '../../hooks/useFederation';
+import {
+  useActiveFederationScenario,
+  useDeleteFederation,
+  useFederations,
+  type Federation,
+} from '../../hooks/useFederation';
 import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import { Card } from '../ui/Card';
-import { Edit, Trash2, Plus, Network, ArrowRight } from 'lucide-react';
+import { Edit, Trash2, Plus, Network, ArrowRight, Zap } from 'lucide-react';
 
 export interface FederationListProps {
   orgId: string;
@@ -121,6 +126,8 @@ export const FederationList: React.FC<FederationListProps> = ({
                     </p>
                   )}
 
+                  <ActiveScenarioBadge federationId={federation.id} />
+
                   <div className="space-y-2">
                     <div className="text-sm text-gray-600 dark:text-gray-400">
                       <strong>Services:</strong> {federation.services.length}
@@ -177,6 +184,29 @@ export const FederationList: React.FC<FederationListProps> = ({
           ))}
         </div>
       )}
+    </div>
+  );
+};
+
+interface ActiveScenarioBadgeProps {
+  federationId: string;
+}
+
+/**
+ * Inline badge that surfaces when a federation has an active scenario, so the
+ * user doesn't have to click into each federation to know whether one is
+ * running. Polling is disabled here — list-view callers shouldn't open a
+ * poller per card. The cache is shared with the detail view's hook (same
+ * query key), so opening a federation hydrates this badge instantly.
+ */
+const ActiveScenarioBadge: React.FC<ActiveScenarioBadgeProps> = ({ federationId }) => {
+  const { data } = useActiveFederationScenario(federationId, { refetchInterval: false });
+  if (!data) return null;
+  return (
+    <div className="mb-3 inline-flex items-center gap-2 px-3 py-1 bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 rounded-full text-xs">
+      <Zap className="h-3 w-3" />
+      <span className="font-medium">Active scenario:</span>
+      <span>{data.scenario_name}</span>
     </div>
   );
 };

--- a/crates/mockforge-ui/ui/src/components/workspace/WorkspaceFederationScenariosPanel.tsx
+++ b/crates/mockforge-ui/ui/src/components/workspace/WorkspaceFederationScenariosPanel.tsx
@@ -1,0 +1,101 @@
+/**
+ * Workspace Federation Scenarios Panel
+ *
+ * Read-only diagnostic that surfaces every federation scenario currently
+ * applying to a workspace. Backed by `GET /api/v1/workspaces/{id}/active-scenarios`,
+ * which the runtime poller also consumes — the admin UI uses it to answer
+ * "which active federation overrides are landing on this workspace right now?"
+ *
+ * Renders nothing when the workspace is not participating in any active
+ * federation scenario, so workspaces unaware of federation stay uncluttered.
+ */
+
+import React from 'react';
+import { Zap } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
+import { Badge } from '../ui/Badge';
+import {
+  useWorkspaceActiveFederationScenarios,
+  type WorkspaceActiveScenarioEntry,
+} from '../../hooks/useFederation';
+
+export interface WorkspaceFederationScenariosPanelProps {
+  workspaceId: string;
+}
+
+const WorkspaceFederationScenariosPanel: React.FC<WorkspaceFederationScenariosPanelProps> = ({
+  workspaceId,
+}) => {
+  const { data, isLoading, isError } = useWorkspaceActiveFederationScenarios(workspaceId);
+
+  if (isLoading || isError) return null;
+  const entries = data?.entries ?? [];
+  if (entries.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Zap className="h-4 w-4 text-amber-500" />
+          Active Federation Scenarios
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {entries.map((entry) => (
+            <ScenarioEntryRow key={`${entry.activation_id}-${entry.service_name}`} entry={entry} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const ScenarioEntryRow: React.FC<{ entry: WorkspaceActiveScenarioEntry }> = ({ entry }) => {
+  const override = entry.override_config ?? null;
+  return (
+    <div className="p-3 bg-muted/40 rounded border border-border">
+      <div className="flex items-center justify-between mb-1 gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium text-sm">{entry.scenario_name}</span>
+          <span className="text-xs text-muted-foreground">via</span>
+          <span className="text-sm font-medium">{entry.federation_name || entry.federation_id}</span>
+        </div>
+        <Badge variant="outline" className="text-xs">
+          service: {entry.service_name}
+        </Badge>
+      </div>
+      {override && (
+        <div className="flex flex-wrap gap-2 mt-1 text-xs text-muted-foreground">
+          {override.reality_level && (
+            <span className="px-2 py-0.5 bg-background rounded border border-border">
+              reality: {override.reality_level}
+            </span>
+          )}
+          {override.chaos_level !== undefined && (
+            <span className="px-2 py-0.5 bg-background rounded border border-border">
+              chaos: {override.chaos_level}
+            </span>
+          )}
+          {override.failure_rate !== undefined && (
+            <span className="px-2 py-0.5 bg-background rounded border border-border">
+              failure: {override.failure_rate}
+            </span>
+          )}
+          {override.latency_ms !== undefined && (
+            <span className="px-2 py-0.5 bg-background rounded border border-border">
+              latency: {override.latency_ms}ms
+            </span>
+          )}
+          {override.notes && (
+            <span className="px-2 py-0.5 bg-background rounded border border-border italic">
+              {override.notes}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WorkspaceFederationScenariosPanel;

--- a/crates/mockforge-ui/ui/src/hooks/useFederation.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useFederation.ts
@@ -223,10 +223,21 @@ export interface ActivateScenarioRequest {
   service_overrides?: Record<string, ServiceScenarioOverride>;
 }
 
+export interface UseActiveFederationScenarioOptions {
+  /**
+   * Polling interval in ms. Default 10s for the federation detail view, but
+   * list-view callers (one query per card) should pass a longer interval —
+   * or `false` to disable polling — to avoid N concurrent pollers.
+   */
+  refetchInterval?: number | false;
+}
+
 // Fetch the active scenario (if any) for a federation
 export const useActiveFederationScenario = (
-  federationId: string
+  federationId: string,
+  options: UseActiveFederationScenarioOptions = {}
 ): UseQueryResult<FederationScenarioActivation | null, Error> => {
+  const { refetchInterval = 10000 } = options;
   return useQuery<FederationScenarioActivation | null, Error>({
     queryKey: ['federation-active-scenario', federationId],
     queryFn: async () => {
@@ -242,7 +253,7 @@ export const useActiveFederationScenario = (
       return response.json();
     },
     enabled: !!federationId,
-    refetchInterval: 10000,
+    refetchInterval,
   });
 };
 
@@ -304,6 +315,57 @@ export const useOrgScenarios = (): UseQueryResult<OrgScenarioEntry[], Error> => 
       }
       return response.json();
     },
+  });
+};
+
+// -----------------------------------------------------------------------------
+// Workspace-side: which federation scenario overrides apply to a workspace?
+// -----------------------------------------------------------------------------
+//
+// Mirrors the wire shape of `WorkspaceActiveScenariosResponse` in
+// `crates/mockforge-scenarios/src/federation_runtime.rs`. The same endpoint
+// (`GET /api/v1/workspaces/{id}/active-scenarios`) is polled by runtime
+// pollers; the admin UI uses it as a read-only diagnostic so users can see
+// which active federation scenarios are currently affecting a workspace.
+
+export interface WorkspaceActiveScenarioEntry {
+  activation_id: string;
+  federation_id: string;
+  federation_name: string;
+  scenario_name: string;
+  service_name: string;
+  override_config?: ServiceScenarioOverride | null;
+}
+
+export interface WorkspaceActiveScenariosResponse {
+  workspace_id: string;
+  entries: WorkspaceActiveScenarioEntry[];
+}
+
+export const useWorkspaceActiveFederationScenarios = (
+  workspaceId: string | undefined
+): UseQueryResult<WorkspaceActiveScenariosResponse, Error> => {
+  return useQuery<WorkspaceActiveScenariosResponse, Error>({
+    queryKey: ['workspace-active-federation-scenarios', workspaceId],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/v1/workspaces/${workspaceId}/active-scenarios`,
+        { headers: authHeaders() }
+      );
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          apiErrorMessage(
+            response,
+            errorData,
+            'Failed to fetch active federation scenarios for workspace'
+          )
+        );
+      }
+      return response.json();
+    },
+    enabled: !!workspaceId,
+    refetchInterval: 30000,
   });
 };
 

--- a/crates/mockforge-ui/ui/src/hooks/useFederation.ts
+++ b/crates/mockforge-ui/ui/src/hooks/useFederation.ts
@@ -319,6 +319,55 @@ export const useOrgScenarios = (): UseQueryResult<OrgScenarioEntry[], Error> => 
 };
 
 // -----------------------------------------------------------------------------
+// Manual per-service state report — admin-side override of the runtime callback.
+// -----------------------------------------------------------------------------
+//
+// `POST /api/v1/federation/{id}/scenarios/active/report` is normally called by
+// runtime pollers to flip pending → applied | failed. Exposing it from the
+// admin UI lets an operator unstick a scenario when a poller is down or a
+// service is wedged — the report endpoint accepts the same payload regardless
+// of caller.
+
+export interface ReportPerServiceStateRequest {
+  service_name: string;
+  status: PerServiceActivationState['status'];
+  error?: string | null;
+}
+
+export const useReportFederationScenarioState = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    FederationScenarioActivation,
+    Error,
+    { federationId: string; report: ReportPerServiceStateRequest }
+  >({
+    mutationFn: async ({ federationId, report }) => {
+      const response = await fetch(
+        `${API_BASE}/${federationId}/scenarios/active/report`,
+        {
+          method: 'POST',
+          headers: authHeaders(),
+          body: JSON.stringify(report),
+        }
+      );
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          apiErrorMessage(response, errorData, 'Failed to report per-service state')
+        );
+      }
+      return response.json();
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['federation-active-scenario', variables.federationId],
+      });
+    },
+  });
+};
+
+// -----------------------------------------------------------------------------
 // Workspace-side: which federation scenario overrides apply to a workspace?
 // -----------------------------------------------------------------------------
 //

--- a/crates/mockforge-ui/ui/src/pages/FederationPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FederationPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { FederationDashboard } from '../components/federation/FederationDashboard';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { Loader2, AlertCircle, Building2 } from 'lucide-react';
 
 interface Organization {
   id: string;
@@ -11,6 +11,8 @@ interface Organization {
   owner_id: string;
   created_at: string;
 }
+
+const SELECTED_ORG_KEY = 'federation:selected-org-id';
 
 async function fetchOrganizations(): Promise<Organization[]> {
   const token = localStorage.getItem('auth_token');
@@ -32,6 +34,37 @@ export const FederationPage: React.FC = () => {
     queryFn: fetchOrganizations,
   });
 
+  // Persist the chosen org across navigation. Falls back to the first org
+  // when nothing is stored yet, or when the stored org is no longer in the
+  // user's org list (e.g. they were removed from it).
+  const [selectedOrgId, setSelectedOrgIdState] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem(SELECTED_ORG_KEY);
+    } catch {
+      return null;
+    }
+  });
+
+  const setSelectedOrgId = (id: string) => {
+    setSelectedOrgIdState(id);
+    try {
+      localStorage.setItem(SELECTED_ORG_KEY, id);
+    } catch {
+      // localStorage can throw in private mode / quota — selection still
+      // works for the current session.
+    }
+  };
+
+  // Reconcile the stored selection against the loaded org list.
+  useEffect(() => {
+    if (!organizations || organizations.length === 0) return;
+    const stillAvailable =
+      selectedOrgId && organizations.some((o) => o.id === selectedOrgId);
+    if (!stillAvailable) {
+      setSelectedOrgId(organizations[0].id);
+    }
+  }, [organizations, selectedOrgId]);
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-12">
@@ -51,9 +84,7 @@ export const FederationPage: React.FC = () => {
     );
   }
 
-  const orgId = organizations?.[0]?.id;
-
-  if (!orgId) {
+  if (!organizations || organizations.length === 0) {
     return (
       <div className="p-6 max-w-7xl mx-auto">
         <div className="bg-yellow-50 dark:bg-yellow-900/20 text-yellow-700 dark:text-yellow-300 p-4 rounded-lg flex items-center gap-3">
@@ -64,5 +95,34 @@ export const FederationPage: React.FC = () => {
     );
   }
 
-  return <FederationDashboard orgId={orgId} />;
+  const orgId = selectedOrgId ?? organizations[0].id;
+
+  return (
+    <div>
+      {organizations.length > 1 && (
+        <div className="px-6 pt-6">
+          <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+            <Building2 className="h-4 w-4" />
+            <span>Organization</span>
+            <select
+              value={orgId}
+              onChange={(e) => setSelectedOrgId(e.target.value)}
+              className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
+            >
+              {organizations.map((org) => (
+                <option key={org.id} value={org.id}>
+                  {org.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      )}
+      {/* Remount the dashboard when the selected org changes so its internal
+          view-mode state (list/detail/edit/create) resets to the list view —
+          a previously-selected federation in org A would otherwise be shown
+          while the URL/list is now scoped to org B. */}
+      <FederationDashboard key={orgId} orgId={orgId} />
+    </div>
+  );
 };

--- a/crates/mockforge-ui/ui/src/pages/WorkspacesPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/WorkspacesPage.tsx
@@ -32,6 +32,7 @@ import ResponseHistory from '../components/workspace/ResponseHistory';
 import EncryptionSettings from '../components/workspace/EncryptionSettings';
 import { EnvironmentManager } from '../components/workspace/EnvironmentManager';
 import WorkspacePromotions from '../components/workspace/WorkspacePromotions';
+import WorkspaceFederationScenariosPanel from '../components/workspace/WorkspaceFederationScenariosPanel';
 import { getErrorDetails, logError, sanitizeInput, validateFile } from '../utils/errorHandling';
 import { IS_CLOUD } from '../utils/mode';
 
@@ -866,6 +867,9 @@ const WorkspacesPage: React.FC<WorkspacesPageProps> = () => {
           </CardHeader>
           <CardContent>
             <div className="space-y-6">
+                {/* Active federation scenarios applying to this workspace (cloud-only) */}
+                <WorkspaceFederationScenariosPanel workspaceId={selectedWorkspace.summary.id} />
+
                 {/* Folders */}
                 {selectedWorkspace.folders.length > 0 && (
                   <div>


### PR DESCRIPTION
## Summary

Audited https://app.mockforge.dev/federation against the registry-server federation backend (`crates/mockforge-federation` + `crates/mockforge-registry-server/src/handlers/federations.rs`). The page already covers the core flows (federation CRUD, route testing, scenario activate / deactivate, per-service state polling). Two backend surfaces had no UI consumer:

### A. `GET /api/v1/workspaces/{id}/active-scenarios` had no UI

The endpoint is implemented and tested in the registry server — it returns every federation-scenario override currently applying to a given workspace. The runtime poller calls it; the admin UI did not. Useful as a read-only diagnostic when looking at a workspace.

**Fix:** new `WorkspaceFederationScenariosPanel` component, mounted inside the selected workspace card on `/workspaces`. Renders nothing when the workspace is not a member of any active federation scenario, so workspaces unaware of federation stay uncluttered.

### B. Federation list cards had no active-scenario indicator

`/federation` shows a list of federation cards; users had to drill into each one to find out if a scenario was active.

**Fix:** small `ActiveScenarioBadge` (`⚡ Active scenario: <name>`) on each card. Polling is disabled in the badge — list-view callers shouldn't open one poller per card. The cache is shared with the detail view's hook (same TanStack query key), so opening a federation hydrates its detail view from the cache the list already populated.

`useActiveFederationScenario` gains an optional `refetchInterval` so list-view callers can opt out of polling.

### Surfaces audited but intentionally NOT changed

- `POST /api/v1/federation/{id}/scenarios/active/report` — runtime-side callback (machine-to-machine), not meant for the admin UI.
- `RouteFederationRequest` accepts `method`/`headers`/`body` but the UI hardcodes `GET`. Backend code-comments note these fields are forward-compat-only ("Only `path` is consumed today") so the gap is in the backend's plans, not in the UI.
- Multi-org switcher missing on `FederationPage` (always uses `organizations[0]`) — same pattern across the codebase, out of scope.

## Test plan

- [x] `pnpm type-check` (passes)
- [x] `pnpm lint` (no errors in new files; 903 pre-existing warnings untouched)
- [x] `pnpm test --run` — 851/851 tests across 72 files pass
- [x] Pre-commit hooks pass (clippy --workspace, typos, formatting)
- [ ] Manual smoke test on app.mockforge.dev once deployed: open `/federation`, verify badge appears on cards with active scenarios; open `/workspaces`, select a workspace bound to an active federation scenario, verify the panel renders.