### PR TITLE
feat(observability,tui): TPS/RPS/CPS rate metrics in TUI + CSV (#79)

### DIFF
--- a/crates/mockforge-chaos/src/chaos_listener.rs
+++ b/crates/mockforge-chaos/src/chaos_listener.rs
@@ -127,6 +127,9 @@ impl axum::serve::Listener for ChaosTcpListener {
                 }
                 // `Http503` (or no fault hit) lets the connection through; the
                 // chaos middleware will still apply its HTTP-level 503 logic.
+                // The accept counter is bumped by `CountingMakeService` when
+                // axum hands the stream to the make-service, so this listener
+                // doesn't need to touch it.
                 _ => return (stream, addr),
             }
         }

--- a/crates/mockforge-chaos/src/request_matcher.rs
+++ b/crates/mockforge-chaos/src/request_matcher.rs
@@ -153,7 +153,7 @@ mod tests {
         pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
     }
 
-    fn iter<'a>(v: &'a [(String, String)]) -> impl IntoIterator<Item = (&'a str, &'a str)> + Clone {
+    fn iter(v: &[(String, String)]) -> impl IntoIterator<Item = (&str, &str)> + Clone {
         v.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect::<Vec<_>>()
     }
 

--- a/crates/mockforge-foundation/src/lib.rs
+++ b/crates/mockforge-foundation/src/lib.rs
@@ -23,6 +23,7 @@ pub mod latency;
 pub mod multi_tenant_types;
 pub mod protocol;
 pub mod protocol_contract_types;
+pub mod rate_counters;
 pub mod response_generation_trace;
 pub mod response_selection;
 pub mod schema_diff;

--- a/crates/mockforge-foundation/src/rate_counters.rs
+++ b/crates/mockforge-foundation/src/rate_counters.rs
@@ -1,0 +1,141 @@
+//! Per-second rate counters for HTTP traffic.
+//!
+//! Simple monotonic atomic counters. The HTTP metrics middleware bumps
+//! the response counters; the TCP-accept counter is bumped at the listener
+//! level (see `mockforge-http`'s `CountingTcpListener` and `mockforge-chaos`'s
+//! `ChaosTcpListener`).
+//!
+//! These are sampled at fixed intervals by the admin dashboard collector
+//! to derive per-second rates:
+//!
+//! * **TPS** — successful (2xx/3xx) responses per second
+//! * **RPS** — 200-OK responses per second
+//! * **CPS** — accepted TCP connections per second  *(plain HTTP only;
+//!   the TLS path uses `axum_server`'s own accept loop and is not yet
+//!   instrumented)*
+//!
+//! The "successful API transaction" definition for TPS is `200..=399`,
+//! matching how load-testing tools (k6, JMeter, etc.) classify a successful
+//! request — anything that wasn't a 4xx/5xx error.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Total successful HTTP responses (status `200..=399`).
+pub static SUCCESSFUL_RESPONSES_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Total HTTP `200 OK` responses.
+pub static OK_RESPONSES_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Total accepted TCP connections (plain HTTP path only — see module docs).
+pub static HTTP_ACCEPTS_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Bump the response counters according to the response's status code.
+#[inline]
+pub fn record_response(status_code: u16) {
+    if (200..=399).contains(&status_code) {
+        SUCCESSFUL_RESPONSES_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
+    if status_code == 200 {
+        OK_RESPONSES_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Bump the TCP-accept counter. Call once per accepted connection.
+#[inline]
+pub fn record_accept() {
+    HTTP_ACCEPTS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Point-in-time snapshot of the rate counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CounterSnapshot {
+    pub successful: u64,
+    pub ok: u64,
+    pub accepts: u64,
+}
+
+/// Read all counters atomically (each load is independent — a snapshot
+/// is not transactional, but for sampling rates this is fine).
+pub fn snapshot() -> CounterSnapshot {
+    CounterSnapshot {
+        successful: SUCCESSFUL_RESPONSES_TOTAL.load(Ordering::Relaxed),
+        ok: OK_RESPONSES_TOTAL.load(Ordering::Relaxed),
+        accepts: HTTP_ACCEPTS_TOTAL.load(Ordering::Relaxed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // The counters are global; serialize tests to avoid cross-test interference.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn reset_counters() {
+        SUCCESSFUL_RESPONSES_TOTAL.store(0, Ordering::Relaxed);
+        OK_RESPONSES_TOTAL.store(0, Ordering::Relaxed);
+        HTTP_ACCEPTS_TOTAL.store(0, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn record_response_classifies_2xx_as_successful() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+        record_response(200);
+        record_response(204);
+        record_response(301);
+        let s = snapshot();
+        assert_eq!(s.successful, 3, "200, 204, 301 are all successful");
+        assert_eq!(s.ok, 1, "only one 200");
+    }
+
+    #[test]
+    fn record_response_excludes_4xx_5xx_from_successful() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+        record_response(404);
+        record_response(429);
+        record_response(500);
+        record_response(503);
+        let s = snapshot();
+        assert_eq!(s.successful, 0);
+        assert_eq!(s.ok, 0);
+    }
+
+    #[test]
+    fn record_accept_increments() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+        record_accept();
+        record_accept();
+        record_accept();
+        let s = snapshot();
+        assert_eq!(s.accepts, 3);
+    }
+
+    #[test]
+    fn snapshot_returns_current_values() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+        record_response(200);
+        record_response(200);
+        record_accept();
+        let s = snapshot();
+        assert_eq!(s.successful, 2);
+        assert_eq!(s.ok, 2);
+        assert_eq!(s.accepts, 1);
+    }
+
+    #[test]
+    fn ok_counter_only_for_status_200() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+        record_response(200);
+        record_response(201);
+        record_response(204);
+        let s = snapshot();
+        assert_eq!(s.ok, 1, "only 200 increments ok counter");
+        assert_eq!(s.successful, 3, "all three are successful");
+    }
+}

--- a/crates/mockforge-http/src/counting_listener.rs
+++ b/crates/mockforge-http/src/counting_listener.rs
@@ -1,0 +1,79 @@
+//! Connection-accept counter for HTTP serve paths.
+//!
+//! Wraps a Tower service (in `axum::serve` / `axum_server::Server::serve`
+//! parlance, the "make-service") so that the per-connection
+//! `make_service.call(target)` increments the global `record_accept()`
+//! counter. The dashboard sampler reads the counter every 10s to derive
+//! a connections-per-second rate.
+//!
+//! Counting at the make-service layer (not the TCP listener layer) works
+//! for **both**:
+//! - plain HTTP via `axum::serve(listener, make_svc)`
+//! - HTTPS via `axum_server::Server::bind_rustls(...).serve(make_svc)`
+//!
+//! For HTTPS, the counter only ticks once the TLS handshake completes —
+//! failed handshakes aren't counted, which is the correct semantic for
+//! "successful connection".
+
+use std::task::{Context, Poll};
+
+/// Tower service that bumps the global accept counter on each `call()`.
+///
+/// `Service<T>` for any `T` — works as an axum make-service regardless
+/// of the connection target type (`SocketAddr`, `ChaosClientAddr`, etc.).
+#[derive(Clone)]
+pub struct CountingMakeService<M> {
+    inner: M,
+}
+
+impl<M> CountingMakeService<M> {
+    /// Wrap a make-service. Each `call(target)` will bump the global
+    /// accept counter before delegating.
+    pub fn new(inner: M) -> Self {
+        Self { inner }
+    }
+}
+
+impl<M, T> tower::Service<T> for CountingMakeService<M>
+where
+    M: tower::Service<T>,
+{
+    type Response = M::Response;
+    type Error = M::Error;
+    type Future = M::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        mockforge_foundation::rate_counters::record_accept();
+        self.inner.call(target)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockforge_foundation::rate_counters;
+    use std::convert::Infallible;
+    use std::sync::atomic::Ordering;
+    use tower::{service_fn, Service, ServiceExt};
+
+    #[tokio::test]
+    async fn counting_make_service_bumps_accept_counter() {
+        let before = rate_counters::HTTP_ACCEPTS_TOTAL.load(Ordering::Relaxed);
+
+        let inner = service_fn(|_addr: std::net::SocketAddr| async {
+            Ok::<_, Infallible>(service_fn(|_req: ()| async { Ok::<_, Infallible>(()) }))
+        });
+        let mut counted = CountingMakeService::new(inner);
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+        let _service = counted.ready().await.unwrap().call(addr).await.unwrap();
+        let _service = counted.ready().await.unwrap().call(addr).await.unwrap();
+
+        let after = rate_counters::HTTP_ACCEPTS_TOTAL.load(Ordering::Relaxed);
+        assert_eq!(after, before + 2, "each make-service call bumps the counter");
+    }
+}

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -177,6 +177,9 @@ pub mod consistency;
 pub mod contract_diff_api;
 /// Contract diff middleware for automatic request capture
 pub mod contract_diff_middleware;
+/// TCP-listener wrapper that bumps the global `record_accept()` counter,
+/// used by the dashboard sampler to derive connections-per-second.
+pub mod counting_listener;
 pub mod coverage;
 pub mod database;
 /// File generation service for creating mock PDF, CSV, JSON files
@@ -1474,12 +1477,17 @@ pub async fn serve_router_with_tls_notify_chaos(
         let make_svc = axum::ServiceExt::<Request<Body>>::into_make_service_with_connect_info::<
             mockforge_chaos::ChaosClientAddr,
         >(app_with_addr_compat);
-        axum::serve(chaos_listener, make_svc).await?;
+        // Bump the accept counter on each connection that gets through chaos.
+        let counted = counting_listener::CountingMakeService::new(make_svc);
+        axum::serve(chaos_listener, counted).await?;
     } else {
         let make_svc = axum::ServiceExt::<Request<Body>>::into_make_service_with_connect_info::<
             SocketAddr,
         >(odata_app);
-        axum::serve(listener, make_svc).await?;
+        // Bump the accept counter once per accepted connection so the
+        // dashboard sampler can derive CPS.
+        let counted = counting_listener::CountingMakeService::new(make_svc);
+        axum::serve(listener, counted).await?;
     }
     Ok(())
 }
@@ -1536,10 +1544,13 @@ async fn serve_with_tls(
     let make_svc = axum::ServiceExt::<Request<Body>>::into_make_service_with_connect_info::<
         SocketAddr,
     >(odata_app);
+    // Bump the accept counter once per successful TLS handshake / connection
+    // so the dashboard sampler can derive CPS for HTTPS-only setups.
+    let counted = counting_listener::CountingMakeService::new(make_svc);
 
     // Serve with TLS using axum-server
     axum_server::bind_rustls(addr, rustls_config)
-        .serve(make_svc)
+        .serve(counted)
         .await
         .map_err(|e| format!("HTTPS server error: {}", e).into())
 }

--- a/crates/mockforge-http/src/metrics_middleware.rs
+++ b/crates/mockforge-http/src/metrics_middleware.rs
@@ -123,6 +123,9 @@ pub async fn collect_http_metrics(
     // Record metrics with pillar information
     registry.record_http_request_with_pillar(&method, status_code, duration_seconds, pillar);
 
+    // Bump TPS / RPS counters for the dashboard rate sampler.
+    mockforge_foundation::rate_counters::record_response(status_code);
+
     // Record errors separately with pillar
     if status_code >= 400 {
         let error_type = if status_code >= 500 {

--- a/crates/mockforge-tui/src/api/models.rs
+++ b/crates/mockforge-tui/src/api/models.rs
@@ -133,6 +133,23 @@ pub struct SystemInfo {
     pub peak_error_rate: f64,
     #[serde(default)]
     pub peaks_since: Option<DateTime<Utc>>,
+    /// Successful (200..=399) responses per second, sampled over the last
+    /// metrics interval. "API transactions/sec" in load-testing terms.
+    #[serde(default)]
+    pub tps: f64,
+    #[serde(default)]
+    pub peak_tps: f64,
+    /// 200-OK responses per second over the last metrics interval.
+    #[serde(default)]
+    pub rps_200: f64,
+    #[serde(default)]
+    pub peak_rps_200: f64,
+    /// Accepted TCP connections per second (plain HTTP path; reads 0 for
+    /// HTTPS-only setups).
+    #[serde(default)]
+    pub cps: f64,
+    #[serde(default)]
+    pub peak_cps: f64,
 }
 
 // ── Request logs ─────────────────────────────────────────────────────

--- a/crates/mockforge-tui/src/screens/dashboard.rs
+++ b/crates/mockforge-tui/src/screens/dashboard.rs
@@ -256,13 +256,21 @@ impl DashboardScreen {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let chunks = Layout::vertical([Constraint::Length(3), Constraint::Min(2)]).split(inner);
+        // Reserve 4 lines for the text stats (Total/ErrRate, Avg RT, TPS/RPS,
+        // CPS); rest goes to the sparkline.
+        let chunks = Layout::vertical([Constraint::Length(4), Constraint::Min(2)]).split(inner);
 
         // Stats summary
         let total = data.metrics.total_requests;
         let avg_rt = data.metrics.average_response_time;
         let err_rate = data.metrics.error_rate;
         let peak_err = data.system.peak_error_rate.max(err_rate);
+        let tps = data.system.tps;
+        let peak_tps = data.system.peak_tps.max(tps);
+        let rps_200 = data.system.rps_200;
+        let peak_rps_200 = data.system.peak_rps_200.max(rps_200);
+        let cps = data.system.cps;
+        let peak_cps = data.system.peak_cps.max(cps);
 
         let stats = vec![
             Line::from(vec![
@@ -285,6 +293,19 @@ impl DashboardScreen {
             Line::from(vec![
                 Span::styled(" Avg RT: ", Theme::dim()),
                 Span::styled(format!("{avg_rt:.0}ms"), Style::default().fg(Theme::FG)),
+            ]),
+            Line::from(vec![
+                Span::styled(" TPS: ", Theme::dim()),
+                Span::styled(format!("{tps:.1}"), Style::default().fg(Theme::FG)),
+                Span::styled(format!(" (peak {peak_tps:.1})"), Theme::dim()),
+                Span::styled("  RPS200: ", Theme::dim()),
+                Span::styled(format!("{rps_200:.1}"), Style::default().fg(Theme::FG)),
+                Span::styled(format!(" (peak {peak_rps_200:.1})"), Theme::dim()),
+            ]),
+            Line::from(vec![
+                Span::styled(" CPS: ", Theme::dim()),
+                Span::styled(format!("{cps:.1}"), Style::default().fg(Theme::FG)),
+                Span::styled(format!(" (peak {peak_cps:.1})"), Theme::dim()),
             ]),
         ];
         frame.render_widget(Paragraph::new(stats), chunks[0]);
@@ -391,7 +412,13 @@ mod tests {
                 "memory_usage_mb": 512,
                 "active_threads": 8,
                 "total_routes": 25,
-                "total_fixtures": 10
+                "total_fixtures": 10,
+                "tps": 42.5,
+                "peak_tps": 120.0,
+                "rps_200": 38.0,
+                "peak_rps_200": 110.0,
+                "cps": 7.5,
+                "peak_cps": 30.0
             },
             "recent_logs": [
                 {

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -130,6 +130,21 @@ pub struct SystemMetrics {
     pub peak_error_rate: f64,
     /// Timestamp peaks were last reset / metrics started — gives a window for long runs
     pub peaks_since: chrono::DateTime<Utc>,
+    /// Successful (status 200..=399) responses per second over the last
+    /// monitoring tick (~10s). "API transactions/sec" in load-testing terms.
+    pub tps: f64,
+    /// Peak `tps` observed since `peaks_since`.
+    pub peak_tps: f64,
+    /// HTTP `200 OK` responses per second over the last monitoring tick.
+    pub rps_200: f64,
+    /// Peak `rps_200` observed since `peaks_since`.
+    pub peak_rps_200: f64,
+    /// Accepted TCP connections per second over the last monitoring tick
+    /// (plain HTTP path only — the TLS path uses `axum-server`'s own accept
+    /// loop and is not yet instrumented).
+    pub cps: f64,
+    /// Peak `cps` observed since `peaks_since`.
+    pub peak_cps: f64,
 }
 
 /// Time series data point
@@ -336,12 +351,19 @@ pub struct AdminState {
 impl AdminState {
     /// Start system monitoring background task.
     ///
-    /// If `MOCKFORGE_METRICS_LOG_FILE` is set, appends a CSV row
-    /// (timestamp,cpu_pct,mem_mb,total_reqs,err_rate) on each tick — gives
-    /// a multi-day, restart-surviving record that can be charted in any
-    /// spreadsheet, Grafana, or dashboarding tool.
+    /// If `MOCKFORGE_METRICS_LOG_FILE` is set, appends a CSV row on each
+    /// tick — `timestamp,cpu_pct,mem_mb,total_reqs,err_rate,tps,rps_200,cps`
+    /// — giving a multi-day, restart-surviving record that can be charted
+    /// in any spreadsheet, Grafana, or dashboarding tool.
+    ///
+    /// `tps`, `rps_200`, and `cps` columns were added in 0.3.126; downstream
+    /// consumers that key off the header row will pick them up automatically,
+    /// positional parsers will still see the original five columns first.
     pub async fn start_system_monitoring(&self) {
+        use mockforge_foundation::rate_counters;
         use std::io::Write as _;
+        use std::time::Instant;
+
         let state_clone = self.clone();
         let metrics_log_path = std::env::var("MOCKFORGE_METRICS_LOG_FILE").ok();
         tokio::spawn(async move {
@@ -357,7 +379,10 @@ impl AdminState {
                             let needs_header =
                                 std::fs::metadata(p).map(|m| m.len() == 0).unwrap_or(true);
                             if needs_header {
-                                let _ = writeln!(f, "timestamp,cpu_pct,mem_mb,total_reqs,err_rate");
+                                let _ = writeln!(
+                                    f,
+                                    "timestamp,cpu_pct,mem_mb,total_reqs,err_rate,tps,rps_200,cps"
+                                );
                             }
                             tracing::info!("system metrics CSV → {}", p);
                             Some(f)
@@ -374,6 +399,11 @@ impl AdminState {
             };
 
             tracing::info!("Starting system monitoring background task");
+
+            // Baseline for rate computation — first tick produces 0/sec
+            // because we have no `prev` yet, which is the desired behavior.
+            let mut prev_snapshot = rate_counters::snapshot();
+            let mut prev_sample_at = Instant::now();
 
             loop {
                 // Refresh system information
@@ -393,19 +423,37 @@ impl AdminState {
                 // Update system metrics
                 let memory_mb_u64 = memory_usage_mb as u64;
 
+                // Compute per-second rates from rate-counter deltas. First
+                // tick after start: dt is small but counters haven't moved
+                // either, so rates are 0 — fine.
+                let now = Instant::now();
+                let cur_snapshot = rate_counters::snapshot();
+                let dt_secs = now.saturating_duration_since(prev_sample_at).as_secs_f64().max(0.01);
+                let tps = cur_snapshot.successful.saturating_sub(prev_snapshot.successful) as f64
+                    / dt_secs;
+                let rps_200 = cur_snapshot.ok.saturating_sub(prev_snapshot.ok) as f64 / dt_secs;
+                let cps =
+                    cur_snapshot.accepts.saturating_sub(prev_snapshot.accepts) as f64 / dt_secs;
+                prev_snapshot = cur_snapshot;
+                prev_sample_at = now;
+
                 // Only log every 10 refreshes to avoid spam
                 if refresh_count.is_multiple_of(10) {
                     tracing::debug!(
-                        "System metrics updated: CPU={:.1}%, Mem={}MB, Threads={}",
+                        "System metrics updated: CPU={:.1}%, Mem={}MB, Threads={}, TPS={:.1}, RPS200={:.1}, CPS={:.1}",
                         cpu_usage,
                         memory_mb_u64,
-                        active_threads
+                        active_threads,
+                        tps,
+                        rps_200,
+                        cps,
                     );
                 }
 
                 state_clone
                     .update_system_metrics(memory_mb_u64, cpu_usage as f64, active_threads)
                     .await;
+                state_clone.update_rate_metrics(tps, rps_200, cps).await;
 
                 if let Some(file) = metrics_log.as_mut() {
                     let m = state_clone.metrics.read().await;
@@ -419,12 +467,15 @@ impl AdminState {
                     drop(m);
                     let _ = writeln!(
                         file,
-                        "{},{:.2},{},{},{:.6}",
+                        "{},{:.2},{},{},{:.6},{:.2},{:.2},{:.2}",
                         Utc::now().to_rfc3339(),
                         cpu_usage,
                         memory_mb_u64,
                         total_reqs,
-                        err_rate
+                        err_rate,
+                        tps,
+                        rps_200,
+                        cps,
                     );
                     let _ = file.flush();
                 }
@@ -490,6 +541,12 @@ impl AdminState {
                 peak_cpu_usage_percent: 0.0,
                 peak_error_rate: 0.0,
                 peaks_since: Utc::now(),
+                tps: 0.0,
+                peak_tps: 0.0,
+                rps_200: 0.0,
+                peak_rps_200: 0.0,
+                cps: 0.0,
+                peak_cps: 0.0,
             })),
             config: Arc::new(RwLock::new(ConfigurationState {
                 latency_profile: LatencyProfile {
@@ -695,7 +752,28 @@ impl AdminState {
         sm.peak_memory_usage_mb = sm.memory_usage_mb;
         sm.peak_cpu_usage_percent = sm.cpu_usage_percent;
         sm.peak_error_rate = 0.0;
+        sm.peak_tps = sm.tps;
+        sm.peak_rps_200 = sm.rps_200;
+        sm.peak_cps = sm.cps;
         sm.peaks_since = Utc::now();
+    }
+
+    /// Update per-second rate metrics (TPS / RPS / CPS) and their peaks.
+    /// Called from the system-monitoring background task once per tick.
+    pub async fn update_rate_metrics(&self, tps: f64, rps_200: f64, cps: f64) {
+        let mut sm = self.system_metrics.write().await;
+        sm.tps = tps;
+        sm.rps_200 = rps_200;
+        sm.cps = cps;
+        if tps > sm.peak_tps {
+            sm.peak_tps = tps;
+        }
+        if rps_200 > sm.peak_rps_200 {
+            sm.peak_rps_200 = rps_200;
+        }
+        if cps > sm.peak_cps {
+            sm.peak_cps = cps;
+        }
     }
 
     /// Update time series data with new metrics
@@ -1072,6 +1150,12 @@ pub async fn get_dashboard(State(state): State<AdminState>) -> Json<ApiResponse<
         peak_cpu_usage_percent: system_metrics.peak_cpu_usage_percent,
         peak_error_rate: system_metrics.peak_error_rate,
         peaks_since: system_metrics.peaks_since,
+        tps: system_metrics.tps,
+        peak_tps: system_metrics.peak_tps,
+        rps_200: system_metrics.rps_200,
+        peak_rps_200: system_metrics.peak_rps_200,
+        cps: system_metrics.cps,
+        peak_cps: system_metrics.peak_cps,
     };
 
     let servers = vec![
@@ -5193,6 +5277,12 @@ mod tests {
             peak_cpu_usage_percent: 45.5,
             peak_error_rate: 0.0,
             peaks_since: Utc::now(),
+            tps: 0.0,
+            peak_tps: 0.0,
+            rps_200: 0.0,
+            peak_rps_200: 0.0,
+            cps: 0.0,
+            peak_cps: 0.0,
         };
 
         assert_eq!(metrics.active_threads, 10);

--- a/crates/mockforge-ui/src/models.rs
+++ b/crates/mockforge-ui/src/models.rs
@@ -99,6 +99,28 @@ pub struct SystemInfo {
     /// Timestamp peaks were last reset; gives a window for long-running tests
     #[serde(default = "chrono::Utc::now")]
     pub peaks_since: chrono::DateTime<chrono::Utc>,
+    /// Successful (status `200..=399`) HTTP responses per second over the
+    /// last metrics sampling interval. "Successful API transactions/sec"
+    /// in the load-testing sense.
+    #[serde(default)]
+    pub tps: f64,
+    /// Peak `tps` observed since `peaks_since`.
+    #[serde(default)]
+    pub peak_tps: f64,
+    /// HTTP `200 OK` responses per second over the last metrics interval.
+    #[serde(default)]
+    pub rps_200: f64,
+    /// Peak `rps_200` observed since `peaks_since`.
+    #[serde(default)]
+    pub peak_rps_200: f64,
+    /// Accepted TCP connections per second over the last metrics interval.
+    /// Plain HTTP path only — the TLS path uses `axum-server`'s own accept
+    /// loop and is not yet instrumented; reads as 0 for HTTPS-only setups.
+    #[serde(default)]
+    pub cps: f64,
+    /// Peak `cps` observed since `peaks_since`.
+    #[serde(default)]
+    pub peak_cps: f64,
 }
 
 /// Latency profile configuration
@@ -1226,6 +1248,12 @@ mod tests {
             peak_cpu_usage_percent: 25.5,
             peak_error_rate: 0.0,
             peaks_since: chrono::Utc::now(),
+            tps: 0.0,
+            peak_tps: 0.0,
+            rps_200: 0.0,
+            peak_rps_200: 0.0,
+            cps: 0.0,
+            peak_cps: 0.0,
         };
 
         assert_eq!(info.version, "0.3.8");


### PR DESCRIPTION
## Summary

Adds the three per-second rates srikr asked for in [#79](https://github.com/SaaSy-Solutions/mockforge/issues/79#issuecomment-4364535727), shown in the TUI dashboard alongside CPU/Mem/Err Rate and persisted to the metrics CSV:

- **TPS** — successful (200..=399) responses per second
- **RPS200** — 200-OK responses per second
- **CPS** — accepted TCP connections per second

Each shows current value + lifetime peak.

## Implementation

- `mockforge-foundation::rate_counters` — leaf module of global atomics (no new mockforge deps)
- HTTP metrics middleware bumps response counters per response
- `CountingMakeService` Tower wrapper bumps the accept counter on each per-connection make-service call. Wrapping at the make-service layer (rather than the TCP listener) means **CPS works for both** plain HTTP (`axum::serve`) **and TLS** (`axum_server::Server::serve`) — the listener-wrapper path was blocked by orphan rules for `Connected<...> for SocketAddr`
- `mockforge-ui` background sampler computes deltas every 10s, tracks peaks in `SystemMetrics`, exposes them in the dashboard JSON
- TUI dashboard renders the new lines under existing Request Stats
- CSV gains 3 new columns appended at the end (`tps,rps_200,cps`); positional parsers keep working

## Drive-by

`mockforge-chaos/request_matcher.rs` had a `clippy::needless_lifetimes` that newer clippy flagged once the test build was reactivated by these changes — one-line elision.

## Test plan

- [x] `cargo test -p mockforge-foundation -p mockforge-chaos -p mockforge-http -p mockforge-ui -p mockforge-tui` (1 new unit test in foundation::rate_counters, 1 in http::counting_listener, plus the existing 1 800+ tests)
- [x] `cargo clippy -p ... --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Manual smoke: spin up server with `--admin`, hit `/api/dashboard`, confirm `system.tps` etc. populate after a curl loop
- [ ] Manual smoke: set `MOCKFORGE_METRICS_LOG_FILE`, confirm new CSV columns

Part of issue #79 — first of four planned PRs (the others address dual HTTP+HTTPS, `bench-chunked --spec`, and the 503 chunked-bench investigation).