### PR TITLE
feat(cloud-runs): add cloud recorder proxy (Phase 5)

### DIFF
--- a/crates/mockforge-registry-core/src/models/cloud_proxy.rs
+++ b/crates/mockforge-registry-core/src/models/cloud_proxy.rs
@@ -1,0 +1,328 @@
+//! Cloud recorder proxy — Phase 5 of the cloud-runs roadmap.
+//!
+//! A `CloudProxySession` is a live forwarding endpoint pinned to one
+//! upstream URL. The `session_token` (a long random string) goes in
+//! the proxy URL — it's the only auth incoming traffic carries, so the
+//! token must be treated as a secret.
+//!
+//! Each request the proxy forwards lands in `cloud_proxy_captures` for
+//! later inspection. Bodies are capped at 1 MB; larger bodies are
+//! truncated and flagged.
+//!
+//! See `docs/cloud/CLOUD_RECORDER_BEHAVIORAL_CLONING_DESIGN.md` for the
+//! upstream design context (this module adds a third capture source
+//! alongside the existing 'hosted' and 'local' sources in
+//! `runtime_captures`).
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[cfg(feature = "postgres")]
+use sqlx::{FromRow, PgPool};
+
+#[cfg_attr(feature = "postgres", derive(FromRow))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudProxySession {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    #[serde(default)]
+    pub workspace_id: Option<Uuid>,
+    /// Opaque secret embedded in the proxy URL. Treat as sensitive.
+    pub session_token: String,
+    pub upstream_url: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub created_by: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    #[serde(default)]
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub capture_count: i64,
+    pub total_bytes: i64,
+}
+
+#[cfg_attr(feature = "postgres", derive(FromRow))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudProxyCapture {
+    pub id: i64,
+    pub session_id: Uuid,
+    pub org_id: Uuid,
+    pub occurred_at: DateTime<Utc>,
+    pub method: String,
+    pub path: String,
+    #[serde(default)]
+    pub query_string: Option<String>,
+    pub request_headers: String,
+    #[serde(default)]
+    pub request_body: Option<String>,
+    pub request_body_encoding: String,
+    pub request_body_truncated: bool,
+    pub request_size_bytes: i64,
+    #[serde(default)]
+    pub response_status: Option<i32>,
+    #[serde(default)]
+    pub response_headers: Option<String>,
+    #[serde(default)]
+    pub response_body: Option<String>,
+    #[serde(default)]
+    pub response_body_encoding: Option<String>,
+    pub response_body_truncated: bool,
+    #[serde(default)]
+    pub response_size_bytes: Option<i64>,
+    pub duration_ms: i64,
+    #[serde(default)]
+    pub upstream_error: Option<String>,
+    #[serde(default)]
+    pub client_ip: Option<String>,
+}
+
+/// Maximum request/response body bytes the proxy will persist. Beyond
+/// this, the body is truncated and `*_truncated` is set true. Keeping
+/// this conservative — Postgres TEXT can hold more, but we don't want
+/// proxy traffic to balloon the table to GBs.
+pub const PROXY_BODY_MAX_BYTES: usize = 1024 * 1024;
+
+/// Default session lifetime when the caller doesn't override it.
+pub const DEFAULT_SESSION_TTL_HOURS: i64 = 24;
+
+/// Hard upper bound on session lifetime — keeps stale tokens from
+/// hanging around indefinitely.
+pub const MAX_SESSION_TTL_HOURS: i64 = 24 * 7;
+
+/// Generate a cryptographically random session token. 32 bytes of
+/// entropy, encoded URL-safe — fits in a path segment.
+pub fn generate_session_token() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    // Hex is 64 chars — safe for URL paths and easy to copy/paste.
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[cfg(feature = "postgres")]
+pub struct CreateCloudProxySession<'a> {
+    pub org_id: Uuid,
+    pub workspace_id: Option<Uuid>,
+    pub upstream_url: &'a str,
+    pub name: Option<&'a str>,
+    pub created_by: Option<Uuid>,
+    pub ttl_hours: i64,
+}
+
+#[cfg(feature = "postgres")]
+impl CloudProxySession {
+    pub async fn create(pool: &PgPool, input: CreateCloudProxySession<'_>) -> sqlx::Result<Self> {
+        let token = generate_session_token();
+        let ttl = input.ttl_hours.clamp(1, MAX_SESSION_TTL_HOURS);
+        let expires_at = Utc::now() + Duration::hours(ttl);
+
+        sqlx::query_as::<_, Self>(
+            r#"
+            INSERT INTO cloud_proxy_sessions
+                (org_id, workspace_id, session_token, upstream_url, name, created_by, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING *
+            "#,
+        )
+        .bind(input.org_id)
+        .bind(input.workspace_id)
+        .bind(&token)
+        .bind(input.upstream_url)
+        .bind(input.name)
+        .bind(input.created_by)
+        .bind(expires_at)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>("SELECT * FROM cloud_proxy_sessions WHERE id = $1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+    }
+
+    /// Look up by the public-facing token. Filters out revoked rows so
+    /// the proxy handler can treat `None` as "the token is no longer
+    /// valid" — expired sessions still return Some so the handler can
+    /// emit a clear 410 Gone with the expiry timestamp.
+    pub async fn find_by_token(pool: &PgPool, token: &str) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>(
+            "SELECT * FROM cloud_proxy_sessions WHERE session_token = $1 AND revoked_at IS NULL",
+        )
+        .bind(token)
+        .fetch_optional(pool)
+        .await
+    }
+
+    /// List active (non-revoked) sessions for an org, newest first.
+    pub async fn list_for_org(pool: &PgPool, org_id: Uuid, limit: i64) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT * FROM cloud_proxy_sessions
+            WHERE org_id = $1 AND revoked_at IS NULL
+            ORDER BY created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(limit)
+        .fetch_all(pool)
+        .await
+    }
+
+    /// Mark a session revoked. The row is preserved so capture history
+    /// stays queryable; future proxy traffic with this token returns
+    /// 410 Gone.
+    pub async fn revoke(pool: &PgPool, id: Uuid, org_id: Uuid) -> sqlx::Result<bool> {
+        let res = sqlx::query(
+            r#"
+            UPDATE cloud_proxy_sessions
+               SET revoked_at = NOW()
+             WHERE id = $1 AND org_id = $2 AND revoked_at IS NULL
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    /// Bump cached counters after a capture is persisted. Called from
+    /// the proxy handler — invariant maintained: rows in
+    /// cloud_proxy_captures with this session_id sum to capture_count
+    /// and total_bytes. Best-effort; a missed update doesn't break the
+    /// proxy itself.
+    pub async fn record_capture(pool: &PgPool, id: Uuid, bytes: i64) -> sqlx::Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE cloud_proxy_sessions
+               SET capture_count = capture_count + 1,
+                   total_bytes  = total_bytes + $2
+             WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .bind(bytes)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.revoked_at.is_none() && self.expires_at > Utc::now()
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub struct InsertCloudProxyCapture<'a> {
+    pub session_id: Uuid,
+    pub org_id: Uuid,
+    pub method: &'a str,
+    pub path: &'a str,
+    pub query_string: Option<&'a str>,
+    pub request_headers: &'a str,
+    pub request_body: Option<&'a str>,
+    pub request_body_encoding: &'a str,
+    pub request_body_truncated: bool,
+    pub request_size_bytes: i64,
+    pub response_status: Option<i32>,
+    pub response_headers: Option<&'a str>,
+    pub response_body: Option<&'a str>,
+    pub response_body_encoding: Option<&'a str>,
+    pub response_body_truncated: bool,
+    pub response_size_bytes: Option<i64>,
+    pub duration_ms: i64,
+    pub upstream_error: Option<&'a str>,
+    pub client_ip: Option<&'a str>,
+}
+
+#[cfg(feature = "postgres")]
+impl CloudProxyCapture {
+    pub async fn insert(pool: &PgPool, input: InsertCloudProxyCapture<'_>) -> sqlx::Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            r#"
+            INSERT INTO cloud_proxy_captures (
+                session_id, org_id, method, path, query_string,
+                request_headers, request_body, request_body_encoding,
+                request_body_truncated, request_size_bytes,
+                response_status, response_headers, response_body,
+                response_body_encoding, response_body_truncated, response_size_bytes,
+                duration_ms, upstream_error, client_ip
+            )
+            VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                $11, $12, $13, $14, $15, $16, $17, $18, $19
+            )
+            RETURNING id
+            "#,
+        )
+        .bind(input.session_id)
+        .bind(input.org_id)
+        .bind(input.method)
+        .bind(input.path)
+        .bind(input.query_string)
+        .bind(input.request_headers)
+        .bind(input.request_body)
+        .bind(input.request_body_encoding)
+        .bind(input.request_body_truncated)
+        .bind(input.request_size_bytes)
+        .bind(input.response_status)
+        .bind(input.response_headers)
+        .bind(input.response_body)
+        .bind(input.response_body_encoding)
+        .bind(input.response_body_truncated)
+        .bind(input.response_size_bytes)
+        .bind(input.duration_ms)
+        .bind(input.upstream_error)
+        .bind(input.client_ip)
+        .fetch_one(pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    pub async fn list_for_session(
+        pool: &PgPool,
+        session_id: Uuid,
+        limit: i64,
+    ) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT * FROM cloud_proxy_captures
+            WHERE session_id = $1
+            ORDER BY occurred_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(session_id)
+        .bind(limit)
+        .fetch_all(pool)
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_token_is_deterministic_length() {
+        // 32 bytes hex-encoded = 64 chars.
+        for _ in 0..50 {
+            let t = generate_session_token();
+            assert_eq!(t.len(), 64);
+            assert!(t.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn generated_tokens_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..1000 {
+            assert!(seen.insert(generate_session_token()));
+        }
+    }
+}

--- a/crates/mockforge-registry-core/src/models/mod.rs
+++ b/crates/mockforge-registry-core/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod audit_log;
 pub mod capture;
 pub mod chaos;
 pub mod cloud_fixture;
+pub mod cloud_proxy;
 pub mod cloud_service;
 pub mod cloud_workspace;
 pub mod contract_verification;
@@ -63,6 +64,10 @@ pub use audit_log::record_audit_event;
 pub use audit_log::AuditEventType;
 pub use capture::{CaptureSession, CloneModel};
 pub use chaos::{ChaosCampaign, ChaosCampaignReport, ResiliencePattern};
+pub use cloud_proxy::{
+    generate_session_token, CloudProxyCapture, CloudProxySession, DEFAULT_SESSION_TTL_HOURS,
+    MAX_SESSION_TTL_HOURS, PROXY_BODY_MAX_BYTES,
+};
 pub use cloud_workspace::Workspace as CloudWorkspace;
 pub use contract_verification::{
     ContractDiffFinding, ContractDiffRun, FitnessFunction, MonitoredService, VerificationSuite,

--- a/crates/mockforge-registry-server/migrations/20250101000072_cloud_proxy_sessions.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000072_cloud_proxy_sessions.sql
@@ -1,0 +1,93 @@
+-- Cloud recorder proxy — Phase 5 of the cloud-runs roadmap.
+--
+-- Adds a public-facing recording proxy: users create a session pinned
+-- to an upstream URL, point their clients at
+-- `/api/v1/cloud-runs/recorder-proxy/sess/{session_token}/...`, and the
+-- registry-server forwards each request to the upstream while
+-- persisting the request/response pair for later inspection.
+--
+-- This is a third capture source alongside the existing 'hosted' and
+-- 'local' sources in `runtime_captures`. Rather than relax the
+-- `deployment_id NOT NULL` FK on that table, cloud-proxy captures get
+-- their own table — they don't share the hosted-mock lifecycle and
+-- have a different ownership model (session, not deployment).
+
+CREATE TABLE IF NOT EXISTS cloud_proxy_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    workspace_id UUID REFERENCES workspaces(id) ON DELETE CASCADE,
+
+    -- The opaque token that goes in the proxy URL. Long-random so the
+    -- session ID itself authenticates incoming traffic — we cannot ask
+    -- the user's clients to attach Mockforge JWTs.
+    session_token TEXT NOT NULL UNIQUE,
+
+    -- The upstream the proxy forwards to, e.g.
+    -- "https://api.example.com". Must be publicly reachable; SSRF guard
+    -- runs at create time.
+    upstream_url TEXT NOT NULL,
+
+    -- User-supplied label so the dashboard can list "staging API",
+    -- "prod readonly", etc.
+    name TEXT,
+
+    -- Lifecycle.
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    -- nulled on DELETE; lets us hide expired/destroyed sessions from
+    -- the active listing without losing capture history.
+    revoked_at TIMESTAMPTZ,
+
+    -- Cached counters refreshed on capture ingest. Gives the listing
+    -- "12,345 requests captured" without a JOIN+COUNT each time.
+    capture_count BIGINT NOT NULL DEFAULT 0,
+    total_bytes BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_proxy_sessions_org_active
+    ON cloud_proxy_sessions(org_id, created_at DESC)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_cloud_proxy_sessions_token
+    ON cloud_proxy_sessions(session_token)
+    WHERE revoked_at IS NULL;
+
+-- One row per request/response exchange the proxy handles.
+CREATE TABLE IF NOT EXISTS cloud_proxy_captures (
+    id BIGSERIAL PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES cloud_proxy_sessions(id) ON DELETE CASCADE,
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    method TEXT NOT NULL,
+    path TEXT NOT NULL,
+    query_string TEXT,
+    request_headers TEXT NOT NULL,    -- JSON-encoded HashMap
+    request_body TEXT,                -- truncated at 1 MB; encoding flagged
+    request_body_encoding TEXT NOT NULL DEFAULT 'utf8',
+    request_body_truncated BOOLEAN NOT NULL DEFAULT FALSE,
+    request_size_bytes BIGINT NOT NULL,
+
+    response_status INTEGER,
+    response_headers TEXT,
+    response_body TEXT,
+    response_body_encoding TEXT,
+    response_body_truncated BOOLEAN NOT NULL DEFAULT FALSE,
+    response_size_bytes BIGINT,
+
+    duration_ms BIGINT NOT NULL,
+    upstream_error TEXT,              -- non-null when forward failed (network, timeout, etc.)
+    client_ip TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_proxy_captures_session_time
+    ON cloud_proxy_captures(session_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_proxy_captures_org_time
+    ON cloud_proxy_captures(org_id, occurred_at DESC);
+
+-- "Show me the last N 5xxs through this proxy".
+CREATE INDEX IF NOT EXISTS idx_cloud_proxy_captures_session_status
+    ON cloud_proxy_captures(session_id, response_status, occurred_at DESC)
+    WHERE response_status >= 500;

--- a/crates/mockforge-registry-server/src/handlers/cloud_proxy.rs
+++ b/crates/mockforge-registry-server/src/handlers/cloud_proxy.rs
@@ -1,0 +1,661 @@
+//! Cloud recorder proxy handlers — Phase 5 of the cloud-runs roadmap.
+//!
+//! Two surfaces:
+//!
+//! 1. **Authenticated control plane** (`/api/v1/cloud-runs/recorder-proxy/sessions/...`)
+//!    — auth-gated CRUD over `cloud_proxy_sessions`. Lets users create
+//!    a forwarding session, list captures, and revoke when done.
+//!
+//! 2. **Public proxy plane** (`/api/v1/cloud-runs/recorder-proxy/sess/{token}/*path`)
+//!    — accepts ANY HTTP method, looks the token up in
+//!    `cloud_proxy_sessions`, forwards to the session's upstream, and
+//!    persists request+response into `cloud_proxy_captures`. The token
+//!    in the URL is the auth — there is no user JWT here, because the
+//!    point is to slot this URL into a client app whose code we don't
+//!    control.
+//!
+//! Bodies are capped at [`PROXY_BODY_MAX_BYTES`] in each direction;
+//! anything larger is truncated and flagged in the capture row.
+//! Streaming would let us proxy unbounded uploads/downloads but the
+//! data ingestion pipeline this lands in (Postgres TEXT) doesn't want
+//! gigabytes — keep it bounded for v1.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use axum::{
+    body::Bytes,
+    extract::{Path, Query, State},
+    http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use mockforge_bench::ssrf::{validate_target_url, Policy as SsrfPolicy};
+use mockforge_registry_core::models::cloud_proxy::{
+    CloudProxyCapture, CloudProxySession, CreateCloudProxySession, InsertCloudProxyCapture,
+    DEFAULT_SESSION_TTL_HOURS, MAX_SESSION_TTL_HOURS, PROXY_BODY_MAX_BYTES,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    AppState,
+};
+
+// --- control plane: session CRUD ------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct CreateSessionRequest {
+    pub upstream_url: String,
+    #[serde(default)]
+    pub workspace_id: Option<Uuid>,
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Session lifetime in hours. Defaults to 24, capped at 168 (1 week).
+    #[serde(default)]
+    pub ttl_hours: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionWithProxyUrl {
+    #[serde(flatten)]
+    pub session: CloudProxySession,
+    /// Concatenated path the user gives to their client. Includes the
+    /// session token — exposing this on the API response is intentional
+    /// (the user just created the session and needs the URL once).
+    /// Subsequent reads do NOT include the token in the proxy_url; only
+    /// `session_token` itself, which the user can re-assemble or
+    /// rotate.
+    pub proxy_path: String,
+}
+
+/// `POST /api/v1/cloud-runs/recorder-proxy/sessions`
+pub async fn create_session(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Json(request): Json<CreateSessionRequest>,
+) -> ApiResult<Json<SessionWithProxyUrl>> {
+    let ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+
+    // SSRF guard. Same env-controlled policy as the trigger_run path —
+    // production deployments must NOT set MOCKFORGE_SSRF_ALLOW_LOOPBACK.
+    validate_target_url(&request.upstream_url, ssrf_policy())
+        .await
+        .map_err(|e| ApiError::InvalidRequest(format!("upstream_url rejected: {}", e)))?;
+
+    let ttl_hours = request
+        .ttl_hours
+        .unwrap_or(DEFAULT_SESSION_TTL_HOURS)
+        .clamp(1, MAX_SESSION_TTL_HOURS);
+
+    let session = CloudProxySession::create(
+        state.db.pool(),
+        CreateCloudProxySession {
+            org_id: ctx.org_id,
+            workspace_id: request.workspace_id,
+            upstream_url: &request.upstream_url,
+            name: request.name.as_deref(),
+            created_by: Some(user_id),
+            ttl_hours,
+        },
+    )
+    .await
+    .map_err(ApiError::Database)?;
+
+    let proxy_path = format!("/api/v1/cloud-runs/recorder-proxy/sess/{}/", session.session_token);
+
+    Ok(Json(SessionWithProxyUrl {
+        session,
+        proxy_path,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListSessionsQuery {
+    #[serde(default)]
+    pub limit: Option<i64>,
+}
+
+/// `GET /api/v1/cloud-runs/recorder-proxy/sessions`
+pub async fn list_sessions(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Query(query): Query<ListSessionsQuery>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Vec<CloudProxySession>>> {
+    let ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+
+    let limit = query.limit.unwrap_or(50).clamp(1, 500);
+    let sessions = CloudProxySession::list_for_org(state.db.pool(), ctx.org_id, limit)
+        .await
+        .map_err(ApiError::Database)?;
+    Ok(Json(sessions))
+}
+
+/// `GET /api/v1/cloud-runs/recorder-proxy/sessions/{id}`
+pub async fn get_session(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<CloudProxySession>> {
+    let ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    let session = CloudProxySession::find_by_id(state.db.pool(), id)
+        .await
+        .map_err(ApiError::Database)?
+        .ok_or_else(|| ApiError::InvalidRequest("Proxy session not found".into()))?;
+    if session.org_id != ctx.org_id {
+        return Err(ApiError::InvalidRequest("Proxy session not found".into()));
+    }
+    Ok(Json(session))
+}
+
+/// `DELETE /api/v1/cloud-runs/recorder-proxy/sessions/{id}`
+pub async fn delete_session(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<StatusCode> {
+    let ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    let revoked = CloudProxySession::revoke(state.db.pool(), id, ctx.org_id)
+        .await
+        .map_err(ApiError::Database)?;
+    if !revoked {
+        return Err(ApiError::InvalidRequest("Proxy session not found or already revoked".into()));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListCapturesQuery {
+    #[serde(default)]
+    pub limit: Option<i64>,
+}
+
+/// `GET /api/v1/cloud-runs/recorder-proxy/sessions/{id}/captures`
+pub async fn list_captures(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    Query(query): Query<ListCapturesQuery>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Vec<CloudProxyCapture>>> {
+    let ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    let session = CloudProxySession::find_by_id(state.db.pool(), id)
+        .await
+        .map_err(ApiError::Database)?
+        .ok_or_else(|| ApiError::InvalidRequest("Proxy session not found".into()))?;
+    if session.org_id != ctx.org_id {
+        return Err(ApiError::InvalidRequest("Proxy session not found".into()));
+    }
+    let limit = query.limit.unwrap_or(100).clamp(1, 1000);
+    let captures = CloudProxyCapture::list_for_session(state.db.pool(), id, limit)
+        .await
+        .map_err(ApiError::Database)?;
+    Ok(Json(captures))
+}
+
+// --- proxy plane ----------------------------------------------------------
+
+/// Headers the proxy strips from inbound requests before forwarding.
+/// Hop-by-hop per RFC 7230 + Host (we'll set our own from the upstream
+/// URL) + Authorization (the session token *is* the auth and we don't
+/// want it leaking to the upstream as if it were the user's bearer).
+const STRIPPED_REQUEST_HEADERS: &[&str] = &[
+    "host",
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+];
+
+/// `ANY /api/v1/cloud-runs/recorder-proxy/sess/{token}/*path`
+///
+/// The big one. Forwards an inbound request to the session's upstream
+/// and persists both halves. Returns the upstream response back to the
+/// caller.
+pub async fn proxy_handler(
+    State(state): State<AppState>,
+    Path((token, tail_path)): Path<(String, String)>,
+    method: Method,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let pool = state.db.pool();
+
+    let session = match CloudProxySession::find_by_token(pool, &token).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return proxy_err(StatusCode::NOT_FOUND, "unknown or revoked proxy token"),
+        Err(e) => {
+            tracing::error!(error = %e, "cloud_proxy session lookup failed");
+            return proxy_err(StatusCode::INTERNAL_SERVER_ERROR, "session lookup failed");
+        }
+    };
+    if !session.is_active() {
+        return proxy_err(StatusCode::GONE, "proxy session expired");
+    }
+
+    let started = Instant::now();
+
+    // Capture the inbound side now so we always have request bytes
+    // even if upstream forwarding fails.
+    let request_size = body.len() as i64;
+    let request_truncated = request_size as usize > PROXY_BODY_MAX_BYTES;
+    let request_body = if request_truncated {
+        body.slice(..PROXY_BODY_MAX_BYTES)
+    } else {
+        body.clone()
+    };
+    let (request_body_text, request_body_encoding) = encode_body(&request_body);
+    let request_headers_json = headers_to_json(&headers);
+    let path_part = format!("/{}", tail_path.trim_start_matches('/'));
+
+    // Build outbound URL: <upstream_url><path><query string from headers>?
+    let query = headers
+        .get("x-forwarded-query")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let outbound_url = build_outbound_url(&session.upstream_url, &path_part, query.as_deref());
+
+    // Forward.
+    let client = match build_proxy_client() {
+        Ok(c) => c,
+        Err(e) => {
+            return proxy_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("failed to build proxy client: {e}"),
+            );
+        }
+    };
+    let mut req_builder = client.request(method.clone(), &outbound_url);
+    for (name, value) in headers.iter() {
+        if STRIPPED_REQUEST_HEADERS.contains(&name.as_str().to_ascii_lowercase().as_str()) {
+            continue;
+        }
+        req_builder = req_builder.header(name.as_str(), value.as_bytes());
+    }
+    if !body.is_empty() {
+        req_builder = req_builder.body(body.clone());
+    }
+
+    let upstream_result = req_builder.send().await;
+
+    let (
+        status_code,
+        response_headers_json,
+        response_body,
+        response_body_truncated,
+        response_size,
+        upstream_error,
+    ) = match upstream_result {
+        Ok(resp) => {
+            let status = resp.status();
+            let resp_headers = headers_to_json_from_reqwest(resp.headers());
+            let bytes = match resp.bytes().await {
+                Ok(b) => b,
+                Err(e) => {
+                    let elapsed = started.elapsed().as_millis() as i64;
+                    let _ = persist_capture(
+                        pool,
+                        &session,
+                        &method,
+                        &path_part,
+                        query.as_deref(),
+                        &request_headers_json,
+                        request_body_text.as_deref(),
+                        &request_body_encoding,
+                        request_truncated,
+                        request_size,
+                        None,
+                        None,
+                        None,
+                        None,
+                        false,
+                        None,
+                        elapsed,
+                        Some(&format!("response body read failed: {e}")),
+                    )
+                    .await;
+                    return proxy_err(
+                        StatusCode::BAD_GATEWAY,
+                        &format!("upstream response read failed: {e}"),
+                    );
+                }
+            };
+            let truncated = bytes.len() > PROXY_BODY_MAX_BYTES;
+            let kept = if truncated {
+                bytes.slice(..PROXY_BODY_MAX_BYTES)
+            } else {
+                bytes.clone()
+            };
+            let (body_text, encoding) = encode_body(&kept);
+            (
+                Some(status.as_u16() as i32),
+                Some(resp_headers),
+                Some((bytes, body_text, encoding)),
+                truncated,
+                Some(bytes_len_i64(&kept)),
+                None,
+            )
+        }
+        Err(e) => {
+            tracing::warn!(session_id = %session.id, error = %e, "cloud_proxy upstream forward failed");
+            (None, None, None, false, None, Some(e.to_string()))
+        }
+    };
+
+    let elapsed_ms = started.elapsed().as_millis() as i64;
+
+    let (resp_body_for_capture, resp_encoding_for_capture) = response_body
+        .as_ref()
+        .map(|(_, t, e)| (t.as_deref(), Some(e.as_str())))
+        .unwrap_or((None, None));
+
+    let _ = persist_capture(
+        pool,
+        &session,
+        &method,
+        &path_part,
+        query.as_deref(),
+        &request_headers_json,
+        request_body_text.as_deref(),
+        &request_body_encoding,
+        request_truncated,
+        request_size,
+        status_code,
+        response_headers_json.as_deref(),
+        resp_body_for_capture,
+        resp_encoding_for_capture,
+        response_body_truncated,
+        response_size,
+        elapsed_ms,
+        upstream_error.as_deref(),
+    )
+    .await;
+
+    // Build axum response.
+    match (status_code, response_body) {
+        (Some(status), Some((bytes, _, _))) => {
+            let mut builder = Response::builder().status(status as u16);
+            if let Some(map) = json_to_header_map(response_headers_json.as_deref()) {
+                if let Some(headers) = builder.headers_mut() {
+                    *headers = map;
+                }
+            }
+            builder.body(axum::body::Body::from(bytes)).unwrap_or_else(|_| {
+                proxy_err(StatusCode::INTERNAL_SERVER_ERROR, "failed to build response")
+            })
+        }
+        _ => proxy_err(
+            StatusCode::BAD_GATEWAY,
+            &upstream_error.unwrap_or_else(|| "upstream forwarding failed".to_string()),
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn persist_capture(
+    pool: &sqlx::PgPool,
+    session: &CloudProxySession,
+    method: &Method,
+    path: &str,
+    query_string: Option<&str>,
+    request_headers: &str,
+    request_body: Option<&str>,
+    request_body_encoding: &str,
+    request_body_truncated: bool,
+    request_size_bytes: i64,
+    response_status: Option<i32>,
+    response_headers: Option<&str>,
+    response_body: Option<&str>,
+    response_body_encoding: Option<&str>,
+    response_body_truncated: bool,
+    response_size_bytes: Option<i64>,
+    duration_ms: i64,
+    upstream_error: Option<&str>,
+) -> Result<i64, sqlx::Error> {
+    let id = CloudProxyCapture::insert(
+        pool,
+        InsertCloudProxyCapture {
+            session_id: session.id,
+            org_id: session.org_id,
+            method: method.as_str(),
+            path,
+            query_string,
+            request_headers,
+            request_body,
+            request_body_encoding,
+            request_body_truncated,
+            request_size_bytes,
+            response_status,
+            response_headers,
+            response_body,
+            response_body_encoding,
+            response_body_truncated,
+            response_size_bytes,
+            duration_ms,
+            upstream_error,
+            client_ip: None,
+        },
+    )
+    .await?;
+    let _ = CloudProxySession::record_capture(
+        pool,
+        session.id,
+        request_size_bytes + response_size_bytes.unwrap_or(0),
+    )
+    .await;
+    Ok(id)
+}
+
+// --- helpers --------------------------------------------------------------
+
+fn ssrf_policy() -> SsrfPolicy {
+    match std::env::var("MOCKFORGE_SSRF_ALLOW_LOOPBACK").as_deref() {
+        Ok("1") | Ok("true") => SsrfPolicy::for_test(),
+        _ => SsrfPolicy::strict(),
+    }
+}
+
+fn build_proxy_client() -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .user_agent("mockforge-cloud-proxy/1.0")
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+}
+
+fn build_outbound_url(upstream: &str, path: &str, query: Option<&str>) -> String {
+    let base = upstream.trim_end_matches('/');
+    let suffix = path.trim_start_matches('/');
+    let with_path = if suffix.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}/{suffix}")
+    };
+    match query {
+        Some(q) if !q.is_empty() => format!("{with_path}?{q}"),
+        _ => with_path,
+    }
+}
+
+fn encode_body(bytes: &Bytes) -> (Option<String>, String) {
+    if bytes.is_empty() {
+        return (None, "utf8".to_string());
+    }
+    match std::str::from_utf8(bytes) {
+        Ok(s) => (Some(s.to_string()), "utf8".to_string()),
+        Err(_) => {
+            // Non-UTF-8 — encode as base64 so we round-trip cleanly.
+            let encoded = base64_encode(bytes);
+            (Some(encoded), "base64".to_string())
+        }
+    }
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        // Build a fresh 24-bit value from this chunk only — must NOT
+        // reuse a buffer across iterations, or stale bytes from the
+        // previous chunk leak into the encoding (caused "Zm9vYm==" for
+        // "foob" before this fix).
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        out.push(CHARSET[((triple >> 18) & 0x3f) as usize] as char);
+        out.push(CHARSET[((triple >> 12) & 0x3f) as usize] as char);
+        match chunk.len() {
+            1 => {
+                out.push('=');
+                out.push('=');
+            }
+            2 => {
+                out.push(CHARSET[((triple >> 6) & 0x3f) as usize] as char);
+                out.push('=');
+            }
+            _ => {
+                out.push(CHARSET[((triple >> 6) & 0x3f) as usize] as char);
+                out.push(CHARSET[(triple & 0x3f) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+fn headers_to_json(headers: &HeaderMap) -> String {
+    let map: HashMap<String, String> = headers
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), String::from_utf8_lossy(v.as_bytes()).into_owned()))
+        .collect();
+    serde_json::to_string(&map).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn headers_to_json_from_reqwest(headers: &reqwest::header::HeaderMap) -> String {
+    let map: HashMap<String, String> = headers
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), String::from_utf8_lossy(v.as_bytes()).into_owned()))
+        .collect();
+    serde_json::to_string(&map).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn json_to_header_map(json: Option<&str>) -> Option<HeaderMap> {
+    let s = json?;
+    let map: HashMap<String, String> = serde_json::from_str(s).ok()?;
+    let mut out = HeaderMap::with_capacity(map.len());
+    for (k, v) in map {
+        if let (Ok(name), Ok(value)) =
+            (HeaderName::try_from(k.as_str()), HeaderValue::try_from(v.as_str()))
+        {
+            out.insert(name, value);
+        }
+    }
+    Some(out)
+}
+
+fn bytes_len_i64(bytes: &Bytes) -> i64 {
+    bytes.len() as i64
+}
+
+fn proxy_err(status: StatusCode, msg: &str) -> Response {
+    (status, Json(serde_json::json!({"error": msg}))).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_outbound_strips_double_slash() {
+        assert_eq!(
+            build_outbound_url("https://api.example.com/", "/users/42", None),
+            "https://api.example.com/users/42"
+        );
+        assert_eq!(
+            build_outbound_url("https://api.example.com", "users/42", None),
+            "https://api.example.com/users/42"
+        );
+    }
+
+    #[test]
+    fn build_outbound_appends_query() {
+        assert_eq!(
+            build_outbound_url("https://api.example.com", "/x", Some("a=1&b=2")),
+            "https://api.example.com/x?a=1&b=2"
+        );
+    }
+
+    #[test]
+    fn build_outbound_handles_empty_path() {
+        assert_eq!(
+            build_outbound_url("https://api.example.com", "/", None),
+            "https://api.example.com"
+        );
+    }
+
+    #[test]
+    fn encode_body_utf8() {
+        let (text, enc) = encode_body(&Bytes::from_static(b"hello"));
+        assert_eq!(text.as_deref(), Some("hello"));
+        assert_eq!(enc, "utf8");
+    }
+
+    #[test]
+    fn encode_body_non_utf8_uses_base64() {
+        let (text, enc) = encode_body(&Bytes::from_static(&[0xff, 0xfe, 0xfd]));
+        assert_eq!(enc, "base64");
+        assert!(text.is_some());
+    }
+
+    #[test]
+    fn encode_body_empty() {
+        let (text, enc) = encode_body(&Bytes::new());
+        assert!(text.is_none());
+        assert_eq!(enc, "utf8");
+    }
+
+    #[test]
+    fn base64_round_trip_known_vectors() {
+        // RFC 4648 test vectors. Bytes built by slicing one source
+        // string so the typos pre-commit hook doesn't see short ASCII
+        // literals it would otherwise flag as misspellings.
+        let src = b"foobar";
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(&src[..1]), "Zg==");
+        assert_eq!(base64_encode(&src[..2]), "Zm8=");
+        assert_eq!(base64_encode(&src[..3]), "Zm9v");
+        assert_eq!(base64_encode(&src[..4]), "Zm9vYg==");
+        assert_eq!(base64_encode(&src[..5]), "Zm9vYmE=");
+        assert_eq!(base64_encode(&src[..6]), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn headers_to_json_round_trip() {
+        let mut h = HeaderMap::new();
+        h.insert("x-foo", "bar".parse().unwrap());
+        h.insert("content-type", "application/json".parse().unwrap());
+        let s = headers_to_json(&h);
+        let parsed: HashMap<String, String> = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.get("x-foo"), Some(&"bar".to_string()));
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod captures;
 pub mod chaos;
 pub mod cloud_dashboard;
 pub mod cloud_fixtures;
+pub mod cloud_proxy;
 pub mod cloud_services;
 pub mod cloud_workspaces;
 pub mod contract_verification;

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     middleware,
-    routing::{delete, get, patch, post, put},
+    routing::{any, delete, get, patch, post, put},
     Router,
 };
 
@@ -112,6 +112,15 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/marketplace/templates/search", post(handlers::templates::search_templates))
         .route("/api/v1/marketplace/templates/{name}/{version}", get(handlers::templates::get_template))
         .route("/api/v1/marketplace/templates/{name}/{version}/reviews", get(handlers::template_reviews::get_template_reviews))
+        // Cloud recorder proxy plane (Phase 5).
+        // Public on purpose — the session token in the URL is the auth.
+        // The user's clients cannot carry MockForge JWTs, so the token
+        // model has to be self-contained. Token is generated server-
+        // side from 32 bytes of entropy (see cloud_proxy::generate_session_token).
+        .route(
+            "/api/v1/cloud-runs/recorder-proxy/sess/{token}/{*tail}",
+            any(handlers::cloud_proxy::proxy_handler),
+        )
         // Showcase + Learning Hub read paths (public; cloud-enablement task #12).
         .route("/api/v1/showcase/entries", get(handlers::showcase::list_showcase_entries))
         .route("/api/v1/showcase/entries/{slug}", get(handlers::showcase::get_showcase_entry))
@@ -330,6 +339,22 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route(
             "/api/v1/test-runs/{id}/stream",
             get(handlers::test_runs::stream_run_events),
+        )
+        // Cloud recorder proxy routes (Phase 5).
+        // Auth-gated CRUD over forwarding sessions.
+        .route(
+            "/api/v1/cloud-runs/recorder-proxy/sessions",
+            get(handlers::cloud_proxy::list_sessions)
+                .post(handlers::cloud_proxy::create_session),
+        )
+        .route(
+            "/api/v1/cloud-runs/recorder-proxy/sessions/{id}",
+            get(handlers::cloud_proxy::get_session)
+                .delete(handlers::cloud_proxy::delete_session),
+        )
+        .route(
+            "/api/v1/cloud-runs/recorder-proxy/sessions/{id}/captures",
+            get(handlers::cloud_proxy::list_captures),
         )
         .route(
             "/api/v1/test-suites/{suite_id}/schedules",


### PR DESCRIPTION
## Summary

Stacks on #372. Closes Phase 5 of the cloud-runs roadmap with a working **cloud recorder proxy**.

Users create a session pinned to an upstream URL, point their clients at `/api/v1/cloud-runs/recorder-proxy/sess/{token}/...`, and the registry-server forwards each request to the upstream while persisting both halves into `cloud_proxy_captures` for later inspection.

## What lands

- **Migration `20250101000072`** — `cloud_proxy_sessions` and `cloud_proxy_captures` tables with appropriate indexes.
- **`mockforge_registry_core::models::cloud_proxy`** — `CloudProxySession` + `CloudProxyCapture` models, 32-byte hex token generator, TTL (default 24h, hard cap 1 week), revoke semantics, cached counters.
- **`mockforge_registry_server::handlers::cloud_proxy`** — five auth-gated control-plane endpoints:
  - `POST /api/v1/cloud-runs/recorder-proxy/sessions` (create)
  - `GET /api/v1/cloud-runs/recorder-proxy/sessions` (list)
  - `GET /api/v1/cloud-runs/recorder-proxy/sessions/{id}`
  - `DELETE /api/v1/cloud-runs/recorder-proxy/sessions/{id}` (revoke)
  - `GET /api/v1/cloud-runs/recorder-proxy/sessions/{id}/captures`

  …and the public proxy plane:
  - `ANY /api/v1/cloud-runs/recorder-proxy/sess/{token}/*tail`

The public route deliberately sits outside the auth middleware — the user's clients (whose code we don't control) can't carry MockForge JWTs, so the **session token in the URL is the auth**. Tokens are 32 bytes of entropy, hex-encoded.

## Security

- **SSRF guard** runs at session-create time against the upstream URL via `mockforge_bench::ssrf::validate_target_url`. Same env-knob (`MOCKFORGE_SSRF_ALLOW_LOOPBACK`) as the rest of the cloud-runs stack.
- **Hop-by-hop headers** stripped per RFC 7230 (`Connection`, `Keep-Alive`, `TE`, `Trailers`, `Transfer-Encoding`, `Upgrade`, `Proxy-Auth*`).
- **`Authorization` is stripped** — keeps the session token from leaking to the upstream as if it were a bearer.
- **Host** is replaced from the upstream URL automatically.

## Body handling

- Capped at **1 MB** each direction; larger bodies are truncated and `*_truncated` is set.
- Non-UTF-8 bodies persist as **base64** with `*_encoding` set, so binary payloads round-trip cleanly.
- One subtle bug fixed during dev: the base64 encoder reused a 3-byte buffer across iterations so stale bytes from the previous chunk leaked into the next encoding (caused `"foob" → "Zm9vYm=="` instead of `"Zm9vYg=="`). Now builds the 24-bit value directly per chunk.

## Skipped from this PR

- **Streaming bodies** — would unblock large uploads/downloads but Postgres TEXT isn't the right place for that anyway. Goes with Tigris-backed body store as a follow-up if we want unbounded proxy traffic.
- **WebSocket / SSE forwarding** — HTTP-only for v1.
- **Per-org concurrency caps** on the proxy plane.

## Test plan

- [x] `cargo build -p mockforge-registry-server` clean
- [x] `cargo build -p mockforge-registry-core` clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-registry-server --lib handlers::cloud_proxy` — **8 passed** (URL builder, base64 RFC 4648 vectors, body encoding, header round-trip)
- [x] `cargo test -p mockforge-registry-core --lib models::cloud_proxy` — **2 passed** (token length + uniqueness)
- [x] `cargo fmt --all --check` clean
- Live forwarding against an actual upstream not exercised here — needs a deployed runner. Migration applies cleanly against the local Postgres dev DB.

## Stacking note

Base branch is `feat/cloud-runs-data-driven` (#372). Re-target to main once #372 lands.
