### PR TITLE
feat(ui): cloud recorder proxy admin tab (Phase 6)

### DIFF
--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -164,6 +164,7 @@ const navSections = [
       { id: 'resilience', labelKey: 'tab.resilience', icon: Shield },
       { id: 'recorder', labelKey: 'tab.recorder', icon: Radio },
       { id: 'cloud-recorder', labelKey: 'tab.cloudRecorder', icon: Radio },
+      { id: 'cloud-proxy', labelKey: 'tab.cloudProxy', icon: Radio },
       { id: 'behavioral-cloning', labelKey: 'tab.behavioralCloning', icon: Copy },
     ]
   },

--- a/crates/mockforge-ui/ui/src/i18n/translations.ts
+++ b/crates/mockforge-ui/ui/src/i18n/translations.ts
@@ -111,6 +111,7 @@ const en: Dictionary = {
   'tab.cloudFlows': 'Cloud Flows',
   'tab.cloudContract': 'Cloud Contract',
   'tab.cloudRecorder': 'Cloud Recorder',
+  'tab.cloudProxy': 'Cloud Proxy',
   'tab.cloudShowcaseAdmin': 'Showcase Admin',
 
   'nav.localOnly.badge': 'Local',

--- a/crates/mockforge-ui/ui/src/pages/CloudProxyPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/CloudProxyPage.tsx
@@ -1,0 +1,466 @@
+/**
+ * Cloud Recorder Proxy — Phase 5 UI.
+ *
+ * Lets users create forwarding sessions pinned to an upstream URL,
+ * copy the proxy URL into their client, and browse the captured
+ * request/response history.
+ *
+ * Wraps cloudProxyApi (`/api/v1/cloud-runs/recorder-proxy/*`).
+ */
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Plus, RefreshCw, Trash2, Copy, ExternalLink } from 'lucide-react';
+import { isCloudMode } from '../utils/cloudMode';
+import {
+  cloudProxyApi,
+  type CloudProxySession,
+  type CloudProxyCapture,
+  type SessionWithProxyUrl,
+} from '../services/api/cloudProxy';
+
+export const CloudProxyPage: React.FC = () => {
+  if (!isCloudMode()) {
+    return (
+      <div className="p-6 max-w-7xl mx-auto">
+        <div className="bg-blue-50 dark:bg-blue-900/20 text-blue-800 dark:text-blue-300 p-4 rounded-lg">
+          The cloud recorder proxy only runs in cloud mode (sessions are
+          backed by the registry server's Postgres). Self-hosted users
+          can run a local proxy via{' '}
+          <code className="font-mono text-xs">mockforge-recorder</code> directly.
+        </div>
+      </div>
+    );
+  }
+  return <CloudProxyView />;
+};
+
+const CloudProxyView: React.FC = () => {
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [justCreated, setJustCreated] = useState<SessionWithProxyUrl | null>(null);
+
+  const queryClient = useQueryClient();
+
+  const sessionsQuery = useQuery({
+    queryKey: ['cloud-proxy', 'sessions'],
+    queryFn: () => cloudProxyApi.listSessions(50),
+    refetchInterval: 30_000,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => cloudProxyApi.deleteSession(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['cloud-proxy', 'sessions'] });
+      setSelectedSessionId(null);
+    },
+  });
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Cloud Recorder Proxy
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Create a forwarding session, route your client traffic through it, and inspect
+            the captures.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => sessionsQuery.refetch()}
+            className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center gap-2"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowCreate(true)}
+            className="px-3 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 flex items-center gap-2"
+          >
+            <Plus className="w-4 h-4" />
+            New session
+          </button>
+        </div>
+      </div>
+
+      {justCreated && (
+        <JustCreatedBanner
+          session={justCreated}
+          onDismiss={() => setJustCreated(null)}
+        />
+      )}
+
+      <div className="grid grid-cols-12 gap-6">
+        <div className="col-span-5">
+          <SessionList
+            sessions={sessionsQuery.data ?? []}
+            selectedId={selectedSessionId}
+            isLoading={sessionsQuery.isLoading}
+            onSelect={setSelectedSessionId}
+            onDelete={(id) => deleteMutation.mutate(id)}
+          />
+        </div>
+        <div className="col-span-7">
+          {selectedSessionId ? (
+            <CaptureBrowser sessionId={selectedSessionId} />
+          ) : (
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-8 text-center text-gray-500 dark:text-gray-400">
+              Select a session to view its captures.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showCreate && (
+        <CreateSessionDialog
+          onClose={() => setShowCreate(false)}
+          onCreated={(s) => {
+            setJustCreated(s);
+            setShowCreate(false);
+            void queryClient.invalidateQueries({ queryKey: ['cloud-proxy', 'sessions'] });
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+interface SessionListProps {
+  sessions: CloudProxySession[];
+  selectedId: string | null;
+  isLoading: boolean;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+const SessionList: React.FC<SessionListProps> = ({
+  sessions,
+  selectedId,
+  isLoading,
+  onSelect,
+  onDelete,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 text-sm text-gray-500 dark:text-gray-400">
+        Loading sessions…
+      </div>
+    );
+  }
+  if (sessions.length === 0) {
+    return (
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 text-sm text-gray-500 dark:text-gray-400">
+        No active proxy sessions. Create one to start recording.
+      </div>
+    );
+  }
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+      <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+        {sessions.map((s) => {
+          const expiresIn = formatExpiresIn(s.expires_at);
+          const isActive = s.id === selectedId;
+          return (
+            <li
+              key={s.id}
+              className={`p-4 cursor-pointer transition-colors ${
+                isActive
+                  ? 'bg-blue-50 dark:bg-blue-900/20'
+                  : 'hover:bg-gray-50 dark:hover:bg-gray-800'
+              }`}
+              onClick={() => onSelect(s.id)}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium text-gray-900 dark:text-gray-100 truncate">
+                    {s.name ?? '(unnamed)'}
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 truncate font-mono">
+                    {s.upstream_url}
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    {s.capture_count.toLocaleString()} captures · {expiresIn}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (
+                      window.confirm(
+                        'Revoke this session? Existing captures stay queryable but the proxy URL stops working immediately.',
+                      )
+                    ) {
+                      onDelete(s.id);
+                    }
+                  }}
+                  className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
+                  aria-label="Revoke session"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+const CaptureBrowser: React.FC<{ sessionId: string }> = ({ sessionId }) => {
+  const capturesQuery = useQuery({
+    queryKey: ['cloud-proxy', 'captures', sessionId],
+    queryFn: () => cloudProxyApi.listCaptures(sessionId, 100),
+    refetchInterval: 5_000,
+  });
+
+  if (capturesQuery.isLoading) {
+    return (
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 text-sm text-gray-500 dark:text-gray-400">
+        Loading captures…
+      </div>
+    );
+  }
+  const captures = capturesQuery.data ?? [];
+  if (captures.length === 0) {
+    return (
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 text-sm text-gray-500 dark:text-gray-400">
+        No captures yet. Send traffic through the proxy URL to populate this view.
+      </div>
+    );
+  }
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+      <div className="px-4 py-2 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-600 dark:text-gray-400 grid grid-cols-12 gap-2">
+        <div className="col-span-1">Method</div>
+        <div className="col-span-6">Path</div>
+        <div className="col-span-2">Status</div>
+        <div className="col-span-3 text-right">Latency</div>
+      </div>
+      <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+        {captures.map((c) => (
+          <CaptureRow key={c.id} capture={c} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const CaptureRow: React.FC<{ capture: CloudProxyCapture }> = ({ capture }) => {
+  const status = capture.response_status;
+  const statusClass = !status
+    ? 'text-gray-500'
+    : status >= 500
+      ? 'text-red-600 dark:text-red-400'
+      : status >= 400
+        ? 'text-amber-600 dark:text-amber-400'
+        : 'text-green-700 dark:text-green-400';
+  return (
+    <li className="px-4 py-2 grid grid-cols-12 gap-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800">
+      <div className="col-span-1 font-mono text-xs">{capture.method}</div>
+      <div className="col-span-6 font-mono text-xs text-gray-700 dark:text-gray-300 truncate">
+        {capture.path}
+        {capture.query_string ? `?${capture.query_string}` : ''}
+      </div>
+      <div className={`col-span-2 font-mono text-xs ${statusClass}`}>
+        {capture.upstream_error ? 'ERR' : (status?.toString() ?? '—')}
+      </div>
+      <div className="col-span-3 text-right text-xs text-gray-500 dark:text-gray-400">
+        {capture.duration_ms.toLocaleString()} ms
+      </div>
+    </li>
+  );
+};
+
+interface CreateDialogProps {
+  onClose: () => void;
+  onCreated: (s: SessionWithProxyUrl) => void;
+}
+
+const CreateSessionDialog: React.FC<CreateDialogProps> = ({ onClose, onCreated }) => {
+  const [upstreamUrl, setUpstreamUrl] = useState('https://');
+  const [name, setName] = useState('');
+  const [ttlHours, setTtlHours] = useState(24);
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      cloudProxyApi.createSession({
+        upstream_url: upstreamUrl.trim(),
+        name: name.trim() || undefined,
+        ttl_hours: ttlHours,
+      }),
+    onSuccess: onCreated,
+    onError: (err: Error) => setError(err.message),
+  });
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-900 rounded-lg shadow-xl p-6 w-full max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          New proxy session
+        </h2>
+        <div className="space-y-4">
+          <div>
+            <label
+              htmlFor="upstream-url"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Upstream URL
+            </label>
+            <input
+              id="upstream-url"
+              type="text"
+              value={upstreamUrl}
+              onChange={(e) => setUpstreamUrl(e.target.value)}
+              placeholder="https://api.example.com"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 text-sm font-mono text-gray-900 dark:text-gray-100"
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Must be publicly reachable. Internal IPs are rejected.
+            </p>
+          </div>
+          <div>
+            <label
+              htmlFor="session-name"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Name (optional)
+            </label>
+            <input
+              id="session-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="staging-api"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="ttl-hours"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Lifetime (hours)
+            </label>
+            <input
+              id="ttl-hours"
+              type="number"
+              min={1}
+              max={168}
+              value={ttlHours}
+              onChange={(e) => setTtlHours(Number(e.target.value))}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100"
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Session auto-expires after this. Capped at 168 (1 week).
+            </p>
+          </div>
+          {error && (
+            <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-3 py-2 rounded">
+              {error}
+            </div>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 mt-6">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setError(null);
+              mutation.mutate();
+            }}
+            disabled={mutation.isPending || !upstreamUrl.trim()}
+            className="px-3 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+          >
+            {mutation.isPending ? 'Creating…' : 'Create'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const JustCreatedBanner: React.FC<{
+  session: SessionWithProxyUrl;
+  onDismiss: () => void;
+}> = ({ session, onDismiss }) => {
+  const fullUrl = `${window.location.origin}${session.proxy_path}`;
+  return (
+    <div className="mb-6 border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20 rounded-lg p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="font-medium text-green-900 dark:text-green-200">
+            Session created — copy the proxy URL now
+          </div>
+          <p className="text-xs text-green-800 dark:text-green-300 mt-1">
+            The token in this URL is the only auth — anyone with it can drive the
+            proxy. We won't show it again, but you can find the token in the session
+            list.
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <code className="font-mono text-xs bg-white dark:bg-gray-900 px-2 py-1 rounded border border-green-300 dark:border-green-700 break-all flex-1">
+              {fullUrl}
+            </code>
+            <button
+              type="button"
+              onClick={() => {
+                void navigator.clipboard.writeText(fullUrl);
+              }}
+              className="p-2 border border-green-300 dark:border-green-700 rounded hover:bg-green-100 dark:hover:bg-green-900/40"
+              aria-label="Copy proxy URL"
+            >
+              <Copy className="w-4 h-4" />
+            </button>
+            <a
+              href={fullUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="p-2 border border-green-300 dark:border-green-700 rounded hover:bg-green-100 dark:hover:bg-green-900/40"
+              aria-label="Open proxy URL in new tab"
+            >
+              <ExternalLink className="w-4 h-4" />
+            </a>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="text-green-700 dark:text-green-400 hover:text-green-900 dark:hover:text-green-200"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+};
+
+function formatExpiresIn(isoTimestamp: string): string {
+  const expiresMs = new Date(isoTimestamp).getTime();
+  const remainingMs = expiresMs - Date.now();
+  if (remainingMs <= 0) return 'expired';
+  const hours = Math.floor(remainingMs / (1000 * 60 * 60));
+  if (hours < 1) {
+    const minutes = Math.floor(remainingMs / (1000 * 60));
+    return `expires in ${minutes}m`;
+  }
+  if (hours < 48) return `expires in ${hours}h`;
+  return `expires in ${Math.floor(hours / 24)}d`;
+}

--- a/crates/mockforge-ui/ui/src/routes/index.tsx
+++ b/crates/mockforge-ui/ui/src/routes/index.tsx
@@ -87,6 +87,9 @@ const CloudIncidentsPage = lazy(() => import('../pages/CloudIncidentsPage').then
 // Cloud test runs (#4) — org-wide history with SSE live stream
 const CloudTestRunsPage = lazy(() => import('../pages/CloudTestRunsPage').then(m => ({ default: m.CloudTestRunsPage })));
 
+// Cloud recorder proxy (Phase 5) — forwarding sessions + capture browser
+const CloudProxyPage = lazy(() => import('../pages/CloudProxyPage').then(m => ({ default: m.CloudProxyPage })));
+
 // Cloud traces (#2) — cross-deployment OTLP search
 const CloudTracesPage = lazy(() => import('../pages/CloudTracesPage').then(m => ({ default: m.CloudTracesPage })));
 
@@ -233,6 +236,7 @@ export const routes: RouteConfig[] = [
   { path: '/cloud-snapshots', element: <CloudSnapshotsPage /> },
   { path: '/cloud-incidents', element: <CloudIncidentsPage /> },
   { path: '/cloud-test-runs', element: <CloudTestRunsPage /> },
+  { path: '/cloud-proxy', element: <CloudProxyPage /> },
   { path: '/cloud-traces', element: <CloudTracesPage /> },
   { path: '/cloud-chaos', element: <CloudChaosPage /> },
   { path: '/cloud-flows', element: <CloudFlowsPage /> },

--- a/crates/mockforge-ui/ui/src/services/api/cloudProxy.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudProxy.ts
@@ -1,0 +1,112 @@
+/**
+ * Cloud recorder proxy API — Phase 5.
+ *
+ * Wraps `/api/v1/cloud-runs/recorder-proxy/*`. Sessions are pinned to
+ * an upstream URL; users point their clients at the returned proxy
+ * path and the registry forwards each request, persisting both halves
+ * for inspection.
+ */
+import { fetchJsonWithErrorBody } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
+
+export interface CloudProxySession {
+  id: string;
+  org_id: string;
+  workspace_id: string | null;
+  /** Treat as sensitive — anyone with the token can drive the proxy. */
+  session_token: string;
+  upstream_url: string;
+  name: string | null;
+  created_by: string | null;
+  created_at: string;
+  expires_at: string;
+  revoked_at: string | null;
+  capture_count: number;
+  total_bytes: number;
+}
+
+export interface SessionWithProxyUrl extends CloudProxySession {
+  /** Concatenated path the user pastes into their client. */
+  proxy_path: string;
+}
+
+export interface CreateSessionRequest {
+  upstream_url: string;
+  workspace_id?: string;
+  name?: string;
+  ttl_hours?: number;
+}
+
+export interface CloudProxyCapture {
+  id: number;
+  session_id: string;
+  org_id: string;
+  occurred_at: string;
+  method: string;
+  path: string;
+  query_string: string | null;
+  request_headers: string;
+  request_body: string | null;
+  request_body_encoding: string;
+  request_body_truncated: boolean;
+  request_size_bytes: number;
+  response_status: number | null;
+  response_headers: string | null;
+  response_body: string | null;
+  response_body_encoding: string | null;
+  response_body_truncated: boolean;
+  response_size_bytes: number | null;
+  duration_ms: number;
+  upstream_error: string | null;
+  client_ip: string | null;
+}
+
+class CloudProxyApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud proxy ${method} only works in cloud mode.`);
+    }
+  }
+
+  async createSession(body: CreateSessionRequest): Promise<SessionWithProxyUrl> {
+    this.guard('createSession');
+    return fetchJsonWithErrorBody('/api/v1/cloud-runs/recorder-proxy/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as Promise<SessionWithProxyUrl>;
+  }
+
+  async listSessions(limit?: number): Promise<CloudProxySession[]> {
+    this.guard('listSessions');
+    const qs = limit ? `?limit=${limit}` : '';
+    return fetchJsonWithErrorBody(
+      `/api/v1/cloud-runs/recorder-proxy/sessions${qs}`,
+    ) as Promise<CloudProxySession[]>;
+  }
+
+  async getSession(id: string): Promise<CloudProxySession> {
+    this.guard('getSession');
+    return fetchJsonWithErrorBody(
+      `/api/v1/cloud-runs/recorder-proxy/sessions/${id}`,
+    ) as Promise<CloudProxySession>;
+  }
+
+  async deleteSession(id: string): Promise<void> {
+    this.guard('deleteSession');
+    await fetchJsonWithErrorBody(
+      `/api/v1/cloud-runs/recorder-proxy/sessions/${id}`,
+      { method: 'DELETE' },
+    );
+  }
+
+  async listCaptures(sessionId: string, limit?: number): Promise<CloudProxyCapture[]> {
+    this.guard('listCaptures');
+    const qs = limit ? `?limit=${limit}` : '';
+    return fetchJsonWithErrorBody(
+      `/api/v1/cloud-runs/recorder-proxy/sessions/${sessionId}/captures${qs}`,
+    ) as Promise<CloudProxyCapture[]>;
+  }
+}
+
+export const cloudProxyApi = new CloudProxyApi();


### PR DESCRIPTION
## Summary

Stacks on #373. Closes Phase 6 — admin UI tab for the cloud recorder proxy that landed in Phase 5.

Three pieces:

1. **`cloudProxyApi` service** — typed wrapper for the five `/api/v1/cloud-runs/recorder-proxy/*` endpoints (`createSession`, `listSessions`, `getSession`, `deleteSession`, `listCaptures`).

2. **`CloudProxyPage`** — split-pane layout:
   - **Left**: sessions list with name, upstream URL, capture count, "expires in Xh" indicator, and a revoke button.
   - **Right**: capture browser (method / path / status / latency grid) auto-refreshing every 5s so users see traffic land live.
   - **Create-session modal**: upstream URL, optional name, TTL hours (1–168).
   - **"Just created" banner**: surfaces the full proxy URL with token, copy button, open-in-new-tab. Tells users plainly that the token is the only auth and they won't see it again.

3. **Wiring**: lazy-loaded route at `/cloud-proxy`, AppShell nav entry under Chaos & Resilience (next to existing Cloud Recorder), i18n key `tab.cloudProxy`.

## UX details

- 5xx statuses go red, 4xx amber, errors get an "ERR" badge — at-a-glance health check.
- Sessions auto-refresh every 30s.
- All actions wrap in `useMutation` with proper invalidation so the list stays consistent after revoke.
- `isCloudMode()` guard at top of the page — self-hosted users get a "use mockforge-recorder locally instead" banner.

## Skipped from this PR

- **Capture detail view** (full request/response bodies + headers). The list view is enough to confirm the proxy is working; detail browsing is a follow-up.
- **Inline upload-URL helper** for data-driven testing — that endpoint itself isn't shipped yet (queued from #372).
- **Search / filter** on captures.

## Verification

- [x] `pnpm type-check` clean
- [x] `pnpm lint` — no warnings on the new files (pre-existing `unused-var` warnings elsewhere are unrelated to this PR)
- [ ] **Browser verification skipped** — needs a deployed registry server with migration `20250101000072` applied. Smoke-testing interactively is a follow-up once the upstream backend stack lands and a runner is deployed.

## Stacking note

Base branch is `feat/cloud-runs-recorder-proxy` (#373). Re-target to main once #373 lands.
