### PR TITLE
feat(ui): header workspace switcher — fix cloud-pages dead-end

### DIFF
--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -11,6 +11,7 @@ import { useLogStore } from '../../stores/useLogStore';
 import { useServiceStore } from '../../stores/useServiceStore';
 import { useHelpStore } from '../../stores/useHelpStore';
 import { usePreferencesStore } from '../../stores/usePreferencesStore';
+import { useWorkspaceStore } from '../../stores/useWorkspaceStore';
 import { useAppShortcuts } from '../../hooks/useKeyboardNavigation';
 import { useSkipLinks } from '../../hooks/useFocusManagement';
 import { useI18n } from '../../i18n/I18nProvider';
@@ -330,6 +331,9 @@ export function AppShell({ children, onRefresh }: AppShellProps) {
   const helpOpen = useHelpStore(state => state.isOpen);
   const openHelp = useHelpStore(state => state.open);
   const setHelpOpen = useHelpStore(state => state.setOpen);
+  const workspaces = useWorkspaceStore(state => state.workspaces);
+  const activeWorkspace = useWorkspaceStore(state => state.activeWorkspace);
+  const setActiveWorkspaceById = useWorkspaceStore(state => state.setActiveWorkspaceById);
   const keyboardShortcutsEnabled = usePreferencesStore(
     state => state.preferences.ui.keyboardShortcuts,
   );
@@ -605,6 +609,29 @@ export function AppShell({ children, onRefresh }: AppShellProps) {
               </div>
               <div className="flex items-center gap-x-4 lg:gap-x-6">
                 <GlobalConnectionStatus className="hidden sm:flex" />
+                {workspaces.length > 0 && (
+                  <select
+                    value={activeWorkspace?.id ?? ''}
+                    onChange={(e) => {
+                      const id = e.target.value;
+                      if (id) void setActiveWorkspaceById(id);
+                    }}
+                    className="hidden sm:block h-9 max-w-[200px] rounded-md border border-border bg-bg-primary px-2 text-xs text-foreground"
+                    aria-label={t('workspace.selector.label')}
+                    title={activeWorkspace?.name ?? t('workspace.selector.placeholder')}
+                  >
+                    {!activeWorkspace && (
+                      <option value="" disabled>
+                        {t('workspace.selector.placeholder')}
+                      </option>
+                    )}
+                    {workspaces.map((w) => (
+                      <option key={w.id} value={w.id}>
+                        {w.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
                 {supportedLocales.length > 1 && (
                   <select
                     value={locale}

--- a/crates/mockforge-ui/ui/src/i18n/translations.ts
+++ b/crates/mockforge-ui/ui/src/i18n/translations.ts
@@ -23,6 +23,8 @@ const en: Dictionary = {
   'search.scope.current': 'Current page',
   'search.scope.logs': 'Logs only',
   'search.scope.services': 'Services only',
+  'workspace.selector.label': 'Active workspace',
+  'workspace.selector.placeholder': 'Select workspace…',
 
   'nav.core': 'Core',
   'nav.servicesData': 'Services & Data',
@@ -154,6 +156,8 @@ const es: Dictionary = {
   'search.scope.current': 'Pagina actual',
   'search.scope.logs': 'Solo registros',
   'search.scope.services': 'Solo servicios',
+  'workspace.selector.label': 'Espacio de trabajo activo',
+  'workspace.selector.placeholder': 'Seleccionar espacio…',
 
   'nav.core': 'Nucleo',
   'nav.servicesData': 'Servicios y Datos',


### PR DESCRIPTION
## Summary
- Cloud pages (`CloudSnapshotsPage`, `CloudFlowsPage`, `CloudChaosPage`, `CloudRecorderPage`, `CloudContractPage`, `PillarAnalyticsPage`, `FixturesPage`, `ImportPage`) gate their UI on `useWorkspaceStore.activeWorkspace` and show *"Select a workspace…"* when it's null — but there was no global workspace selector. The only path was: navigate to `/workspaces`, click one, navigate back. The empty-state copy implied an inline selector existed; none was rendered.
- Adds a `<select>` to the `AppShell` header (between connection status and locale picker) bound to the workspace store. Hidden when `workspaces` is empty (pre-auth/loading). Switching dispatches `setActiveWorkspaceById`, which calls the server and refetches; cloud pages keyed on `workspaceId` refetch automatically via TanStack Query.
- Two i18n keys added (`workspace.selector.label`, `workspace.selector.placeholder`) for en + es.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm lint` 0 errors (warnings pre-existing on main)
- [x] `pnpm test --run` — 26 pre-existing failures on main reproduce without these changes; no new regressions
- [ ] Visual: open `https://app.mockforge.dev/cloud-snapshots`, confirm the header now shows a workspace dropdown, pick one, see the snapshot list load
- [ ] Visual: same on `/cloud-flows` — confirm dropdown is shared (single source of truth)