### PR TITLE
fix(http,observability): layer metrics middleware on production router (#79)

### DIFF
--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -2028,6 +2028,17 @@ pub async fn handle_serve(
         println!("✅ Chaos middleware integrated - latency recording enabled");
     }
 
+    // Layer the HTTP metrics middleware as the outermost wrapper so every
+    // response — including chaos-mutated ones — bumps the rate-counter
+    // snapshot the dashboard's TPS / RPS200 sampler reads from. Without
+    // this layer those gauges stay flat at 0 even under heavy traffic
+    // (issue #79: `record_response` was wired but never on the request
+    // path).
+    {
+        use axum::middleware::from_fn;
+        http_app = http_app.layer(from_fn(mockforge_http::collect_http_metrics));
+    }
+
     // Note: OData URI rewrite is applied at the service level in serve_router_with_tls()
 
     println!(

--- a/crates/mockforge-http/src/metrics_middleware.rs
+++ b/crates/mockforge-http/src/metrics_middleware.rs
@@ -466,4 +466,38 @@ mod tests {
         let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
     }
+
+    /// Issue #79 regression — the middleware must actually advance the
+    /// `mockforge_foundation::rate_counters` snapshot so the dashboard's
+    /// TPS / RPS200 sampler can compute non-zero rates. Earlier landings
+    /// of TPS/RPS/CPS asserted only response status, which let a quiet
+    /// regression slip through where the layer wasn't wired onto the
+    /// production router. This test pins the actual counter delta.
+    #[tokio::test]
+    async fn middleware_advances_rate_counters_on_2xx() {
+        use mockforge_foundation::rate_counters;
+
+        let app = Router::new()
+            .route("/ok", axum::routing::get(test_handler))
+            .layer(middleware::from_fn(collect_http_metrics));
+
+        let before = rate_counters::snapshot();
+        let request = Request::builder().uri("/ok").body(Body::empty()).unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let after = rate_counters::snapshot();
+
+        assert!(
+            after.successful > before.successful,
+            "200 OK must bump SUCCESSFUL_RESPONSES_TOTAL: before={} after={}",
+            before.successful,
+            after.successful
+        );
+        assert!(
+            after.ok > before.ok,
+            "200 OK must bump OK_RESPONSES_TOTAL: before={} after={}",
+            before.ok,
+            after.ok
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Issue #79 followup — @srikr reported TPS / RPS200 stuck at 0 on the dashboard despite heavy traffic ([screenshot](https://github.com/user-attachments/assets/6596e166-bfef-4b4a-93f4-cc814593e0b6)) while CPS was advancing.

**Root cause**: regression introduced when #326 landed. `record_response()` (which bumps `SUCCESSFUL_RESPONSES_TOTAL` for 200–399 and `OK_RESPONSES_TOTAL` for 200) is called inside the `collect_http_metrics` middleware — but the middleware was exported from `mockforge-http` and **never `.layer()`d onto the production router** built in `serve.rs`. CPS kept ticking because `CountingMakeService` wraps the make-service at a different layer (`record_accept` is bumped per connection accept, regardless of whether any response middleware is wired).

**Fix**:
- `crates/mockforge-cli/src/serve.rs` — layer `collect_http_metrics` as the outermost wrapper on `http_app` (after the chaos middleware) so every response, including chaos-mutated ones, bumps the rate counters the dashboard sampler reads from.
- `crates/mockforge-http/src/metrics_middleware.rs` — add a regression test (`middleware_advances_rate_counters_on_2xx`) that snapshots `rate_counters` before/after a 2xx and asserts the counters moved. The pre-existing middleware tests asserted only response status, which let this bug slip through.

## Verified locally

```
50 GETs against /ping in ~10s → /__mockforge/dashboard "system" block:
  peak_tps=5.02   (50 successful 2xx / 10s sampler window)
  peak_rps_200=5.02
  peak_cps=5.02   (each curl was a fresh connection)
```

Without this PR, `peak_tps` and `peak_rps_200` stay at 0.0 regardless of load — exactly what srikr saw.

## Test plan

- [x] `cargo clippy -p mockforge-http --all-targets -- -D warnings` (clean)
- [x] `cargo test -p mockforge-http --lib middleware_advances_rate_counters_on_2xx` passes
- [x] Manual e2e: started `mockforge serve --spec test.yaml --admin`, drove 50 requests, confirmed dashboard counters advanced