### PR TITLE
feat(cli): --https-port for nginx-style dual HTTP+HTTPS (#79)

### DIFF
--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -92,6 +92,13 @@ struct PortArgs {
     #[arg(long, help_heading = "Server Ports")]
     pub http_port: Option<u16>,
 
+    /// HTTPS server port. When set, runs an additional TLS listener
+    /// alongside `--http-port` (which always serves plain HTTP in this
+    /// mode). Requires `--tls-cert` and `--tls-key`. Lets you serve the
+    /// same routes on, e.g., 80 and 443 simultaneously like nginx.
+    #[arg(long, help_heading = "Server Ports")]
+    pub https_port: Option<u16>,
+
     /// WebSocket server port (defaults to config or 3001)
     #[arg(long, help_heading = "Server Ports")]
     pub ws_port: Option<u16>,
@@ -2275,6 +2282,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 eprintln!("Error: --mtls {} requires --tls-enabled", args.tls.mtls);
                 std::process::exit(1);
             }
+            // --https-port runs a TLS listener alongside the plain --http-port,
+            // so it always needs a cert + key (independent of --tls-enabled).
+            if args.ports.https_port.is_some()
+                && (args.tls.tls_cert.is_none() || args.tls.tls_key.is_none())
+            {
+                eprintln!("Error: --https-port requires --tls-cert and --tls-key");
+                std::process::exit(1);
+            }
+            if let (Some(http), Some(https)) = (args.ports.http_port, args.ports.https_port) {
+                if http == https {
+                    eprintln!(
+                        "Error: --http-port ({}) and --https-port ({}) must differ",
+                        http, https
+                    );
+                    std::process::exit(1);
+                }
+            }
 
             // Validate spec flags (mutually exclusive)
             if !args.spec.is_empty() && args.spec_dir.is_some() {
@@ -2296,6 +2320,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 config_path: args.config,
                 profile: args.profile,
                 http_port: args.ports.http_port,
+                https_port: args.ports.https_port,
                 ws_port: args.ports.ws_port,
                 grpc_port: args.ports.grpc_port,
                 tcp_port: args.ports.tcp_port,

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -21,6 +21,10 @@ pub(crate) struct ServeArgs {
     pub(crate) config_path: Option<PathBuf>,
     pub(crate) profile: Option<String>,
     pub(crate) http_port: Option<u16>,
+    /// HTTPS server port. When set, an additional TLS listener runs
+    /// alongside `http_port` (which always serves plain HTTP in this mode).
+    /// Requires `tls_cert` + `tls_key`.
+    pub(crate) https_port: Option<u16>,
     pub(crate) ws_port: Option<u16>,
     pub(crate) grpc_port: Option<u16>,
     pub(crate) tcp_port: Option<u16>,
@@ -102,6 +106,7 @@ impl Default for ServeArgs {
             config_path: None,
             profile: None,
             http_port: None,
+            https_port: None,
             ws_port: None,
             grpc_port: None,
             tcp_port: None,
@@ -2154,9 +2159,24 @@ pub async fn handle_serve(
     } else {
         None
     };
+    // Dual HTTP+HTTPS mode: when --https-port is set, the HTTP listener on
+    // --http-port is forced to plain HTTP and a second TLS listener is
+    // spawned on --https-port. Mirrors how nginx/apache let you serve the
+    // same routes on 80 and 443 simultaneously.
+    let dual_https_port = serve_args.https_port;
+    let plain_http_tls_config = if dual_https_port.is_some() {
+        None
+    } else {
+        http_tls_config_final.clone()
+    };
+    // Clones for the parallel HTTPS listener (taken before the HTTP spawn
+    // moves the originals). `Router` and `Option<Arc<RwLock<ChaosConfig>>>`
+    // are both cheap to clone.
+    let http_app_clone_for_dual = http_app.clone();
+    let chaos_listener_cfg_for_dual = chaos_listener_cfg.clone();
     let http_handle = tokio::spawn(async move {
         tokio::select! {
-            result = mockforge_http::serve_router_with_tls_notify_chaos(http_port, http_app, http_tls_config_final, Some(http_bound_tx), chaos_listener_cfg) => {
+            result = mockforge_http::serve_router_with_tls_notify_chaos(http_port, http_app, plain_http_tls_config, Some(http_bound_tx), chaos_listener_cfg) => {
                 result.map_err(|e| format!("HTTP server error: {}", e))
             }
             _ = http_shutdown.cancelled() => {
@@ -2164,6 +2184,41 @@ pub async fn handle_serve(
             }
         }
     });
+
+    // Spawn the parallel HTTPS listener on --https-port if requested.
+    // Reuses the same router (cloned) and the TLS config built above.
+    let https_handle = if let Some(https_port) = dual_https_port {
+        // Build the HTTPS TLS config from the CLI/file-derived config.
+        // serve_args is moved into handle_serve so we re-derive from
+        // http_tls_config_final, which already incorporates CLI overrides.
+        // If the user passed --https-port without --tls-enabled but with
+        // cert+key, fabricate an enabled TLS config so the second listener
+        // serves HTTPS even when the first is plain.
+        let mut https_tls = http_tls_config_final.clone();
+        if https_tls.as_ref().map(|t| !t.enabled).unwrap_or(true) {
+            // Promote to enabled if cert+key are present; the CLI validates
+            // that this is the case when --https-port is set.
+            if let Some(t) = https_tls.as_mut() {
+                t.enabled = true;
+            }
+        }
+        let https_app = http_app_clone_for_dual.clone();
+        let https_shutdown = shutdown_token.clone();
+        let chaos_listener_cfg_https = chaos_listener_cfg_for_dual.clone();
+        Some(tokio::spawn(async move {
+            println!("🔒 HTTPS server listening on https://localhost:{}", https_port);
+            tokio::select! {
+                result = mockforge_http::serve_router_with_tls_notify_chaos(https_port, https_app, https_tls, None, chaos_listener_cfg_https) => {
+                    result.map_err(|e| format!("HTTPS server error: {}", e))
+                }
+                _ = https_shutdown.cancelled() => {
+                    Ok(())
+                }
+            }
+        }))
+    } else {
+        None
+    };
 
     // Start WebSocket server
     let ws_handle: tokio::task::JoinHandle<Result<(), String>> = {
@@ -2820,6 +2875,32 @@ pub async fn handle_serve(
                     eprintln!("❌ {}", error);
                     Some(error)
                 }
+            }
+        }
+        result = async {
+            // Pend forever when --https-port wasn't passed; otherwise this
+            // arm watches the second TLS listener for shutdown / errors.
+            if let Some(handle) = https_handle {
+                Some(handle.await)
+            } else {
+                std::future::pending::<Option<Result<Result<(), String>, tokio::task::JoinError>>>().await
+            }
+        } => {
+            match result {
+                Some(Ok(Ok(()))) => {
+                    println!("🔒 HTTPS server stopped gracefully");
+                    None
+                }
+                Some(Ok(Err(e))) => {
+                    eprintln!("❌ {}", e);
+                    Some(e)
+                }
+                Some(Err(e)) => {
+                    let error = format!("HTTPS server task panicked: {}", e);
+                    eprintln!("❌ {}", error);
+                    Some(error)
+                }
+                None => None,
             }
         }
         result = ws_handle => {


### PR DESCRIPTION
## Summary

Adds `--https-port`, addressing srikr's [#79 question 3](https://github.com/SaaSy-Solutions/mockforge/issues/79#issuecomment-4364535727):

> Is it possible to run mockforge-server in both port 80 and 443 at the sametime like the way how nginx or apache run

When `--https-port` is set, MockForge spawns a second TLS listener alongside the existing `--http-port` listener. Same router, same fixtures, same chaos config, same admin UI — served on both ports simultaneously.

## Example

\`\`\`
mockforge serve \\
  --http-port 80 --https-port 443 \\
  --tls-cert server.pem --tls-key key.pem \\
  --spec api.json --no-rate-limit
\`\`\`

## Validation

- \`--https-port\` requires \`--tls-cert\` + \`--tls-key\` (independent of \`--tls-enabled\` — the second listener is implicitly TLS)
- \`--http-port\` and \`--https-port\` must differ

When \`--https-port\` isn't set, behavior is unchanged.

## Test plan

- [x] \`cargo check -p mockforge-cli\`
- [x] \`cargo clippy -p mockforge-cli --all-targets -- -D warnings\`
- [x] \`cargo fmt --all --check\`
- [x] \`cargo test -p mockforge-cli\` (skip 20 pre-existing \`CARGO_BIN_EXE_mockforge\` panics — same on main, unrelated)
- [ ] Manual: \`mockforge serve --http-port 8080 --https-port 8443 --tls-cert ... --tls-key ...\` and confirm both \`curl http://localhost:8080/health\` and \`curl -k https://localhost:8443/health\` work

Part of issue #79 — second of four planned PRs.