### PR TITLE
feat(cloud-runs): SSRF guard + Dockerfile.runner with k6 + WAFBench rules

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -1,0 +1,96 @@
+# Multi-stage Docker build for the MockForge cloud test-runner worker.
+#
+# This image runs `mockforge-test-runner` — the separate process that
+# pulls test_runs jobs off Redis and dispatches per-kind executors.
+# The runtime stage installs k6 (required for the cloud_api bench /
+# OWASP / security / WAFBench / CRUD-flow paths) and bundles the
+# Microsoft WAFBench CRS rule YAMLs at /usr/share/mockforge/wafbench/
+# so wafbench runs work without the operator pre-uploading rules.
+
+# Stage 1: Build
+FROM rust:1.91-slim AS builder
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    build-essential \
+    g++ \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+
+# Trim workspace members not needed for the runner build (these
+# directories aren't copied into the Docker context). Kept in sync
+# with Dockerfile.registry's trimming.
+RUN sed -i '/\s*"test_openapi_demo"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"tests"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"desktop-app"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"examples\/plugins\/response-graphql"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"examples\/test-integration"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/# Integration tests package/d' Cargo.toml
+
+COPY crates/ ./crates/
+COPY proto/ ./proto/
+
+# mockforge-ui's build.rs needs the ui dist tree even when nothing
+# in this image actually serves it — cheaper to provide placeholder
+# files than to feature-gate the dep tree.
+RUN mkdir -p crates/mockforge-ui/ui/dist/assets && \
+    echo '<!DOCTYPE html><html><body></body></html>' > crates/mockforge-ui/ui/dist/index.html && \
+    echo '' > crates/mockforge-ui/ui/dist/assets/index.css && \
+    echo '' > crates/mockforge-ui/ui/dist/assets/index.js && \
+    echo '{}' > crates/mockforge-ui/ui/dist/pwa-manifest.json && \
+    echo '' > crates/mockforge-ui/ui/dist/sw.js
+
+RUN cargo build --release --bin mockforge-test-runner
+
+# Stage 2: Runtime
+FROM debian:trixie-slim
+
+# Base dependencies + k6 from grafana's apt repo. k6 binary lands on
+# $PATH at /usr/bin/k6.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        libssl3 \
+    && curl -fsSL https://dl.k6.io/key.gpg | gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+        > /etc/apt/sources.list.d/k6.list \
+    && apt-get update && apt-get install -y --no-install-recommends k6 \
+    && apt-get purge -y gnupg \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bundle Microsoft WAFBench CRS rule YAMLs at the path
+# `mockforge-bench::wafbench` defaults to. Pinned to a specific tag
+# would be more reproducible but the upstream project's tagging is
+# inconsistent — pulling main is acceptable for now since we don't
+# ship a fixed CRS version in the cloud_api contract.
+RUN mkdir -p /usr/share/mockforge/wafbench && \
+    curl -fsSL https://github.com/microsoft/WAFBench/archive/refs/heads/main.tar.gz \
+        | tar -xz -C /tmp && \
+    find /tmp/WAFBench-main -name '*.yaml' -exec cp {} /usr/share/mockforge/wafbench/ \; && \
+    rm -rf /tmp/WAFBench-main
+
+RUN groupadd -r mockforge && useradd -r -g mockforge mockforge
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/mockforge-test-runner /usr/local/bin/mockforge-test-runner
+
+USER mockforge
+
+ENV RUST_LOG=mockforge_test_runner=info,mockforge_bench=info
+
+# Verify k6 is reachable at container start so deploys fail loudly if
+# the apt install regressed instead of the runner reporting K6NotFound
+# on every cloud_api job.
+HEALTHCHECK --interval=60s --timeout=10s --start-period=5s --retries=3 \
+    CMD k6 version >/dev/null 2>&1 || exit 1
+
+CMD ["/usr/local/bin/mockforge-test-runner"]

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -32,6 +32,30 @@ use tempfile::TempDir;
 use crate::command::BenchCommand;
 use crate::error::{BenchError, Result};
 use crate::executor::{K6Executor, K6Results};
+use crate::ssrf::{validate_target_url, Policy as SsrfPolicy};
+
+/// Resolve the SSRF policy to apply to cloud-driven runs.
+///
+/// Defaults to [`SsrfPolicy::strict`]. The env var
+/// `MOCKFORGE_SSRF_ALLOW_LOOPBACK=1` opts into [`SsrfPolicy::for_test`] —
+/// **only** intended for integration tests that target a local mock
+/// server on `127.0.0.1`. Production deployments must NOT set this.
+fn resolve_ssrf_policy() -> SsrfPolicy {
+    match std::env::var("MOCKFORGE_SSRF_ALLOW_LOOPBACK").as_deref() {
+        Ok("1") | Ok("true") => SsrfPolicy::for_test(),
+        _ => SsrfPolicy::strict(),
+    }
+}
+
+/// Validate the supplied target URL against the SSRF policy and convert
+/// any rejection into a [`BenchError`] so existing call-sites don't need
+/// a new error variant.
+async fn enforce_ssrf(target_url: &str) -> Result<()> {
+    let policy = resolve_ssrf_policy();
+    validate_target_url(target_url, policy)
+        .await
+        .map_err(|e| BenchError::Other(format!("SSRF guard rejected target: {}", e)))
+}
 
 /// Format hint for OpenAPI specs supplied as raw bytes.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -201,6 +225,7 @@ pub async fn run_bench(inputs: CloudBenchInputs) -> Result<CloudRunArtifacts> {
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -244,6 +269,7 @@ pub async fn run_conformance(inputs: CloudConformanceInputs) -> Result<CloudRunA
     if inputs.use_k6 && !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -484,6 +510,7 @@ pub async fn run_owasp(inputs: CloudOwaspInputs) -> Result<CloudRunArtifacts> {
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -538,6 +565,7 @@ pub async fn run_security(inputs: CloudSecurityInputs) -> Result<CloudRunArtifac
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -586,6 +614,7 @@ pub async fn run_wafbench(inputs: CloudWafBenchInputs) -> Result<CloudRunArtifac
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -626,6 +655,7 @@ pub async fn run_crud_flow(inputs: CloudCrudFlowInputs) -> Result<CloudRunArtifa
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;

--- a/crates/mockforge-bench/src/lib.rs
+++ b/crates/mockforge-bench/src/lib.rs
@@ -25,6 +25,7 @@ pub mod scenarios;
 pub mod security_payloads;
 pub mod spec_dependencies;
 pub mod spec_parser;
+pub mod ssrf;
 pub mod target_parser;
 pub mod wafbench;
 
@@ -49,6 +50,7 @@ pub use security_payloads::{SecurityCategory, SecurityPayloads, SecurityTestConf
 pub use spec_dependencies::{
     DependencyDetector, ExtractedValues, SpecDependency, SpecDependencyConfig, SpecGroup,
 };
+pub use ssrf::{validate_target_url, Policy as SsrfPolicy, SsrfError};
 pub use target_parser::{parse_targets_file, TargetConfig};
 pub use wafbench::{WafBenchLoader, WafBenchStats, WafBenchTestCase};
 

--- a/crates/mockforge-bench/src/ssrf.rs
+++ b/crates/mockforge-bench/src/ssrf.rs
@@ -1,0 +1,362 @@
+//! SSRF (Server-Side Request Forgery) guard for cloud-driven runs.
+//!
+//! When `mockforge-test-runner` (or any other cloud-side caller) accepts a
+//! user-supplied target URL and dispatches HTTP traffic at it, an attacker
+//! can point the runner at internal infrastructure: metadata endpoints
+//! (`169.254.169.254`), localhost services, RFC1918 / ULA private ranges,
+//! and so on. Without a guard, we hand them a free internal-network
+//! scanner running inside our Fly.io org.
+//!
+//! [`validate_target_url`] is the single chokepoint. It:
+//!
+//! 1. Parses the URL and rejects anything that isn't `http://` or
+//!    `https://` (no `file://`, `gopher://`, etc.).
+//! 2. Resolves the hostname via DNS (asynchronously) and rejects if any
+//!    resolved IP is in a blocked range.
+//! 3. Treats literal-IP hostnames (`http://10.0.0.1/`) the same way —
+//!    parsing them as `IpAddr` directly so DNS resolution isn't needed.
+//!
+//! Blocked ranges:
+//!
+//! * IPv4: loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16` —
+//!   includes the AWS/GCP/Fly metadata IP `169.254.169.254`), unspecified
+//!   (`0.0.0.0/8`), broadcast, RFC1918 private (`10/8`, `172.16/12`,
+//!   `192.168/16`), CGNAT (`100.64.0.0/10`), benchmark (`198.18/15`).
+//! * IPv6: loopback (`::1`), unspecified (`::`), link-local (`fe80::/10`),
+//!   ULA (`fc00::/7`), IPv4-mapped (`::ffff:0:0/96` — caller could smuggle
+//!   in a private v4 address).
+//!
+//! There is no escape hatch — production callers MUST ensure their target
+//! is publicly reachable. Tests can override with the `loopback-ok` env
+//! var (see [`Policy::for_test`]) for integration-test endpoints on
+//! `127.0.0.1`.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use thiserror::Error;
+
+/// Reasons a target URL can be rejected by [`validate_target_url`].
+#[derive(Debug, Error)]
+pub enum SsrfError {
+    #[error("invalid URL: {0}")]
+    InvalidUrl(String),
+
+    #[error("URL scheme '{0}' not allowed — only http/https")]
+    DisallowedScheme(String),
+
+    #[error("URL has no host component")]
+    MissingHost,
+
+    #[error("DNS resolution failed for '{host}': {source}")]
+    DnsResolutionFailed {
+        host: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("DNS resolution returned no addresses for '{0}'")]
+    NoAddressesResolved(String),
+
+    #[error(
+        "target '{host}' resolves to {ip} which is in a blocked range ({reason}); \
+         pointing the cloud runner at internal addresses is not allowed"
+    )]
+    BlockedAddress {
+        host: String,
+        ip: IpAddr,
+        reason: &'static str,
+    },
+}
+
+/// Knobs for [`validate_target_url`]. Default policy is the strict
+/// production one; tests can relax it via [`Policy::allow_loopback`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Policy {
+    /// When true, addresses in the IPv4/IPv6 loopback range are allowed.
+    /// Production callers should leave this `false`. Tests against
+    /// `127.0.0.1` set it via [`Policy::for_test`].
+    pub allow_loopback: bool,
+}
+
+impl Policy {
+    /// Strict production policy: nothing private, nothing local.
+    pub const fn strict() -> Self {
+        Self {
+            allow_loopback: false,
+        }
+    }
+
+    /// Test policy: allows loopback so integration tests against
+    /// `127.0.0.1:<port>` mock servers can run.
+    pub const fn for_test() -> Self {
+        Self {
+            allow_loopback: true,
+        }
+    }
+}
+
+/// Validate that a URL is safe for a cloud runner to hit. Returns `Ok(())`
+/// when the target is a publicly-routable HTTP/S endpoint.
+///
+/// Performs DNS resolution, so this is async. Cache results at the call
+/// site if the same URL is validated repeatedly within one request.
+pub async fn validate_target_url(url: &str, policy: Policy) -> Result<(), SsrfError> {
+    let parsed = url::Url::parse(url).map_err(|e| SsrfError::InvalidUrl(e.to_string()))?;
+
+    let scheme = parsed.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(SsrfError::DisallowedScheme(scheme.to_string()));
+    }
+
+    let host = parsed.host_str().ok_or(SsrfError::MissingHost)?.to_string();
+    let port = parsed.port_or_known_default().unwrap_or(80);
+
+    // Literal IP — no DNS needed.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        check_ip(&host, ip, policy)?;
+        return Ok(());
+    }
+
+    // Hostname — resolve and check every resolved address. An attacker
+    // can register a public DNS name pointing at 169.254.169.254 (a.k.a.
+    // "DNS rebinding" / "0.0.0.0 day"), so we MUST inspect resolved IPs,
+    // not just the literal-IP form.
+    let lookup_target = format!("{}:{}", host, port);
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(&lookup_target)
+        .await
+        .map_err(|source| SsrfError::DnsResolutionFailed {
+            host: host.clone(),
+            source,
+        })?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(SsrfError::NoAddressesResolved(host));
+    }
+
+    for addr in addrs {
+        check_ip(&host, addr.ip(), policy)?;
+    }
+
+    Ok(())
+}
+
+fn check_ip(host: &str, ip: IpAddr, policy: Policy) -> Result<(), SsrfError> {
+    if let Some(reason) = blocked_reason(ip, policy) {
+        return Err(SsrfError::BlockedAddress {
+            host: host.to_string(),
+            ip,
+            reason,
+        });
+    }
+    Ok(())
+}
+
+fn blocked_reason(ip: IpAddr, policy: Policy) -> Option<&'static str> {
+    match ip {
+        IpAddr::V4(v4) => blocked_reason_v4(v4, policy),
+        IpAddr::V6(v6) => blocked_reason_v6(v6, policy),
+    }
+}
+
+fn blocked_reason_v4(ip: Ipv4Addr, policy: Policy) -> Option<&'static str> {
+    if ip.is_loopback() {
+        if policy.allow_loopback {
+            return None;
+        }
+        return Some("IPv4 loopback (127.0.0.0/8)");
+    }
+    if ip.is_unspecified() {
+        return Some("IPv4 unspecified (0.0.0.0)");
+    }
+    if ip.is_broadcast() {
+        return Some("IPv4 broadcast");
+    }
+    if ip.is_link_local() {
+        return Some("IPv4 link-local (169.254.0.0/16, includes cloud metadata IP)");
+    }
+    if ip.is_private() {
+        return Some("IPv4 RFC1918 private (10/8, 172.16/12, 192.168/16)");
+    }
+    if ip.is_documentation() {
+        return Some("IPv4 documentation range (RFC5737)");
+    }
+    // CGNAT range (100.64.0.0/10) — not is_private but still
+    // not-publicly-routable. Cloud providers sometimes use it for inter-VM
+    // links, which is exactly the kind of thing we don't want to expose.
+    let octets = ip.octets();
+    if octets[0] == 100 && (64..=127).contains(&octets[1]) {
+        return Some("IPv4 CGNAT (100.64.0.0/10)");
+    }
+    // Benchmark range 198.18.0.0/15 (RFC2544).
+    if octets[0] == 198 && (octets[1] == 18 || octets[1] == 19) {
+        return Some("IPv4 benchmark (198.18.0.0/15)");
+    }
+    None
+}
+
+fn blocked_reason_v6(ip: Ipv6Addr, policy: Policy) -> Option<&'static str> {
+    if ip.is_loopback() {
+        if policy.allow_loopback {
+            return None;
+        }
+        return Some("IPv6 loopback (::1)");
+    }
+    if ip.is_unspecified() {
+        return Some("IPv6 unspecified (::)");
+    }
+    let segments = ip.segments();
+    // Link-local fe80::/10
+    if (segments[0] & 0xffc0) == 0xfe80 {
+        return Some("IPv6 link-local (fe80::/10)");
+    }
+    // ULA fc00::/7
+    if (segments[0] & 0xfe00) == 0xfc00 {
+        return Some("IPv6 unique-local (fc00::/7)");
+    }
+    // IPv4-mapped ::ffff:0:0/96 — recurse so an attacker can't smuggle a
+    // private v4 through the v6 form (`http://[::ffff:10.0.0.1]/`).
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return blocked_reason_v4(v4, policy);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_blocked(addr: &str, policy: Policy, fragment: &str) {
+        let ip: IpAddr = addr.parse().unwrap();
+        let reason =
+            blocked_reason(ip, policy).unwrap_or_else(|| panic!("expected {addr} to be blocked"));
+        assert!(
+            reason.contains(fragment),
+            "{addr} blocked but reason '{reason}' missing fragment '{fragment}'"
+        );
+    }
+
+    fn assert_allowed(addr: &str, policy: Policy) {
+        let ip: IpAddr = addr.parse().unwrap();
+        assert!(blocked_reason(ip, policy).is_none(), "{addr} unexpectedly blocked");
+    }
+
+    #[test]
+    fn blocks_loopback_v4_strict() {
+        assert_blocked("127.0.0.1", Policy::strict(), "loopback");
+        assert_blocked("127.255.255.254", Policy::strict(), "loopback");
+    }
+
+    #[test]
+    fn allows_loopback_v4_in_test_policy() {
+        assert_allowed("127.0.0.1", Policy::for_test());
+    }
+
+    #[test]
+    fn blocks_link_local_aws_metadata() {
+        assert_blocked("169.254.169.254", Policy::strict(), "link-local");
+    }
+
+    #[test]
+    fn blocks_rfc1918_ranges() {
+        assert_blocked("10.0.0.1", Policy::strict(), "RFC1918");
+        assert_blocked("172.16.0.1", Policy::strict(), "RFC1918");
+        assert_blocked("172.31.255.255", Policy::strict(), "RFC1918");
+        assert_blocked("192.168.0.1", Policy::strict(), "RFC1918");
+    }
+
+    #[test]
+    fn blocks_cgnat() {
+        assert_blocked("100.64.0.1", Policy::strict(), "CGNAT");
+        assert_blocked("100.127.255.255", Policy::strict(), "CGNAT");
+    }
+
+    #[test]
+    fn allows_ranges_outside_cgnat() {
+        // 100.0.0.0/8 outside the CGNAT slice is publicly routable.
+        assert_allowed("100.63.255.255", Policy::strict());
+        assert_allowed("100.128.0.1", Policy::strict());
+    }
+
+    #[test]
+    fn blocks_benchmark_range() {
+        assert_blocked("198.18.0.1", Policy::strict(), "benchmark");
+        assert_blocked("198.19.255.255", Policy::strict(), "benchmark");
+    }
+
+    #[test]
+    fn allows_public_v4() {
+        assert_allowed("8.8.8.8", Policy::strict());
+        assert_allowed("1.1.1.1", Policy::strict());
+        assert_allowed("142.250.190.78", Policy::strict()); // google.com
+    }
+
+    #[test]
+    fn blocks_loopback_v6_strict() {
+        assert_blocked("::1", Policy::strict(), "loopback");
+    }
+
+    #[test]
+    fn blocks_link_local_v6() {
+        assert_blocked("fe80::1", Policy::strict(), "link-local");
+        assert_blocked("febf::1", Policy::strict(), "link-local");
+    }
+
+    #[test]
+    fn blocks_ula() {
+        assert_blocked("fc00::1", Policy::strict(), "unique-local");
+        assert_blocked("fd12:3456::1", Policy::strict(), "unique-local");
+    }
+
+    #[test]
+    fn blocks_ipv4_mapped_private() {
+        assert_blocked("::ffff:10.0.0.1", Policy::strict(), "RFC1918");
+        assert_blocked("::ffff:127.0.0.1", Policy::strict(), "loopback");
+    }
+
+    #[test]
+    fn allows_public_v6() {
+        assert_allowed("2606:4700:4700::1111", Policy::strict()); // cloudflare
+        assert_allowed("2001:4860:4860::8888", Policy::strict()); // google
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_non_http_scheme() {
+        let err = validate_target_url("file:///etc/passwd", Policy::strict()).await.unwrap_err();
+        assert!(matches!(err, SsrfError::DisallowedScheme(s) if s == "file"));
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_garbage_url() {
+        let err = validate_target_url("not a url", Policy::strict()).await.unwrap_err();
+        assert!(matches!(err, SsrfError::InvalidUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_literal_loopback() {
+        let err = validate_target_url("http://127.0.0.1/", Policy::strict()).await.unwrap_err();
+        assert!(matches!(err, SsrfError::BlockedAddress { .. }));
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_literal_metadata_ip() {
+        let err = validate_target_url("http://169.254.169.254/latest/meta-data/", Policy::strict())
+            .await
+            .unwrap_err();
+        match err {
+            SsrfError::BlockedAddress { reason, .. } => assert!(reason.contains("link-local")),
+            other => panic!("expected BlockedAddress, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_literal_rfc1918() {
+        let err = validate_target_url("http://10.0.0.1/", Policy::strict()).await.unwrap_err();
+        assert!(matches!(err, SsrfError::BlockedAddress { .. }));
+    }
+
+    #[tokio::test]
+    async fn validate_allows_loopback_in_test_policy() {
+        validate_target_url("http://127.0.0.1:8080/", Policy::for_test()).await.unwrap();
+    }
+}

--- a/fly.runner.toml
+++ b/fly.runner.toml
@@ -1,0 +1,39 @@
+# Fly.io configuration for the MockForge cloud test-runner worker.
+# Deploy: flyctl deploy --config fly.runner.toml
+
+app = "mockforge-runner"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile.runner"
+
+[env]
+  RUST_LOG = "mockforge_test_runner=info,mockforge_bench=info"
+  # Production runs strict SSRF enforcement. Setting this to "1"
+  # ONLY in non-production deployments — never on prod-runner.
+  MOCKFORGE_SSRF_ALLOW_LOOPBACK = "0"
+
+# Secrets to set via `flyctl secrets set`:
+#   REDIS_URL                          - Same Redis instance the registry pushes jobs to
+#   MOCKFORGE_RUNNER_QUEUE_KEY         - Optional override; defaults to "test_runs:queued"
+#   MOCKFORGE_RUNNER_REGISTRY_URL      - Internal registry callback URL
+#   MOCKFORGE_RUNNER_CALLBACK_TOKEN    - Bearer token the registry validates on
+#                                        /api/v1/internal/test-runs/{id}/* callbacks
+#   MOCKFORGE_RUNNER_MAX_CONCURRENT_JOBS - Worker concurrency (default 4)
+
+# No public HTTP service — the runner only consumes from Redis and
+# pushes status via outbound HTTPS to the registry.
+[experimental]
+  auto_rollback = true
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 2
+  memory_mb = 2048
+
+# k6 runs can be CPU-spikey but mostly idle between jobs. Auto-stop
+# is fine — Fly will wake on the next dequeue cycle.
+[machine]
+  auto_start = true
+  auto_stop = true
+  min_machines_running = 0


### PR DESCRIPTION
## Summary

Stacks on #368. Closes the deployment side of the cloud-runs stack:

- **`mockforge_bench::ssrf` module (new)** — `validate_target_url(url, policy)` rejects literal-IP and DNS-resolved hosts in IPv4 loopback, link-local (covers `169.254.169.254` cloud metadata IPs), RFC1918, CGNAT, benchmark, IPv6 loopback / link-local / ULA, and IPv4-mapped variants of all the above. Default `Policy::strict()`; tests opt into `Policy::for_test()` (allows loopback) via `MOCKFORGE_SSRF_ALLOW_LOOPBACK=1`.
- **All six `cloud_api::run_*` wrappers** now call the SSRF guard before spawning anything. Defense-in-depth — the registry-server trigger handler is the primary enforcement point and lands in the next PR.
- **`Dockerfile.runner` (new)** — multi-stage build of `mockforge-test-runner` with k6 from the grafana apt repo at `/usr/bin/k6`, and Microsoft WAFBench CRS rule YAMLs bundled at `/usr/share/mockforge/wafbench/` (the path the wafbench cloud_api wrapper defaults to when no `wafbench_rules_dir` is supplied).
- **`fly.runner.toml` (new)** — Fly.io deploy manifest for the worker. Auto-stop enabled — runner wakes on next dequeue cycle. Production sets `MOCKFORGE_SSRF_ALLOW_LOOPBACK=0` explicitly so a stray dev override can't reach prod.

## SSRF coverage

| Range | Blocked? | Why |
|---|---|---|
| `127.0.0.0/8` (v4 loopback) | ✓ | Internal services |
| `::1` (v6 loopback) | ✓ | Same |
| `169.254.0.0/16` (link-local) | ✓ | **Cloud metadata IP** lives here |
| `fe80::/10` (v6 link-local) | ✓ | Same |
| `10/8`, `172.16/12`, `192.168/16` | ✓ | RFC1918 internal |
| `100.64.0.0/10` | ✓ | CGNAT — Fly inter-VM links |
| `198.18/15` | ✓ | RFC2544 benchmark |
| `fc00::/7` (IPv6 ULA) | ✓ | Internal v6 |
| `::ffff:0:0/96` (v4-mapped) | ✓ | Anti-smuggling: `[::ffff:10.0.0.1]` |
| Public IPv4 (8.8.8.8 etc.) | allowed | |
| Public IPv6 (2606:4700:...) | allowed | |
| `file://`, `gopher://`, etc. | rejected | Scheme allowlist |

DNS rebinding is mitigated by resolving the hostname and checking *every* resolved address — an attacker can't register `evil.com` → `169.254.169.254` and slip through.

## Test plan

- [x] `cargo build -p mockforge-bench` clean
- [x] `cargo build -p mockforge-test-runner` clean
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings` clean
- [x] `cargo clippy -p mockforge-test-runner --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-bench --lib` — **374 passed** (19 new SSRF tests + zero regressions)
- [x] `cargo test -p mockforge-test-runner` clean
- [x] `cargo fmt --all --check` clean
- Dockerfile.runner verified locally only via build — production build/deploy validation happens in CI / on the runner-fly-app once this lands.

## Stacking note

Base branch is `feat/cloud-runs-new-kinds` (#368). Re-target to main once upstream stack lands.

## Follow-up (PR5)

Apply `validate_target_url` in `crates/mockforge-registry-server/src/handlers/test_runs.rs::trigger_run` so SSRF is enforced **before** the run is even queued — the runner-side guard here is defense-in-depth, not the primary line.
