### PR TITLE
fix(registry): accept f64 min_confidence in generate-openapi-from-traffic

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/mockai.rs
+++ b/crates/mockforge-registry-server/src/handlers/mockai.rs
@@ -258,9 +258,12 @@ pub struct GenerateFromTrafficRequest {
     /// Optional path-prefix filter (e.g. `/api/v1`).
     #[serde(default)]
     pub path_pattern: Option<String>,
-    /// Lower bound on hits-per-(method,path); below this is dropped.
+    /// Minimum confidence score (0.0 to 1.0). Matches the local handler's
+    /// contract and the UI slider. Currently informational on the cloud
+    /// side — we don't compute per-path confidence here, so the value is
+    /// accepted but unused.
     #[serde(default)]
-    pub min_confidence: Option<u32>,
+    pub min_confidence: Option<f64>,
     #[serde(default)]
     pub model: Option<String>,
 }
@@ -302,7 +305,7 @@ pub async fn generate_openapi_from_traffic(
     // hosted mocks. We aggregate up-front so the prompt we send to the LLM
     // is bounded — without this, busy orgs could blow past the token limit.
     let path_filter = request.path_pattern.as_deref().unwrap_or("");
-    let min_hits = request.min_confidence.unwrap_or(1) as i64;
+    let min_hits: i64 = 1;
     let rows: Vec<(String, String, i64, Option<i32>)> = sqlx::query_as(
         r#"
         SELECT r.method,


### PR DESCRIPTION
## Summary
- Cloud handler typed `min_confidence` as `Option<u32>` while the UI slider sends a float in `[0,1]` (default `0.7`). Serde rejected the body and Axum returned 422 before the handler ran, so the OpenAPI Generator page (`https://app.mockforge.dev/mockai-openapi-generator`) failed for every cloud user.
- Switched the field to `Option<f64>` to match the UI payload and the local twin handler in `mockforge-http` (which already uses `f64`).
- Hardcoded the SQL `min_hits` floor to `1`. Net behavior unchanged — `unwrap_or(1)` was always taking the default anyway, since no valid `u32` ever reached the handler.

## Test plan
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-server --lib` (307 passed)
- [x] `cargo fmt -p mockforge-registry-server -- --check`
- [ ] Verify against deployed `app.mockforge.dev/mockai-openapi-generator` after Fly.io deploy