### PR TITLE
feat(cloud): real fitness function evaluation + page cloud dispatch (#355)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9044,6 +9044,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 

--- a/crates/mockforge-registry-server/src/handlers/contract_verification.rs
+++ b/crates/mockforge-registry-server/src/handlers/contract_verification.rs
@@ -336,6 +336,112 @@ pub async fn delete_fitness_function(
     Ok(Json(serde_json::json!({ "deleted": true })))
 }
 
+/// `POST /api/v1/fitness-functions/{id}/runs`
+///
+/// Triggers a `fitness_evaluation` test_run for one fitness function.
+/// Same lifecycle as #4 test runs: inserts a `test_runs` row + Redis
+/// queue job; the runner-side `ContractExecutor::fitness_evaluation`
+/// picks it up, queries the registry's internal endpoints for the
+/// metric, and reports passed/failed. Failures get translated into a
+/// fitness-source incident by the registry-side post-processing in the
+/// run-finished handler.
+pub async fn trigger_fitness_run(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<TestRun>> {
+    let fn_row = FitnessFunction::find_by_id(state.db.pool(), id)
+        .await
+        .map_err(ApiError::Database)?
+        .ok_or_else(|| ApiError::InvalidRequest("Fitness function not found".into()))?;
+    authorize_workspace(&state, user_id, &headers, fn_row.workspace_id).await?;
+
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), fn_row.workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+
+    let run = TestRun::enqueue(
+        state.db.pool(),
+        EnqueueTestRun {
+            suite_id: fn_row.id,
+            org_id: workspace.org_id,
+            kind: "fitness_evaluation",
+            triggered_by: "manual",
+            triggered_by_user: Some(user_id),
+            git_ref: None,
+            git_sha: None,
+        },
+    )
+    .await
+    .map_err(ApiError::Database)?;
+
+    if let Err(e) = crate::run_queue::enqueue(
+        state.redis.as_ref(),
+        crate::run_queue::EnqueuedJob {
+            run_id: run.id,
+            org_id: run.org_id,
+            source_id: fn_row.id,
+            kind: "fitness_evaluation",
+            payload: serde_json::json!({
+                "fitness_function_id": fn_row.id,
+                "fitness_kind": fn_row.kind,
+                "fitness_name": fn_row.name,
+                "fitness_config": fn_row.config,
+                "workspace_id": fn_row.workspace_id,
+            }),
+        },
+    )
+    .await
+    {
+        tracing::error!(run_id = %run.id, error = %e, "failed to enqueue fitness_evaluation run");
+    }
+
+    Ok(Json(run))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateFitnessFunctionRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub config: Option<serde_json::Value>,
+}
+
+/// `PATCH /api/v1/fitness-functions/{id}` — rename / reconfigure.
+pub async fn update_fitness_function(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(request): Json<UpdateFitnessFunctionRequest>,
+) -> ApiResult<Json<FitnessFunction>> {
+    let fn_row = FitnessFunction::find_by_id(state.db.pool(), id)
+        .await
+        .map_err(ApiError::Database)?
+        .ok_or_else(|| ApiError::InvalidRequest("Fitness function not found".into()))?;
+    authorize_workspace(&state, user_id, &headers, fn_row.workspace_id).await?;
+
+    let new_name = request.name.unwrap_or_else(|| fn_row.name.clone());
+    let new_config = request.config.unwrap_or_else(|| fn_row.config.clone());
+
+    let updated: FitnessFunction = sqlx::query_as(
+        r#"
+        UPDATE fitness_functions
+        SET name = $1, config = $2, updated_at = NOW()
+        WHERE id = $3
+        RETURNING *
+        "#,
+    )
+    .bind(new_name)
+    .bind(new_config)
+    .bind(id)
+    .fetch_one(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+    Ok(Json(updated))
+}
+
 // --- verification suites ---------------------------------------------------
 
 /// `GET /api/v1/workspaces/{workspace_id}/verification-suites`

--- a/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
+++ b/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
@@ -13,11 +13,11 @@
 //! cert plumbing lands separately.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::HeaderMap,
     Json,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
@@ -451,6 +451,165 @@ pub async fn get_workspace_endpoint_hits(
     .await
     .map_err(ApiError::Database)?;
     Ok(Json(rows))
+}
+
+/// `GET /api/v1/internal/workspaces/{id}/runtime-stats?window_minutes=N&path_prefix=X`
+///
+/// Internal-only — the FitnessExecutor (#355) calls this to evaluate
+/// latency / error-rate fitness functions. Aggregates over
+/// `runtime_captures` because that's where the cloud-side request log
+/// for a workspace lives (`runtime_request_logs` is deployment-scoped,
+/// not workspace-scoped).
+pub async fn get_workspace_runtime_stats(
+    State(state): State<AppState>,
+    Path(workspace_id): Path<Uuid>,
+    Query(params): Query<RuntimeStatsQuery>,
+    headers: HeaderMap,
+) -> ApiResult<Json<WorkspaceRuntimeStats>> {
+    require_internal_auth(&headers)?;
+    let window_minutes = params.window_minutes.unwrap_or(60).clamp(1, 60 * 24 * 7);
+    let path_prefix = params.path_prefix.unwrap_or_default();
+    let interval_str = format!("{} minutes", window_minutes);
+
+    let row: WorkspaceRuntimeStatsRow = sqlx::query_as(
+        r#"
+        WITH window_rows AS (
+            SELECT
+                COALESCE(rc.duration_ms, 0)::float8 AS duration_ms,
+                rc.response_status_code AS status
+            FROM runtime_captures rc
+            WHERE rc.workspace_id = $1
+              AND rc.occurred_at >= NOW() - ($2::text)::interval
+              AND ($3 = '' OR rc.path LIKE $3 || '%')
+        )
+        SELECT
+            COUNT(*)::int8                                            AS total_requests,
+            COALESCE(
+                PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_ms),
+                0.0
+            )::float8                                                 AS p50_ms,
+            COALESCE(
+                PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms),
+                0.0
+            )::float8                                                 AS p95_ms,
+            COALESCE(
+                PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY duration_ms),
+                0.0
+            )::float8                                                 AS p99_ms,
+            COUNT(*) FILTER (WHERE status >= 500)::int8               AS server_errors,
+            COUNT(*) FILTER (WHERE status >= 400 AND status < 500)::int8 AS client_errors
+        FROM window_rows
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(&interval_str)
+    .bind(&path_prefix)
+    .fetch_one(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(WorkspaceRuntimeStats {
+        window_minutes,
+        path_prefix,
+        total_requests: row.total_requests,
+        p50_ms: row.p50_ms,
+        p95_ms: row.p95_ms,
+        p99_ms: row.p99_ms,
+        server_errors: row.server_errors,
+        client_errors: row.client_errors,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RuntimeStatsQuery {
+    #[serde(default)]
+    pub window_minutes: Option<i64>,
+    #[serde(default)]
+    pub path_prefix: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkspaceRuntimeStats {
+    pub window_minutes: i64,
+    pub path_prefix: String,
+    pub total_requests: i64,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub p99_ms: f64,
+    pub server_errors: i64,
+    pub client_errors: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct WorkspaceRuntimeStatsRow {
+    total_requests: i64,
+    p50_ms: f64,
+    p95_ms: f64,
+    p99_ms: f64,
+    server_errors: i64,
+    client_errors: i64,
+}
+
+/// Body for `POST /api/v1/internal/incidents/raise-from-runner` —
+/// the runner-side incident raise that the FitnessExecutor uses
+/// when an evaluation fails.
+#[derive(Debug, Deserialize)]
+pub struct RaiseIncidentFromRunnerBody {
+    pub workspace_id: Uuid,
+    pub source: String,
+    #[serde(default)]
+    pub source_ref: Option<String>,
+    pub dedupe_key: String,
+    pub severity: String,
+    pub title: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// `POST /api/v1/internal/incidents/raise-from-runner`
+///
+/// Runner-side incident raise. Used by the FitnessExecutor (#355) to
+/// translate a failed fitness evaluation into a fitness-source
+/// incident. Looks up the workspace's org_id so the runner doesn't
+/// need it on hand.
+pub async fn raise_incident_from_runner(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<RaiseIncidentFromRunnerBody>,
+) -> ApiResult<Json<serde_json::Value>> {
+    require_internal_auth(&headers)?;
+    use mockforge_registry_core::models::incident::RaiseIncidentInput;
+    use mockforge_registry_core::models::Incident;
+
+    let workspace = mockforge_registry_core::models::CloudWorkspace::find_by_id(
+        state.db.pool(),
+        body.workspace_id,
+    )
+    .await
+    .map_err(ApiError::Database)?
+    .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+
+    let incident = Incident::raise(
+        state.db.pool(),
+        RaiseIncidentInput {
+            org_id: workspace.org_id,
+            workspace_id: Some(body.workspace_id),
+            source: &body.source,
+            source_ref: body.source_ref.as_deref(),
+            dedupe_key: &body.dedupe_key,
+            severity: &body.severity,
+            title: &body.title,
+            description: body.description.as_deref(),
+        },
+    )
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(serde_json::json!({
+        "id": incident.id,
+        "status": incident.status,
+        "dedupe_key": incident.dedupe_key,
+    })))
 }
 
 /// `GET /api/v1/internal/capture-sessions/{id}/exchanges`

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -96,6 +96,14 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             get(handlers::internal_test_runs::get_workspace_endpoint_hits),
         )
         .route(
+            "/api/v1/internal/workspaces/{id}/runtime-stats",
+            get(handlers::internal_test_runs::get_workspace_runtime_stats),
+        )
+        .route(
+            "/api/v1/internal/incidents/raise-from-runner",
+            post(handlers::internal_test_runs::raise_incident_from_runner),
+        )
+        .route(
             "/api/v1/internal/hosted-mocks/{id}/chaos",
             post(handlers::internal_test_runs::proxy_chaos_toggle),
         )
@@ -521,7 +529,12 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         )
         .route(
             "/api/v1/fitness-functions/{id}",
-            axum::routing::delete(handlers::contract_verification::delete_fitness_function),
+            axum::routing::patch(handlers::contract_verification::update_fitness_function)
+                .delete(handlers::contract_verification::delete_fitness_function),
+        )
+        .route(
+            "/api/v1/fitness-functions/{id}/runs",
+            post(handlers::contract_verification::trigger_fitness_run),
         )
         .route(
             "/api/v1/workspaces/{workspace_id}/verification-suites",

--- a/crates/mockforge-test-runner/Cargo.toml
+++ b/crates/mockforge-test-runner/Cargo.toml
@@ -36,6 +36,9 @@ chrono = { workspace = true }
 # HTTP for callbacks to registry (mTLS-secured POSTs)
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 
+# URL-encoding for runtime-stats path_prefix query strings (#355).
+urlencoding = "2.1"
+
 # YAML parser used by ContractExecutor when an OpenAPI spec is served as YAML.
 serde_yaml = "0.9"
 

--- a/crates/mockforge-test-runner/src/callbacks.rs
+++ b/crates/mockforge-test-runner/src/callbacks.rs
@@ -133,6 +133,46 @@ impl RegistryCallbacks {
         Ok(rows)
     }
 
+    /// Pull aggregate latency / error stats for a workspace. Used by
+    /// the FitnessExecutor (#355) to evaluate latency_threshold and
+    /// error_rate fitness functions. `path_prefix` is optional ("" =
+    /// no filter); `window_minutes` clamped to 1..=10080 server-side.
+    pub async fn fetch_workspace_runtime_stats(
+        &self,
+        workspace_id: Uuid,
+        window_minutes: i64,
+        path_prefix: Option<&str>,
+    ) -> Result<WorkspaceRuntimeStats> {
+        let mut url = format!(
+            "{}/api/v1/internal/workspaces/{workspace_id}/runtime-stats?window_minutes={window_minutes}",
+            self.base_url.trim_end_matches('/'),
+        );
+        if let Some(p) = path_prefix {
+            if !p.is_empty() {
+                url.push_str("&path_prefix=");
+                url.push_str(&urlencoding::encode(p));
+            }
+        }
+        let resp = self.http.get(&url).bearer_auth(&self.token).send().await?;
+        let resp = resp.error_for_status()?;
+        let stats: WorkspaceRuntimeStats = resp.json().await?;
+        Ok(stats)
+    }
+
+    /// Raise an incident from the runner side. Used by the
+    /// FitnessExecutor (#355) when a fitness function evaluates as
+    /// failed — same dedupe semantics as raise_incident_external on
+    /// the public surface, but auth'd via the internal token.
+    pub async fn raise_incident(&self, body: RaiseIncidentBody<'_>) -> Result<()> {
+        let url = format!(
+            "{}/api/v1/internal/incidents/raise-from-runner",
+            self.base_url.trim_end_matches('/'),
+        );
+        let resp = self.http.post(&url).bearer_auth(&self.token).json(&body).send().await?;
+        resp.error_for_status()?;
+        Ok(())
+    }
+
     /// Toggle chaos on a hosted-mock deployment via the registry's
     /// internal proxy. Used by the chaos executor for
     /// target_kind=hosted_mock — the registry resolves the
@@ -162,6 +202,38 @@ pub struct EndpointHit {
     pub method: String,
     pub path: String,
     pub hits: i64,
+}
+
+/// Aggregate latency / error stats for a workspace returned by
+/// `/api/v1/internal/workspaces/{id}/runtime-stats`. Used by the
+/// FitnessExecutor (#355).
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkspaceRuntimeStats {
+    pub window_minutes: i64,
+    pub path_prefix: String,
+    pub total_requests: i64,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub p99_ms: f64,
+    pub server_errors: i64,
+    pub client_errors: i64,
+}
+
+/// Body for `RegistryCallbacks::raise_incident`. Mirrors the registry's
+/// internal `RaiseIncidentFromRunnerBody`.
+#[allow(missing_docs)] // wire-format struct; field semantics live on the registry side
+#[derive(Debug, Serialize)]
+pub struct RaiseIncidentBody<'a> {
+    pub workspace_id: Uuid,
+    pub source: &'a str,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<&'a str>,
+    pub dedupe_key: &'a str,
+    pub severity: &'a str,
+    pub title: &'a str,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<&'a str>,
 }
 
 #[derive(Serialize)]

--- a/crates/mockforge-test-runner/src/executors/contract.rs
+++ b/crates/mockforge-test-runner/src/executors/contract.rs
@@ -40,6 +40,29 @@ impl Executor for ContractExecutor {
 
     async fn execute(&self, job: RunJob, callbacks: &RegistryCallbacks) -> Result<JobOutcome> {
         let started = Instant::now();
+
+        // Fitness evaluation has its own real path that queries the
+        // workspace's runtime stats and (optionally) raises an
+        // incident when the threshold is breached. See #355.
+        if self.kind == "fitness_evaluation" {
+            let workspace_id = job
+                .payload
+                .get("workspace_id")
+                .and_then(|v| v.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok());
+            let fitness_kind =
+                job.payload.get("fitness_kind").and_then(|v| v.as_str()).map(String::from);
+            let fitness_config = job.payload.get("fitness_config").cloned();
+            if let (Some(ws_id), Some(kind), Some(cfg)) =
+                (workspace_id, fitness_kind, fitness_config)
+            {
+                return crate::executors::fitness::run_real_fitness(
+                    job, callbacks, started, ws_id, &kind, &cfg,
+                )
+                .await;
+            }
+        }
+
         callbacks.run_started(job.run_id).await?;
 
         let service_name = job

--- a/crates/mockforge-test-runner/src/executors/fitness.rs
+++ b/crates/mockforge-test-runner/src/executors/fitness.rs
@@ -1,0 +1,540 @@
+//! Real fitness-function evaluation for `kind = "fitness_evaluation"`
+//! test runs (#355).
+//!
+//! Fitness functions are declarative checks against the workspace's
+//! observability data. Today we evaluate two kinds end-to-end against
+//! real `runtime_captures`:
+//!
+//!   - `latency_threshold` — reads p95 (or configured percentile) over
+//!     a window and fails when it exceeds the configured limit.
+//!   - `error_rate` — reads the 4xx/5xx fraction of total requests
+//!     over the window and fails when it exceeds the limit.
+//!
+//! `contract_stability` and `custom_query` stay in synthetic mode
+//! until follow-up slices land — the executor logs that explicitly so
+//! UIs can surface the gap. Failures (real or synthetic) raise a
+//! workspace-scoped incident with `source = "fitness"` so the
+//! incident dispatcher can route them through the same channels as
+//! the rest of #3.
+
+use std::time::Instant;
+
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::callbacks::{RaiseIncidentBody, RegistryCallbacks};
+use crate::error::Result;
+use crate::executors::{JobOutcome, JobStatus, RunJob};
+
+#[derive(Debug, Default, Deserialize)]
+struct FitnessConfig {
+    /// Window in minutes the metric is evaluated over. Default 60.
+    #[serde(default)]
+    window_minutes: Option<i64>,
+    /// Optional path prefix filter (e.g. `/api/v1/users`). Default: any.
+    #[serde(default)]
+    path_prefix: Option<String>,
+    /// `latency_threshold`: which percentile to evaluate (50 / 95 / 99).
+    /// Default 95.
+    #[serde(default)]
+    percentile: Option<u8>,
+    /// `latency_threshold`: max allowed value for the chosen percentile.
+    #[serde(default, alias = "max_latency_ms")]
+    threshold_ms: Option<f64>,
+    /// `error_rate`: max allowed fraction (0.0..=1.0). 0.05 = 5%.
+    #[serde(default, alias = "max_error_rate")]
+    error_rate: Option<f64>,
+    /// `error_rate`: which class counts as an error — `5xx` (default)
+    /// or `4xx_5xx`.
+    #[serde(default)]
+    counts: Option<String>,
+    /// Severity for the raised incident if the function fails.
+    #[serde(default)]
+    severity: Option<String>,
+}
+
+/// Run a fitness evaluation and report passed/failed back through
+/// `callbacks`. On failure also raises a deduped fitness-source
+/// incident in the workspace.
+pub async fn run_real_fitness(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    workspace_id: Uuid,
+    kind: &str,
+    config: &serde_json::Value,
+) -> Result<JobOutcome> {
+    callbacks.run_started(job.run_id).await?;
+
+    let cfg: FitnessConfig = serde_json::from_value(config.clone()).unwrap_or_default();
+    let window = cfg.window_minutes.unwrap_or(60).clamp(1, 60 * 24 * 7);
+    let path_prefix = cfg.path_prefix.clone().unwrap_or_default();
+    let fitness_name = job
+        .payload
+        .get("fitness_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(unnamed)")
+        .to_string();
+    let fitness_id = job
+        .payload
+        .get("fitness_function_id")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!(
+                    "Fitness eval: kind='{kind}', name='{fitness_name}', window={}m, path_prefix='{}'",
+                    window, path_prefix,
+                ),
+                "tracking_task": 355,
+            }),
+        )
+        .await?;
+
+    // Pull the same stats payload regardless of kind — it's one
+    // network call per evaluation, and the `fetch_workspace_runtime_stats`
+    // endpoint already aggregates lazily.
+    let stats = match callbacks
+        .fetch_workspace_runtime_stats(
+            workspace_id,
+            window,
+            if path_prefix.is_empty() {
+                None
+            } else {
+                Some(&path_prefix)
+            },
+        )
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            callbacks
+                .run_event(
+                    job.run_id,
+                    2,
+                    "log",
+                    serde_json::json!({
+                        "level": "error",
+                        "message": format!("runtime-stats fetch failed: {e}"),
+                    }),
+                )
+                .await?;
+            return Ok(JobOutcome {
+                status: JobStatus::Errored,
+                runner_seconds: started.elapsed().as_secs_f64().ceil() as i32,
+                summary: Some(serde_json::json!({
+                    "executor_phase": "real",
+                    "tracking_task": 355,
+                    "kind": "fitness_evaluation",
+                    "error": format!("runtime-stats fetch failed: {e}"),
+                })),
+            });
+        }
+    };
+
+    let evaluation = match kind {
+        "latency_threshold" => evaluate_latency(&cfg, &stats),
+        "error_rate" => evaluate_error_rate(&cfg, &stats),
+        "contract_stability" | "custom_query" => Evaluation::Synthetic {
+            reason: format!(
+                "kind='{kind}' has no real evaluator yet — passing synthetically. \
+                 Follow-up issue tracks the real impl."
+            ),
+        },
+        other => Evaluation::Errored {
+            reason: format!("Unknown fitness kind: {other}"),
+        },
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            2,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": "runtime stats fetched",
+                "stats": {
+                    "total_requests": stats.total_requests,
+                    "p50_ms": stats.p50_ms,
+                    "p95_ms": stats.p95_ms,
+                    "p99_ms": stats.p99_ms,
+                    "server_errors": stats.server_errors,
+                    "client_errors": stats.client_errors,
+                },
+            }),
+        )
+        .await?;
+
+    let elapsed = started.elapsed();
+    let runner_seconds = (elapsed.as_secs_f64().ceil() as i32).max(1);
+
+    let (status, summary_extras, failure_msg) = match &evaluation {
+        Evaluation::Passed {
+            observed,
+            threshold,
+        } => {
+            callbacks
+                .run_event(
+                    job.run_id,
+                    3,
+                    "fitness_pass",
+                    serde_json::json!({
+                        "fitness_name": fitness_name,
+                        "kind": kind,
+                        "observed": observed,
+                        "threshold": threshold,
+                    }),
+                )
+                .await?;
+            (
+                JobStatus::Passed,
+                serde_json::json!({
+                    "result": "passed",
+                    "observed": observed,
+                    "threshold": threshold,
+                }),
+                None,
+            )
+        }
+        Evaluation::Failed {
+            observed,
+            threshold,
+            description,
+        } => {
+            callbacks
+                .run_event(
+                    job.run_id,
+                    3,
+                    "fitness_fail",
+                    serde_json::json!({
+                        "fitness_name": fitness_name,
+                        "kind": kind,
+                        "observed": observed,
+                        "threshold": threshold,
+                        "description": description,
+                    }),
+                )
+                .await?;
+            (
+                JobStatus::Failed,
+                serde_json::json!({
+                    "result": "failed",
+                    "observed": observed,
+                    "threshold": threshold,
+                    "description": description,
+                }),
+                Some(description.clone()),
+            )
+        }
+        Evaluation::Synthetic { reason } => {
+            callbacks
+                .run_event(
+                    job.run_id,
+                    3,
+                    "log",
+                    serde_json::json!({
+                        "level": "warn",
+                        "message": reason,
+                        "synthetic": true,
+                    }),
+                )
+                .await?;
+            (
+                JobStatus::Passed,
+                serde_json::json!({
+                    "result": "synthetic_pass",
+                    "reason": reason,
+                }),
+                None,
+            )
+        }
+        Evaluation::Errored { reason } => {
+            callbacks
+                .run_event(
+                    job.run_id,
+                    3,
+                    "log",
+                    serde_json::json!({
+                        "level": "error",
+                        "message": reason,
+                    }),
+                )
+                .await?;
+            (
+                JobStatus::Errored,
+                serde_json::json!({
+                    "result": "errored",
+                    "reason": reason,
+                }),
+                None,
+            )
+        }
+    };
+
+    if let (Some(msg), Some(id)) = (failure_msg.as_deref(), fitness_id.as_deref()) {
+        let dedupe_key = format!("fitness:{}", id);
+        let severity = cfg.severity.as_deref().unwrap_or("major");
+        let title = format!("Fitness function '{fitness_name}' failed");
+        if let Err(e) = callbacks
+            .raise_incident(RaiseIncidentBody {
+                workspace_id,
+                source: "fitness",
+                source_ref: Some(id),
+                dedupe_key: &dedupe_key,
+                severity,
+                title: &title,
+                description: Some(msg),
+            })
+            .await
+        {
+            // Don't fail the run because incident dispatch failed — log
+            // it and let the user see the run-level fitness_fail event.
+            callbacks
+                .run_event(
+                    job.run_id,
+                    4,
+                    "log",
+                    serde_json::json!({
+                        "level": "warn",
+                        "message": format!("incident raise failed: {e}"),
+                    }),
+                )
+                .await?;
+        }
+    }
+
+    Ok(JobOutcome {
+        status,
+        runner_seconds,
+        summary: Some(serde_json::json!({
+            "executor_phase": match &evaluation {
+                Evaluation::Synthetic { .. } => "synthetic",
+                _ => "real",
+            },
+            "tracking_task": 355,
+            "kind": "fitness_evaluation",
+            "fitness_kind": kind,
+            "fitness_name": fitness_name,
+            "wall_ms": elapsed.as_millis() as u64,
+            "evaluation": summary_extras,
+        })),
+    })
+}
+
+enum Evaluation {
+    Passed {
+        observed: serde_json::Value,
+        threshold: serde_json::Value,
+    },
+    Failed {
+        observed: serde_json::Value,
+        threshold: serde_json::Value,
+        description: String,
+    },
+    Synthetic {
+        reason: String,
+    },
+    Errored {
+        reason: String,
+    },
+}
+
+fn evaluate_latency(
+    cfg: &FitnessConfig,
+    stats: &crate::callbacks::WorkspaceRuntimeStats,
+) -> Evaluation {
+    let percentile = cfg.percentile.unwrap_or(95);
+    let observed_ms = match percentile {
+        50 => stats.p50_ms,
+        99 => stats.p99_ms,
+        _ => stats.p95_ms,
+    };
+    let threshold_ms = match cfg.threshold_ms {
+        Some(t) => t,
+        None => {
+            return Evaluation::Errored {
+                reason: "latency_threshold config missing 'threshold_ms'".into(),
+            };
+        }
+    };
+    if stats.total_requests == 0 {
+        return Evaluation::Synthetic {
+            reason: format!(
+                "no traffic in the last {} minutes — nothing to evaluate",
+                cfg.window_minutes.unwrap_or(60),
+            ),
+        };
+    }
+    if observed_ms > threshold_ms {
+        Evaluation::Failed {
+            observed: serde_json::json!({ "p": percentile, "ms": observed_ms }),
+            threshold: serde_json::json!({ "ms": threshold_ms }),
+            description: format!(
+                "p{percentile} latency {observed_ms:.1}ms > threshold {threshold_ms}ms"
+            ),
+        }
+    } else {
+        Evaluation::Passed {
+            observed: serde_json::json!({ "p": percentile, "ms": observed_ms }),
+            threshold: serde_json::json!({ "ms": threshold_ms }),
+        }
+    }
+}
+
+fn evaluate_error_rate(
+    cfg: &FitnessConfig,
+    stats: &crate::callbacks::WorkspaceRuntimeStats,
+) -> Evaluation {
+    let max_rate = match cfg.error_rate {
+        Some(r) => r.clamp(0.0, 1.0),
+        None => {
+            return Evaluation::Errored {
+                reason: "error_rate config missing 'error_rate'".into(),
+            };
+        }
+    };
+    if stats.total_requests == 0 {
+        return Evaluation::Synthetic {
+            reason: format!(
+                "no traffic in the last {} minutes — nothing to evaluate",
+                cfg.window_minutes.unwrap_or(60),
+            ),
+        };
+    }
+    let counts = cfg.counts.as_deref().unwrap_or("5xx");
+    let error_count = match counts {
+        "4xx_5xx" => stats.server_errors + stats.client_errors,
+        _ => stats.server_errors,
+    };
+    let observed_rate = (error_count as f64) / (stats.total_requests as f64);
+    if observed_rate > max_rate {
+        Evaluation::Failed {
+            observed: serde_json::json!({
+                "rate": observed_rate,
+                "errors": error_count,
+                "total": stats.total_requests,
+                "counts": counts,
+            }),
+            threshold: serde_json::json!({ "rate": max_rate }),
+            description: format!(
+                "{counts} error rate {:.4} ({error_count}/{}) > threshold {max_rate}",
+                observed_rate, stats.total_requests,
+            ),
+        }
+    } else {
+        Evaluation::Passed {
+            observed: serde_json::json!({
+                "rate": observed_rate,
+                "errors": error_count,
+                "total": stats.total_requests,
+                "counts": counts,
+            }),
+            threshold: serde_json::json!({ "rate": max_rate }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::callbacks::WorkspaceRuntimeStats;
+
+    fn stats(
+        total: i64,
+        p95: f64,
+        server_errors: i64,
+        client_errors: i64,
+    ) -> WorkspaceRuntimeStats {
+        WorkspaceRuntimeStats {
+            window_minutes: 60,
+            path_prefix: String::new(),
+            total_requests: total,
+            p50_ms: p95 / 2.0,
+            p95_ms: p95,
+            p99_ms: p95 * 1.2,
+            server_errors,
+            client_errors,
+        }
+    }
+
+    #[test]
+    fn latency_passes_when_under_threshold() {
+        let cfg = FitnessConfig {
+            threshold_ms: Some(500.0),
+            ..Default::default()
+        };
+        let s = stats(100, 200.0, 0, 0);
+        match evaluate_latency(&cfg, &s) {
+            Evaluation::Passed { .. } => {}
+            other => panic!(
+                "expected Passed, got {other:?}",
+                other = match other {
+                    Evaluation::Failed { description, .. } => description,
+                    Evaluation::Synthetic { reason } => reason,
+                    Evaluation::Errored { reason } => reason,
+                    _ => "unreachable".into(),
+                }
+            ),
+        }
+    }
+
+    #[test]
+    fn latency_fails_when_over_threshold() {
+        let cfg = FitnessConfig {
+            threshold_ms: Some(100.0),
+            ..Default::default()
+        };
+        let s = stats(100, 250.0, 0, 0);
+        assert!(matches!(evaluate_latency(&cfg, &s), Evaluation::Failed { .. }));
+    }
+
+    #[test]
+    fn latency_with_no_traffic_is_synthetic() {
+        let cfg = FitnessConfig {
+            threshold_ms: Some(100.0),
+            ..Default::default()
+        };
+        let s = stats(0, 0.0, 0, 0);
+        assert!(matches!(evaluate_latency(&cfg, &s), Evaluation::Synthetic { .. }));
+    }
+
+    #[test]
+    fn error_rate_5xx_only_passes() {
+        let cfg = FitnessConfig {
+            error_rate: Some(0.05),
+            ..Default::default()
+        };
+        // 2/100 5xx = 2% < 5%
+        let s = stats(100, 50.0, 2, 0);
+        assert!(matches!(evaluate_error_rate(&cfg, &s), Evaluation::Passed { .. }));
+    }
+
+    #[test]
+    fn error_rate_5xx_only_fails() {
+        let cfg = FitnessConfig {
+            error_rate: Some(0.05),
+            ..Default::default()
+        };
+        let s = stats(100, 50.0, 10, 0);
+        assert!(matches!(evaluate_error_rate(&cfg, &s), Evaluation::Failed { .. }));
+    }
+
+    #[test]
+    fn error_rate_includes_4xx_when_configured() {
+        let cfg = FitnessConfig {
+            error_rate: Some(0.05),
+            counts: Some("4xx_5xx".into()),
+            ..Default::default()
+        };
+        // 6/100 (4xx+5xx) = 6% > 5%
+        let s = stats(100, 50.0, 1, 5);
+        assert!(matches!(evaluate_error_rate(&cfg, &s), Evaluation::Failed { .. }));
+    }
+}

--- a/crates/mockforge-test-runner/src/executors/mod.rs
+++ b/crates/mockforge-test-runner/src/executors/mod.rs
@@ -17,6 +17,7 @@
 pub mod chaos;
 pub mod clone_train;
 pub mod contract;
+pub mod fitness;
 pub mod flow;
 pub mod replay;
 pub mod snapshot;

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -267,6 +267,10 @@ const cloudNavItemIds = new Set([
   'cloud-flows',
   // Cloud contract diff + verification via cloudContractApi.
   'cloud-contract',
+  // Fitness functions persist via cloudFitnessApi (workspace-scoped)
+  // and execute through the FitnessExecutor in mockforge-test-runner
+  // (#355). Failures raise a fitness-source incident.
+  'fitness-functions',
   // Cloud recorder + behavioral cloning via cloudRecorderApi.
   'cloud-recorder',
   // Showcase admin authoring via cloudShowcaseApi.adminList / adminCreate /

--- a/crates/mockforge-ui/ui/src/pages/FitnessFunctionsPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FitnessFunctionsPage.tsx
@@ -17,7 +17,10 @@ import {
   BarChart3,
   TrendingUp,
 } from 'lucide-react';
-import { driftApi, type FitnessFunction, type CreateFitnessFunctionRequest, type FitnessTestResult, type DriftIncident } from '../services/driftApi';
+import { driftApi, type FitnessFunction, type CreateFitnessFunctionRequest, type FitnessTestResult, type DriftIncident, type FitnessFunctionType, type FitnessScope } from '../services/driftApi';
+import { cloudFitnessApi, type CloudFitnessFunction } from '../services/api/cloudFitness';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 import { useDriftIncidents } from '../hooks/useApi';
 import {
   PageHeader,
@@ -679,19 +682,89 @@ export function FitnessFunctionsPage() {
   const [showSummary, setShowSummary] = useState(true);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
+  const cloud = isCloudMode();
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+
+  // Adapt the cloud row shape onto the local FitnessFunction shape so
+  // the rest of the page (cards / forms / dialogs) stays put.
+  const cloudKindToFunctionType = (kind: string): FitnessFunctionType => {
+    switch (kind) {
+      case 'latency_threshold':
+        return 'latency_p95';
+      case 'error_rate':
+        return 'error_rate';
+      case 'contract_stability':
+      case 'custom_query':
+      default:
+        return 'custom';
+    }
+  };
+  const adaptCloudRow = (row: CloudFitnessFunction): FitnessFunction => ({
+    id: row.id,
+    name: row.name,
+    description:
+      typeof row.config?.description === 'string'
+        ? (row.config.description as string)
+        : '',
+    function_type: cloudKindToFunctionType(row.kind),
+    config: row.config ?? {},
+    scope:
+      (row.config?.scope as FitnessScope) ?? { type: 'global' },
+    enabled: true,
+    created_at: Date.parse(row.created_at) / 1000,
+    updated_at: Date.parse(row.updated_at) / 1000,
+  });
+
   // Fetch fitness functions
   const { data, isLoading, refetch } = useQuery({
-    queryKey: ['fitness-functions'],
-    queryFn: () => driftApi.listFitnessFunctions(),
+    queryKey: ['fitness-functions', cloud, activeWorkspace?.id],
+    queryFn: async () => {
+      if (cloud) {
+        if (!activeWorkspace?.id) {
+          return { functions: [] as FitnessFunction[] };
+        }
+        const rows = await cloudFitnessApi.listForWorkspace(activeWorkspace.id);
+        return { functions: rows.map(adaptCloudRow) };
+      }
+      return driftApi.listFitnessFunctions();
+    },
   });
 
   // Fetch incidents to aggregate fitness results
   const { data: incidentsData } = useDriftIncidents({}, { refetchInterval: 10000 });
   const incidents = incidentsData?.incidents || [];
 
+  // Map a local-form CreateFitnessFunctionRequest onto the cloud
+  // shape (kind + config blob). Description and scope ride along in
+  // config so they're preserved on round-trips.
+  const localTypeToCloudKind = (t: FitnessFunctionType): string => {
+    if (t === 'latency_p95' || t === 'latency_p99') return 'latency_threshold';
+    if (t === 'error_rate') return 'error_rate';
+    if (t === 'contract_drift') return 'contract_stability';
+    return 'custom_query';
+  };
+  const toCloudCreate = (request: CreateFitnessFunctionRequest) => ({
+    name: request.name,
+    kind: localTypeToCloudKind(request.function_type),
+    config: {
+      ...(request.config ?? {}),
+      description: request.description,
+      scope: request.scope,
+    },
+  });
+
   // Create mutation
   const createMutation = useMutation({
-    mutationFn: (request: CreateFitnessFunctionRequest) => driftApi.createFitnessFunction(request),
+    mutationFn: async (request: CreateFitnessFunctionRequest) => {
+      if (cloud) {
+        if (!activeWorkspace?.id) {
+          throw new Error('No active workspace selected.');
+        }
+        await cloudFitnessApi.create(activeWorkspace.id, toCloudCreate(request));
+        return;
+      }
+      await driftApi.createFitnessFunction(request);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fitness-functions'] });
       setShowForm(false);
@@ -705,8 +778,16 @@ export function FitnessFunctionsPage() {
 
   // Update mutation
   const updateMutation = useMutation({
-    mutationFn: ({ id, request }: { id: string; request: CreateFitnessFunctionRequest }) =>
-      driftApi.updateFitnessFunction(id, request),
+    mutationFn: async ({ id, request }: { id: string; request: CreateFitnessFunctionRequest }) => {
+      if (cloud) {
+        await cloudFitnessApi.update(id, {
+          name: request.name,
+          config: toCloudCreate(request).config,
+        });
+        return;
+      }
+      await driftApi.updateFitnessFunction(id, request);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fitness-functions'] });
       setShowForm(false);
@@ -720,7 +801,13 @@ export function FitnessFunctionsPage() {
 
   // Delete mutation
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => driftApi.deleteFitnessFunction(id),
+    mutationFn: async (id: string) => {
+      if (cloud) {
+        await cloudFitnessApi.delete(id);
+        return;
+      }
+      await driftApi.deleteFitnessFunction(id);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fitness-functions'] });
     },
@@ -730,9 +817,26 @@ export function FitnessFunctionsPage() {
     },
   });
 
-  // Test mutation
+  // Test mutation — in cloud mode this triggers an asynchronous
+  // fitness_evaluation test_run; results stream over Cloud Test Runs SSE
+  // and the row's status updates after.
   const testMutation = useMutation({
-    mutationFn: (id: string) => driftApi.testFitnessFunction(id, {}),
+    mutationFn: async (id: string) => {
+      if (cloud) {
+        const run = await cloudFitnessApi.triggerRun(id);
+        return {
+          results: [
+            {
+              function_id: id,
+              function_name: '(cloud)',
+              passed: true,
+              message: `Run ${run.id} enqueued (${run.status}). Watch progress in Cloud Test Runs.`,
+            } as FitnessTestResult,
+          ],
+        };
+      }
+      return driftApi.testFitnessFunction(id, {});
+    },
     onSuccess: (data) => {
       setTestResults(data.results || []);
       setShowTestResults(true);

--- a/crates/mockforge-ui/ui/src/services/api/cloudFitness.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudFitness.ts
@@ -1,0 +1,104 @@
+/**
+ * Cloud fitness functions API client (#355).
+ *
+ * Wraps the registry's workspace-scoped fitness function CRUD plus the
+ * trigger-run endpoint that enqueues a `kind=fitness_evaluation`
+ * test_run. The runner-side FitnessExecutor evaluates against
+ * `runtime_captures` and raises a fitness-source incident on failure.
+ */
+import { fetchJsonWithErrorBody } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
+import type { TestRun } from './cloudTestRuns';
+
+/** One of the four kinds the registry recognizes. */
+export type CloudFitnessKind =
+  | 'latency_threshold'
+  | 'error_rate'
+  | 'contract_stability'
+  | 'custom_query';
+
+export interface CloudFitnessFunction {
+  id: string;
+  workspace_id: string;
+  name: string;
+  kind: CloudFitnessKind | string;
+  config: Record<string, unknown>;
+  last_evaluated_at: string | null;
+  last_status: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateCloudFitnessRequest {
+  name: string;
+  kind: CloudFitnessKind | string;
+  config: Record<string, unknown>;
+}
+
+export interface UpdateCloudFitnessRequest {
+  name?: string;
+  config?: Record<string, unknown>;
+}
+
+class CloudFitnessApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud fitness ${method} only works in cloud mode.`);
+    }
+  }
+
+  async listForWorkspace(workspaceId: string): Promise<CloudFitnessFunction[]> {
+    this.guard('listForWorkspace');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/fitness-functions`,
+    ) as Promise<CloudFitnessFunction[]>;
+  }
+
+  async create(
+    workspaceId: string,
+    body: CreateCloudFitnessRequest,
+  ): Promise<CloudFitnessFunction> {
+    this.guard('create');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/fitness-functions`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    ) as Promise<CloudFitnessFunction>;
+  }
+
+  async update(
+    id: string,
+    body: UpdateCloudFitnessRequest,
+  ): Promise<CloudFitnessFunction> {
+    this.guard('update');
+    return fetchJsonWithErrorBody(`/api/v1/fitness-functions/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as Promise<CloudFitnessFunction>;
+  }
+
+  async delete(id: string): Promise<{ deleted: boolean }> {
+    this.guard('delete');
+    return fetchJsonWithErrorBody(`/api/v1/fitness-functions/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    }) as Promise<{ deleted: boolean }>;
+  }
+
+  /**
+   * Enqueue a fitness_evaluation run. Live progress events flow over
+   * cloudTestRunsApi.streamRunEvents(run.id).
+   */
+  async triggerRun(id: string): Promise<TestRun> {
+    this.guard('triggerRun');
+    return fetchJsonWithErrorBody(
+      `/api/v1/fitness-functions/${encodeURIComponent(id)}/runs`,
+      { method: 'POST' },
+    ) as Promise<TestRun>;
+  }
+}
+
+export const cloudFitnessApi = new CloudFitnessApi();


### PR DESCRIPTION
## Summary

- Real `FitnessExecutor` (kind='fitness_evaluation' was synthetic-pass before) — evaluates latency_threshold / error_rate against `runtime_captures`, raises a fitness-source incident on fail.
- FitnessFunctionsPage UI now dispatches through new `cloudFitnessApi` when `isCloudMode()`; local mode unchanged.
- New trigger + PATCH routes on the registry; new internal stats + incident-raise endpoints for the runner to call.
- No DB migration — piggy-backs on `fitness_functions` / `test_runs` / `runtime_captures` shipped in #324.

Closes #355.

## Backend

- `handlers/contract_verification.rs`:
  - `POST /api/v1/fitness-functions/{id}/runs` — enqueues a `fitness_evaluation` test_run with the function's config baked into the queue payload.
  - `PATCH /api/v1/fitness-functions/{id}` — rename + reconfigure.
- `handlers/internal_test_runs.rs` (new internal-token routes):
  - `GET /api/v1/internal/workspaces/{id}/runtime-stats?window_minutes=N&path_prefix=X` — p50/p95/p99 latency + 4xx/5xx counts from `runtime_captures`.
  - `POST /api/v1/internal/incidents/raise-from-runner` — runner-side incident raise; resolves org_id from workspace.

## Runner

- `executors/fitness.rs`:
  - `latency_threshold` — evaluates p95 (or configured percentile) against `threshold_ms`.
  - `error_rate` — evaluates 5xx fraction (or 4xx_5xx via `counts`) against `error_rate`.
  - `contract_stability` + `custom_query` → synthetic-pass with a log explaining the gap (follow-up issues track real impl).
  - Empty windows (zero traffic) are reported as synthetic passes with an explanatory log so users aren't misled into thinking "all green" means "no issues" when the data was actually empty.
  - Failures emit a `fitness_fail` event AND raise an incident with `source='fitness'` + `dedupe_key='fitness:{id}'`, so the existing dispatcher (#3) routes it through configured channels.
- `ContractExecutor::execute` dispatches to `fitness::run_real_fitness` when `kind=='fitness_evaluation'` and the queue payload carries `workspace_id` + `fitness_kind` + `fitness_config`.
- `RegistryCallbacks` gains `fetch_workspace_runtime_stats()` + `raise_incident()`.
- 6 new unit tests cover latency / error-rate happy paths, empty-window behavior, and the 4xx_5xx counts switch.

## UI

- `services/api/cloudFitness.ts` — new client with list / create / update / delete / triggerRun.
- `FitnessFunctionsPage.tsx` — every mutation branches on `isCloudMode()`:
  - List uses `cloudFitnessApi.listForWorkspace` and maps the cloud row shape onto the local `FitnessFunction` so the rest of the page (forms, dialogs) stays put.
  - Create / update / delete map between the local `CreateFitnessFunctionRequest` shape and the cloud `{kind, config}` shape; description + scope ride along inside `config` so they round-trip.
  - "Test" in cloud mode triggers an async fitness_evaluation run and surfaces the run id with a pointer to Cloud Test Runs (SSE).
- `AppShell`: `fitness-functions` added to `cloudNavItemIds`.

## Test plan

- [ ] `cargo clippy -p mockforge-test-runner --all-targets --no-deps` and `cargo test -p mockforge-test-runner` pass (verified — 28 tests).
- [ ] In cloud mode, navigate to Fitness Functions; confirm it no longer shows "Local only".
- [ ] Create a `latency_threshold` function with `threshold_ms=100` against a workspace with active hosted-mock traffic; click Test; verify a `fitness_evaluation` run lands in Cloud Test Runs with a `fitness_pass` or `fitness_fail` event reflecting actual p95.
- [ ] Set `threshold_ms=1` so the function fails; verify an incident appears with `source='fitness'` and the dispatcher fires whatever notification channel is configured.
- [ ] Local mode unchanged: existing `driftApi.listFitnessFunctions / testFitnessFunction` flows still work.