### PR TITLE
fix(ui): cloud-mode crash on /config — skip local-only API calls

### DIFF
--- a/crates/mockforge-ui/ui/src/hooks/api/useConfigApi.ts
+++ b/crates/mockforge-ui/ui/src/hooks/api/useConfigApi.ts
@@ -6,11 +6,12 @@ import { useValidation } from './useValidationApi';
 /**
  * Configuration hooks
  */
-export function useConfig() {
+export function useConfig(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: queryKeys.config,
     queryFn: configApi.getConfig,
     staleTime: 30000,
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/crates/mockforge-ui/ui/src/hooks/api/useServerApi.ts
+++ b/crates/mockforge-ui/ui/src/hooks/api/useServerApi.ts
@@ -5,11 +5,12 @@ import { queryKeys } from './queryKeys';
 /**
  * Server management hooks
  */
-export function useServerInfo() {
+export function useServerInfo(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: queryKeys.serverInfo,
     queryFn: serverApi.getServerInfo,
     staleTime: 30000,
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/crates/mockforge-ui/ui/src/hooks/api/useValidationApi.ts
+++ b/crates/mockforge-ui/ui/src/hooks/api/useValidationApi.ts
@@ -5,11 +5,12 @@ import { queryKeys } from './queryKeys';
 /**
  * Validation hooks
  */
-export function useValidation() {
+export function useValidation(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: queryKeys.validation,
     queryFn: validationApi.getValidation,
     staleTime: 30000,
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/crates/mockforge-ui/ui/src/pages/ConfigPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ConfigPage.tsx
@@ -31,6 +31,7 @@ import { useRealityShortcuts } from '../hooks/useRealityShortcuts';
 import { authenticatedFetch } from '../utils/apiClient';
 import { serverApi } from '../services/api';
 import { useI18n } from '../i18n/I18nProvider';
+import { isCloudMode } from '../utils/cloudMode';
 
 function extractPort(address?: string): string {
   if (!address) return '';
@@ -55,7 +56,8 @@ function isValidPort(port: number): boolean {
 
 export function ConfigPage() {
   const { t } = useI18n();
-  const [activeSection, setActiveSection] = useState<'general' | 'latency' | 'faults' | 'traffic-shaping' | 'proxy' | 'validation' | 'environment' | 'protocols' | 'reality'>('general');
+  const isCloud = isCloudMode();
+  const [activeSection, setActiveSection] = useState<'general' | 'latency' | 'faults' | 'traffic-shaping' | 'proxy' | 'validation' | 'environment' | 'protocols' | 'reality'>(isCloud ? 'reality' : 'general');
   const { activeWorkspace } = useWorkspaceStore();
   const workspaceId = activeWorkspace?.id || 'default-workspace';
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -78,9 +80,13 @@ export function ConfigPage() {
     },
   });
 
-  const { data: config, isLoading: configLoading } = useConfig();
-  const { data: validation, isLoading: validationLoading } = useValidation();
-  const { data: serverInfo, isLoading: serverInfoLoading } = useServerInfo();
+  // In cloud mode the local-server endpoints (/__mockforge/config, /validation,
+  // /server-info) don't exist on the registry — these settings only apply to a
+  // self-hosted MockForge instance. Skip the calls entirely and render only the
+  // workspace-scoped sections (Reality, Environment).
+  const { data: config, isLoading: configLoading } = useConfig({ enabled: !isCloud });
+  const { data: validation, isLoading: validationLoading } = useValidation({ enabled: !isCloud });
+  const { data: serverInfo, isLoading: serverInfoLoading } = useServerInfo({ enabled: !isCloud });
 
   // Mutations
   const updateLatency = useUpdateLatency();
@@ -684,17 +690,18 @@ export function ConfigPage() {
     );
   }
 
-  const sections = [
-    { id: 'reality', label: 'Reality Slider', icon: Zap, description: 'Unified realism control' },
-    { id: 'general', label: 'General', icon: Settings, description: 'Basic MockForge settings' },
-    { id: 'protocols', label: 'Protocols', icon: Server, description: 'Protocol enable/disable settings' },
-    { id: 'latency', label: 'Latency', icon: Zap, description: 'Response delay and timing' },
-    { id: 'faults', label: 'Fault Injection', icon: Shield, description: 'Error simulation and failure modes' },
-    { id: 'traffic-shaping', label: 'Traffic Shaping', icon: Wifi, description: 'Bandwidth control and network simulation' },
-    { id: 'proxy', label: 'Proxy', icon: Server, description: 'Upstream proxy configuration' },
-    { id: 'validation', label: 'Validation', icon: Database, description: 'Request/response validation' },
-    { id: 'environment', label: 'Environment', icon: Settings, description: 'Environment variables' },
+  const allSections = [
+    { id: 'reality', label: 'Reality Slider', icon: Zap, description: 'Unified realism control', cloudAvailable: true },
+    { id: 'general', label: 'General', icon: Settings, description: 'Basic MockForge settings', cloudAvailable: false },
+    { id: 'protocols', label: 'Protocols', icon: Server, description: 'Protocol enable/disable settings', cloudAvailable: false },
+    { id: 'latency', label: 'Latency', icon: Zap, description: 'Response delay and timing', cloudAvailable: false },
+    { id: 'faults', label: 'Fault Injection', icon: Shield, description: 'Error simulation and failure modes', cloudAvailable: false },
+    { id: 'traffic-shaping', label: 'Traffic Shaping', icon: Wifi, description: 'Bandwidth control and network simulation', cloudAvailable: false },
+    { id: 'proxy', label: 'Proxy', icon: Server, description: 'Upstream proxy configuration', cloudAvailable: false },
+    { id: 'validation', label: 'Validation', icon: Database, description: 'Request/response validation', cloudAvailable: false },
+    { id: 'environment', label: 'Environment', icon: Settings, description: 'Environment variables', cloudAvailable: true },
   ];
+  const sections = isCloud ? allSections.filter(s => s.cloudAvailable) : allSections;
 
   return (
     <div className="space-y-8">
@@ -708,24 +715,28 @@ export function ConfigPage() {
         action={
           <div className="flex items-center gap-3">
             <RealityIndicator />
-            <Button
-              variant="outline"
-              size="sm"
-              className="flex items-center gap-2"
-              onClick={handleResetAll}
-            >
-              <RefreshCw className="h-4 w-4" />
-              Reset All
-            </Button>
-            <Button
-              variant="default"
-              size="sm"
-              className="flex items-center gap-2"
-              onClick={handleSaveAll}
-            >
-              <Save className="h-4 w-4" />
-              Save All Changes
-            </Button>
+            {!isCloud && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex items-center gap-2"
+                  onClick={handleResetAll}
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  Reset All
+                </Button>
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="flex items-center gap-2"
+                  onClick={handleSaveAll}
+                >
+                  <Save className="h-4 w-4" />
+                  Save All Changes
+                </Button>
+              </>
+            )}
           </div>
         }
       />

--- a/crates/mockforge-ui/ui/src/pages/__tests__/ConfigPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/ConfigPage.test.tsx
@@ -105,6 +105,12 @@ describe('ConfigPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    // Force local (self-hosted) mode for these tests — the global test setup
+    // sets VITE_API_BASE_URL, which would otherwise put ConfigPage in cloud
+    // mode and hide the local-only sections (General, Latency, Faults, etc.)
+    // that these tests exercise. See cloud-mode test below for the inverse.
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('VITE_MOCKFORGE_MODE', '');
     mockUseApi.useConfig.mockReturnValue({ data: mockUseApi.defaultConfig, isLoading: false });
     mockUseApi.useValidation.mockReturnValue({ data: mockUseApi.defaultValidation, isLoading: false });
     mockUseApi.useServerInfo.mockReturnValue({ data: mockUseApi.defaultServerInfo, isLoading: false });
@@ -408,5 +414,84 @@ describe('ConfigPage', () => {
     fireEvent.click(screen.getByText('Environment'));
 
     expect(screen.getAllByText('Template Testing').length).toBeGreaterThan(0);
+  });
+});
+
+describe('ConfigPage (cloud mode)', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider>{children}</I18nProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.mockforge.dev');
+    vi.stubEnv('VITE_MOCKFORGE_MODE', 'cloud');
+
+    // Cloud mode skips these queries via the new `enabled` option, so the
+    // hooks return the standard "disabled-query" shape.
+    mockUseApi.useConfig.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseApi.useValidation.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseApi.useServerInfo.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseApi.useUpdateLatency.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseApi.useUpdateFaults.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseApi.useUpdateProxy.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseApi.useUpdateProtocols.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseApi.useUpdateAiMode.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseApi.useUpdateValidation.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseApi.useRestartServers.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseApi.useRestartStatus.mockReturnValue({ data: { restarting: false } });
+    mockUseApi.useRealityLevel.mockReturnValue({ data: mockUseApi.defaultReality, isLoading: false });
+    mockUseApi.useSetRealityLevel.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseApi.useRealityPresets.mockReturnValue({ data: [], isLoading: false });
+    mockUseApi.useImportRealityPreset.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseApi.useExportRealityPreset.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseApi.useAutocomplete.mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue([]), isPending: false });
+  });
+
+  it('renders without crashing when local-only data is missing', () => {
+    // Regression test: previously, undefined `validation.overrides` fed into
+    // Object.entries() and crashed the page on app.mockforge.dev/config.
+    expect(() => render(<ConfigPage />, { wrapper: createWrapper() })).not.toThrow();
+  });
+
+  it('shows only cloud-applicable sections', () => {
+    render(<ConfigPage />, { wrapper: createWrapper() });
+
+    // Section descriptions are unique to the nav buttons, so they're a
+    // reliable selector — section labels like "Latency" can collide with
+    // similarly-named labels inside the Reality slider content.
+    expect(screen.getByText('Unified realism control')).toBeInTheDocument();
+    expect(screen.getByText('Environment variables')).toBeInTheDocument();
+
+    expect(screen.queryByText('Basic MockForge settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Response delay and timing')).not.toBeInTheDocument();
+    expect(screen.queryByText('Error simulation and failure modes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Request/response validation')).not.toBeInTheDocument();
+    expect(screen.queryByText('Upstream proxy configuration')).not.toBeInTheDocument();
+    expect(screen.queryByText('Protocol enable/disable settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Bandwidth control and network simulation')).not.toBeInTheDocument();
+  });
+
+  it('hides global Save All / Reset All toolbar', () => {
+    render(<ConfigPage />, { wrapper: createWrapper() });
+
+    expect(screen.queryByText('Save All Changes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Reset All')).not.toBeInTheDocument();
+  });
+
+  it('skips local-only API calls', () => {
+    render(<ConfigPage />, { wrapper: createWrapper() });
+
+    expect(mockUseApi.useConfig).toHaveBeenCalledWith({ enabled: false });
+    expect(mockUseApi.useValidation).toHaveBeenCalledWith({ enabled: false });
+    expect(mockUseApi.useServerInfo).toHaveBeenCalledWith({ enabled: false });
   });
 });

--- a/crates/mockforge-ui/ui/src/utils/apiClient.ts
+++ b/crates/mockforge-ui/ui/src/utils/apiClient.ts
@@ -26,16 +26,6 @@ function createCloudStubResponse(url: string): Response {
     }}), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
 
-  // Config — needed by Config page components
-  if (path === '/__mockforge/config') {
-    return new Response(JSON.stringify({ success: true, data: {
-      latency: { enabled: false, base_ms: 0, jitter_ms: 0, tag_overrides: {} },
-      faults: { enabled: false, failure_rate: 0, status_codes: [] },
-      proxy: { enabled: false, upstream_url: null, timeout_seconds: 30 },
-      validation: { mode: 'disabled', aggregate_errors: false, validate_responses: false, overrides: {} },
-    }}), { status: 200, headers: { 'Content-Type': 'application/json' } });
-  }
-
   // Time travel — needed by TimeTravelWidget
   if (path.startsWith('/__mockforge/time-travel')) {
     return new Response(JSON.stringify({ success: true, data: {


### PR DESCRIPTION
## Summary
- Production crash on https://app.mockforge.dev/config: `Cannot convert undefined or null to object` at `Object.entries(formData.validation.overrides)`.
- Root cause: ConfigPage was calling `/__mockforge/config`, `/__mockforge/validation`, `/__mockforge/server-info` — all embedded-admin-server endpoints that don't exist on the cloud registry. They fell through to the generic stub in `apiClient.ts` returning `data: {}`, leaving `validation.overrides` undefined.
- Fix: make ConfigPage cloud-aware instead of stubbing endpoints that don't apply to the cloud SaaS.
  - `useConfig` / `useValidation` / `useServerInfo` now accept `{ enabled }`.
  - In cloud mode, ConfigPage passes `{ enabled: false }` so those queries never fire.
  - Section nav is filtered to only **Reality Slider** and **Environment** in cloud mode (the only sections backed by real cloud APIs).
  - "Save All" / "Reset All" toolbar is hidden in cloud mode.
  - Removed the now-unused `/__mockforge/config` cloud stub from `apiClient.ts`.

## Test plan
- [x] `pnpm exec vitest run ConfigPage` — 26/26 passing (22 existing local-mode tests + 4 new cloud-mode tests including a regression test for the crash).
- [x] `pnpm type-check` clean.
- [x] Production deploy to `app.mockforge.dev` verified — `/config` loads without the `Object.entries` crash.