### PR TITLE
feat(cli): bench-chunked --spec + clearer chunk-math help (#79)

### DIFF
--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2093,20 +2093,41 @@ enum Commands {
     /// produce on-the-wire chunking (Go's `net/http` decides chunking from
     /// body type and may send Content-Length instead).
     ///
+    /// Without --spec, runs against the single URL given by --target.
+    /// With --spec, --target becomes the base URL and the bench iterates
+    /// every POST/PUT/PATCH operation in the spec sequentially, running
+    /// for --duration each.
+    ///
     /// Examples:
     ///   mockforge bench-chunked --target http://localhost:3000/upload
     ///   mockforge bench-chunked --target http://localhost:3000/upload \
     ///     --concurrency 10 --duration 60 \
     ///     --chunk-size-bytes 4096 --total-size-bytes 10485760 \
     ///     --chunk-interval-ms 50
+    ///   mockforge bench-chunked --spec api.json --target https://192.168.2.86 \
+    ///     --duration 60 --insecure
     #[cfg(feature = "bench")]
     #[command(verbatim_doc_comment)]
     BenchChunked {
-        /// Target URL to send chunked requests to.
+        /// Target URL. Without --spec: full URL of the chunked endpoint
+        /// (e.g. `http://host:3000/upload`). With --spec: base URL only
+        /// (e.g. `https://192.168.2.86`); the path is taken from each
+        /// matching operation in the spec.
         #[arg(short, long)]
         target: String,
 
-        /// HTTP method (POST, PUT, PATCH).
+        /// OpenAPI spec to drive the bench. When set, runs one chunked
+        /// bench per POST/PUT/PATCH operation, each for --duration.
+        #[arg(long)]
+        spec: Option<PathBuf>,
+
+        /// Run only the operation with this `operationId` (when --spec
+        /// is given). Without this flag, all POST/PUT/PATCH ops run.
+        #[arg(long)]
+        operation_id: Option<String>,
+
+        /// HTTP method (POST, PUT, PATCH). Ignored when --spec is set —
+        /// the method comes from each spec operation.
         #[arg(short, long, default_value = "POST")]
         method: String,
 
@@ -2114,19 +2135,29 @@ enum Commands {
         #[arg(short, long, default_value = "10")]
         concurrency: u32,
 
-        /// Duration in seconds.
+        /// Duration in seconds. **Per operation** when --spec is set
+        /// (so a spec with 3 POST/PATCH ops and --duration 30 runs
+        /// for ~90s total).
         #[arg(short, long, default_value = "30")]
         duration: u64,
 
-        /// Bytes per chunk emitted into the body stream.
+        /// Size of each chunk emitted into the request body, in bytes.
+        /// The body is streamed without a Content-Length, so hyper sends
+        /// `Transfer-Encoding: chunked` automatically.
         #[arg(long, default_value = "1024")]
         chunk_size_bytes: usize,
 
-        /// Total body size per request, in bytes.
+        /// Body size **per request**, in bytes. With --chunk-size-bytes,
+        /// each request emits `total_size_bytes / chunk_size_bytes` chunks
+        /// at --chunk-interval-ms apart, then the next request starts.
+        /// Total bytes over the whole run = total_size_bytes × completed
+        /// requests. (e.g. 10 MiB / 4 KiB = 2560 chunks per request.)
         #[arg(long, default_value = "1048576")]
         total_size_bytes: usize,
 
-        /// Sleep between chunks (ms). 0 = back-to-back.
+        /// Sleep between chunks (ms). 0 = back-to-back. With non-zero
+        /// values, each request takes at least `(total_size_bytes /
+        /// chunk_size_bytes) * chunk_interval_ms` milliseconds.
         #[arg(long, default_value = "0")]
         chunk_interval_ms: u64,
 
@@ -2938,6 +2969,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         #[cfg(feature = "bench")]
         Commands::BenchChunked {
             target,
+            spec,
+            operation_id,
             method,
             concurrency,
             duration,
@@ -2947,56 +2980,160 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             header,
             insecure,
         } => {
-            use mockforge_bench::chunked_bench::{run, ChunkedBenchConfig};
+            use mockforge_bench::chunked_bench::{run, ChunkedBenchConfig, ChunkedBenchResult};
             use std::collections::HashMap;
-            let method = match reqwest::Method::from_bytes(method.to_uppercase().as_bytes()) {
-                Ok(m) => m,
-                Err(_) => {
-                    eprintln!("Invalid HTTP method: {}", method);
-                    std::process::exit(1);
-                }
-            };
+
             let mut headers = HashMap::new();
             for h in header {
                 if let Some((k, v)) = h.split_once(':') {
                     headers.insert(k.trim().to_string(), v.trim().to_string());
                 }
             }
-            let cfg = ChunkedBenchConfig {
-                target_url: target,
-                method,
-                concurrency,
-                duration: std::time::Duration::from_secs(duration),
-                chunk_size_bytes,
-                total_size_bytes,
-                chunk_interval_ms,
-                headers,
-                skip_tls_verify: insecure,
-            };
-            match run(cfg).await {
-                Ok(r) => {
-                    println!("Chunked bench complete in {:?}", r.elapsed);
-                    println!("  Total requests: {}", r.total_requests);
-                    println!("  Successful:     {}", r.successful);
-                    println!("  Failed:         {}", r.failed);
-                    println!("  Bytes sent:     {}", r.bytes_sent);
-                    println!("  Throughput:     {:.2} req/s", r.req_per_sec);
-                    println!(
-                        "  Latency:        avg={:.1}ms p50={}ms p95={}ms p99={}ms",
-                        r.avg_latency_ms, r.p50_ms, r.p95_ms, r.p99_ms
+
+            // Helper to print one result block; used by both single-target
+            // and spec-driven flows.
+            fn print_result(label: &str, r: &ChunkedBenchResult) {
+                println!("Chunked bench [{}] complete in {:?}", label, r.elapsed);
+                println!("  Total requests: {}", r.total_requests);
+                println!("  Successful:     {}", r.successful);
+                println!("  Failed:         {}", r.failed);
+                println!("  Bytes sent:     {}", r.bytes_sent);
+                println!("  Throughput:     {:.2} req/s", r.req_per_sec);
+                println!(
+                    "  Latency:        avg={:.1}ms p50={}ms p95={}ms p99={}ms",
+                    r.avg_latency_ms, r.p50_ms, r.p95_ms, r.p99_ms
+                );
+                if !r.status_counts.is_empty() {
+                    println!("  Status codes:");
+                    let mut codes: Vec<_> = r.status_counts.iter().collect();
+                    codes.sort_by_key(|(k, _)| **k);
+                    for (code, n) in codes {
+                        println!("    {} = {}", code, n);
+                    }
+                }
+            }
+
+            if let Some(spec_path) = spec {
+                // Spec-driven mode: iterate POST/PUT/PATCH operations.
+                use mockforge_bench::request_gen::RequestGenerator;
+                use mockforge_bench::spec_parser::SpecParser;
+
+                let parser = match SpecParser::from_file(&spec_path).await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("Failed to parse spec {:?}: {}", spec_path, e);
+                        std::process::exit(1);
+                    }
+                };
+                let base_url = target.trim_end_matches('/').to_string();
+                let want_methods = ["POST", "PUT", "PATCH"];
+                let ops: Vec<_> = parser
+                    .get_operations()
+                    .into_iter()
+                    .filter(|op| want_methods.contains(&op.method.to_uppercase().as_str()))
+                    .filter(|op| match &operation_id {
+                        Some(id) => op.operation_id.as_deref() == Some(id.as_str()),
+                        None => true,
+                    })
+                    .collect();
+                if ops.is_empty() {
+                    eprintln!(
+                        "No POST/PUT/PATCH operations matched in {:?}{}",
+                        spec_path,
+                        operation_id
+                            .as_deref()
+                            .map(|id| format!(" (operation-id={id})"))
+                            .unwrap_or_default()
                     );
-                    if !r.status_counts.is_empty() {
-                        println!("  Status codes:");
-                        let mut codes: Vec<_> = r.status_counts.iter().collect();
-                        codes.sort_by_key(|(k, _)| **k);
-                        for (code, n) in codes {
-                            println!("    {} = {}", code, n);
+                    std::process::exit(1);
+                }
+
+                println!(
+                    "→ {} chunked bench {} from {:?} (base {})",
+                    ops.len(),
+                    if ops.len() == 1 {
+                        "operation"
+                    } else {
+                        "operations"
+                    },
+                    spec_path,
+                    base_url
+                );
+
+                let mut any_failed = false;
+                for op in &ops {
+                    let template = match RequestGenerator::generate_template(op) {
+                        Ok(t) => t,
+                        Err(e) => {
+                            eprintln!(
+                                "✗ {} {}: failed to build request template: {}",
+                                op.method, op.path, e
+                            );
+                            any_failed = true;
+                            continue;
+                        }
+                    };
+                    let url = format!("{}{}", base_url, template.generate_path());
+                    let label = op.display_name();
+                    let method =
+                        match reqwest::Method::from_bytes(op.method.to_uppercase().as_bytes()) {
+                            Ok(m) => m,
+                            Err(_) => {
+                                eprintln!("✗ {}: invalid method `{}`", label, op.method);
+                                any_failed = true;
+                                continue;
+                            }
+                        };
+                    println!();
+                    println!("→ {} {}  ({})", op.method.to_uppercase(), op.path, url);
+                    let cfg = ChunkedBenchConfig {
+                        target_url: url,
+                        method,
+                        concurrency,
+                        duration: std::time::Duration::from_secs(duration),
+                        chunk_size_bytes,
+                        total_size_bytes,
+                        chunk_interval_ms,
+                        headers: headers.clone(),
+                        skip_tls_verify: insecure,
+                    };
+                    match run(cfg).await {
+                        Ok(r) => print_result(&label, &r),
+                        Err(e) => {
+                            eprintln!("✗ {}: chunked bench failed: {}", label, e);
+                            any_failed = true;
                         }
                     }
                 }
-                Err(e) => {
-                    eprintln!("Chunked bench failed: {}", e);
+                if any_failed {
                     std::process::exit(1);
+                }
+            } else {
+                // Single-target mode (original behavior).
+                let method = match reqwest::Method::from_bytes(method.to_uppercase().as_bytes()) {
+                    Ok(m) => m,
+                    Err(_) => {
+                        eprintln!("Invalid HTTP method: {}", method);
+                        std::process::exit(1);
+                    }
+                };
+                let cfg = ChunkedBenchConfig {
+                    target_url: target,
+                    method,
+                    concurrency,
+                    duration: std::time::Duration::from_secs(duration),
+                    chunk_size_bytes,
+                    total_size_bytes,
+                    chunk_interval_ms,
+                    headers,
+                    skip_tls_verify: insecure,
+                };
+                match run(cfg).await {
+                    Ok(r) => print_result("single-target", &r),
+                    Err(e) => {
+                        eprintln!("Chunked bench failed: {}", e);
+                        std::process::exit(1);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Two changes responding to srikr in [#79](https://github.com/SaaSy-Solutions/mockforge/issues/79#issuecomment-4364535727):

### 1. \`--spec\` for \`bench-chunked\`

> a) I am not able to run these option using spec mainly wanted for POST and PATCH Requests for different durations

When \`--spec\` is passed, \`--target\` becomes the **base URL** and the bench iterates every POST/PUT/PATCH operation in the spec sequentially, each for \`--duration\`. \`--operation-id\` narrows to a single op. Path params get filled in by the existing \`RequestGenerator\` placeholder logic.

\`\`\`
mockforge bench-chunked --spec api.json --target https://192.168.2.86 \\
  --duration 60 --chunk-size-bytes 4096 --total-size-bytes 10485760 --insecure
\`\`\`

Without \`--spec\`, behavior is unchanged.

### 2. Clearer chunk-math help

> c) Also based on Total Request Count why only 30 Request, I thought based on values of --chunk-size-bytes 4096 --total-size-bytes 10485760 , Total request send should be 10485760 / 4096 correct which is 2560.

\`--total-size-bytes\` is **per request**, not total over the run. The 2560 srikr expected is the *chunks per request* (10 MiB / 4 KiB). The 30 he got is the *number of requests* that fit in the duration at the chosen concurrency. Updated CLI help to make this explicit and added the same kind of note to \`--chunk-interval-ms\` (each request takes at least \`chunks * interval\` ms).

## Test plan

- [x] \`cargo check -p mockforge-cli\`
- [x] \`cargo clippy -p mockforge-cli --all-targets -- -D warnings\`
- [x] \`cargo fmt --all --check\`
- [ ] Manual: \`mockforge bench-chunked --spec examples/openapi-demo.json --target http://localhost:3000 --duration 5\` against a running mockforge — confirms iteration and per-op output

Part of issue #79 — third of four planned PRs.