### PR TITLE
docs(deploy): systemd unit + run-forever wrapper for unattended runs (#79)

### DIFF
--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -8,6 +8,11 @@ Automated deployment scripts for MockForge on major cloud platforms.
 - `deploy-gcp.sh` - Deploy to Google Cloud Run
 - `deploy-azure.sh` - Deploy to Azure Container Apps
 - `deploy-digitalocean.sh` - Deploy to DigitalOcean App Platform
+- `run-forever.sh` - Lightweight bash supervisor that restarts
+  `mockforge serve` on any non-clean exit. Use on hosts without
+  systemd or for ad-hoc test sessions. See
+  [`../systemd/README.md`](../systemd/README.md) for the systemd
+  alternative.
 
 ## Prerequisites
 

--- a/deploy/scripts/run-forever.sh
+++ b/deploy/scripts/run-forever.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Lightweight supervisor for `mockforge serve` — restarts the binary
+# whenever it exits, until the wrapper itself is killed (Ctrl-C or
+# `kill <pid>`). Use this on hosts without systemd or when you don't
+# want to write a service unit.
+#
+# Issue #79: under heavy chunked traffic the server can be killed by
+# the kernel OOM killer or by an in-process panic. This wrapper makes
+# the recovery automatic so a single crash doesn't end the test.
+#
+# Usage:
+#   ./run-forever.sh <serve args...>
+#
+# Examples:
+#   ./run-forever.sh --spec api.json --http-port 80 --https-port 443 \
+#     --tls-cert server.pem --tls-key key.pem --no-rate-limit
+#
+#   MOCKFORGE_BIN=/usr/local/bin/mockforge \
+#     RESTART_BACKOFF_SECS=10 RESTART_LOG=/var/log/mockforge-supervisor.log \
+#     ./run-forever.sh --spec api.json --admin --admin-port 9080
+#
+# Environment overrides:
+#   MOCKFORGE_BIN          path to the binary (default: `mockforge` on $PATH)
+#   RESTART_BACKOFF_SECS   sleep between restart attempts (default: 5)
+#   RESTART_LOG            file to append restart events to (default: stderr only)
+#
+# Send SIGINT/SIGTERM to this script (Ctrl-C, `kill`) to stop cleanly —
+# the running mockforge child gets the signal forwarded.
+
+set -u
+
+BIN="${MOCKFORGE_BIN:-mockforge}"
+BACKOFF="${RESTART_BACKOFF_SECS:-5}"
+LOG="${RESTART_LOG:-}"
+
+if ! command -v "$BIN" >/dev/null 2>&1 && ! [ -x "$BIN" ]; then
+  echo "run-forever: $BIN not found on PATH and not executable" >&2
+  exit 127
+fi
+
+log() {
+  local msg="[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+  echo "$msg" >&2
+  if [ -n "$LOG" ]; then
+    echo "$msg" >> "$LOG"
+  fi
+}
+
+stop_requested=0
+child_pid=0
+
+forward_signal() {
+  local sig="$1"
+  stop_requested=1
+  if [ "$child_pid" -ne 0 ] && kill -0 "$child_pid" 2>/dev/null; then
+    log "supervisor received SIG$sig — forwarding to child PID $child_pid"
+    kill -s "$sig" "$child_pid" 2>/dev/null || true
+  fi
+}
+
+trap 'forward_signal INT' INT
+trap 'forward_signal TERM' TERM
+
+attempt=0
+while [ "$stop_requested" -eq 0 ]; do
+  attempt=$((attempt + 1))
+  log "starting mockforge serve (attempt $attempt): $BIN serve $*"
+  set +e
+  "$BIN" serve "$@" &
+  child_pid=$!
+  wait "$child_pid"
+  rc=$?
+  set -e
+  child_pid=0
+
+  if [ "$stop_requested" -eq 1 ]; then
+    log "supervisor exiting after explicit stop request (last child rc=$rc)"
+    exit "$rc"
+  fi
+
+  log "mockforge exited with rc=$rc; restarting in ${BACKOFF}s"
+  # Use a single sleep that responds to signals so Ctrl-C during the
+  # backoff window stops the supervisor immediately.
+  sleep "$BACKOFF" &
+  wait $! 2>/dev/null || true
+done

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,62 @@
+# Running `mockforge serve` unattended
+
+Two equivalent options, pick one:
+
+| Option | When to use | File |
+|---|---|---|
+| **systemd service** | Linux host, want logs in `journalctl`, OS-level restart policy, resource limits | [`mockforge.service`](mockforge.service) |
+| **`run-forever.sh` wrapper** | macOS / non-systemd host, container, ad-hoc test session, or bench rigs | [`../scripts/run-forever.sh`](../scripts/run-forever.sh) |
+
+Both restart `mockforge serve` after any non-clean exit. Issue #79 — heavy
+chunked-upload traffic can OOM-kill or crash the server; either wrapper
+keeps it alive without manual intervention.
+
+## systemd quick start
+
+```bash
+sudo install -m 0755 target/release/mockforge /usr/local/bin/mockforge
+sudo useradd -r -s /usr/sbin/nologin mockforge
+sudo install -d -o mockforge -g mockforge /etc/mockforge /var/log/mockforge
+sudo cp your-spec.yaml /etc/mockforge/spec.yaml
+sudo install -m 0644 deploy/systemd/mockforge.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now mockforge
+
+# Tail logs
+journalctl -u mockforge -f
+
+# Override flags without editing the unit file
+sudo systemctl edit mockforge   # adds /etc/systemd/system/mockforge.service.d/override.conf
+```
+
+## run-forever quick start
+
+```bash
+deploy/scripts/run-forever.sh \
+  --spec /path/to/spec.yaml \
+  --http-port 80 --https-port 443 \
+  --tls-cert server.pem --tls-key server.key \
+  --no-rate-limit
+
+# With a restart log
+RESTART_LOG=/var/log/mockforge-supervisor.log \
+RESTART_BACKOFF_SECS=10 \
+  deploy/scripts/run-forever.sh --spec api.json --admin --admin-port 9080
+
+# Stop: Ctrl-C, or `kill <pid>` — SIGINT/SIGTERM are forwarded to the child.
+```
+
+## Tuning for high traffic
+
+If the kernel keeps OOM-killing the server even with these wrappers, the
+two knobs that matter most:
+
+- `MemoryMax` (systemd) / `ulimit -v` (shell) — bump above the working set
+  size. A `bench-chunked` run with `--concurrency 10 --total-size-bytes
+  10485760` will hold ~100 MiB of in-flight body buffers; size accordingly.
+- `LimitNOFILE` (systemd) / `ulimit -n` (shell) — at high concurrency,
+  each in-flight request is a file descriptor. 65536 covers most cases.
+
+Set `MOCKFORGE_METRICS_LOG_FILE` to a path on persistent disk to capture
+CPU / memory / TPS / RPS200 / CPS every 10 seconds across restarts —
+useful for postmortem-ing exactly when and how the server fell over.

--- a/deploy/systemd/mockforge.service
+++ b/deploy/systemd/mockforge.service
@@ -1,0 +1,70 @@
+; mockforge serve as a systemd service.
+;
+; Setup:
+;   sudo install -m 0755 deploy/scripts/run-forever.sh /usr/local/bin/  # optional fallback
+;   sudo install -m 0755 target/release/mockforge /usr/local/bin/mockforge
+;   sudo useradd -r -s /usr/sbin/nologin mockforge
+;   sudo install -d -o mockforge -g mockforge /etc/mockforge /var/log/mockforge
+;   sudo cp your-spec.yaml /etc/mockforge/spec.yaml
+;   sudo install -m 0644 deploy/systemd/mockforge.service /etc/systemd/system/
+;   sudo systemctl daemon-reload
+;   sudo systemctl enable --now mockforge
+;
+; Notes for issue #79:
+;   * `Restart=always` + `RestartSec=5` matches what `run-forever.sh` does;
+;     pick whichever wrapper fits your host. Don't run both.
+;   * `MemoryMax` and `LimitNOFILE` are the two knobs most likely to need
+;     tuning under heavy chunked-upload load. Defaults below are reasonable
+;     starting points for a 4 GiB host.
+;   * `MOCKFORGE_METRICS_LOG_FILE` writes a CSV row every 10s (CPU, mem,
+;     TPS, RPS200, CPS, error rate). Plot it in Grafana for postmortems.
+
+[Unit]
+Description=MockForge mock API server
+Documentation=https://github.com/SaaSy-Solutions/mockforge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=mockforge
+Group=mockforge
+WorkingDirectory=/etc/mockforge
+
+# Override the ExecStart line via a drop-in (`systemctl edit mockforge`)
+# rather than editing this file in place. Common flags:
+#   --spec /etc/mockforge/spec.yaml
+#   --http-port 80 --https-port 443
+#   --tls-cert /etc/mockforge/tls/server.pem
+#   --tls-key  /etc/mockforge/tls/server.key
+#   --admin --admin-port 9080
+#   --no-rate-limit
+ExecStart=/usr/local/bin/mockforge serve --spec /etc/mockforge/spec.yaml --http-port 8080 --admin --admin-port 9080
+
+Environment=MOCKFORGE_METRICS_LOG_FILE=/var/log/mockforge/metrics.csv
+Environment=RUST_LOG=info
+
+# Restart on any non-clean exit (panic, OOM kill, segfault).
+Restart=always
+RestartSec=5
+StartLimitIntervalSec=0
+
+# Resource limits — tune for your host.
+LimitNOFILE=65536
+MemoryMax=2G
+TasksMax=4096
+
+# Graceful shutdown: SIGTERM → drain → SIGKILL after 30s.
+TimeoutStopSec=30
+KillMode=mixed
+
+# Hardening (drop if it conflicts with your spec/tls paths).
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/log/mockforge
+ReadOnlyPaths=/etc/mockforge
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Issue #79 — under heavy chunked-upload traffic the server can be killed (OOM, panic), and srikr asked for a way to keep it running unattended. Two equivalent supervisor options now ship in `deploy/`:

- **`deploy/systemd/mockforge.service`** — systemd unit with `Restart=always`, resource limits (`MemoryMax`, `LimitNOFILE`, `TasksMax`), graceful-stop window, and hardening directives. Standard install dance documented in the unit comments.
- **`deploy/scripts/run-forever.sh`** — bash supervisor that restarts the binary after any non-clean exit. Forwards SIGINT/SIGTERM to the child so Ctrl-C/`kill` stops cleanly. Useful on macOS / non-systemd hosts and ad-hoc bench rigs.

`deploy/systemd/README.md` is a short picker between the two and lists the two knobs (`MemoryMax`, `LimitNOFILE`) most likely to need tuning at high concurrency. Both setups recommend setting `MOCKFORGE_METRICS_LOG_FILE` so the CSV captures CPU/mem/TPS/RPS200/CPS across restarts for postmortems.

## Test plan

- [x] `bash -n` passes on `run-forever.sh`
- [x] Manual: ran `run-forever.sh` against a fake binary that exits 137 → restart loop kicks in, attempts increment, SIGTERM is forwarded to the child and the supervisor exits cleanly
- [ ] systemd unit will be smoke-tested on the issue-79 follow-up host once merged