### PR TITLE
fix(registry): decode plugin.rating_avg as Decimal, not f64

### DIFF
--- a/crates/mockforge-registry-core/src/models/plugin.rs
+++ b/crates/mockforge-registry-core/src/models/plugin.rs
@@ -16,8 +16,7 @@ pub struct Plugin {
     pub repository: Option<String>,
     pub homepage: Option<String>,
     pub downloads_total: i64,
-    #[sqlx(try_from = "f64")]
-    pub rating_avg: f64,
+    pub rating_avg: rust_decimal::Decimal,
     pub rating_count: i32,
     pub author_id: Uuid,
     pub verified_at: Option<DateTime<Utc>>,

--- a/crates/mockforge-registry-server/src/handlers/admin.rs
+++ b/crates/mockforge-registry-server/src/handlers/admin.rs
@@ -362,7 +362,7 @@ pub async fn get_plugin_badges(
     }
 
     // Check for "Highly Rated" badge (4.5+ stars with 10+ reviews)
-    if plugin.rating_avg >= 4.5 && plugin.rating_count >= 10 {
+    if plugin.rating_avg >= rust_decimal::Decimal::new(45, 1) && plugin.rating_count >= 10 {
         badges.push("highly-rated".to_string());
     }
 

--- a/crates/mockforge-registry-server/src/handlers/plugins.rs
+++ b/crates/mockforge-registry-server/src/handlers/plugins.rs
@@ -149,7 +149,7 @@ pub async fn search_plugins(
             tags,
             category,
             downloads: plugin.downloads_total as u64,
-            rating: plugin.rating_avg,
+            rating: decimal_to_f64(plugin.rating_avg),
             reviews_count: plugin.rating_count as u32,
             security_score,
             language,
@@ -251,7 +251,7 @@ pub async fn get_plugin(
         tags,
         category,
         downloads: plugin.downloads_total as u64,
-        rating: plugin.rating_avg.to_string().parse().unwrap_or(0.0),
+        rating: decimal_to_f64(plugin.rating_avg),
         reviews_count: plugin.rating_count as u32,
         security_score,
         language,
@@ -639,10 +639,19 @@ fn derive_security_score(plugin: &crate::models::Plugin) -> u8 {
     if plugin.updated_at > ninety_days_ago {
         score += 5;
     }
-    if plugin.rating_avg >= 4.0 && plugin.rating_count >= 5 {
+    if plugin.rating_avg >= rust_decimal::Decimal::new(40, 1) && plugin.rating_count >= 5 {
         score += 5;
     }
     score.clamp(0, 100) as u8
+}
+
+/// NUMERIC plugin ratings come back as `rust_decimal::Decimal` from Postgres
+/// (sqlx's `rust_decimal` feature is enabled). The public marketplace JSON
+/// shape is `f64`, so we lossy-convert at the response boundary rather than
+/// piping `Decimal` through `RegistryEntry`.
+fn decimal_to_f64(d: rust_decimal::Decimal) -> f64 {
+    use rust_decimal::prelude::ToPrimitive;
+    d.to_f64().unwrap_or(0.0)
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary
- `Plugin.rating_avg` was declared `f64` with `#[sqlx(try_from = "f64")]`, but sqlx is built with the `rust_decimal` feature so Postgres `NUMERIC` only decodes via `rust_decimal::Decimal`. Every Plugin row failed to deserialize → `POST /api/v1/plugins/search` and `GET /api/v1/plugins/{name}` 500'd with `DATABASE_ERROR`.
- Switched the field to `rust_decimal::Decimal` (matches `Scenario.rating_avg`) and added a `decimal_to_f64` shim at the JSON response boundary so the public `RegistryEntry.rating: f64` shape is unchanged.
- Updated the two `Decimal >= 4.x` comparison sites in `derive_security_score` and `get_plugin_badges`.

## Root cause confirmation
Reproducer against prod Neon DB:
```
ERR: ColumnDecode { index: "rating_avg", source: "mismatched types; Rust type f64 (as SQL type FLOAT8) is not compatible with SQL type NUMERIC" }
```
After fix: `OK got 1 rows: Some(("auth-jwt", 4.80))`.

The error was invisible in fly logs because `RUST_LOG=mockforge_registry_server=info,tower_http=info` filters out the `tracing::error!` in `mockforge_registry_core::error`.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-core -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-core --lib` (266 ok)
- [x] `cargo test -p mockforge-registry-server --lib` (307 ok)
- [x] Standalone reproducer hits prod DB and decodes successfully with the fix
- [ ] Post-deploy: `curl -X POST https://app.mockforge.dev/api/v1/plugins/search -d '{...}'` returns 200 and `/plugin-registry` page loads