### PR TITLE
fix(ui): import useEffect in IntegrationTestBuilder

### DIFF
--- a/crates/mockforge-ui/ui/src/pages/IntegrationTestBuilder.tsx
+++ b/crates/mockforge-ui/ui/src/pages/IntegrationTestBuilder.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   Container,


### PR DESCRIPTION
## Summary
- `IntegrationTestBuilder` calls `useEffect` (cloud-suite preload added in #356) but only `useState` was imported
- Page crashed at mount with \`useEffect is not defined\`, caught by the ErrorBoundary on app.mockforge.dev/integration-test-builder
- One-line import fix; no behavior change

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm eslint src/pages/IntegrationTestBuilder.tsx` — 0 errors (pre-existing warnings only)
- [ ] After merge: `make deploy-ui` and verify the page mounts on app.mockforge.dev