### PR TITLE
feat(cloud-runs): add data-driven kind backed by Tigris-hosted test vectors

### DIFF
--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -497,6 +497,84 @@ impl Default for CloudCrudFlowInputs {
     }
 }
 
+/// Format hint for data-driven test vectors.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DataFormat {
+    /// CSV (with or without header — see [`CloudDataDrivenInputs::csv_has_header`]).
+    Csv,
+    /// JSON array of objects.
+    Json,
+    /// Sniff from the first non-whitespace byte: `{`/`[` → JSON, otherwise CSV.
+    #[default]
+    Auto,
+}
+
+impl DataFormat {
+    fn extension(self, bytes: &[u8]) -> &'static str {
+        match self {
+            DataFormat::Csv => "csv",
+            DataFormat::Json => "json",
+            DataFormat::Auto => match bytes.iter().find(|b| !b.is_ascii_whitespace()) {
+                Some(b'{') | Some(b'[') => "json",
+                _ => "csv",
+            },
+        }
+    }
+}
+
+/// Inputs for [`run_data_driven`] — k6 load test driven by per-iteration
+/// test vectors loaded from a CSV or JSON file.
+///
+/// `data_bytes` is the file content. The cloud runner typically downloads
+/// this from Tigris (S3-compatible) before invoking the wrapper —
+/// `mockforge_bench::cloud_api` itself stays storage-agnostic.
+#[derive(Debug, Clone)]
+pub struct CloudDataDrivenInputs {
+    pub spec_bytes: Vec<u8>,
+    pub spec_format: SpecFormat,
+    pub data_bytes: Vec<u8>,
+    pub data_format: DataFormat,
+    pub target_url: String,
+    pub base_path: Option<String>,
+    pub duration: String,
+    pub vus: u32,
+    pub scenario: String,
+    /// `"unique-per-vu"` (default), `"unique-per-iteration"`, `"random"`,
+    /// or `"sequential"`.
+    pub distribution: String,
+    /// Comma-separated `column:target` mappings (e.g.
+    /// `"user_id:path.id,name:body.name"`).
+    pub mappings: Option<String>,
+    /// When true, each row provides method + uri + body itself instead of
+    /// being mapped onto an OpenAPI operation.
+    pub per_uri_control: bool,
+    pub auth: Option<String>,
+    pub headers: Option<String>,
+    pub skip_tls_verify: bool,
+}
+
+impl Default for CloudDataDrivenInputs {
+    fn default() -> Self {
+        Self {
+            spec_bytes: Vec::new(),
+            spec_format: SpecFormat::Auto,
+            data_bytes: Vec::new(),
+            data_format: DataFormat::Auto,
+            target_url: String::new(),
+            base_path: None,
+            duration: "30s".to_string(),
+            vus: 10,
+            scenario: "constant".to_string(),
+            distribution: "unique-per-vu".to_string(),
+            mappings: None,
+            per_uri_control: false,
+            auth: None,
+            headers: None,
+            skip_tls_verify: false,
+        }
+    }
+}
+
 /// Run an OWASP API Security Top 10 test.
 ///
 /// Requires k6 on `$PATH`.
@@ -686,6 +764,63 @@ pub async fn run_crud_flow(inputs: CloudCrudFlowInputs) -> Result<CloudRunArtifa
         crud_flow: true,
         flow_config: flow_config_path,
         extract_fields: inputs.extract_fields,
+        ..default_bench_command(&output_dir)
+    };
+
+    cmd.execute().await?;
+    read_artifacts(&output_dir)
+}
+
+/// Run a k6 load test driven by per-iteration test vectors loaded from
+/// CSV or JSON.
+///
+/// Requires k6 on `$PATH`. The cloud runner is responsible for fetching
+/// `data_bytes` from object storage (typically Tigris) before calling
+/// this — `cloud_api` itself stays storage-agnostic.
+pub async fn run_data_driven(inputs: CloudDataDrivenInputs) -> Result<CloudRunArtifacts> {
+    if inputs.target_url.trim().is_empty() {
+        return Err(BenchError::Other("target_url is required".to_string()));
+    }
+    if inputs.spec_bytes.is_empty() {
+        return Err(BenchError::Other("spec_bytes is required for data-driven runs".to_string()));
+    }
+    if inputs.data_bytes.is_empty() {
+        return Err(BenchError::Other("data_bytes is required for data-driven runs".to_string()));
+    }
+    if !K6Executor::is_k6_installed() {
+        return Err(BenchError::K6NotFound);
+    }
+    enforce_ssrf(&inputs.target_url).await?;
+
+    let workdir = TempDir::new()
+        .map_err(|e| BenchError::Other(format!("Failed to create tempdir: {}", e)))?;
+    let spec_path = write_spec(workdir.path(), &inputs.spec_bytes, inputs.spec_format)?;
+    let output_dir = workdir.path().join("output");
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| BenchError::Other(format!("Failed to create output dir: {}", e)))?;
+
+    // Write data to a tempdir file with the right extension — the
+    // BenchCommand's data_file path drives the loader's CSV-vs-JSON
+    // detection, so the extension matters.
+    let data_filename = format!("data.{}", inputs.data_format.extension(&inputs.data_bytes));
+    let data_path = workdir.path().join(data_filename);
+    std::fs::write(&data_path, &inputs.data_bytes)
+        .map_err(|e| BenchError::Other(format!("Failed to write data file: {}", e)))?;
+
+    let cmd = BenchCommand {
+        spec: vec![spec_path],
+        target: inputs.target_url,
+        base_path: inputs.base_path,
+        duration: inputs.duration,
+        vus: inputs.vus,
+        scenario: inputs.scenario,
+        auth: inputs.auth,
+        headers: inputs.headers,
+        skip_tls_verify: inputs.skip_tls_verify,
+        data_file: Some(data_path),
+        data_distribution: inputs.distribution,
+        data_mappings: inputs.mappings,
+        per_uri_control: inputs.per_uri_control,
         ..default_bench_command(&output_dir)
     };
 
@@ -980,5 +1115,49 @@ mod tests {
     async fn run_crud_flow_rejects_missing_inputs() {
         let err = run_crud_flow(CloudCrudFlowInputs::default()).await.unwrap_err();
         assert!(matches!(err, BenchError::Other(_)));
+    }
+
+    #[test]
+    fn data_format_extension_for_known_inputs() {
+        assert_eq!(DataFormat::Auto.extension(b"  [{\"a\":1}]"), "json");
+        assert_eq!(DataFormat::Auto.extension(b"col1,col2\nv1,v2\n"), "csv");
+        assert_eq!(DataFormat::Csv.extension(b"[]"), "csv");
+        assert_eq!(DataFormat::Json.extension(b"col1,col2"), "json");
+    }
+
+    #[tokio::test]
+    async fn run_data_driven_rejects_missing_inputs() {
+        let no_target = run_data_driven(CloudDataDrivenInputs {
+            spec_bytes: br#"{"openapi":"3.0.0"}"#.to_vec(),
+            data_bytes: b"a,b\n1,2\n".to_vec(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+        assert!(matches!(no_target, BenchError::Other(_)));
+
+        let no_spec = run_data_driven(CloudDataDrivenInputs {
+            target_url: "https://x.com".to_string(),
+            data_bytes: b"a,b\n1,2\n".to_vec(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&no_spec, BenchError::Other(msg) if msg.contains("spec_bytes")),
+            "got: {no_spec}",
+        );
+
+        let no_data = run_data_driven(CloudDataDrivenInputs {
+            target_url: "https://x.com".to_string(),
+            spec_bytes: br#"{"openapi":"3.0.0"}"#.to_vec(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&no_data, BenchError::Other(msg) if msg.contains("data_bytes")),
+            "got: {no_data}",
+        );
     }
 }

--- a/crates/mockforge-bench/src/lib.rs
+++ b/crates/mockforge-bench/src/lib.rs
@@ -30,9 +30,10 @@ pub mod target_parser;
 pub mod wafbench;
 
 pub use cloud_api::{
-    run_bench, run_conformance, run_crud_flow, run_owasp, run_security, run_wafbench,
-    CloudBenchInputs, CloudConformanceInputs, CloudCrudFlowInputs, CloudOwaspInputs,
-    CloudRunArtifacts, CloudSecurityInputs, CloudWafBenchInputs, SpecFormat,
+    run_bench, run_conformance, run_crud_flow, run_data_driven, run_owasp, run_security,
+    run_wafbench, CloudBenchInputs, CloudConformanceInputs, CloudCrudFlowInputs,
+    CloudDataDrivenInputs, CloudOwaspInputs, CloudRunArtifacts, CloudSecurityInputs,
+    CloudWafBenchInputs, DataFormat, SpecFormat,
 };
 pub use command::BenchCommand;
 pub use crud_flow::{CrudFlow, CrudFlowConfig, CrudFlowDetector, FlowStep};

--- a/crates/mockforge-test-runner/src/executors/mod.rs
+++ b/crates/mockforge-test-runner/src/executors/mod.rs
@@ -112,8 +112,8 @@ impl Default for ExecutorRegistry {
 
         // Test execution suite (#4) — kinds that share the TestExecutor
         // impl. The cloud_api path (run_cloud_*) handles bench/owasp/
-        // conformance/security/wafbench/crud_flow when payloads opt in;
-        // unit/integration fall through to synthetic mode.
+        // conformance/security/wafbench/crud_flow/data_driven when
+        // payloads opt in; unit/integration fall through to synthetic mode.
         for k in [
             "unit",
             "integration",
@@ -123,6 +123,7 @@ impl Default for ExecutorRegistry {
             "security",
             "wafbench",
             "crud_flow",
+            "data_driven",
         ] {
             by_kind.insert(k, Box::new(test::TestExecutor::for_kind(k)));
         }
@@ -200,6 +201,7 @@ mod tests {
             "security",
             "wafbench",
             "crud_flow",
+            "data_driven",
             "chaos_campaign",
             "behavioral_clone",
             "snapshot_capture",

--- a/crates/mockforge-test-runner/src/executors/test.rs
+++ b/crates/mockforge-test-runner/src/executors/test.rs
@@ -30,8 +30,9 @@ use async_trait::async_trait;
 use std::time::Instant;
 
 use mockforge_bench::cloud_api::{
-    self, CloudBenchInputs, CloudConformanceInputs, CloudCrudFlowInputs, CloudOwaspInputs,
-    CloudRunArtifacts, CloudSecurityInputs, CloudWafBenchInputs, SpecFormat,
+    self, CloudBenchInputs, CloudConformanceInputs, CloudCrudFlowInputs, CloudDataDrivenInputs,
+    CloudOwaspInputs, CloudRunArtifacts, CloudSecurityInputs, CloudWafBenchInputs, DataFormat,
+    SpecFormat,
 };
 
 use crate::callbacks::RegistryCallbacks;
@@ -111,6 +112,11 @@ impl Executor for TestExecutor {
                 "crud_flow" => {
                     if let Some(spec) = extract_spec_bytes(&job.payload) {
                         return run_cloud_crud_flow(job, callbacks, started, spec).await;
+                    }
+                }
+                "data_driven" => {
+                    if let Some(spec) = extract_spec_bytes(&job.payload) {
+                        return run_cloud_data_driven(job, callbacks, started, spec).await;
                     }
                 }
                 _ => {}
@@ -811,6 +817,183 @@ async fn run_cloud_crud_flow(
         }
         Err(e) => {
             finish_cloud_error(job.run_id, callbacks, started, "crud_flow", &target_url, 2, e).await
+        }
+    }
+}
+
+/// Maximum size of a data-driven payload the runner will pull from
+/// object storage. 64 MB is generous for CSV/JSON test vectors and
+/// well below the runner's memory budget; bigger files should be
+/// split or pre-processed.
+const DATA_DRIVEN_MAX_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Fetch a CSV/JSON test-data file via HTTP. Used by the data-driven
+/// kind to pull the test-vector payload from Tigris (or any other
+/// presigned-URL-capable storage) before invoking
+/// [`cloud_api::run_data_driven`].
+async fn fetch_data_bytes(
+    url: &str,
+) -> std::result::Result<Vec<u8>, mockforge_bench::error::BenchError> {
+    use mockforge_bench::error::BenchError;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .user_agent("mockforge-test-runner/1.0")
+        .build()
+        .map_err(|e| BenchError::Other(format!("Failed to build HTTP client: {}", e)))?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| BenchError::Other(format!("Failed to GET data_url: {}", e)))?;
+    if !response.status().is_success() {
+        return Err(BenchError::Other(format!("data_url returned HTTP {}", response.status())));
+    }
+    if let Some(len) = response.content_length() {
+        if len > DATA_DRIVEN_MAX_BYTES {
+            return Err(BenchError::Other(format!(
+                "data_url too large ({} bytes; max {})",
+                len, DATA_DRIVEN_MAX_BYTES
+            )));
+        }
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| BenchError::Other(format!("Failed to read data_url body: {}", e)))?;
+    if bytes.len() as u64 > DATA_DRIVEN_MAX_BYTES {
+        return Err(BenchError::Other(format!(
+            "data_url body too large ({} bytes; max {})",
+            bytes.len(),
+            DATA_DRIVEN_MAX_BYTES
+        )));
+    }
+    Ok(bytes.to_vec())
+}
+
+fn extract_data_format(payload: &serde_json::Value) -> DataFormat {
+    match payload.get("data_format").and_then(|v| v.as_str()).unwrap_or("auto") {
+        "csv" => DataFormat::Csv,
+        "json" => DataFormat::Json,
+        _ => DataFormat::Auto,
+    }
+}
+
+/// Drive a data-driven k6 run via `cloud_api::run_data_driven`.
+///
+/// Reads `data_url` from the payload (typically a Tigris presigned GET
+/// URL), fetches the CSV/JSON body, and dispatches. Inline-bytes mode
+/// is intentionally not supported here — large test-vector files belong
+/// in object storage, not Postgres JSONB.
+async fn run_cloud_data_driven(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    spec_bytes: Vec<u8>,
+) -> Result<JobOutcome> {
+    let Some(target_url) = extract_target_url(&job.payload) else {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "data_driven",
+            "",
+            1,
+            mockforge_bench::error::BenchError::Other(
+                "use_cloud_api=true data_driven job missing target_url".to_string(),
+            ),
+        )
+        .await;
+    };
+
+    let Some(data_url) = extract_string(&job.payload, "data_url") else {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "data_driven",
+            &target_url,
+            1,
+            mockforge_bench::error::BenchError::Other(
+                "data_driven job missing data_url (Tigris presigned GET)".to_string(),
+            ),
+        )
+        .await;
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!("Cloud data-driven against {target_url} (fetching test vectors from {data_url})"),
+                "executor_phase": "cloud_api",
+            }),
+        )
+        .await?;
+
+    let data_bytes = match fetch_data_bytes(&data_url).await {
+        Ok(b) => b,
+        Err(e) => {
+            return finish_cloud_error(
+                job.run_id,
+                callbacks,
+                started,
+                "data_driven",
+                &target_url,
+                2,
+                e,
+            )
+            .await;
+        }
+    };
+
+    let inputs = CloudDataDrivenInputs {
+        spec_bytes,
+        spec_format: extract_spec_format(&job.payload),
+        data_bytes,
+        data_format: extract_data_format(&job.payload),
+        target_url: target_url.clone(),
+        base_path: extract_string(&job.payload, "base_path"),
+        duration: extract_string(&job.payload, "duration").unwrap_or_else(|| "30s".to_string()),
+        vus: job.payload.get("vus").and_then(|v| v.as_u64()).unwrap_or(10).clamp(1, 1000) as u32,
+        scenario: extract_string(&job.payload, "scenario")
+            .unwrap_or_else(|| "constant".to_string()),
+        distribution: extract_string(&job.payload, "data_distribution")
+            .unwrap_or_else(|| "unique-per-vu".to_string()),
+        mappings: extract_string(&job.payload, "data_mappings"),
+        per_uri_control: job
+            .payload
+            .get("per_uri_control")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        auth: extract_string(&job.payload, "auth"),
+        headers: extract_string(&job.payload, "headers"),
+        skip_tls_verify: job
+            .payload
+            .get("skip_tls_verify")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    };
+
+    match cloud_api::run_data_driven(inputs).await {
+        Ok(artifacts) => {
+            finish_cloud_run(
+                job.run_id,
+                callbacks,
+                started,
+                "data_driven",
+                &target_url,
+                artifacts,
+                3,
+            )
+            .await
+        }
+        Err(e) => {
+            finish_cloud_error(job.run_id, callbacks, started, "data_driven", &target_url, 3, e)
+                .await
         }
     }
 }


### PR DESCRIPTION
## Summary

Stacks on #371. Closes Phase 4 of the cloud-runs roadmap with the seventh and final cloud_api wrapper:

- **`mockforge_bench::cloud_api::run_data_driven`** — k6 load test driven by per-iteration test vectors loaded from CSV or JSON. Takes `data_bytes` directly so the library stays storage-agnostic.
- **`data_driven` kind registered in `mockforge-test-runner`** — the executor reads `data_url` from the payload (typically a Tigris presigned GET URL), fetches the file via reqwest with a **64 MB cap** and **60s timeout**, then dispatches to cloud_api.

Inline-bytes mode is intentionally not supported in the cloud path — large CSVs belong in object storage, not Postgres JSONB.

## Payload (additive, JSONB)

```jsonc
{
  "use_cloud_api": true,
  "kind": "data_driven",
  "target_url": "https://api.example.com",
  "spec": "openapi: 3.0.0\n...",
  "data_url": "https://fly.storage.tigris.dev/...?X-Amz-Signature=...",
  "data_format": "csv",
  "data_distribution": "unique-per-vu",
  "data_mappings": "user_id:path.id,name:body.name",
  "duration": "1m",
  "vus": 50
}
```

## Coverage now

`ExecutorRegistry` covers **all 21 documented kinds** (was 20). SSRF guard auto-applies to `target_url` via the existing cloud_api plumbing — `data_url` is a server-controlled presigned URL so no additional check needed.

## Test plan

- [x] `cargo build -p mockforge-bench && -p mockforge-test-runner` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean for both
- [x] `cargo test -p mockforge-bench --lib cloud_api` — **15 passed** (2 new for data-driven)
- [x] `cargo test -p mockforge-test-runner --lib` — **30 passed** (registry now covers 21 kinds)
- [x] `cargo fmt --all --check` clean

## Skipped from this PR (queued follow-up)

A registry-server endpoint that returns a presigned PUT URL so the UI can upload directly to Tigris without users juggling the AWS CLI. The cloud_api + executor pieces work today against any HTTP-fetchable URL — the upload-URL endpoint is strictly DX, not core capability. Will land alongside the cloud-runs UI tab.

## Stacking note

Base branch is `feat/cloud-runs-trigger-ssrf` (#371). Re-target to main once #371 lands.
