### PR TITLE
feat(cloud-runs): cloud_api lib + test-runner integration + SSRF guard + Dockerfile.runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9104,6 +9104,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "mockforge-bench",
  "redis 0.25.4",
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8808,6 +8808,7 @@ dependencies = [
  "jsonwebtoken",
  "lettre",
  "mockforge-analytics",
+ "mockforge-bench",
  "mockforge-collab",
  "mockforge-core",
  "mockforge-federation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6700,7 +6700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
@@ -6727,7 +6727,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -1,0 +1,96 @@
+# Multi-stage Docker build for the MockForge cloud test-runner worker.
+#
+# This image runs `mockforge-test-runner` — the separate process that
+# pulls test_runs jobs off Redis and dispatches per-kind executors.
+# The runtime stage installs k6 (required for the cloud_api bench /
+# OWASP / security / WAFBench / CRUD-flow paths) and bundles the
+# Microsoft WAFBench CRS rule YAMLs at /usr/share/mockforge/wafbench/
+# so wafbench runs work without the operator pre-uploading rules.
+
+# Stage 1: Build
+FROM rust:1.91-slim AS builder
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    build-essential \
+    g++ \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+
+# Trim workspace members not needed for the runner build (these
+# directories aren't copied into the Docker context). Kept in sync
+# with Dockerfile.registry's trimming.
+RUN sed -i '/\s*"test_openapi_demo"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"tests"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"desktop-app"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"examples\/plugins\/response-graphql"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"examples\/test-integration"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/# Integration tests package/d' Cargo.toml
+
+COPY crates/ ./crates/
+COPY proto/ ./proto/
+
+# mockforge-ui's build.rs needs the ui dist tree even when nothing
+# in this image actually serves it — cheaper to provide placeholder
+# files than to feature-gate the dep tree.
+RUN mkdir -p crates/mockforge-ui/ui/dist/assets && \
+    echo '<!DOCTYPE html><html><body></body></html>' > crates/mockforge-ui/ui/dist/index.html && \
+    echo '' > crates/mockforge-ui/ui/dist/assets/index.css && \
+    echo '' > crates/mockforge-ui/ui/dist/assets/index.js && \
+    echo '{}' > crates/mockforge-ui/ui/dist/pwa-manifest.json && \
+    echo '' > crates/mockforge-ui/ui/dist/sw.js
+
+RUN cargo build --release --bin mockforge-test-runner
+
+# Stage 2: Runtime
+FROM debian:trixie-slim
+
+# Base dependencies + k6 from grafana's apt repo. k6 binary lands on
+# $PATH at /usr/bin/k6.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        libssl3 \
+    && curl -fsSL https://dl.k6.io/key.gpg | gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+        > /etc/apt/sources.list.d/k6.list \
+    && apt-get update && apt-get install -y --no-install-recommends k6 \
+    && apt-get purge -y gnupg \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bundle Microsoft WAFBench CRS rule YAMLs at the path
+# `mockforge-bench::wafbench` defaults to. Pinned to a specific tag
+# would be more reproducible but the upstream project's tagging is
+# inconsistent — pulling main is acceptable for now since we don't
+# ship a fixed CRS version in the cloud_api contract.
+RUN mkdir -p /usr/share/mockforge/wafbench && \
+    curl -fsSL https://github.com/microsoft/WAFBench/archive/refs/heads/main.tar.gz \
+        | tar -xz -C /tmp && \
+    find /tmp/WAFBench-main -name '*.yaml' -exec cp {} /usr/share/mockforge/wafbench/ \; && \
+    rm -rf /tmp/WAFBench-main
+
+RUN groupadd -r mockforge && useradd -r -g mockforge mockforge
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/mockforge-test-runner /usr/local/bin/mockforge-test-runner
+
+USER mockforge
+
+ENV RUST_LOG=mockforge_test_runner=info,mockforge_bench=info
+
+# Verify k6 is reachable at container start so deploys fail loudly if
+# the apt install regressed instead of the runner reporting K6NotFound
+# on every cloud_api job.
+HEALTHCHECK --interval=60s --timeout=10s --start-period=5s --retries=3 \
+    CMD k6 version >/dev/null 2>&1 || exit 1
+
+CMD ["/usr/local/bin/mockforge-test-runner"]

--- a/crates/mockforge-bench/Cargo.toml
+++ b/crates/mockforge-bench/Cargo.toml
@@ -75,10 +75,12 @@ atty = "0.2"
 # JSON Schema validation for native conformance executor
 jsonschema = { workspace = true }
 
+# Temp directories for cloud_api run isolation
+tempfile = "3.27"
+
 [dev-dependencies]
 mockito = "1.5"
 proptest = "1.11"
-tempfile = "3.27"
 
 [features]
 default = []

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -1,0 +1,527 @@
+//! Cloud-friendly entry points for invoking bench and conformance runs
+//! programmatically.
+//!
+//! The CLI in `command.rs` is the primary user-facing surface, but it assumes
+//! the caller can supply paths on disk and is OK with stdout reporting. Cloud
+//! callers (the registry server) need to:
+//!
+//! 1. Pass the OpenAPI spec as raw bytes (no filesystem coordination).
+//! 2. Receive every artifact that was written to the run's output directory
+//!    as in-memory bytes, so they can be persisted to Postgres / Tigris.
+//! 3. Read structured `K6Results` without re-parsing `summary.json`.
+//!
+//! This module provides exactly that. Each `run_*` function:
+//!
+//! * Creates a private tempdir,
+//! * Writes the supplied spec bytes into it,
+//! * Builds a [`BenchCommand`] with cloud-appropriate defaults,
+//! * Executes the run,
+//! * Slurps every file produced under the output dir into a
+//!   [`CloudRunArtifacts`] map.
+//!
+//! The CLI is unchanged — it still uses [`BenchCommand`] directly. Progress
+//! reporting (`TerminalReporter`) still goes to stdout; suppressing or
+//! redirecting it is intentionally out of scope for this module and will be
+//! handled by a follow-up that introduces a `ProgressSink`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use crate::command::BenchCommand;
+use crate::error::{BenchError, Result};
+use crate::executor::{K6Executor, K6Results};
+
+/// Format hint for OpenAPI specs supplied as raw bytes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SpecFormat {
+    /// Pretty-printed JSON or a single-line JSON document.
+    Json,
+    /// YAML 1.1/1.2 document.
+    Yaml,
+    /// Sniff from the first non-whitespace byte: `{`/`[` → JSON, otherwise YAML.
+    #[default]
+    Auto,
+}
+
+impl SpecFormat {
+    fn extension(self, bytes: &[u8]) -> &'static str {
+        match self {
+            SpecFormat::Json => "json",
+            SpecFormat::Yaml => "yaml",
+            SpecFormat::Auto => match bytes.iter().find(|b| !b.is_ascii_whitespace()) {
+                Some(b'{') | Some(b'[') => "json",
+                _ => "yaml",
+            },
+        }
+    }
+}
+
+/// Inputs for [`run_bench`] — a k6 load test against an external URL.
+///
+/// All fields mirror the CLI flags one-for-one, minus filesystem-only options
+/// (`--output`, `--script-output`, `--targets-file`, etc.) that have no
+/// meaning in a hosted context.
+#[derive(Debug, Clone)]
+pub struct CloudBenchInputs {
+    pub spec_bytes: Vec<u8>,
+    pub spec_format: SpecFormat,
+    pub target_url: String,
+    pub base_path: Option<String>,
+    pub duration: String,
+    pub vus: u32,
+    pub scenario: String,
+    pub operations: Option<String>,
+    pub exclude_operations: Option<String>,
+    pub auth: Option<String>,
+    /// Comma-separated `Key:Value,Key2:Value2` header list (matches CLI
+    /// `--headers` semantics — see [`crate::command::parse_header_string`]).
+    pub headers: Option<String>,
+    pub threshold_percentile: String,
+    pub threshold_ms: u64,
+    pub max_error_rate: f64,
+    pub skip_tls_verify: bool,
+    pub chunked_request_bodies: bool,
+}
+
+impl Default for CloudBenchInputs {
+    fn default() -> Self {
+        Self {
+            spec_bytes: Vec::new(),
+            spec_format: SpecFormat::Auto,
+            target_url: String::new(),
+            base_path: None,
+            duration: "30s".to_string(),
+            vus: 10,
+            scenario: "constant".to_string(),
+            operations: None,
+            exclude_operations: None,
+            auth: None,
+            headers: None,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 1000,
+            max_error_rate: 0.01,
+            skip_tls_verify: false,
+            chunked_request_bodies: false,
+        }
+    }
+}
+
+/// Inputs for [`run_conformance`] — OpenAPI 3.0.0 conformance testing against
+/// an external URL.
+///
+/// Setting `spec_bytes` enables spec-driven mode (preferred). Leaving it `None`
+/// falls through to the reference-check mode that the underlying executor
+/// supports.
+#[derive(Debug, Clone)]
+pub struct CloudConformanceInputs {
+    pub spec_bytes: Option<Vec<u8>>,
+    pub spec_format: SpecFormat,
+    pub target_url: String,
+    pub base_path: Option<String>,
+    pub api_key: Option<String>,
+    /// `user:pass` for HTTP basic auth.
+    pub basic_auth: Option<String>,
+    /// Comma-separated category list (e.g. `"parameters,security"`).
+    pub categories: Option<String>,
+    /// `Header-Name: value` strings, one per entry.
+    pub headers: Vec<String>,
+    pub all_operations: bool,
+    pub request_delay_ms: u64,
+    /// When true, route conformance through k6 instead of the native Rust
+    /// executor. Native is faster and the default.
+    pub use_k6: bool,
+    pub skip_tls_verify: bool,
+    /// `"json"` (default) or `"sarif"`.
+    pub report_format: String,
+    pub export_requests: bool,
+    pub validate_requests: bool,
+}
+
+impl Default for CloudConformanceInputs {
+    fn default() -> Self {
+        Self {
+            spec_bytes: None,
+            spec_format: SpecFormat::Auto,
+            target_url: String::new(),
+            base_path: None,
+            api_key: None,
+            basic_auth: None,
+            categories: None,
+            headers: Vec::new(),
+            all_operations: false,
+            request_delay_ms: 0,
+            use_k6: false,
+            skip_tls_verify: false,
+            report_format: "json".to_string(),
+            export_requests: false,
+            validate_requests: false,
+        }
+    }
+}
+
+/// Every artifact produced by a cloud run.
+///
+/// Each file under the run's output directory is read into `files` keyed by
+/// its filename. `k6_results` is populated from `summary.json` when the run
+/// went through k6.
+#[derive(Debug, Default, Clone)]
+pub struct CloudRunArtifacts {
+    pub k6_results: Option<K6Results>,
+    pub files: HashMap<String, Vec<u8>>,
+}
+
+impl CloudRunArtifacts {
+    pub fn get(&self, name: &str) -> Option<&[u8]> {
+        self.files.get(name).map(Vec::as_slice)
+    }
+
+    pub fn get_string(&self, name: &str) -> Option<String> {
+        self.get(name).map(|b| String::from_utf8_lossy(b).into_owned())
+    }
+
+    pub fn get_json(&self, name: &str) -> Option<serde_json::Value> {
+        self.get(name).and_then(|b| serde_json::from_slice(b).ok())
+    }
+}
+
+/// Run a k6 load test against [`CloudBenchInputs::target_url`] and return all
+/// produced artifacts in memory.
+///
+/// Requires the `k6` binary on `$PATH`. Returns [`BenchError::K6NotFound`] if
+/// not present.
+pub async fn run_bench(inputs: CloudBenchInputs) -> Result<CloudRunArtifacts> {
+    if inputs.target_url.trim().is_empty() {
+        return Err(BenchError::Other("target_url is required".to_string()));
+    }
+    if inputs.spec_bytes.is_empty() {
+        return Err(BenchError::Other("spec_bytes is required for bench runs".to_string()));
+    }
+    if !K6Executor::is_k6_installed() {
+        return Err(BenchError::K6NotFound);
+    }
+
+    let workdir = TempDir::new()
+        .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
+    let spec_path = write_spec(workdir.path(), &inputs.spec_bytes, inputs.spec_format)?;
+    let output_dir = workdir.path().join("output");
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| BenchError::Other(format!("Failed to create output dir: {}", e)))?;
+
+    let cmd = BenchCommand {
+        spec: vec![spec_path],
+        target: inputs.target_url,
+        base_path: inputs.base_path,
+        duration: inputs.duration,
+        vus: inputs.vus,
+        scenario: inputs.scenario,
+        operations: inputs.operations,
+        exclude_operations: inputs.exclude_operations,
+        auth: inputs.auth,
+        headers: inputs.headers,
+        threshold_percentile: inputs.threshold_percentile,
+        threshold_ms: inputs.threshold_ms,
+        max_error_rate: inputs.max_error_rate,
+        skip_tls_verify: inputs.skip_tls_verify,
+        chunked_request_bodies: inputs.chunked_request_bodies,
+        ..default_bench_command(&output_dir)
+    };
+
+    cmd.execute().await?;
+    read_artifacts(&output_dir)
+}
+
+/// Run an OpenAPI 3.0.0 conformance test against
+/// [`CloudConformanceInputs::target_url`].
+///
+/// When `use_k6` is false (default) the native Rust executor runs in-process —
+/// no k6 binary required. When `use_k6` is true, k6 must be on `$PATH`.
+pub async fn run_conformance(inputs: CloudConformanceInputs) -> Result<CloudRunArtifacts> {
+    if inputs.target_url.trim().is_empty() {
+        return Err(BenchError::Other("target_url is required".to_string()));
+    }
+    if inputs.use_k6 && !K6Executor::is_k6_installed() {
+        return Err(BenchError::K6NotFound);
+    }
+
+    let workdir = TempDir::new()
+        .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
+    let output_dir = workdir.path().join("output");
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| BenchError::Other(format!("Failed to create output dir: {}", e)))?;
+
+    let spec_paths = if let Some(bytes) = &inputs.spec_bytes {
+        vec![write_spec(workdir.path(), bytes, inputs.spec_format)?]
+    } else {
+        Vec::new()
+    };
+
+    let report_path = output_dir.join("conformance-report.json");
+    let cmd = BenchCommand {
+        spec: spec_paths,
+        target: inputs.target_url,
+        base_path: inputs.base_path,
+        skip_tls_verify: inputs.skip_tls_verify,
+        conformance: true,
+        conformance_api_key: inputs.api_key,
+        conformance_basic_auth: inputs.basic_auth,
+        conformance_report: report_path,
+        conformance_categories: inputs.categories,
+        conformance_report_format: inputs.report_format,
+        conformance_headers: inputs.headers,
+        conformance_all_operations: inputs.all_operations,
+        conformance_delay_ms: inputs.request_delay_ms,
+        use_k6: inputs.use_k6,
+        export_requests: inputs.export_requests,
+        validate_requests: inputs.validate_requests,
+        ..default_bench_command(&output_dir)
+    };
+
+    cmd.execute().await?;
+    read_artifacts(&output_dir)
+}
+
+/// Build a [`BenchCommand`] populated with sensible defaults for a single-spec
+/// run targeting the given output directory.
+///
+/// Caller should overwrite the fields relevant to their run via
+/// `..default_bench_command(&output_dir)` struct update syntax.
+fn default_bench_command(output_dir: &Path) -> BenchCommand {
+    BenchCommand {
+        spec: Vec::new(),
+        spec_dir: None,
+        merge_conflicts: "error".to_string(),
+        spec_mode: "merge".to_string(),
+        dependency_config: None,
+        target: String::new(),
+        base_path: None,
+        duration: "30s".to_string(),
+        vus: 10,
+        scenario: "constant".to_string(),
+        operations: None,
+        exclude_operations: None,
+        auth: None,
+        headers: None,
+        output: output_dir.to_path_buf(),
+        generate_only: false,
+        script_output: None,
+        threshold_percentile: "p(95)".to_string(),
+        threshold_ms: 1000,
+        max_error_rate: 0.01,
+        verbose: false,
+        skip_tls_verify: false,
+        chunked_request_bodies: false,
+        targets_file: None,
+        max_concurrency: None,
+        results_format: "aggregated".to_string(),
+        params_file: None,
+        crud_flow: false,
+        flow_config: None,
+        extract_fields: None,
+        parallel_create: None,
+        data_file: None,
+        data_distribution: "unique-per-vu".to_string(),
+        data_mappings: None,
+        per_uri_control: false,
+        error_rate: None,
+        error_types: None,
+        security_test: false,
+        security_payloads: None,
+        security_categories: None,
+        security_target_fields: None,
+        wafbench_dir: None,
+        wafbench_cycle_all: false,
+        conformance: false,
+        conformance_api_key: None,
+        conformance_basic_auth: None,
+        conformance_report: output_dir.join("conformance-report.json"),
+        conformance_categories: None,
+        conformance_report_format: "json".to_string(),
+        conformance_headers: Vec::new(),
+        conformance_all_operations: false,
+        conformance_custom: None,
+        conformance_delay_ms: 0,
+        use_k6: false,
+        conformance_custom_filter: None,
+        export_requests: false,
+        validate_requests: false,
+        owasp_api_top10: false,
+        owasp_categories: None,
+        owasp_auth_header: "Authorization".to_string(),
+        owasp_auth_token: None,
+        owasp_admin_paths: None,
+        owasp_id_fields: None,
+        owasp_report: None,
+        owasp_report_format: "json".to_string(),
+        owasp_iterations: 1,
+    }
+}
+
+fn write_spec(dir: &Path, bytes: &[u8], format: SpecFormat) -> Result<PathBuf> {
+    let filename = format!("spec.{}", format.extension(bytes));
+    let path = dir.join(filename);
+    std::fs::write(&path, bytes)
+        .map_err(|e| BenchError::Other(format!("Failed to write spec to tempdir: {}", e)))?;
+    Ok(path)
+}
+
+fn read_artifacts(output_dir: &Path) -> Result<CloudRunArtifacts> {
+    let mut files = HashMap::new();
+    if output_dir.exists() {
+        let entries = std::fs::read_dir(output_dir)
+            .map_err(|e| BenchError::Other(format!("Failed to read output dir: {}", e)))?;
+        for entry in entries {
+            let entry =
+                entry.map_err(|e| BenchError::Other(format!("Failed to read entry: {}", e)))?;
+            let metadata = entry
+                .metadata()
+                .map_err(|e| BenchError::Other(format!("Failed to stat entry: {}", e)))?;
+            if !metadata.is_file() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            let bytes = std::fs::read(entry.path()).map_err(|e| {
+                BenchError::Other(format!("Failed to read artifact {}: {}", name, e))
+            })?;
+            files.insert(name, bytes);
+        }
+    }
+
+    let k6_results = files.get("summary.json").and_then(|bytes| parse_k6_summary(bytes).ok());
+
+    Ok(CloudRunArtifacts { k6_results, files })
+}
+
+fn parse_k6_summary(bytes: &[u8]) -> Result<K6Results> {
+    let json: serde_json::Value =
+        serde_json::from_slice(bytes).map_err(|e| BenchError::ResultsParseError(e.to_string()))?;
+    let duration_values = &json["metrics"]["http_req_duration"]["values"];
+    Ok(K6Results {
+        total_requests: json["metrics"]["http_reqs"]["values"]["count"].as_u64().unwrap_or(0),
+        // See `K6Executor::parse_results` for the rationale on why
+        // http_req_failed.passes is the failure count.
+        failed_requests: json["metrics"]["http_req_failed"]["values"]["passes"]
+            .as_u64()
+            .unwrap_or(0),
+        avg_duration_ms: duration_values["avg"].as_f64().unwrap_or(0.0),
+        p95_duration_ms: duration_values["p(95)"].as_f64().unwrap_or(0.0),
+        p99_duration_ms: duration_values["p(99)"].as_f64().unwrap_or(0.0),
+        rps: json["metrics"]["http_reqs"]["values"]["rate"].as_f64().unwrap_or(0.0),
+        vus_max: json["metrics"]["vus_max"]["values"]["value"].as_u64().unwrap_or(0) as u32,
+        min_duration_ms: duration_values["min"].as_f64().unwrap_or(0.0),
+        max_duration_ms: duration_values["max"].as_f64().unwrap_or(0.0),
+        med_duration_ms: duration_values["med"].as_f64().unwrap_or(0.0),
+        p90_duration_ms: duration_values["p(90)"].as_f64().unwrap_or(0.0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spec_format_extension_for_json_bytes() {
+        assert_eq!(SpecFormat::Auto.extension(b"  {\"openapi\":\"3.0.0\"}"), "json");
+        assert_eq!(SpecFormat::Auto.extension(b"openapi: 3.0.0\n"), "yaml");
+        assert_eq!(SpecFormat::Json.extension(b"openapi: 3.0.0"), "json");
+        assert_eq!(SpecFormat::Yaml.extension(b"{}"), "yaml");
+    }
+
+    #[test]
+    fn write_spec_round_trips_bytes() {
+        let dir = TempDir::new().unwrap();
+        let path = write_spec(dir.path(), b"openapi: 3.0.0\n", SpecFormat::Yaml).unwrap();
+        assert!(path.ends_with("spec.yaml"));
+        let read_back = std::fs::read(&path).unwrap();
+        assert_eq!(read_back, b"openapi: 3.0.0\n");
+    }
+
+    #[test]
+    fn read_artifacts_collects_top_level_files_only() {
+        let dir = TempDir::new().unwrap();
+        let out = dir.path();
+        std::fs::write(out.join("summary.json"), br#"{"metrics":{}}"#).unwrap();
+        std::fs::write(out.join("k6-output.log"), b"hello").unwrap();
+        // Subdirectory should be ignored.
+        std::fs::create_dir(out.join("nested")).unwrap();
+        std::fs::write(out.join("nested").join("ignored.txt"), b"nope").unwrap();
+
+        let artifacts = read_artifacts(out).unwrap();
+        assert_eq!(artifacts.files.len(), 2);
+        assert!(artifacts.files.contains_key("summary.json"));
+        assert!(artifacts.files.contains_key("k6-output.log"));
+        assert!(!artifacts.files.contains_key("ignored.txt"));
+    }
+
+    #[test]
+    fn parse_k6_summary_handles_minimal_input() {
+        let bytes = br#"{"metrics":{}}"#;
+        let r = parse_k6_summary(bytes).unwrap();
+        assert_eq!(r.total_requests, 0);
+        assert_eq!(r.failed_requests, 0);
+        assert_eq!(r.error_rate(), 0.0);
+    }
+
+    #[test]
+    fn parse_k6_summary_extracts_values() {
+        let bytes = br#"{
+            "metrics": {
+                "http_reqs": {"values": {"count": 100, "rate": 33.5}},
+                "http_req_failed": {"values": {"passes": 4}},
+                "http_req_duration": {"values": {
+                    "avg": 12.3, "med": 10.0, "min": 1.0, "max": 50.0,
+                    "p(90)": 20.0, "p(95)": 25.0, "p(99)": 40.0
+                }},
+                "vus_max": {"values": {"value": 10}}
+            }
+        }"#;
+        let r = parse_k6_summary(bytes).unwrap();
+        assert_eq!(r.total_requests, 100);
+        assert_eq!(r.failed_requests, 4);
+        assert_eq!(r.rps, 33.5);
+        assert_eq!(r.p95_duration_ms, 25.0);
+        assert_eq!(r.vus_max, 10);
+    }
+
+    #[test]
+    fn cloud_run_artifacts_get_helpers() {
+        let mut a = CloudRunArtifacts::default();
+        a.files.insert("hello.txt".to_string(), b"world".to_vec());
+        a.files.insert("payload.json".to_string(), br#"{"x":1}"#.to_vec());
+
+        assert_eq!(a.get("hello.txt").unwrap(), b"world");
+        assert_eq!(a.get_string("hello.txt").unwrap(), "world");
+        assert_eq!(a.get_json("payload.json").unwrap()["x"], 1);
+        assert!(a.get("missing").is_none());
+    }
+
+    #[tokio::test]
+    async fn run_bench_rejects_empty_target() {
+        let inputs = CloudBenchInputs {
+            spec_bytes: br#"{"openapi":"3.0.0"}"#.to_vec(),
+            ..Default::default()
+        };
+        let err = run_bench(inputs).await.unwrap_err();
+        assert!(matches!(err, BenchError::Other(_)));
+    }
+
+    #[tokio::test]
+    async fn run_bench_rejects_empty_spec() {
+        let inputs = CloudBenchInputs {
+            target_url: "https://example.com".to_string(),
+            ..Default::default()
+        };
+        let err = run_bench(inputs).await.unwrap_err();
+        assert!(matches!(err, BenchError::Other(_)));
+    }
+
+    #[tokio::test]
+    async fn run_conformance_rejects_empty_target() {
+        let inputs = CloudConformanceInputs::default();
+        let err = run_conformance(inputs).await.unwrap_err();
+        assert!(matches!(err, BenchError::Other(_)));
+    }
+}

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -32,6 +32,30 @@ use tempfile::TempDir;
 use crate::command::BenchCommand;
 use crate::error::{BenchError, Result};
 use crate::executor::{K6Executor, K6Results};
+use crate::ssrf::{validate_target_url, Policy as SsrfPolicy};
+
+/// Resolve the SSRF policy to apply to cloud-driven runs.
+///
+/// Defaults to [`SsrfPolicy::strict`]. The env var
+/// `MOCKFORGE_SSRF_ALLOW_LOOPBACK=1` opts into [`SsrfPolicy::for_test`] —
+/// **only** intended for integration tests that target a local mock
+/// server on `127.0.0.1`. Production deployments must NOT set this.
+fn resolve_ssrf_policy() -> SsrfPolicy {
+    match std::env::var("MOCKFORGE_SSRF_ALLOW_LOOPBACK").as_deref() {
+        Ok("1") | Ok("true") => SsrfPolicy::for_test(),
+        _ => SsrfPolicy::strict(),
+    }
+}
+
+/// Validate the supplied target URL against the SSRF policy and convert
+/// any rejection into a [`BenchError`] so existing call-sites don't need
+/// a new error variant.
+async fn enforce_ssrf(target_url: &str) -> Result<()> {
+    let policy = resolve_ssrf_policy();
+    validate_target_url(target_url, policy)
+        .await
+        .map_err(|e| BenchError::Other(format!("SSRF guard rejected target: {}", e)))
+}
 
 /// Format hint for OpenAPI specs supplied as raw bytes.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -201,6 +225,7 @@ pub async fn run_bench(inputs: CloudBenchInputs) -> Result<CloudRunArtifacts> {
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -244,6 +269,7 @@ pub async fn run_conformance(inputs: CloudConformanceInputs) -> Result<CloudRunA
     if inputs.use_k6 && !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -484,6 +510,7 @@ pub async fn run_owasp(inputs: CloudOwaspInputs) -> Result<CloudRunArtifacts> {
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -538,6 +565,7 @@ pub async fn run_security(inputs: CloudSecurityInputs) -> Result<CloudRunArtifac
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -586,6 +614,7 @@ pub async fn run_wafbench(inputs: CloudWafBenchInputs) -> Result<CloudRunArtifac
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
@@ -626,6 +655,7 @@ pub async fn run_crud_flow(inputs: CloudCrudFlowInputs) -> Result<CloudRunArtifa
     if !K6Executor::is_k6_installed() {
         return Err(BenchError::K6NotFound);
     }
+    enforce_ssrf(&inputs.target_url).await?;
 
     let workdir = TempDir::new()
         .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -1,5 +1,5 @@
-//! Cloud-friendly entry points for invoking bench and conformance runs
-//! programmatically.
+//! Cloud-friendly entry points for invoking bench, conformance, OWASP,
+//! security-payload, WAFBench, and CRUD-flow runs programmatically.
 //!
 //! The CLI in `command.rs` is the primary user-facing surface, but it assumes
 //! the caller can supply paths on disk and is OK with stdout reporting. Cloud
@@ -282,6 +282,387 @@ pub async fn run_conformance(inputs: CloudConformanceInputs) -> Result<CloudRunA
     read_artifacts(&output_dir)
 }
 
+/// Inputs for [`run_owasp`] — OWASP API Security Top 10 testing.
+///
+/// Built-in `categories` cover OWASP API1–API10 and run k6-driven; supplying
+/// `admin_paths` is recommended for the BOLA / privilege-escalation checks
+/// (they default to a small built-in list otherwise).
+#[derive(Debug, Clone)]
+pub struct CloudOwaspInputs {
+    pub spec_bytes: Vec<u8>,
+    pub spec_format: SpecFormat,
+    pub target_url: String,
+    pub base_path: Option<String>,
+    /// Comma-separated list of OWASP category short names (e.g.
+    /// `"api1,api3,api7"`). Empty = all categories.
+    pub categories: Option<String>,
+    /// Header name to use for auth checks. Defaults to `"Authorization"`.
+    pub auth_header: String,
+    /// Valid token used as the baseline for auth-bypass checks. Without it,
+    /// auth-related findings are limited.
+    pub auth_token: Option<String>,
+    /// Inline list of admin / privileged paths (one per line in the OWASP
+    /// admin-paths file format — comments with `#` are allowed). When empty,
+    /// the OWASP generator's built-in default list is used.
+    pub admin_paths: Vec<String>,
+    /// Comma-separated field names known to be resource IDs (e.g.
+    /// `"id,user_id,order_id"`).
+    pub id_fields: Option<String>,
+    /// `"json"` (default) or `"sarif"`.
+    pub report_format: String,
+    /// Iterations per VU. Defaults to 1.
+    pub iterations: u32,
+    pub vus: u32,
+    pub skip_tls_verify: bool,
+    /// `Key:Value,Key2:Value2` header string.
+    pub headers: Option<String>,
+}
+
+impl Default for CloudOwaspInputs {
+    fn default() -> Self {
+        Self {
+            spec_bytes: Vec::new(),
+            spec_format: SpecFormat::Auto,
+            target_url: String::new(),
+            base_path: None,
+            categories: None,
+            auth_header: "Authorization".to_string(),
+            auth_token: None,
+            admin_paths: Vec::new(),
+            id_fields: None,
+            report_format: "json".to_string(),
+            iterations: 1,
+            vus: 10,
+            skip_tls_verify: false,
+            headers: None,
+        }
+    }
+}
+
+/// Inputs for [`run_security`] — payload-injection security testing layered on
+/// a standard k6 bench run.
+///
+/// Built-in payload categories (SQL injection, XSS, command injection, path
+/// traversal, etc.) are baked into the binary. Supplying a custom payloads
+/// file is intentionally not supported in cloud mode — submit overrides via
+/// `categories` instead.
+#[derive(Debug, Clone)]
+pub struct CloudSecurityInputs {
+    pub spec_bytes: Vec<u8>,
+    pub spec_format: SpecFormat,
+    pub target_url: String,
+    pub base_path: Option<String>,
+    pub duration: String,
+    pub vus: u32,
+    pub scenario: String,
+    /// Comma-separated category names (e.g. `"sql,xss,cmd"`). Empty = all.
+    pub categories: Option<String>,
+    /// Comma-separated field names to inject into (e.g. `"username,query"`).
+    pub target_fields: Option<String>,
+    pub auth: Option<String>,
+    pub headers: Option<String>,
+    pub skip_tls_verify: bool,
+}
+
+impl Default for CloudSecurityInputs {
+    fn default() -> Self {
+        Self {
+            spec_bytes: Vec::new(),
+            spec_format: SpecFormat::Auto,
+            target_url: String::new(),
+            base_path: None,
+            duration: "30s".to_string(),
+            vus: 10,
+            scenario: "constant".to_string(),
+            categories: None,
+            target_fields: None,
+            auth: None,
+            headers: None,
+            skip_tls_verify: false,
+        }
+    }
+}
+
+/// Inputs for [`run_wafbench`] — Microsoft WAFBench-style coverage tests using
+/// the OWASP Core Rule Set attack patterns.
+///
+/// `rules_dir` must be a directory or glob pattern reachable on the host
+/// running the bench. In production this is the bundled CRS install path
+/// (e.g. `/usr/share/mockforge/wafbench/`); leaving it empty is an error.
+#[derive(Debug, Clone)]
+pub struct CloudWafBenchInputs {
+    pub spec_bytes: Vec<u8>,
+    pub spec_format: SpecFormat,
+    pub target_url: String,
+    pub base_path: Option<String>,
+    pub duration: String,
+    pub vus: u32,
+    pub scenario: String,
+    /// Filesystem path or glob pattern to WAFBench rule YAMLs.
+    pub rules_dir: String,
+    /// When true, exhaustively cycle through every payload instead of random
+    /// sampling. Use for coverage runs; expect long durations.
+    pub cycle_all: bool,
+    pub auth: Option<String>,
+    pub headers: Option<String>,
+    pub skip_tls_verify: bool,
+}
+
+impl Default for CloudWafBenchInputs {
+    fn default() -> Self {
+        Self {
+            spec_bytes: Vec::new(),
+            spec_format: SpecFormat::Auto,
+            target_url: String::new(),
+            base_path: None,
+            duration: "30s".to_string(),
+            vus: 10,
+            scenario: "constant".to_string(),
+            rules_dir: String::new(),
+            cycle_all: false,
+            auth: None,
+            headers: None,
+            skip_tls_verify: false,
+        }
+    }
+}
+
+/// Inputs for [`run_crud_flow`] — CRUD chain testing (Create → Read → Update →
+/// Delete sequences with cross-step ID extraction).
+///
+/// When `flow_config_yaml` is `None`, flows are auto-detected from the spec.
+/// When provided, the YAML follows the schema understood by `CrudFlowConfig`.
+#[derive(Debug, Clone)]
+pub struct CloudCrudFlowInputs {
+    pub spec_bytes: Vec<u8>,
+    pub spec_format: SpecFormat,
+    pub target_url: String,
+    pub base_path: Option<String>,
+    pub duration: String,
+    pub vus: u32,
+    pub scenario: String,
+    /// Inline YAML defining custom flows. When `None`, flows are auto-detected
+    /// from the OpenAPI spec.
+    pub flow_config_yaml: Option<String>,
+    /// Comma-separated response fields to extract for cross-step references
+    /// (e.g. `"id,user_id"`).
+    pub extract_fields: Option<String>,
+    pub auth: Option<String>,
+    pub headers: Option<String>,
+    pub skip_tls_verify: bool,
+}
+
+impl Default for CloudCrudFlowInputs {
+    fn default() -> Self {
+        Self {
+            spec_bytes: Vec::new(),
+            spec_format: SpecFormat::Auto,
+            target_url: String::new(),
+            base_path: None,
+            duration: "30s".to_string(),
+            vus: 10,
+            scenario: "constant".to_string(),
+            flow_config_yaml: None,
+            extract_fields: None,
+            auth: None,
+            headers: None,
+            skip_tls_verify: false,
+        }
+    }
+}
+
+/// Run an OWASP API Security Top 10 test.
+///
+/// Requires k6 on `$PATH`.
+pub async fn run_owasp(inputs: CloudOwaspInputs) -> Result<CloudRunArtifacts> {
+    if inputs.target_url.trim().is_empty() {
+        return Err(BenchError::Other("target_url is required".to_string()));
+    }
+    if inputs.spec_bytes.is_empty() {
+        return Err(BenchError::Other("spec_bytes is required for OWASP runs".to_string()));
+    }
+    if !K6Executor::is_k6_installed() {
+        return Err(BenchError::K6NotFound);
+    }
+
+    let workdir = TempDir::new()
+        .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
+    let spec_path = write_spec(workdir.path(), &inputs.spec_bytes, inputs.spec_format)?;
+    let output_dir = workdir.path().join("output");
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| BenchError::Other(format!("Failed to create output dir: {}", e)))?;
+
+    let admin_paths_path = if !inputs.admin_paths.is_empty() {
+        let p = workdir.path().join("admin-paths.txt");
+        std::fs::write(&p, inputs.admin_paths.join("\n"))
+            .map_err(|e| BenchError::Other(format!("Failed to write admin paths file: {}", e)))?;
+        Some(p)
+    } else {
+        None
+    };
+
+    let report_path = output_dir.join("owasp-report.json");
+    let cmd = BenchCommand {
+        spec: vec![spec_path],
+        target: inputs.target_url,
+        base_path: inputs.base_path,
+        vus: inputs.vus,
+        skip_tls_verify: inputs.skip_tls_verify,
+        headers: inputs.headers,
+        owasp_api_top10: true,
+        owasp_categories: inputs.categories,
+        owasp_auth_header: inputs.auth_header,
+        owasp_auth_token: inputs.auth_token,
+        owasp_admin_paths: admin_paths_path,
+        owasp_id_fields: inputs.id_fields,
+        owasp_report: Some(report_path),
+        owasp_report_format: inputs.report_format,
+        owasp_iterations: inputs.iterations,
+        ..default_bench_command(&output_dir)
+    };
+
+    cmd.execute().await?;
+    read_artifacts(&output_dir)
+}
+
+/// Run a payload-injection security test layered on a standard k6 bench.
+///
+/// Requires k6 on `$PATH`.
+pub async fn run_security(inputs: CloudSecurityInputs) -> Result<CloudRunArtifacts> {
+    if inputs.target_url.trim().is_empty() {
+        return Err(BenchError::Other("target_url is required".to_string()));
+    }
+    if inputs.spec_bytes.is_empty() {
+        return Err(BenchError::Other("spec_bytes is required for security runs".to_string()));
+    }
+    if !K6Executor::is_k6_installed() {
+        return Err(BenchError::K6NotFound);
+    }
+
+    let workdir = TempDir::new()
+        .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
+    let spec_path = write_spec(workdir.path(), &inputs.spec_bytes, inputs.spec_format)?;
+    let output_dir = workdir.path().join("output");
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| BenchError::Other(format!("Failed to create output dir: {}", e)))?;
+
+    let cmd = BenchCommand {
+        spec: vec![spec_path],
+        target: inputs.target_url,
+        base_path: inputs.base_path,
+        duration: inputs.duration,
+        vus: inputs.vus,
+        scenario: inputs.scenario,
+        auth: inputs.auth,
+        headers: inputs.headers,
+        skip_tls_verify: inputs.skip_tls_verify,
+        security_test: true,
+        security_categories: inputs.categories,
+        security_target_fields: inputs.target_fields,
+        ..default_bench_command(&output_dir)
+    };
+
+    cmd.execute().await?;
+    read_artifacts(&output_dir)
+}
+
+/// Run a WAFBench (OWASP CRS) coverage test.
+///
+/// Requires k6 on `$PATH` and the WAFBench rules accessible at
+/// [`CloudWafBenchInputs::rules_dir`] on the bench host.
+pub async fn run_wafbench(inputs: CloudWafBenchInputs) -> Result<CloudRunArtifacts> {
+    if inputs.target_url.trim().is_empty() {
+        return Err(BenchError::Other("target_url is required".to_string()));
+    }
+    if inputs.spec_bytes.is_empty() {
+        return Err(BenchError::Other("spec_bytes is required for WAFBench runs".to_string()));
+    }
+    if inputs.rules_dir.trim().is_empty() {
+        return Err(BenchError::Other(
+            "rules_dir is required for WAFBench runs (point at the bundled CRS install)"
+                .to_string(),
+        ));
+    }
+    if !K6Executor::is_k6_installed() {
+        return Err(BenchError::K6NotFound);
+    }
+
+    let workdir = TempDir::new()
+        .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
+    let spec_path = write_spec(workdir.path(), &inputs.spec_bytes, inputs.spec_format)?;
+    let output_dir = workdir.path().join("output");
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| BenchError::Other(format!("Failed to create output dir: {}", e)))?;
+
+    let cmd = BenchCommand {
+        spec: vec![spec_path],
+        target: inputs.target_url,
+        base_path: inputs.base_path,
+        duration: inputs.duration,
+        vus: inputs.vus,
+        scenario: inputs.scenario,
+        auth: inputs.auth,
+        headers: inputs.headers,
+        skip_tls_verify: inputs.skip_tls_verify,
+        wafbench_dir: Some(inputs.rules_dir),
+        wafbench_cycle_all: inputs.cycle_all,
+        ..default_bench_command(&output_dir)
+    };
+
+    cmd.execute().await?;
+    read_artifacts(&output_dir)
+}
+
+/// Run a CRUD flow test against [`CloudCrudFlowInputs::target_url`].
+///
+/// Requires k6 on `$PATH`.
+pub async fn run_crud_flow(inputs: CloudCrudFlowInputs) -> Result<CloudRunArtifacts> {
+    if inputs.target_url.trim().is_empty() {
+        return Err(BenchError::Other("target_url is required".to_string()));
+    }
+    if inputs.spec_bytes.is_empty() {
+        return Err(BenchError::Other("spec_bytes is required for CRUD flow runs".to_string()));
+    }
+    if !K6Executor::is_k6_installed() {
+        return Err(BenchError::K6NotFound);
+    }
+
+    let workdir = TempDir::new()
+        .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
+    let spec_path = write_spec(workdir.path(), &inputs.spec_bytes, inputs.spec_format)?;
+    let output_dir = workdir.path().join("output");
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| BenchError::Other(format!("Failed to create output dir: {}", e)))?;
+
+    let flow_config_path = if let Some(yaml) = &inputs.flow_config_yaml {
+        let p = workdir.path().join("flow-config.yaml");
+        std::fs::write(&p, yaml)
+            .map_err(|e| BenchError::Other(format!("Failed to write flow config: {}", e)))?;
+        Some(p)
+    } else {
+        None
+    };
+
+    let cmd = BenchCommand {
+        spec: vec![spec_path],
+        target: inputs.target_url,
+        base_path: inputs.base_path,
+        duration: inputs.duration,
+        vus: inputs.vus,
+        scenario: inputs.scenario,
+        auth: inputs.auth,
+        headers: inputs.headers,
+        skip_tls_verify: inputs.skip_tls_verify,
+        crud_flow: true,
+        flow_config: flow_config_path,
+        extract_fields: inputs.extract_fields,
+        ..default_bench_command(&output_dir)
+    };
+
+    cmd.execute().await?;
+    read_artifacts(&output_dir)
+}
+
 /// Build a [`BenchCommand`] populated with sensible defaults for a single-spec
 /// run targeting the given output directory.
 ///
@@ -522,6 +903,52 @@ mod tests {
     async fn run_conformance_rejects_empty_target() {
         let inputs = CloudConformanceInputs::default();
         let err = run_conformance(inputs).await.unwrap_err();
+        assert!(matches!(err, BenchError::Other(_)));
+    }
+
+    #[tokio::test]
+    async fn run_owasp_rejects_missing_inputs() {
+        let no_target = run_owasp(CloudOwaspInputs {
+            spec_bytes: br#"{"openapi":"3.0.0"}"#.to_vec(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+        assert!(matches!(no_target, BenchError::Other(_)));
+
+        let no_spec = run_owasp(CloudOwaspInputs {
+            target_url: "https://example.com".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+        assert!(matches!(no_spec, BenchError::Other(_)));
+    }
+
+    #[tokio::test]
+    async fn run_security_rejects_missing_inputs() {
+        let err = run_security(CloudSecurityInputs::default()).await.unwrap_err();
+        assert!(matches!(err, BenchError::Other(_)));
+    }
+
+    #[tokio::test]
+    async fn run_wafbench_rejects_missing_rules_dir() {
+        let err = run_wafbench(CloudWafBenchInputs {
+            spec_bytes: br#"{"openapi":"3.0.0"}"#.to_vec(),
+            target_url: "https://example.com".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+        let BenchError::Other(msg) = err else {
+            panic!("expected BenchError::Other");
+        };
+        assert!(msg.contains("rules_dir"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_crud_flow_rejects_missing_inputs() {
+        let err = run_crud_flow(CloudCrudFlowInputs::default()).await.unwrap_err();
         assert!(matches!(err, BenchError::Other(_)));
     }
 }

--- a/crates/mockforge-bench/src/executor.rs
+++ b/crates/mockforge-bench/src/executor.rs
@@ -335,7 +335,7 @@ impl Default for K6Executor {
 }
 
 /// k6 test results
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct K6Results {
     pub total_requests: u64,
     pub failed_requests: u64,

--- a/crates/mockforge-bench/src/lib.rs
+++ b/crates/mockforge-bench/src/lib.rs
@@ -25,6 +25,7 @@ pub mod scenarios;
 pub mod security_payloads;
 pub mod spec_dependencies;
 pub mod spec_parser;
+pub mod ssrf;
 pub mod target_parser;
 pub mod wafbench;
 
@@ -49,6 +50,7 @@ pub use security_payloads::{SecurityCategory, SecurityPayloads, SecurityTestConf
 pub use spec_dependencies::{
     DependencyDetector, ExtractedValues, SpecDependency, SpecDependencyConfig, SpecGroup,
 };
+pub use ssrf::{validate_target_url, Policy as SsrfPolicy, SsrfError};
 pub use target_parser::{parse_targets_file, TargetConfig};
 pub use wafbench::{WafBenchLoader, WafBenchStats, WafBenchTestCase};
 

--- a/crates/mockforge-bench/src/lib.rs
+++ b/crates/mockforge-bench/src/lib.rs
@@ -29,8 +29,9 @@ pub mod target_parser;
 pub mod wafbench;
 
 pub use cloud_api::{
-    run_bench, run_conformance, CloudBenchInputs, CloudConformanceInputs, CloudRunArtifacts,
-    SpecFormat,
+    run_bench, run_conformance, run_crud_flow, run_owasp, run_security, run_wafbench,
+    CloudBenchInputs, CloudConformanceInputs, CloudCrudFlowInputs, CloudOwaspInputs,
+    CloudRunArtifacts, CloudSecurityInputs, CloudWafBenchInputs, SpecFormat,
 };
 pub use command::BenchCommand;
 pub use crud_flow::{CrudFlow, CrudFlowConfig, CrudFlowDetector, FlowStep};

--- a/crates/mockforge-bench/src/lib.rs
+++ b/crates/mockforge-bench/src/lib.rs
@@ -4,6 +4,7 @@
 //! using OpenAPI specifications to generate realistic traffic patterns.
 
 pub mod chunked_bench;
+pub mod cloud_api;
 pub mod command;
 pub mod conformance;
 pub mod crud_flow;
@@ -27,6 +28,10 @@ pub mod spec_parser;
 pub mod target_parser;
 pub mod wafbench;
 
+pub use cloud_api::{
+    run_bench, run_conformance, CloudBenchInputs, CloudConformanceInputs, CloudRunArtifacts,
+    SpecFormat,
+};
 pub use command::BenchCommand;
 pub use crud_flow::{CrudFlow, CrudFlowConfig, CrudFlowDetector, FlowStep};
 pub use data_driven::{

--- a/crates/mockforge-bench/src/ssrf.rs
+++ b/crates/mockforge-bench/src/ssrf.rs
@@ -1,0 +1,362 @@
+//! SSRF (Server-Side Request Forgery) guard for cloud-driven runs.
+//!
+//! When `mockforge-test-runner` (or any other cloud-side caller) accepts a
+//! user-supplied target URL and dispatches HTTP traffic at it, an attacker
+//! can point the runner at internal infrastructure: metadata endpoints
+//! (`169.254.169.254`), localhost services, RFC1918 / ULA private ranges,
+//! and so on. Without a guard, we hand them a free internal-network
+//! scanner running inside our Fly.io org.
+//!
+//! [`validate_target_url`] is the single chokepoint. It:
+//!
+//! 1. Parses the URL and rejects anything that isn't `http://` or
+//!    `https://` (no `file://`, `gopher://`, etc.).
+//! 2. Resolves the hostname via DNS (asynchronously) and rejects if any
+//!    resolved IP is in a blocked range.
+//! 3. Treats literal-IP hostnames (`http://10.0.0.1/`) the same way —
+//!    parsing them as `IpAddr` directly so DNS resolution isn't needed.
+//!
+//! Blocked ranges:
+//!
+//! * IPv4: loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16` —
+//!   includes the AWS/GCP/Fly metadata IP `169.254.169.254`), unspecified
+//!   (`0.0.0.0/8`), broadcast, RFC1918 private (`10/8`, `172.16/12`,
+//!   `192.168/16`), CGNAT (`100.64.0.0/10`), benchmark (`198.18/15`).
+//! * IPv6: loopback (`::1`), unspecified (`::`), link-local (`fe80::/10`),
+//!   ULA (`fc00::/7`), IPv4-mapped (`::ffff:0:0/96` — caller could smuggle
+//!   in a private v4 address).
+//!
+//! There is no escape hatch — production callers MUST ensure their target
+//! is publicly reachable. Tests can override with the `loopback-ok` env
+//! var (see [`Policy::for_test`]) for integration-test endpoints on
+//! `127.0.0.1`.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use thiserror::Error;
+
+/// Reasons a target URL can be rejected by [`validate_target_url`].
+#[derive(Debug, Error)]
+pub enum SsrfError {
+    #[error("invalid URL: {0}")]
+    InvalidUrl(String),
+
+    #[error("URL scheme '{0}' not allowed — only http/https")]
+    DisallowedScheme(String),
+
+    #[error("URL has no host component")]
+    MissingHost,
+
+    #[error("DNS resolution failed for '{host}': {source}")]
+    DnsResolutionFailed {
+        host: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("DNS resolution returned no addresses for '{0}'")]
+    NoAddressesResolved(String),
+
+    #[error(
+        "target '{host}' resolves to {ip} which is in a blocked range ({reason}); \
+         pointing the cloud runner at internal addresses is not allowed"
+    )]
+    BlockedAddress {
+        host: String,
+        ip: IpAddr,
+        reason: &'static str,
+    },
+}
+
+/// Knobs for [`validate_target_url`]. Default policy is the strict
+/// production one; tests can relax it via [`Policy::allow_loopback`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Policy {
+    /// When true, addresses in the IPv4/IPv6 loopback range are allowed.
+    /// Production callers should leave this `false`. Tests against
+    /// `127.0.0.1` set it via [`Policy::for_test`].
+    pub allow_loopback: bool,
+}
+
+impl Policy {
+    /// Strict production policy: nothing private, nothing local.
+    pub const fn strict() -> Self {
+        Self {
+            allow_loopback: false,
+        }
+    }
+
+    /// Test policy: allows loopback so integration tests against
+    /// `127.0.0.1:<port>` mock servers can run.
+    pub const fn for_test() -> Self {
+        Self {
+            allow_loopback: true,
+        }
+    }
+}
+
+/// Validate that a URL is safe for a cloud runner to hit. Returns `Ok(())`
+/// when the target is a publicly-routable HTTP/S endpoint.
+///
+/// Performs DNS resolution, so this is async. Cache results at the call
+/// site if the same URL is validated repeatedly within one request.
+pub async fn validate_target_url(url: &str, policy: Policy) -> Result<(), SsrfError> {
+    let parsed = url::Url::parse(url).map_err(|e| SsrfError::InvalidUrl(e.to_string()))?;
+
+    let scheme = parsed.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(SsrfError::DisallowedScheme(scheme.to_string()));
+    }
+
+    let host = parsed.host_str().ok_or(SsrfError::MissingHost)?.to_string();
+    let port = parsed.port_or_known_default().unwrap_or(80);
+
+    // Literal IP — no DNS needed.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        check_ip(&host, ip, policy)?;
+        return Ok(());
+    }
+
+    // Hostname — resolve and check every resolved address. An attacker
+    // can register a public DNS name pointing at 169.254.169.254 (a.k.a.
+    // "DNS rebinding" / "0.0.0.0 day"), so we MUST inspect resolved IPs,
+    // not just the literal-IP form.
+    let lookup_target = format!("{}:{}", host, port);
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(&lookup_target)
+        .await
+        .map_err(|source| SsrfError::DnsResolutionFailed {
+            host: host.clone(),
+            source,
+        })?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(SsrfError::NoAddressesResolved(host));
+    }
+
+    for addr in addrs {
+        check_ip(&host, addr.ip(), policy)?;
+    }
+
+    Ok(())
+}
+
+fn check_ip(host: &str, ip: IpAddr, policy: Policy) -> Result<(), SsrfError> {
+    if let Some(reason) = blocked_reason(ip, policy) {
+        return Err(SsrfError::BlockedAddress {
+            host: host.to_string(),
+            ip,
+            reason,
+        });
+    }
+    Ok(())
+}
+
+fn blocked_reason(ip: IpAddr, policy: Policy) -> Option<&'static str> {
+    match ip {
+        IpAddr::V4(v4) => blocked_reason_v4(v4, policy),
+        IpAddr::V6(v6) => blocked_reason_v6(v6, policy),
+    }
+}
+
+fn blocked_reason_v4(ip: Ipv4Addr, policy: Policy) -> Option<&'static str> {
+    if ip.is_loopback() {
+        if policy.allow_loopback {
+            return None;
+        }
+        return Some("IPv4 loopback (127.0.0.0/8)");
+    }
+    if ip.is_unspecified() {
+        return Some("IPv4 unspecified (0.0.0.0)");
+    }
+    if ip.is_broadcast() {
+        return Some("IPv4 broadcast");
+    }
+    if ip.is_link_local() {
+        return Some("IPv4 link-local (169.254.0.0/16, includes cloud metadata IP)");
+    }
+    if ip.is_private() {
+        return Some("IPv4 RFC1918 private (10/8, 172.16/12, 192.168/16)");
+    }
+    if ip.is_documentation() {
+        return Some("IPv4 documentation range (RFC5737)");
+    }
+    // CGNAT range (100.64.0.0/10) — not is_private but still
+    // not-publicly-routable. Cloud providers sometimes use it for inter-VM
+    // links, which is exactly the kind of thing we don't want to expose.
+    let octets = ip.octets();
+    if octets[0] == 100 && (64..=127).contains(&octets[1]) {
+        return Some("IPv4 CGNAT (100.64.0.0/10)");
+    }
+    // Benchmark range 198.18.0.0/15 (RFC2544).
+    if octets[0] == 198 && (octets[1] == 18 || octets[1] == 19) {
+        return Some("IPv4 benchmark (198.18.0.0/15)");
+    }
+    None
+}
+
+fn blocked_reason_v6(ip: Ipv6Addr, policy: Policy) -> Option<&'static str> {
+    if ip.is_loopback() {
+        if policy.allow_loopback {
+            return None;
+        }
+        return Some("IPv6 loopback (::1)");
+    }
+    if ip.is_unspecified() {
+        return Some("IPv6 unspecified (::)");
+    }
+    let segments = ip.segments();
+    // Link-local fe80::/10
+    if (segments[0] & 0xffc0) == 0xfe80 {
+        return Some("IPv6 link-local (fe80::/10)");
+    }
+    // ULA fc00::/7
+    if (segments[0] & 0xfe00) == 0xfc00 {
+        return Some("IPv6 unique-local (fc00::/7)");
+    }
+    // IPv4-mapped ::ffff:0:0/96 — recurse so an attacker can't smuggle a
+    // private v4 through the v6 form (`http://[::ffff:10.0.0.1]/`).
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return blocked_reason_v4(v4, policy);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_blocked(addr: &str, policy: Policy, fragment: &str) {
+        let ip: IpAddr = addr.parse().unwrap();
+        let reason =
+            blocked_reason(ip, policy).unwrap_or_else(|| panic!("expected {addr} to be blocked"));
+        assert!(
+            reason.contains(fragment),
+            "{addr} blocked but reason '{reason}' missing fragment '{fragment}'"
+        );
+    }
+
+    fn assert_allowed(addr: &str, policy: Policy) {
+        let ip: IpAddr = addr.parse().unwrap();
+        assert!(blocked_reason(ip, policy).is_none(), "{addr} unexpectedly blocked");
+    }
+
+    #[test]
+    fn blocks_loopback_v4_strict() {
+        assert_blocked("127.0.0.1", Policy::strict(), "loopback");
+        assert_blocked("127.255.255.254", Policy::strict(), "loopback");
+    }
+
+    #[test]
+    fn allows_loopback_v4_in_test_policy() {
+        assert_allowed("127.0.0.1", Policy::for_test());
+    }
+
+    #[test]
+    fn blocks_link_local_aws_metadata() {
+        assert_blocked("169.254.169.254", Policy::strict(), "link-local");
+    }
+
+    #[test]
+    fn blocks_rfc1918_ranges() {
+        assert_blocked("10.0.0.1", Policy::strict(), "RFC1918");
+        assert_blocked("172.16.0.1", Policy::strict(), "RFC1918");
+        assert_blocked("172.31.255.255", Policy::strict(), "RFC1918");
+        assert_blocked("192.168.0.1", Policy::strict(), "RFC1918");
+    }
+
+    #[test]
+    fn blocks_cgnat() {
+        assert_blocked("100.64.0.1", Policy::strict(), "CGNAT");
+        assert_blocked("100.127.255.255", Policy::strict(), "CGNAT");
+    }
+
+    #[test]
+    fn allows_ranges_outside_cgnat() {
+        // 100.0.0.0/8 outside the CGNAT slice is publicly routable.
+        assert_allowed("100.63.255.255", Policy::strict());
+        assert_allowed("100.128.0.1", Policy::strict());
+    }
+
+    #[test]
+    fn blocks_benchmark_range() {
+        assert_blocked("198.18.0.1", Policy::strict(), "benchmark");
+        assert_blocked("198.19.255.255", Policy::strict(), "benchmark");
+    }
+
+    #[test]
+    fn allows_public_v4() {
+        assert_allowed("8.8.8.8", Policy::strict());
+        assert_allowed("1.1.1.1", Policy::strict());
+        assert_allowed("142.250.190.78", Policy::strict()); // google.com
+    }
+
+    #[test]
+    fn blocks_loopback_v6_strict() {
+        assert_blocked("::1", Policy::strict(), "loopback");
+    }
+
+    #[test]
+    fn blocks_link_local_v6() {
+        assert_blocked("fe80::1", Policy::strict(), "link-local");
+        assert_blocked("febf::1", Policy::strict(), "link-local");
+    }
+
+    #[test]
+    fn blocks_ula() {
+        assert_blocked("fc00::1", Policy::strict(), "unique-local");
+        assert_blocked("fd12:3456::1", Policy::strict(), "unique-local");
+    }
+
+    #[test]
+    fn blocks_ipv4_mapped_private() {
+        assert_blocked("::ffff:10.0.0.1", Policy::strict(), "RFC1918");
+        assert_blocked("::ffff:127.0.0.1", Policy::strict(), "loopback");
+    }
+
+    #[test]
+    fn allows_public_v6() {
+        assert_allowed("2606:4700:4700::1111", Policy::strict()); // cloudflare
+        assert_allowed("2001:4860:4860::8888", Policy::strict()); // google
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_non_http_scheme() {
+        let err = validate_target_url("file:///etc/passwd", Policy::strict()).await.unwrap_err();
+        assert!(matches!(err, SsrfError::DisallowedScheme(s) if s == "file"));
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_garbage_url() {
+        let err = validate_target_url("not a url", Policy::strict()).await.unwrap_err();
+        assert!(matches!(err, SsrfError::InvalidUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_literal_loopback() {
+        let err = validate_target_url("http://127.0.0.1/", Policy::strict()).await.unwrap_err();
+        assert!(matches!(err, SsrfError::BlockedAddress { .. }));
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_literal_metadata_ip() {
+        let err = validate_target_url("http://169.254.169.254/latest/meta-data/", Policy::strict())
+            .await
+            .unwrap_err();
+        match err {
+            SsrfError::BlockedAddress { reason, .. } => assert!(reason.contains("link-local")),
+            other => panic!("expected BlockedAddress, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_literal_rfc1918() {
+        let err = validate_target_url("http://10.0.0.1/", Policy::strict()).await.unwrap_err();
+        assert!(matches!(err, SsrfError::BlockedAddress { .. }));
+    }
+
+    #[tokio::test]
+    async fn validate_allows_loopback_in_test_policy() {
+        validate_target_url("http://127.0.0.1:8080/", Policy::for_test()).await.unwrap();
+    }
+}

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -147,6 +147,10 @@ mockforge-federation = { version = "0.3.70", path = "../mockforge-federation" }
 mockforge-scenarios = { version = "0.3.70", path = "../mockforge-scenarios" }
 mockforge-plugin-registry = { version = "0.3.70", path = "../mockforge-plugin-registry" }
 mockforge-observability = { version = "0.3.70", path = "../mockforge-observability" }
+# SSRF guard reused at the trigger_run handler — primary enforcement
+# before runs hit the Redis queue. The runner-side guard in
+# mockforge_bench::cloud_api is defense-in-depth.
+mockforge-bench = { path = "../mockforge-bench" }
 
 # Metrics
 prometheus = { version = "0.14", features = ["process"] }

--- a/crates/mockforge-registry-server/src/handlers/test_runs.rs
+++ b/crates/mockforge-registry-server/src/handlers/test_runs.rs
@@ -19,6 +19,7 @@ use axum::{
     Json,
 };
 use futures_util::stream::{self, Stream};
+use mockforge_bench::ssrf::{validate_target_url, Policy as SsrfPolicy};
 use mockforge_registry_core::models::test_run::EnqueueTestRun;
 use serde::Deserialize;
 use std::convert::Infallible;
@@ -111,7 +112,19 @@ pub async fn trigger_run(
         ));
     }
 
-    // 4. Insert the test_runs row.
+    // 4. SSRF guard. When the suite config carries a `target_url`,
+    // validate it before we even create the test_run row. This is the
+    // primary enforcement point — by the time the worker picks the job
+    // up, an attacker pointing us at internal infrastructure has
+    // already burned a runner slot and a queue write. The runner-side
+    // guard in mockforge_bench::cloud_api is defense-in-depth.
+    if let Some(target_url) = extract_target_url(&suite.config) {
+        validate_target_url(&target_url, ssrf_policy())
+            .await
+            .map_err(|e| ApiError::InvalidRequest(format!("target_url rejected: {}", e)))?;
+    }
+
+    // 5. Insert the test_runs row.
     let run = TestRun::enqueue(
         state.db.pool(),
         EnqueueTestRun {
@@ -127,7 +140,7 @@ pub async fn trigger_run(
     .await
     .map_err(ApiError::Database)?;
 
-    // 5. Push onto the Redis queue so mockforge-test-runner picks it up.
+    // 6. Push onto the Redis queue so mockforge-test-runner picks it up.
     // We pass the suite's config straight through as the payload — the
     // executor reads kind-specific knobs from there (synthetic_steps,
     // target URL, etc.) so the user's authored config actually drives
@@ -428,9 +441,34 @@ fn is_valid_trigger_source(s: &str) -> bool {
     matches!(s, "manual" | "schedule" | "ci" | "webhook")
 }
 
+/// Pull a `target_url` string out of a suite config JSON. Returns
+/// `None` when the field is absent, blank, or not a string — caller
+/// treats that as "no SSRF check needed", which is correct for kinds
+/// like `unit` that don't make outbound requests.
+fn extract_target_url(config: &serde_json::Value) -> Option<String> {
+    let raw = config.get("target_url")?.as_str()?.trim();
+    if raw.is_empty() {
+        None
+    } else {
+        Some(raw.to_string())
+    }
+}
+
+/// Resolve the SSRF policy for trigger-time validation. Mirrors the
+/// runner-side env-var contract in `mockforge_bench::cloud_api`:
+/// `MOCKFORGE_SSRF_ALLOW_LOOPBACK=1` opts into [`SsrfPolicy::for_test`]
+/// for non-prod deployments. Production must NOT set this.
+fn ssrf_policy() -> SsrfPolicy {
+    match std::env::var("MOCKFORGE_SSRF_ALLOW_LOOPBACK").as_deref() {
+        Ok("1") | Ok("true") => SsrfPolicy::for_test(),
+        _ => SsrfPolicy::strict(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn trigger_source_accepts_canonical_values() {
@@ -445,5 +483,52 @@ mod tests {
         assert!(!is_valid_trigger_source("MANUAL"));
         assert!(!is_valid_trigger_source(""));
         assert!(!is_valid_trigger_source("api"));
+    }
+
+    #[test]
+    fn extract_target_url_pulls_string() {
+        assert_eq!(
+            extract_target_url(&json!({"target_url": "https://api.example.com"})),
+            Some("https://api.example.com".to_string())
+        );
+        assert_eq!(
+            extract_target_url(&json!({"target_url": "  https://x.com  "})),
+            Some("https://x.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_target_url_none_when_missing_blank_or_wrong_type() {
+        assert!(extract_target_url(&json!({})).is_none());
+        assert!(extract_target_url(&json!({"target_url": ""})).is_none());
+        assert!(extract_target_url(&json!({"target_url": "   "})).is_none());
+        assert!(extract_target_url(&json!({"target_url": 42})).is_none());
+        assert!(extract_target_url(&json!({"other": "https://x.com"})).is_none());
+    }
+
+    #[tokio::test]
+    async fn ssrf_policy_blocks_loopback_target_in_strict_mode() {
+        std::env::remove_var("MOCKFORGE_SSRF_ALLOW_LOOPBACK");
+        let policy = ssrf_policy();
+        let err = validate_target_url("http://127.0.0.1/", policy).await.unwrap_err();
+        assert!(err.to_string().contains("loopback"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn ssrf_policy_blocks_metadata_ip() {
+        std::env::remove_var("MOCKFORGE_SSRF_ALLOW_LOOPBACK");
+        let policy = ssrf_policy();
+        let err = validate_target_url("http://169.254.169.254/latest/meta-data/", policy)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("link-local"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn ssrf_policy_loose_allows_loopback() {
+        std::env::set_var("MOCKFORGE_SSRF_ALLOW_LOOPBACK", "1");
+        let policy = ssrf_policy();
+        validate_target_url("http://127.0.0.1:8080/", policy).await.unwrap();
+        std::env::remove_var("MOCKFORGE_SSRF_ALLOW_LOOPBACK");
     }
 }

--- a/crates/mockforge-test-runner/Cargo.toml
+++ b/crates/mockforge-test-runner/Cargo.toml
@@ -42,6 +42,12 @@ serde_yaml = "0.9"
 # Redis queue (matches the registry-server's choice).
 redis = { version = "0.25", features = ["tokio-comp", "connection-manager"] }
 
+# Cloud-friendly bench/conformance/OWASP entry points (see
+# mockforge-bench::cloud_api). Adds k6 + handlebars + openapi parser to
+# the runner image; in production the Dockerfile must also install the
+# k6 binary on $PATH.
+mockforge-bench = { path = "../mockforge-bench" }
+
 # tracing-subscriber is only used by the binary entry point; pulling it
 # into normal deps so the binary builds without juggling features.
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/mockforge-test-runner/src/executors/mod.rs
+++ b/crates/mockforge-test-runner/src/executors/mod.rs
@@ -110,8 +110,20 @@ impl Default for ExecutorRegistry {
     fn default() -> Self {
         let mut by_kind: HashMap<&'static str, Box<dyn Executor>> = HashMap::new();
 
-        // Test execution suite (#4) — five kinds map to the same impl.
-        for k in ["unit", "integration", "conformance", "bench", "owasp"] {
+        // Test execution suite (#4) — kinds that share the TestExecutor
+        // impl. The cloud_api path (run_cloud_*) handles bench/owasp/
+        // conformance/security/wafbench/crud_flow when payloads opt in;
+        // unit/integration fall through to synthetic mode.
+        for k in [
+            "unit",
+            "integration",
+            "conformance",
+            "bench",
+            "owasp",
+            "security",
+            "wafbench",
+            "crud_flow",
+        ] {
             by_kind.insert(k, Box::new(test::TestExecutor::for_kind(k)));
         }
 
@@ -185,6 +197,9 @@ mod tests {
             "conformance",
             "bench",
             "owasp",
+            "security",
+            "wafbench",
+            "crud_flow",
             "chaos_campaign",
             "behavioral_clone",
             "snapshot_capture",

--- a/crates/mockforge-test-runner/src/executors/test.rs
+++ b/crates/mockforge-test-runner/src/executors/test.rs
@@ -29,6 +29,10 @@
 use async_trait::async_trait;
 use std::time::Instant;
 
+use mockforge_bench::cloud_api::{
+    self, CloudBenchInputs, CloudConformanceInputs, CloudOwaspInputs, CloudRunArtifacts, SpecFormat,
+};
+
 use crate::callbacks::RegistryCallbacks;
 use crate::error::Result;
 use crate::executors::{Executor, JobOutcome, JobStatus, RunJob};
@@ -69,6 +73,33 @@ impl Executor for TestExecutor {
     async fn execute(&self, job: RunJob, callbacks: &RegistryCallbacks) -> Result<JobOutcome> {
         let started = Instant::now();
         callbacks.run_started(job.run_id).await?;
+
+        // Cloud-API path: when the payload opts in via `use_cloud_api: true`
+        // and supplies an OpenAPI spec, dispatch to the
+        // mockforge_bench::cloud_api wrappers — same logic as the local
+        // `mockforge-cli bench` command, just driven from the cloud worker
+        // against an external target. Requires the k6 binary on $PATH (the
+        // runner Dockerfile installs it). When the payload doesn't opt in,
+        // bench/owasp fall through to the lighter-weight reqwest paths
+        // below and conformance falls through to synthetic mode.
+        if uses_cloud_api(&job.payload) {
+            match self.kind {
+                "conformance" => {
+                    return run_cloud_conformance(job, callbacks, started).await;
+                }
+                "bench" => {
+                    if let Some(spec) = extract_spec_bytes(&job.payload) {
+                        return run_cloud_bench(job, callbacks, started, spec).await;
+                    }
+                }
+                "owasp" => {
+                    if let Some(spec) = extract_spec_bytes(&job.payload) {
+                        return run_cloud_owasp(job, callbacks, started, spec).await;
+                    }
+                }
+                _ => {}
+            }
+        }
 
         // OWASP kind has a real path when payload.target_url is set —
         // scan response headers for the standard security-header set.
@@ -163,6 +194,403 @@ impl Executor for TestExecutor {
                 "wall_ms": elapsed.as_millis() as u64,
             })),
         })
+    }
+}
+
+/// Whether the queued payload opts into the [`mockforge_bench::cloud_api`]
+/// path. Defaults to `false` so callers that haven't migrated keep the
+/// existing reqwest-based behavior.
+fn uses_cloud_api(payload: &serde_json::Value) -> bool {
+    payload.get("use_cloud_api").and_then(|v| v.as_bool()).unwrap_or(false)
+}
+
+/// Pull the OpenAPI spec out of the payload as bytes. Looks at
+/// `payload.spec` first (a UTF-8 JSON or YAML document inline) — most
+/// callers will use this. Returns `None` when no usable spec is supplied
+/// so the caller can decide whether to error or fall back.
+fn extract_spec_bytes(payload: &serde_json::Value) -> Option<Vec<u8>> {
+    let raw = payload.get("spec")?.as_str()?;
+    if raw.trim().is_empty() {
+        return None;
+    }
+    Some(raw.as_bytes().to_vec())
+}
+
+fn extract_spec_format(payload: &serde_json::Value) -> SpecFormat {
+    match payload.get("spec_format").and_then(|v| v.as_str()).unwrap_or("auto") {
+        "json" => SpecFormat::Json,
+        "yaml" | "yml" => SpecFormat::Yaml,
+        _ => SpecFormat::Auto,
+    }
+}
+
+fn extract_target_url(payload: &serde_json::Value) -> Option<String> {
+    payload
+        .get("target_url")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+fn extract_string(payload: &serde_json::Value, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+fn extract_string_vec(payload: &serde_json::Value, key: &str) -> Vec<String> {
+    payload
+        .get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Map a [`CloudRunArtifacts`] result to a `JobOutcome` and emit summary
+/// events. Status is `Passed` when no `summary.json` was produced (e.g.
+/// conformance native executor) or when k6 reported an error rate below 1%.
+async fn finish_cloud_run(
+    job_run_id: uuid::Uuid,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    kind: &'static str,
+    target_url: &str,
+    artifacts: CloudRunArtifacts,
+    next_seq: u32,
+) -> Result<JobOutcome> {
+    // Emit a metric event with the structured summary so the SSE stream
+    // shows the run results live without consumers having to fetch
+    // artifacts.
+    let summary_json = artifacts
+        .k6_results
+        .as_ref()
+        .map(|r| {
+            serde_json::json!({
+                "name": format!("{kind}_summary"),
+                "total_requests": r.total_requests,
+                "failed_requests": r.failed_requests,
+                "error_rate_pct": r.error_rate(),
+                "rps": r.rps,
+                "p95_ms": r.p95_duration_ms,
+                "p99_ms": r.p99_duration_ms,
+                "vus_max": r.vus_max,
+            })
+        })
+        .unwrap_or_else(|| {
+            serde_json::json!({
+                "name": format!("{kind}_summary"),
+                "artifacts": artifacts.files.keys().collect::<Vec<_>>(),
+            })
+        });
+
+    callbacks.run_event(job_run_id, next_seq, "metric", summary_json).await?;
+
+    let elapsed = started.elapsed();
+    let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
+    let status = match artifacts.k6_results.as_ref() {
+        Some(r) if r.error_rate() >= 1.0 => JobStatus::Failed,
+        _ => JobStatus::Passed,
+    };
+    Ok(JobOutcome {
+        status,
+        runner_seconds: secs,
+        summary: Some(serde_json::json!({
+            "executor_phase": "cloud_api",
+            "kind": kind,
+            "target_url": target_url,
+            "artifact_files": artifacts.files.keys().collect::<Vec<_>>(),
+            "k6_results": artifacts.k6_results,
+            "wall_ms": elapsed.as_millis() as u64,
+        })),
+    })
+}
+
+/// Map a `cloud_api` error to an `Errored` outcome with the failure
+/// message captured as a `step_fail` event.
+async fn finish_cloud_error(
+    job_run_id: uuid::Uuid,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    kind: &'static str,
+    target_url: &str,
+    next_seq: u32,
+    err: mockforge_bench::error::BenchError,
+) -> Result<JobOutcome> {
+    callbacks
+        .run_event(
+            job_run_id,
+            next_seq,
+            "step_fail",
+            serde_json::json!({
+                "step": 1,
+                "name": format!("cloud_api_{kind}"),
+                "error": err.to_string(),
+            }),
+        )
+        .await?;
+    let elapsed = started.elapsed();
+    Ok(JobOutcome {
+        status: JobStatus::Errored,
+        runner_seconds: (elapsed.as_secs_f64().ceil() as i32).max(1),
+        summary: Some(serde_json::json!({
+            "executor_phase": "cloud_api",
+            "kind": kind,
+            "target_url": target_url,
+            "error": err.to_string(),
+            "wall_ms": elapsed.as_millis() as u64,
+        })),
+    })
+}
+
+/// Drive a k6 load test via `cloud_api::run_bench`.
+async fn run_cloud_bench(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    spec_bytes: Vec<u8>,
+) -> Result<JobOutcome> {
+    let Some(target_url) = extract_target_url(&job.payload) else {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "bench",
+            "",
+            1,
+            mockforge_bench::error::BenchError::Other(
+                "use_cloud_api=true bench job missing target_url".to_string(),
+            ),
+        )
+        .await;
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!("Cloud bench against {target_url}"),
+                "executor_phase": "cloud_api",
+            }),
+        )
+        .await?;
+
+    let inputs = CloudBenchInputs {
+        spec_bytes,
+        spec_format: extract_spec_format(&job.payload),
+        target_url: target_url.clone(),
+        base_path: extract_string(&job.payload, "base_path"),
+        duration: extract_string(&job.payload, "duration").unwrap_or_else(|| "30s".to_string()),
+        vus: job.payload.get("vus").and_then(|v| v.as_u64()).unwrap_or(10).clamp(1, 1000) as u32,
+        scenario: extract_string(&job.payload, "scenario")
+            .unwrap_or_else(|| "constant".to_string()),
+        operations: extract_string(&job.payload, "operations"),
+        exclude_operations: extract_string(&job.payload, "exclude_operations"),
+        auth: extract_string(&job.payload, "auth"),
+        headers: extract_string(&job.payload, "headers"),
+        threshold_percentile: extract_string(&job.payload, "threshold_percentile")
+            .unwrap_or_else(|| "p(95)".to_string()),
+        threshold_ms: job.payload.get("threshold_ms").and_then(|v| v.as_u64()).unwrap_or(1000),
+        max_error_rate: job.payload.get("max_error_rate").and_then(|v| v.as_f64()).unwrap_or(0.01),
+        skip_tls_verify: job
+            .payload
+            .get("skip_tls_verify")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        chunked_request_bodies: false,
+    };
+
+    match cloud_api::run_bench(inputs).await {
+        Ok(artifacts) => {
+            finish_cloud_run(job.run_id, callbacks, started, "bench", &target_url, artifacts, 2)
+                .await
+        }
+        Err(e) => {
+            finish_cloud_error(job.run_id, callbacks, started, "bench", &target_url, 2, e).await
+        }
+    }
+}
+
+/// Drive an OWASP API Top 10 run via `cloud_api::run_owasp`.
+async fn run_cloud_owasp(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    spec_bytes: Vec<u8>,
+) -> Result<JobOutcome> {
+    let Some(target_url) = extract_target_url(&job.payload) else {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "owasp",
+            "",
+            1,
+            mockforge_bench::error::BenchError::Other(
+                "use_cloud_api=true owasp job missing target_url".to_string(),
+            ),
+        )
+        .await;
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!("Cloud OWASP scan against {target_url}"),
+                "executor_phase": "cloud_api",
+            }),
+        )
+        .await?;
+
+    let inputs = CloudOwaspInputs {
+        spec_bytes,
+        spec_format: extract_spec_format(&job.payload),
+        target_url: target_url.clone(),
+        base_path: extract_string(&job.payload, "base_path"),
+        categories: extract_string(&job.payload, "owasp_categories"),
+        auth_header: extract_string(&job.payload, "owasp_auth_header")
+            .unwrap_or_else(|| "Authorization".to_string()),
+        auth_token: extract_string(&job.payload, "owasp_auth_token"),
+        admin_paths: extract_string_vec(&job.payload, "owasp_admin_paths"),
+        id_fields: extract_string(&job.payload, "owasp_id_fields"),
+        report_format: extract_string(&job.payload, "owasp_report_format")
+            .unwrap_or_else(|| "json".to_string()),
+        iterations: job
+            .payload
+            .get("owasp_iterations")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1)
+            .clamp(1, 100) as u32,
+        vus: job.payload.get("vus").and_then(|v| v.as_u64()).unwrap_or(10).clamp(1, 1000) as u32,
+        skip_tls_verify: job
+            .payload
+            .get("skip_tls_verify")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        headers: extract_string(&job.payload, "headers"),
+    };
+
+    match cloud_api::run_owasp(inputs).await {
+        Ok(artifacts) => {
+            finish_cloud_run(job.run_id, callbacks, started, "owasp", &target_url, artifacts, 2)
+                .await
+        }
+        Err(e) => {
+            finish_cloud_error(job.run_id, callbacks, started, "owasp", &target_url, 2, e).await
+        }
+    }
+}
+
+/// Drive an OpenAPI 3.0.0 conformance run via `cloud_api::run_conformance`.
+///
+/// Unlike bench/owasp, the spec is optional — the native conformance
+/// executor's reference-check mode runs without one. So this path opts
+/// in purely on `kind == "conformance" && use_cloud_api == true`.
+async fn run_cloud_conformance(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+) -> Result<JobOutcome> {
+    let Some(target_url) = extract_target_url(&job.payload) else {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "conformance",
+            "",
+            1,
+            mockforge_bench::error::BenchError::Other(
+                "use_cloud_api=true conformance job missing target_url".to_string(),
+            ),
+        )
+        .await;
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!("Cloud conformance against {target_url}"),
+                "executor_phase": "cloud_api",
+            }),
+        )
+        .await?;
+
+    let inputs = CloudConformanceInputs {
+        spec_bytes: extract_spec_bytes(&job.payload),
+        spec_format: extract_spec_format(&job.payload),
+        target_url: target_url.clone(),
+        base_path: extract_string(&job.payload, "base_path"),
+        api_key: extract_string(&job.payload, "conformance_api_key"),
+        basic_auth: extract_string(&job.payload, "conformance_basic_auth"),
+        categories: extract_string(&job.payload, "conformance_categories"),
+        headers: extract_string_vec(&job.payload, "conformance_headers"),
+        all_operations: job
+            .payload
+            .get("conformance_all_operations")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        request_delay_ms: job
+            .payload
+            .get("conformance_delay_ms")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        use_k6: job.payload.get("use_k6").and_then(|v| v.as_bool()).unwrap_or(false),
+        skip_tls_verify: job
+            .payload
+            .get("skip_tls_verify")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        report_format: extract_string(&job.payload, "conformance_report_format")
+            .unwrap_or_else(|| "json".to_string()),
+        export_requests: job
+            .payload
+            .get("export_requests")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        validate_requests: job
+            .payload
+            .get("validate_requests")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    };
+
+    match cloud_api::run_conformance(inputs).await {
+        Ok(artifacts) => {
+            finish_cloud_run(
+                job.run_id,
+                callbacks,
+                started,
+                "conformance",
+                &target_url,
+                artifacts,
+                2,
+            )
+            .await
+        }
+        Err(e) => {
+            finish_cloud_error(job.run_id, callbacks, started, "conformance", &target_url, 2, e)
+                .await
+        }
     }
 }
 
@@ -517,5 +945,63 @@ mod tests {
     #[test]
     fn synthetic_step_ms_default() {
         assert_eq!(TestExecutor::synthetic_step_ms(&json!({})), 100);
+    }
+
+    #[test]
+    fn uses_cloud_api_default_false() {
+        assert!(!uses_cloud_api(&json!({})));
+        assert!(!uses_cloud_api(&json!(null)));
+        assert!(!uses_cloud_api(&json!({"use_cloud_api": false})));
+    }
+
+    #[test]
+    fn uses_cloud_api_explicit_true() {
+        assert!(uses_cloud_api(&json!({"use_cloud_api": true})));
+    }
+
+    #[test]
+    fn extract_spec_bytes_from_string() {
+        let p = json!({"spec": "openapi: 3.0.0\n"});
+        assert_eq!(extract_spec_bytes(&p).unwrap(), b"openapi: 3.0.0\n".to_vec());
+    }
+
+    #[test]
+    fn extract_spec_bytes_returns_none_when_missing_or_blank() {
+        assert!(extract_spec_bytes(&json!({})).is_none());
+        assert!(extract_spec_bytes(&json!({"spec": ""})).is_none());
+        assert!(extract_spec_bytes(&json!({"spec": "   "})).is_none());
+        assert!(extract_spec_bytes(&json!({"spec": 42})).is_none());
+    }
+
+    #[test]
+    fn extract_spec_format_maps_known_strings() {
+        assert!(matches!(extract_spec_format(&json!({"spec_format": "json"})), SpecFormat::Json));
+        assert!(matches!(extract_spec_format(&json!({"spec_format": "yaml"})), SpecFormat::Yaml));
+        assert!(matches!(extract_spec_format(&json!({"spec_format": "yml"})), SpecFormat::Yaml));
+        assert!(matches!(extract_spec_format(&json!({})), SpecFormat::Auto));
+        assert!(matches!(extract_spec_format(&json!({"spec_format": "junk"})), SpecFormat::Auto));
+    }
+
+    #[test]
+    fn extract_target_url_trims_and_skips_blank() {
+        assert_eq!(
+            extract_target_url(&json!({"target_url": "  https://x.com  "})),
+            Some("https://x.com".to_string())
+        );
+        assert!(extract_target_url(&json!({"target_url": ""})).is_none());
+        assert!(extract_target_url(&json!({"target_url": "   "})).is_none());
+        assert!(extract_target_url(&json!({})).is_none());
+    }
+
+    #[test]
+    fn extract_string_vec_picks_strings() {
+        let p = json!({"owasp_admin_paths": ["/admin", "  /root  ", "", 42]});
+        assert_eq!(extract_string_vec(&p, "owasp_admin_paths"), vec!["/admin", "/root"]);
+    }
+
+    #[test]
+    fn extract_string_vec_empty_for_missing() {
+        let v: Vec<String> = extract_string_vec(&json!({}), "anything");
+        assert!(v.is_empty());
     }
 }

--- a/crates/mockforge-test-runner/src/executors/test.rs
+++ b/crates/mockforge-test-runner/src/executors/test.rs
@@ -30,7 +30,8 @@ use async_trait::async_trait;
 use std::time::Instant;
 
 use mockforge_bench::cloud_api::{
-    self, CloudBenchInputs, CloudConformanceInputs, CloudOwaspInputs, CloudRunArtifacts, SpecFormat,
+    self, CloudBenchInputs, CloudConformanceInputs, CloudCrudFlowInputs, CloudOwaspInputs,
+    CloudRunArtifacts, CloudSecurityInputs, CloudWafBenchInputs, SpecFormat,
 };
 
 use crate::callbacks::RegistryCallbacks;
@@ -95,6 +96,21 @@ impl Executor for TestExecutor {
                 "owasp" => {
                     if let Some(spec) = extract_spec_bytes(&job.payload) {
                         return run_cloud_owasp(job, callbacks, started, spec).await;
+                    }
+                }
+                "security" => {
+                    if let Some(spec) = extract_spec_bytes(&job.payload) {
+                        return run_cloud_security(job, callbacks, started, spec).await;
+                    }
+                }
+                "wafbench" => {
+                    if let Some(spec) = extract_spec_bytes(&job.payload) {
+                        return run_cloud_wafbench(job, callbacks, started, spec).await;
+                    }
+                }
+                "crud_flow" => {
+                    if let Some(spec) = extract_spec_bytes(&job.payload) {
+                        return run_cloud_crud_flow(job, callbacks, started, spec).await;
                     }
                 }
                 _ => {}
@@ -590,6 +606,211 @@ async fn run_cloud_conformance(
         Err(e) => {
             finish_cloud_error(job.run_id, callbacks, started, "conformance", &target_url, 2, e)
                 .await
+        }
+    }
+}
+
+/// Drive a payload-injection security run via `cloud_api::run_security`.
+async fn run_cloud_security(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    spec_bytes: Vec<u8>,
+) -> Result<JobOutcome> {
+    let Some(target_url) = extract_target_url(&job.payload) else {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "security",
+            "",
+            1,
+            mockforge_bench::error::BenchError::Other(
+                "use_cloud_api=true security job missing target_url".to_string(),
+            ),
+        )
+        .await;
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!("Cloud security scan against {target_url}"),
+                "executor_phase": "cloud_api",
+            }),
+        )
+        .await?;
+
+    let inputs = CloudSecurityInputs {
+        spec_bytes,
+        spec_format: extract_spec_format(&job.payload),
+        target_url: target_url.clone(),
+        base_path: extract_string(&job.payload, "base_path"),
+        duration: extract_string(&job.payload, "duration").unwrap_or_else(|| "30s".to_string()),
+        vus: job.payload.get("vus").and_then(|v| v.as_u64()).unwrap_or(10).clamp(1, 1000) as u32,
+        scenario: extract_string(&job.payload, "scenario")
+            .unwrap_or_else(|| "constant".to_string()),
+        categories: extract_string(&job.payload, "security_categories"),
+        target_fields: extract_string(&job.payload, "security_target_fields"),
+        auth: extract_string(&job.payload, "auth"),
+        headers: extract_string(&job.payload, "headers"),
+        skip_tls_verify: job
+            .payload
+            .get("skip_tls_verify")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    };
+
+    match cloud_api::run_security(inputs).await {
+        Ok(artifacts) => {
+            finish_cloud_run(job.run_id, callbacks, started, "security", &target_url, artifacts, 2)
+                .await
+        }
+        Err(e) => {
+            finish_cloud_error(job.run_id, callbacks, started, "security", &target_url, 2, e).await
+        }
+    }
+}
+
+/// Drive a WAFBench coverage run via `cloud_api::run_wafbench`.
+///
+/// `payload.wafbench_rules_dir` must point to a path or glob accessible
+/// to the runner. In production this is the bundled CRS install at
+/// `/usr/share/mockforge/wafbench/` (see the runner Dockerfile).
+async fn run_cloud_wafbench(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    spec_bytes: Vec<u8>,
+) -> Result<JobOutcome> {
+    let Some(target_url) = extract_target_url(&job.payload) else {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "wafbench",
+            "",
+            1,
+            mockforge_bench::error::BenchError::Other(
+                "use_cloud_api=true wafbench job missing target_url".to_string(),
+            ),
+        )
+        .await;
+    };
+
+    let rules_dir = extract_string(&job.payload, "wafbench_rules_dir")
+        .unwrap_or_else(|| "/usr/share/mockforge/wafbench/*.yaml".to_string());
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!("Cloud WAFBench against {target_url} using {rules_dir}"),
+                "executor_phase": "cloud_api",
+            }),
+        )
+        .await?;
+
+    let inputs = CloudWafBenchInputs {
+        spec_bytes,
+        spec_format: extract_spec_format(&job.payload),
+        target_url: target_url.clone(),
+        base_path: extract_string(&job.payload, "base_path"),
+        duration: extract_string(&job.payload, "duration").unwrap_or_else(|| "30s".to_string()),
+        vus: job.payload.get("vus").and_then(|v| v.as_u64()).unwrap_or(10).clamp(1, 1000) as u32,
+        scenario: extract_string(&job.payload, "scenario")
+            .unwrap_or_else(|| "constant".to_string()),
+        rules_dir,
+        cycle_all: job.payload.get("wafbench_cycle_all").and_then(|v| v.as_bool()).unwrap_or(false),
+        auth: extract_string(&job.payload, "auth"),
+        headers: extract_string(&job.payload, "headers"),
+        skip_tls_verify: job
+            .payload
+            .get("skip_tls_verify")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    };
+
+    match cloud_api::run_wafbench(inputs).await {
+        Ok(artifacts) => {
+            finish_cloud_run(job.run_id, callbacks, started, "wafbench", &target_url, artifacts, 2)
+                .await
+        }
+        Err(e) => {
+            finish_cloud_error(job.run_id, callbacks, started, "wafbench", &target_url, 2, e).await
+        }
+    }
+}
+
+/// Drive a CRUD-flow chain run via `cloud_api::run_crud_flow`.
+async fn run_cloud_crud_flow(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    spec_bytes: Vec<u8>,
+) -> Result<JobOutcome> {
+    let Some(target_url) = extract_target_url(&job.payload) else {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "crud_flow",
+            "",
+            1,
+            mockforge_bench::error::BenchError::Other(
+                "use_cloud_api=true crud_flow job missing target_url".to_string(),
+            ),
+        )
+        .await;
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!("Cloud CRUD flow against {target_url}"),
+                "executor_phase": "cloud_api",
+            }),
+        )
+        .await?;
+
+    let inputs = CloudCrudFlowInputs {
+        spec_bytes,
+        spec_format: extract_spec_format(&job.payload),
+        target_url: target_url.clone(),
+        base_path: extract_string(&job.payload, "base_path"),
+        duration: extract_string(&job.payload, "duration").unwrap_or_else(|| "30s".to_string()),
+        vus: job.payload.get("vus").and_then(|v| v.as_u64()).unwrap_or(10).clamp(1, 1000) as u32,
+        scenario: extract_string(&job.payload, "scenario")
+            .unwrap_or_else(|| "constant".to_string()),
+        flow_config_yaml: extract_string(&job.payload, "flow_config_yaml"),
+        extract_fields: extract_string(&job.payload, "extract_fields"),
+        auth: extract_string(&job.payload, "auth"),
+        headers: extract_string(&job.payload, "headers"),
+        skip_tls_verify: job
+            .payload
+            .get("skip_tls_verify")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    };
+
+    match cloud_api::run_crud_flow(inputs).await {
+        Ok(artifacts) => {
+            finish_cloud_run(job.run_id, callbacks, started, "crud_flow", &target_url, artifacts, 2)
+                .await
+        }
+        Err(e) => {
+            finish_cloud_error(job.run_id, callbacks, started, "crud_flow", &target_url, 2, e).await
         }
     }
 }

--- a/fly.runner.toml
+++ b/fly.runner.toml
@@ -1,0 +1,39 @@
+# Fly.io configuration for the MockForge cloud test-runner worker.
+# Deploy: flyctl deploy --config fly.runner.toml
+
+app = "mockforge-runner"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile.runner"
+
+[env]
+  RUST_LOG = "mockforge_test_runner=info,mockforge_bench=info"
+  # Production runs strict SSRF enforcement. Setting this to "1"
+  # ONLY in non-production deployments — never on prod-runner.
+  MOCKFORGE_SSRF_ALLOW_LOOPBACK = "0"
+
+# Secrets to set via `flyctl secrets set`:
+#   REDIS_URL                          - Same Redis instance the registry pushes jobs to
+#   MOCKFORGE_RUNNER_QUEUE_KEY         - Optional override; defaults to "test_runs:queued"
+#   MOCKFORGE_RUNNER_REGISTRY_URL      - Internal registry callback URL
+#   MOCKFORGE_RUNNER_CALLBACK_TOKEN    - Bearer token the registry validates on
+#                                        /api/v1/internal/test-runs/{id}/* callbacks
+#   MOCKFORGE_RUNNER_MAX_CONCURRENT_JOBS - Worker concurrency (default 4)
+
+# No public HTTP service — the runner only consumes from Redis and
+# pushes status via outbound HTTPS to the registry.
+[experimental]
+  auto_rollback = true
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 2
+  memory_mb = 2048
+
+# k6 runs can be CPU-spikey but mostly idle between jobs. Auto-stop
+# is fine — Fly will wake on the next dequeue cycle.
+[machine]
+  auto_start = true
+  auto_stop = true
+  min_machines_running = 0


### PR DESCRIPTION
## Summary

Combined cloud-runs landing PR. Replaces the stacked sequence #362 / #364 / #367 / #368 / #369, all of which were "merged" in cascade between intermediate stack branches but whose downstream commits never reached main. This PR brings the same five commits to `main` in one squash.

Original PRs (closed):

- **#362** — `mockforge_bench::cloud_api` foundation: `run_bench`, `run_conformance`
- **#364** — `cloud_api`: `run_owasp`, `run_security`, `run_wafbench`, `run_crud_flow`
- **#367** — `mockforge-test-runner`: dispatch bench/owasp/conformance through `cloud_api` (replaces homebrew reqwest paths)
- **#368** — `mockforge-test-runner`: register `security`, `wafbench`, `crud_flow` run kinds
- **#369** — SSRF guard module + `Dockerfile.runner` with k6 + WAFBench CRS rules

## Net effect on main

| Crate | What changed |
|---|---|
| `mockforge-bench` | New `cloud_api` module (6 wrappers, spec-as-bytes inputs, in-memory artifacts). New `ssrf` module (`validate_target_url` with strict default policy, blocks loopback/link-local/RFC1918/CGNAT/benchmark/IPv6-ULA/IPv4-mapped). `K6Results` gains `Serialize`/`Deserialize`. |
| `mockforge-test-runner` | TestExecutor dispatches to `cloud_api::run_*` when payload sets `use_cloud_api: true`; existing reqwest paths kept as fall-throughs. Three new run kinds wired (`security`, `wafbench`, `crud_flow`). |
| Repo root | New `Dockerfile.runner` (k6 from grafana apt + bundled CRS rules at `/usr/share/mockforge/wafbench/`) and `fly.runner.toml` deploy manifest. |

No DB migration required — `test_runs.payload` is JSONB and the new fields are additive.

## What's NOT in this PR

- **PR5**: applying `validate_target_url` at the `trigger_run` handler in `mockforge-registry-server` (primary SSRF enforcement before enqueue, not just defense-in-depth at the worker).
- **Phase 4**: data-driven endpoint with file upload via Tigris.
- **Phase 5**: cloud recorder proxy.
- **Phase 6**: admin-UI cloud-runs tab.

## Test plan

- [x] `cargo build -p mockforge-bench` clean
- [x] `cargo build -p mockforge-test-runner` clean
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings` clean
- [x] `cargo clippy -p mockforge-test-runner --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-bench --lib` — **374 passed** (38 new tests across `cloud_api` + `ssrf`)
- [x] `cargo test -p mockforge-test-runner --lib` — **30 passed** (7 new dispatch tests, registry now covers all 20 documented kinds)
- [x] `cargo fmt --all --check` clean
