### PR TITLE
feat(cloud-runs): Tigris upload-URL endpoint + capture detail view

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/cloud_runs.rs
+++ b/crates/mockforge-registry-server/src/handlers/cloud_runs.rs
@@ -1,0 +1,165 @@
+//! Cloud Runs control-plane endpoints — DX helpers that aren't tied
+//! to one specific run kind.
+//!
+//! Routes:
+//!
+//! * `POST /api/v1/cloud-runs/data-driven/upload-url` — returns a
+//!   presigned PUT URL the UI uses to upload a CSV/JSON test-vector
+//!   file directly to Tigris (skipping the registry as a relay), plus
+//!   a longer-lived GET URL the user pastes into their suite config
+//!   so the runner can fetch the data when the run fires.
+//!
+//! Per-kind endpoints (bench / conformance / OWASP / ...) ride the
+//! existing `/api/v1/test-suites/{id}/runs` trigger flow with payload
+//! flags (`use_cloud_api: true`, `kind: "data_driven"`, etc.).
+
+use std::time::Duration;
+
+use axum::{extract::State, http::HeaderMap, Json};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    AppState,
+};
+
+/// Default TTL for the PUT URL — five minutes is plenty for a browser
+/// upload and short enough that an exfiltrated URL has limited useful
+/// life.
+const DEFAULT_UPLOAD_TTL_SECS: u64 = 5 * 60;
+
+/// Hard cap on the PUT URL TTL. One hour is the max anyone reasonably
+/// needs for a single upload.
+const MAX_UPLOAD_TTL_SECS: u64 = 60 * 60;
+
+/// Default TTL for the GET URL — 24 hours covers most "create suite,
+/// trigger later that day" workflows.
+const DEFAULT_DATA_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// Hard cap on the GET URL TTL. One week is the upper bound — past
+/// that, users should regenerate.
+const MAX_DATA_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+
+#[derive(Debug, Deserialize)]
+pub struct DataDrivenUploadUrlRequest {
+    /// File extension hint (`"csv"`, `"json"`, etc.). Sanitized
+    /// server-side. Defaults to `"csv"`.
+    #[serde(default)]
+    pub extension: Option<String>,
+    /// PUT URL lifetime in seconds. Defaults to 300, capped at 3600.
+    #[serde(default)]
+    pub upload_ttl_seconds: Option<u64>,
+    /// GET URL lifetime in seconds. Defaults to 86400, capped at 604800.
+    #[serde(default)]
+    pub data_ttl_seconds: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DataDrivenUploadUrlResponse {
+    /// Presigned PUT URL — upload directly to Tigris (skip the
+    /// registry server). Short-lived.
+    pub upload_url: String,
+    /// Presigned GET URL the user pastes into their suite config as
+    /// `data_url`. Longer-lived.
+    pub data_url: String,
+    /// Tigris object key for reference (e.g. for manual cleanup).
+    pub object_key: String,
+    pub upload_expires_in_seconds: u64,
+    pub data_expires_in_seconds: u64,
+}
+
+/// `POST /api/v1/cloud-runs/data-driven/upload-url`
+pub async fn data_driven_upload_url(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Json(request): Json<DataDrivenUploadUrlRequest>,
+) -> ApiResult<Json<DataDrivenUploadUrlResponse>> {
+    let ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+
+    let upload_ttl = Duration::from_secs(
+        request
+            .upload_ttl_seconds
+            .unwrap_or(DEFAULT_UPLOAD_TTL_SECS)
+            .clamp(60, MAX_UPLOAD_TTL_SECS),
+    );
+    let data_ttl = Duration::from_secs(
+        request
+            .data_ttl_seconds
+            .unwrap_or(DEFAULT_DATA_TTL_SECS)
+            .clamp(60, MAX_DATA_TTL_SECS),
+    );
+    let extension = request.extension.as_deref().unwrap_or("csv");
+
+    let urls = state
+        .storage
+        .presign_data_driven_upload(ctx.org_id, extension, upload_ttl, data_ttl)
+        .await
+        .map_err(|e| {
+            // Local-storage backends explicitly don't support presigning.
+            // Surface the reason cleanly so the UI can tell the user
+            // "this only works in cloud mode" instead of a 500.
+            ApiError::InvalidRequest(format!("upload URL generation failed: {}", e))
+        })?;
+
+    Ok(Json(DataDrivenUploadUrlResponse {
+        upload_url: urls.upload_url,
+        data_url: urls.data_url,
+        object_key: urls.object_key,
+        upload_expires_in_seconds: urls.upload_expires_in_seconds,
+        data_expires_in_seconds: urls.data_expires_in_seconds,
+    }))
+}
+
+// Compile-time invariants on the TTL policy. If anyone bumps the
+// constants out of order, the build fails before tests even run.
+const _: () = assert!(DEFAULT_UPLOAD_TTL_SECS <= MAX_UPLOAD_TTL_SECS);
+const _: () = assert!(DEFAULT_DATA_TTL_SECS <= MAX_DATA_TTL_SECS);
+const _: () = assert!(MAX_UPLOAD_TTL_SECS <= MAX_DATA_TTL_SECS);
+const _: () = assert!(DEFAULT_UPLOAD_TTL_SECS >= 60);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clamp_upload(input: Option<u64>) -> u64 {
+        input.unwrap_or(DEFAULT_UPLOAD_TTL_SECS).clamp(60, MAX_UPLOAD_TTL_SECS)
+    }
+
+    fn clamp_data(input: Option<u64>) -> u64 {
+        input.unwrap_or(DEFAULT_DATA_TTL_SECS).clamp(60, MAX_DATA_TTL_SECS)
+    }
+
+    #[test]
+    fn upload_ttl_default() {
+        assert_eq!(clamp_upload(None), DEFAULT_UPLOAD_TTL_SECS);
+    }
+
+    #[test]
+    fn upload_ttl_clamps_low() {
+        assert_eq!(clamp_upload(Some(1)), 60);
+    }
+
+    #[test]
+    fn upload_ttl_clamps_high() {
+        assert_eq!(clamp_upload(Some(u64::MAX)), MAX_UPLOAD_TTL_SECS);
+    }
+
+    #[test]
+    fn upload_ttl_honors_intermediate() {
+        assert_eq!(clamp_upload(Some(900)), 900);
+    }
+
+    #[test]
+    fn data_ttl_default() {
+        assert_eq!(clamp_data(None), DEFAULT_DATA_TTL_SECS);
+    }
+
+    #[test]
+    fn data_ttl_clamps_high() {
+        assert_eq!(clamp_data(Some(u64::MAX)), MAX_DATA_TTL_SECS);
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod chaos;
 pub mod cloud_dashboard;
 pub mod cloud_fixtures;
 pub mod cloud_proxy;
+pub mod cloud_runs;
 pub mod cloud_services;
 pub mod cloud_workspaces;
 pub mod contract_verification;

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -343,6 +343,10 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         // Cloud recorder proxy routes (Phase 5).
         // Auth-gated CRUD over forwarding sessions.
         .route(
+            "/api/v1/cloud-runs/data-driven/upload-url",
+            post(handlers::cloud_runs::data_driven_upload_url),
+        )
+        .route(
             "/api/v1/cloud-runs/recorder-proxy/sessions",
             get(handlers::cloud_proxy::list_sessions)
                 .post(handlers::cloud_proxy::create_session),

--- a/crates/mockforge-registry-server/src/storage.rs
+++ b/crates/mockforge-registry-server/src/storage.rs
@@ -4,9 +4,11 @@ use anyhow::{Context, Result};
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::{
     config::{Credentials, Region},
+    presigning::PresigningConfig,
     Client as S3Client,
 };
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::config::Config;
 
@@ -486,6 +488,102 @@ impl PluginStorage {
             StorageBackend::Local { base_dir } => Self::local_delete(base_dir, &key).await,
         }
     }
+
+    /// Generate a presigned PUT + GET pair for a data-driven test
+    /// vector upload. Used by the Cloud Runs data-driven trigger flow:
+    /// the UI calls the upload-URL endpoint, gets back a PUT URL the
+    /// browser uploads to directly (skipping the registry as a relay),
+    /// and a longer-lived GET URL the suite config holds onto so the
+    /// runner can fetch the data when the run fires.
+    ///
+    /// `put_ttl` should be short (minutes) — the upload happens
+    /// immediately after the URL is issued. `get_ttl` should comfortably
+    /// outlast the lag between suite-create and run-trigger plus
+    /// expected run duration; default callers use 24h.
+    ///
+    /// Object key shape: `data-driven/{org_id}/{uuid}.{ext}` — keeps
+    /// org-scoped objects partitioned cleanly so per-org listing /
+    /// retention policies stay simple.
+    ///
+    /// Local-storage backend returns an error: presigning has no
+    /// meaning without a public S3-compatible store.
+    pub async fn presign_data_driven_upload(
+        &self,
+        org_id: uuid::Uuid,
+        ext: &str,
+        put_ttl: Duration,
+        get_ttl: Duration,
+    ) -> Result<DataDrivenUploadUrls> {
+        match &self.backend {
+            StorageBackend::S3 { client, bucket } => {
+                let safe_ext = Self::sanitize_extension(ext);
+                let object_key =
+                    format!("data-driven/{}/{}.{}", org_id, uuid::Uuid::new_v4(), safe_ext,);
+
+                let put_cfg =
+                    PresigningConfig::expires_in(put_ttl).context("invalid PUT presign TTL")?;
+                let get_cfg =
+                    PresigningConfig::expires_in(get_ttl).context("invalid GET presign TTL")?;
+
+                let put_req = client
+                    .put_object()
+                    .bucket(bucket)
+                    .key(&object_key)
+                    .presigned(put_cfg)
+                    .await
+                    .context("failed to presign PUT for data-driven upload")?;
+                let get_req = client
+                    .get_object()
+                    .bucket(bucket)
+                    .key(&object_key)
+                    .presigned(get_cfg)
+                    .await
+                    .context("failed to presign GET for data-driven upload")?;
+
+                Ok(DataDrivenUploadUrls {
+                    upload_url: put_req.uri().to_string(),
+                    data_url: get_req.uri().to_string(),
+                    object_key,
+                    upload_expires_in_seconds: put_ttl.as_secs(),
+                    data_expires_in_seconds: get_ttl.as_secs(),
+                })
+            }
+            StorageBackend::Local { .. } => Err(anyhow::anyhow!(
+                "presigned uploads require S3-compatible storage (Tigris); \
+                 PluginStorage is currently in local-filesystem fallback mode"
+            )),
+        }
+    }
+
+    /// Strip everything but ASCII alphanumerics from a file extension
+    /// hint so the object key stays clean. Falls back to `bin` if the
+    /// caller passed something unparsable.
+    fn sanitize_extension(ext: &str) -> String {
+        let cleaned: String = ext
+            .trim_start_matches('.')
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .collect();
+        if cleaned.is_empty() {
+            "bin".to_string()
+        } else {
+            cleaned.to_ascii_lowercase()
+        }
+    }
+}
+
+/// Presigned URL pair returned by
+/// [`PluginStorage::presign_data_driven_upload`]. The `upload_url` is
+/// the short-lived PUT target the UI uses to push bytes to Tigris
+/// directly; the `data_url` is the longer-lived GET URL the suite
+/// config persists so the runner can fetch the bytes at run time.
+#[derive(Debug, Clone)]
+pub struct DataDrivenUploadUrls {
+    pub upload_url: String,
+    pub data_url: String,
+    pub object_key: String,
+    pub upload_expires_in_seconds: u64,
+    pub data_expires_in_seconds: u64,
 }
 
 #[cfg(test)]
@@ -667,5 +765,35 @@ mod tests {
 
         storage.delete_plugin(key).await.unwrap();
         assert!(storage.download_plugin(key).await.is_err());
+    }
+
+    #[test]
+    fn sanitize_extension_strips_garbage() {
+        assert_eq!(PluginStorage::sanitize_extension("csv"), "csv");
+        assert_eq!(PluginStorage::sanitize_extension(".CSV"), "csv");
+        assert_eq!(PluginStorage::sanitize_extension("json"), "json");
+        assert_eq!(PluginStorage::sanitize_extension("../etc/passwd"), "etcpasswd");
+        assert_eq!(PluginStorage::sanitize_extension(""), "bin");
+        assert_eq!(PluginStorage::sanitize_extension("..."), "bin");
+        assert_eq!(PluginStorage::sanitize_extension("yaml.bak"), "yamlbak");
+    }
+
+    #[tokio::test]
+    async fn presign_data_driven_local_backend_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let storage = PluginStorage {
+            backend: StorageBackend::Local {
+                base_dir: temp_dir.path().to_path_buf(),
+            },
+        };
+        let result = storage
+            .presign_data_driven_upload(
+                uuid::Uuid::new_v4(),
+                "csv",
+                Duration::from_secs(60),
+                Duration::from_secs(86400),
+            )
+            .await;
+        assert!(result.is_err(), "expected local-backend presign to error");
     }
 }

--- a/crates/mockforge-ui/ui/src/pages/CloudProxyPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/CloudProxyPage.tsx
@@ -9,7 +9,7 @@
  */
 import React, { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plus, RefreshCw, Trash2, Copy, ExternalLink } from 'lucide-react';
+import { Plus, RefreshCw, Trash2, Copy, ExternalLink, X } from 'lucide-react';
 import { isCloudMode } from '../utils/cloudMode';
 import {
   cloudProxyApi,
@@ -36,6 +36,7 @@ export const CloudProxyPage: React.FC = () => {
 
 const CloudProxyView: React.FC = () => {
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [selectedCapture, setSelectedCapture] = useState<CloudProxyCapture | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [justCreated, setJustCreated] = useState<SessionWithProxyUrl | null>(null);
 
@@ -106,7 +107,10 @@ const CloudProxyView: React.FC = () => {
         </div>
         <div className="col-span-7">
           {selectedSessionId ? (
-            <CaptureBrowser sessionId={selectedSessionId} />
+            <CaptureBrowser
+              sessionId={selectedSessionId}
+              onSelect={setSelectedCapture}
+            />
           ) : (
             <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-8 text-center text-gray-500 dark:text-gray-400">
               Select a session to view its captures.
@@ -123,6 +127,13 @@ const CloudProxyView: React.FC = () => {
             setShowCreate(false);
             void queryClient.invalidateQueries({ queryKey: ['cloud-proxy', 'sessions'] });
           }}
+        />
+      )}
+
+      {selectedCapture && (
+        <CaptureDetailDialog
+          capture={selectedCapture}
+          onClose={() => setSelectedCapture(null)}
         />
       )}
     </div>
@@ -212,7 +223,12 @@ const SessionList: React.FC<SessionListProps> = ({
   );
 };
 
-const CaptureBrowser: React.FC<{ sessionId: string }> = ({ sessionId }) => {
+interface CaptureBrowserProps {
+  sessionId: string;
+  onSelect: (capture: CloudProxyCapture) => void;
+}
+
+const CaptureBrowser: React.FC<CaptureBrowserProps> = ({ sessionId, onSelect }) => {
   const capturesQuery = useQuery({
     queryKey: ['cloud-proxy', 'captures', sessionId],
     queryFn: () => cloudProxyApi.listCaptures(sessionId, 100),
@@ -244,14 +260,19 @@ const CaptureBrowser: React.FC<{ sessionId: string }> = ({ sessionId }) => {
       </div>
       <ul className="divide-y divide-gray-200 dark:divide-gray-700">
         {captures.map((c) => (
-          <CaptureRow key={c.id} capture={c} />
+          <CaptureRow key={c.id} capture={c} onSelect={onSelect} />
         ))}
       </ul>
     </div>
   );
 };
 
-const CaptureRow: React.FC<{ capture: CloudProxyCapture }> = ({ capture }) => {
+interface CaptureRowProps {
+  capture: CloudProxyCapture;
+  onSelect: (capture: CloudProxyCapture) => void;
+}
+
+const CaptureRow: React.FC<CaptureRowProps> = ({ capture, onSelect }) => {
   const status = capture.response_status;
   const statusClass = !status
     ? 'text-gray-500'
@@ -261,7 +282,10 @@ const CaptureRow: React.FC<{ capture: CloudProxyCapture }> = ({ capture }) => {
         ? 'text-amber-600 dark:text-amber-400'
         : 'text-green-700 dark:text-green-400';
   return (
-    <li className="px-4 py-2 grid grid-cols-12 gap-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800">
+    <li
+      className="px-4 py-2 grid grid-cols-12 gap-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer"
+      onClick={() => onSelect(capture)}
+    >
       <div className="col-span-1 font-mono text-xs">{capture.method}</div>
       <div className="col-span-6 font-mono text-xs text-gray-700 dark:text-gray-300 truncate">
         {capture.path}
@@ -274,6 +298,208 @@ const CaptureRow: React.FC<{ capture: CloudProxyCapture }> = ({ capture }) => {
         {capture.duration_ms.toLocaleString()} ms
       </div>
     </li>
+  );
+};
+
+const CaptureDetailDialog: React.FC<{
+  capture: CloudProxyCapture;
+  onClose: () => void;
+}> = ({ capture, onClose }) => {
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-2 p-4 border-b border-gray-200 dark:border-gray-700">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <code className="font-mono text-sm font-semibold text-gray-900 dark:text-gray-100">
+                {capture.method}
+              </code>
+              <code className="font-mono text-sm text-gray-700 dark:text-gray-300 truncate">
+                {capture.path}
+                {capture.query_string ? `?${capture.query_string}` : ''}
+              </code>
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {new Date(capture.occurred_at).toLocaleString()} ·{' '}
+              {capture.duration_ms.toLocaleString()} ms
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 text-gray-500 hover:text-gray-900 dark:hover:text-gray-100"
+            aria-label="Close detail"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto p-4 space-y-6 flex-1">
+          {capture.upstream_error && (
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-300 text-sm px-3 py-2 rounded">
+              <div className="font-semibold mb-1">Upstream error</div>
+              <code className="font-mono text-xs whitespace-pre-wrap break-all">
+                {capture.upstream_error}
+              </code>
+            </div>
+          )}
+
+          <CaptureSection title="Request">
+            <DetailRow label="Size">
+              {capture.request_size_bytes.toLocaleString()} bytes
+              {capture.request_body_truncated && (
+                <span className="ml-2 text-amber-600 dark:text-amber-400">
+                  (truncated to 1 MB)
+                </span>
+              )}
+            </DetailRow>
+            <DetailRow label="Headers">
+              <HeaderTable raw={capture.request_headers} />
+            </DetailRow>
+            <DetailRow label="Body">
+              <BodyView
+                content={capture.request_body}
+                encoding={capture.request_body_encoding}
+                truncated={capture.request_body_truncated}
+              />
+            </DetailRow>
+          </CaptureSection>
+
+          <CaptureSection title="Response">
+            <DetailRow label="Status">
+              <StatusBadge status={capture.response_status} />
+            </DetailRow>
+            <DetailRow label="Size">
+              {capture.response_size_bytes !== null
+                ? `${capture.response_size_bytes.toLocaleString()} bytes`
+                : '—'}
+              {capture.response_body_truncated && (
+                <span className="ml-2 text-amber-600 dark:text-amber-400">
+                  (truncated to 1 MB)
+                </span>
+              )}
+            </DetailRow>
+            <DetailRow label="Headers">
+              <HeaderTable raw={capture.response_headers} />
+            </DetailRow>
+            <DetailRow label="Body">
+              <BodyView
+                content={capture.response_body}
+                encoding={capture.response_body_encoding}
+                truncated={capture.response_body_truncated}
+              />
+            </DetailRow>
+          </CaptureSection>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const CaptureSection: React.FC<{ title: string; children: React.ReactNode }> = ({
+  title,
+  children,
+}) => (
+  <section>
+    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">{title}</h3>
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+      {children}
+    </div>
+  </section>
+);
+
+const DetailRow: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <div className="grid grid-cols-12 gap-2 px-3 py-2 border-b last:border-b-0 border-gray-200 dark:border-gray-700">
+    <div className="col-span-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+      {label}
+    </div>
+    <div className="col-span-9 text-sm text-gray-900 dark:text-gray-100 min-w-0">
+      {children}
+    </div>
+  </div>
+);
+
+const StatusBadge: React.FC<{ status: number | null }> = ({ status }) => {
+  if (status === null) return <span className="text-gray-500">—</span>;
+  const cls =
+    status >= 500
+      ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+      : status >= 400
+        ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+        : status >= 300
+          ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
+          : 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-mono font-semibold ${cls}`}>
+      {status}
+    </span>
+  );
+};
+
+const HeaderTable: React.FC<{ raw: string | null }> = ({ raw }) => {
+  if (!raw) {
+    return <span className="text-xs text-gray-500 dark:text-gray-400">(none)</span>;
+  }
+  let parsed: Record<string, string>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, string>;
+  } catch {
+    return (
+      <code className="font-mono text-xs whitespace-pre-wrap text-gray-700 dark:text-gray-300">
+        {raw}
+      </code>
+    );
+  }
+  const entries = Object.entries(parsed);
+  if (entries.length === 0) {
+    return <span className="text-xs text-gray-500 dark:text-gray-400">(none)</span>;
+  }
+  return (
+    <dl className="font-mono text-xs space-y-0.5">
+      {entries.map(([name, value]) => (
+        <div key={name} className="grid grid-cols-12 gap-2">
+          <dt className="col-span-4 text-gray-600 dark:text-gray-400 truncate">{name}:</dt>
+          <dd className="col-span-8 text-gray-800 dark:text-gray-200 break-all">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+};
+
+const BodyView: React.FC<{
+  content: string | null;
+  encoding: string | null;
+  truncated: boolean;
+}> = ({ content, encoding, truncated }) => {
+  if (!content) {
+    return <span className="text-xs text-gray-500 dark:text-gray-400">(empty)</span>;
+  }
+  const isBase64 = encoding === 'base64';
+  return (
+    <div>
+      {isBase64 && (
+        <div className="text-xs text-amber-700 dark:text-amber-400 mb-1">
+          Non-UTF-8 body — shown as base64.
+        </div>
+      )}
+      <pre className="font-mono text-xs whitespace-pre-wrap break-all bg-gray-50 dark:bg-gray-800 rounded p-2 max-h-64 overflow-auto text-gray-800 dark:text-gray-200">
+        {content}
+      </pre>
+      {truncated && (
+        <div className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+          Body was truncated at 1 MB; the full payload was not persisted.
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/crates/mockforge-ui/ui/src/services/api/cloudRuns.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudRuns.ts
@@ -1,0 +1,56 @@
+/**
+ * Cloud Runs control-plane API — DX helpers that aren't tied to one
+ * specific run kind.
+ *
+ * Right now: just the data-driven Tigris upload URL endpoint. Per-kind
+ * trigger flows continue to live on cloudTestRunsApi.
+ */
+import { fetchJsonWithErrorBody } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
+
+export interface DataDrivenUploadUrlRequest {
+  /** File extension hint (`csv`, `json`). Defaults to `csv` server-side. */
+  extension?: string;
+  /** PUT URL lifetime in seconds. Defaults to 300, capped at 3600. */
+  upload_ttl_seconds?: number;
+  /** GET URL lifetime in seconds. Defaults to 86400, capped at 604800. */
+  data_ttl_seconds?: number;
+}
+
+export interface DataDrivenUploadUrlResponse {
+  /** Presigned PUT URL — upload the CSV/JSON directly here. Short-lived. */
+  upload_url: string;
+  /** Presigned GET URL — paste into the suite config as `data_url`. Longer-lived. */
+  data_url: string;
+  /** Tigris object key (for reference / manual cleanup). */
+  object_key: string;
+  upload_expires_in_seconds: number;
+  data_expires_in_seconds: number;
+}
+
+class CloudRunsApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud Runs ${method} only works in cloud mode.`);
+    }
+  }
+
+  /**
+   * Request a presigned PUT/GET URL pair for a data-driven test-vector
+   * upload. UI uploads directly to the returned `upload_url` (skipping
+   * the registry as a relay), then puts the `data_url` in the suite
+   * config so the runner fetches it at run time.
+   */
+  async requestDataDrivenUploadUrl(
+    body: DataDrivenUploadUrlRequest = {},
+  ): Promise<DataDrivenUploadUrlResponse> {
+    this.guard('requestDataDrivenUploadUrl');
+    return fetchJsonWithErrorBody('/api/v1/cloud-runs/data-driven/upload-url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as Promise<DataDrivenUploadUrlResponse>;
+  }
+}
+
+export const cloudRunsApi = new CloudRunsApi();


### PR DESCRIPTION
## Summary

Stacks on #374. Closes the two highest-value follow-ups from the cloud-runs roadmap that I documented as "queued" in earlier PRs:

### 1. `POST /api/v1/cloud-runs/data-driven/upload-url` (backend)

Returns a presigned PUT/GET URL pair so the UI can upload CSV/JSON test vectors directly to Tigris (skipping the registry as a relay), then put the GET URL in the suite config so the runner fetches the file at run time.

- `PluginStorage::presign_data_driven_upload` generates the pair via `aws-sdk-s3::presigning` against the existing Tigris client (`S3_ENDPOINT`-configured `aws_config`).
- Object keys: `data-driven/{org_id}/{uuid}.{ext}` — sanitized extension keeps Tigris keys clean.
- TTL defaults: PUT 5 min (cap 1 h), GET 24 h (cap 1 week). Constants verified at compile-time so a future bump can't reorder them silently.
- Local-storage fallback returns a clean 4xx with the reason — surfaces "this only works in cloud mode" to the UI instead of a 500.

### 2. CloudProxyPage capture detail view (UI)

Click any capture row in the proxy page → modal opens with:
- Method + path + timestamp + duration banner
- Upstream-error banner (when forwarding failed)
- **Request**: size (with truncation flag), parsed headers table, body (UTF-8 inline / base64 with explanation banner)
- **Response**: status badge (color-coded by class), size, headers, body
- Truncation warnings when bodies hit the 1 MB cap

New `cloudRunsApi` service stub for the upload endpoint — typed client landed so future suite-create UI integrations don't redo the wiring.

## Test plan

- [x] `cargo build -p mockforge-registry-server` clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-registry-server --lib cloud_runs` — **6 passed** (TTL clamp + default behavior)
- [x] `cargo test -p mockforge-registry-server --lib storage::tests::sanitize_extension` — **1 passed**
- [x] `cargo test -p mockforge-registry-server --lib storage::tests::presign_data_driven` — **1 passed** (local-backend rejection)
- [x] `cargo fmt --all --check` clean
- [x] `pnpm type-check` / `pnpm lint` clean for the new UI files
- [ ] **Browser verification still skipped** — needs a deployed registry + a real Tigris bucket with creds. Smoke test post-deploy.

## Stacking note

Base branch is `feat/cloud-runs-ui` (#374). Re-target to main once #374 lands.
