### PR TITLE
chore(deploy): pin wrangler@4.85.0 in Makefile and package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ deploy-ui: ## Build & deploy admin UI to Cloudflare Pages (production)
 	@cd crates/mockforge-ui/ui && pnpm install --frozen-lockfile && $(DEPLOY_UI_ENV) pnpm build
 	@echo "Deploying to Cloudflare Pages (main branch = production)..."
 	@cd crates/mockforge-ui/ui && CLOUDFLARE_ACCOUNT_ID=0d3a86eae0519c72f1bf7b96b38fea94 \
-		pnpm dlx wrangler@latest pages deploy dist \
+		pnpm dlx wrangler@4.85.0 pages deploy dist \
 			--project-name=mockforge-admin-ui \
 			--branch=main \
 			--commit-dirty=true
@@ -373,7 +373,7 @@ deploy-ui-preview: ## Build & deploy admin UI as a preview (uses current git bra
 		echo "Deploying preview on branch: $$BRANCH (cloud mode)"; \
 		cd crates/mockforge-ui/ui && pnpm install --frozen-lockfile && $(DEPLOY_UI_ENV) pnpm build && \
 		CLOUDFLARE_ACCOUNT_ID=0d3a86eae0519c72f1bf7b96b38fea94 \
-			pnpm dlx wrangler@latest pages deploy dist \
+			pnpm dlx wrangler@4.85.0 pages deploy dist \
 				--project-name=mockforge-admin-ui \
 				--branch="$$BRANCH" \
 				--commit-dirty=true

--- a/crates/mockforge-ui/ui/package.json
+++ b/crates/mockforge-ui/ui/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "build:cloud": "VITE_MOCKFORGE_MODE=cloud VITE_API_BASE_URL=https://api.mockforge.dev vite build",
     "build:analyze": "vite build && open dist/stats.html",
-    "deploy:cloud": "pnpm build:cloud && wrangler pages deploy dist --project-name mockforge-admin-ui --branch main --commit-dirty=true",
+    "deploy:cloud": "pnpm build:cloud && pnpm dlx wrangler@4.85.0 pages deploy dist --project-name mockforge-admin-ui --branch main --commit-dirty=true",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- `wrangler@latest` recently bumped its minimum to Node 22, so `make deploy-ui` and the `deploy:cloud` npm script fail on Node 20 with `Wrangler requires at least Node.js v22.0.0`. Hit while running today's manual `make deploy-ui` for the cloud admin UI.
- The GHA workflow at \`.github/workflows/deploy-ui.yml\` already pins to \`wrangler@4.85.0\`; aligning the local-deploy paths so they don't silently rot when wrangler ships breaking platform-version bumps.
- Bigger picture (Node 20 → 22, unpinning wrangler) intentionally out of scope.

## Test plan
- [x] \`make deploy-ui\` invocation reaches the wrangler step on Node 20 without erroring (verified by re-running the manual deploy with \`pnpm dlx wrangler@4.85.0\`)
- [ ] Next deploy via \`make deploy-ui\` succeeds end-to-end