### PR TITLE
feat(ui): cloud-enable Showcase + Learning Hub + flows quartet + fitness functions

### DIFF
--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -286,6 +286,11 @@ const cloudNavItemIds = new Set([
   // Showcase admin authoring via cloudShowcaseApi.adminList / adminCreate /
   // adminUpdate / adminDelete.
   'cloud-showcase-admin',
+  // Public showcase + learning hub adapt /api/v1/showcase/* and
+  // /api/v1/learning/* into the legacy ShowcaseProject / LearningResource
+  // shapes via cloudCommunityApi (services/api/cloudCommunity.ts).
+  'showcase',
+  'learning-hub',
   // Notification channels (cloud-only) — incident dispatch destinations
   // wired through cloudNotificationsApi.
   'notification-channels',

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -279,6 +279,29 @@ const cloudNavItemIds = new Set([
   // Chains share the flows resource (kind='chain') and are executed by
   // the ChainExecutor in mockforge-test-runner (#354).
   'chains',
+  // Scenario Studio uses cloudFlowsApi with kind='scenario'. Each flow
+  // version stores the full {flow_type, steps, connections, tags}
+  // payload as the FlowVersion config; runs queue through test_runs.
+  'scenario-studio',
+  // State Machine Editor uses cloudFlowsApi with kind='state_machine'.
+  // The page exposes a workspace-scoped picker; the selected flow's
+  // current FlowVersion.config carries {state_machine, visual_layout}.
+  'state-machine-editor',
+  // Orchestration Builder uses cloudFlowsApi with kind='orchestration'.
+  // The page persists the full Orchestration object (name, description,
+  // variables, hooks, steps, conditionalSteps, assertions,
+  // enableReporting) as the FlowVersion config.
+  'orchestration-builder',
+  // Orchestration Execution viewer streams test_run_events via
+  // cloudTestRunsApi.streamRunEvents for the cloudFlowsApi.triggerRun
+  // result. step_start / step_pass / step_fail / step_skip / done get
+  // mapped onto the existing ExecutionStep visualization.
+  'orchestration-execution',
+  // Fitness Functions: read-only via cloudContractApi.listFitnessFunctions.
+  // Cloud rows have a generic {kind, config} blob — we adapt them into
+  // the local typed shape and hide create/edit/delete (no write paths
+  // on the registry yet).
+  'fitness-functions',
   // Cloud contract diff + verification via cloudContractApi.
   'cloud-contract',
   // Cloud recorder + behavioral cloning via cloudRecorderApi.
@@ -305,16 +328,35 @@ const cloudNavItemIds = new Set([
   'support',
 ]);
 
+// Items in this set are HIDDEN entirely in cloud mode because a cloud-*
+// sibling page already supersedes them. Showing both creates sidebar
+// noise without adding value (e.g. ChaosPage vs CloudChaosPage).
+const cloudHiddenNavItemIds = new Set([
+  // Each entry has a cloud sibling that serves the same purpose:
+  'chaos',                  // → cloud-chaos
+  'recorder',               // → cloud-recorder
+  'incidents',              // → cloud-incidents
+  'traces',                 // → cloud-traces
+  'contract-diff',          // → cloud-contract
+  'plugins',                // → plugin-registry (cloud-side plugin discovery)
+  'test-execution',         // → cloud-test-runs (TestExecutionDashboard is mock-data only)
+  'analytics',              // → pillar-analytics (request-traffic analytics is local-only)
+]);
+
 // In cloud mode, items outside the allowlist are shown as disabled "Local only"
 // entries so users can discover the full product surface and understand what
 // requires a local MockForge instance. In self-hosted mode every item is active.
-const effectiveNavSections = navSections.map(section => ({
-  ...section,
-  items: section.items.map(item => ({
-    ...item,
-    localOnly: isCloudMode && !cloudNavItemIds.has(item.id),
-  })),
-}));
+const effectiveNavSections = navSections
+  .map(section => ({
+    ...section,
+    items: section.items
+      .filter(item => !(isCloudMode && cloudHiddenNavItemIds.has(item.id)))
+      .map(item => ({
+        ...item,
+        localOnly: isCloudMode && !cloudNavItemIds.has(item.id),
+      })),
+  }))
+  .filter(section => section.items.length > 0);
 
 // Flattened items for title lookup (includes non-sidebar pages for breadcrumb resolution)
 const allNavItems = [

--- a/crates/mockforge-ui/ui/src/components/scenario-studio/FlowExecutor.tsx
+++ b/crates/mockforge-ui/ui/src/components/scenario-studio/FlowExecutor.tsx
@@ -7,6 +7,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/Badge';
 import { Play, Square, CheckCircle2, XCircle, Clock, Loader2 } from 'lucide-react';
+import { cloudFlowsApi } from '../../services/api/cloudFlows';
+import { isCloudMode } from '../../utils/cloudMode';
 
 interface FlowExecutionStep {
   stepId: string;
@@ -27,13 +29,28 @@ export function FlowExecutor({ flowId, onClose }: FlowExecutorProps) {
   const [isExecuting, setIsExecuting] = useState(false);
   const [executionSteps, setExecutionSteps] = useState<FlowExecutionStep[]>([]);
   const [currentStepIndex, setCurrentStepIndex] = useState(-1);
+  const [cloudRunInfo, setCloudRunInfo] = useState<{
+    runId: string;
+    status: string;
+  } | null>(null);
 
   const executeFlow = async () => {
     setIsExecuting(true);
     setExecutionSteps([]);
     setCurrentStepIndex(-1);
+    setCloudRunInfo(null);
 
     try {
+      if (isCloudMode()) {
+        // Cloud-mode scenario flows queue a test_run and stream live
+        // progress over cloudTestRunsApi.streamRunEvents. This panel
+        // surfaces the queued status; users follow the SSE timeline on
+        // the Cloud Test Runs page.
+        const run = await cloudFlowsApi.triggerRun(flowId);
+        setCloudRunInfo({ runId: run.id, status: run.status });
+        return;
+      }
+
       const response = await fetch(`/api/v1/scenario-studio/flows/${flowId}/execute`, {
         method: 'POST',
         headers: {
@@ -146,7 +163,18 @@ export function FlowExecutor({ flowId, onClose }: FlowExecutorProps) {
       </CardHeader>
       <CardContent>
         <div className="space-y-2 max-h-96 overflow-y-auto">
-          {executionSteps.length === 0 && !isExecuting && (
+          {cloudRunInfo && (
+            <div className="p-3 border rounded-lg bg-info-50 dark:bg-info-900/20 text-xs space-y-1">
+              <div className="font-medium">
+                Run queued: <span className="font-mono">{cloudRunInfo.runId}</span>
+              </div>
+              <div className="text-muted-foreground">
+                Status: {cloudRunInfo.status}. Live progress streams on the
+                Cloud Test Runs page.
+              </div>
+            </div>
+          )}
+          {executionSteps.length === 0 && !isExecuting && !cloudRunInfo && (
             <div className="text-center text-muted-foreground py-8">
               Click Execute to run the flow
             </div>

--- a/crates/mockforge-ui/ui/src/pages/FitnessFunctionsPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FitnessFunctionsPage.tsx
@@ -17,8 +17,11 @@ import {
   BarChart3,
   TrendingUp,
 } from 'lucide-react';
-import { driftApi, type FitnessFunction, type CreateFitnessFunctionRequest, type FitnessTestResult, type DriftIncident } from '../services/driftApi';
+import { driftApi, type FitnessFunction, type FitnessFunctionType, type FitnessScope, type CreateFitnessFunctionRequest, type FitnessTestResult, type DriftIncident } from '../services/driftApi';
 import { useDriftIncidents } from '../hooks/useApi';
+import { cloudContractApi, type FitnessFunction as CloudFitnessFunction } from '../services/api/cloudContract';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 import {
   PageHeader,
   ModernCard,
@@ -92,11 +95,13 @@ function FitnessFunctionRow({
   onEdit,
   onDelete,
   onTest,
+  readOnly = false,
 }: {
   function: FitnessFunction;
   onEdit: (func: FitnessFunction) => void;
   onDelete: (id: string) => void;
   onTest: (id: string) => void;
+  readOnly?: boolean;
 }) {
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleString();
@@ -130,32 +135,34 @@ function FitnessFunctionRow({
             </div>
           </div>
 
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onTest(func.id)}
-            >
-              <Play className="w-4 h-4 mr-1" />
-              Test
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onEdit(func)}
-            >
-              <Edit className="w-4 h-4 mr-1" />
-              Edit
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onDelete(func.id)}
-              className="text-danger-600 hover:text-danger-700 hover:bg-danger-50"
-            >
-              <Trash2 className="w-4 h-4" />
-            </Button>
-          </div>
+          {!readOnly && (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onTest(func.id)}
+              >
+                <Play className="w-4 h-4 mr-1" />
+                Test
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onEdit(func)}
+              >
+                <Edit className="w-4 h-4 mr-1" />
+                Edit
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onDelete(func.id)}
+                className="text-danger-600 hover:text-danger-700 hover:bg-danger-50"
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -670,6 +677,33 @@ function GlobalFitnessSummary({ incidents }: { incidents: DriftIncident[] }) {
   );
 }
 
+// Adapt the generic cloud FitnessFunction (kind + config blob) into the
+// richer typed shape the local UI expects. Cloud rows are read-only —
+// the registry exposes a list endpoint only — so the mapping is
+// best-effort and only needs to keep the table viewable.
+function adaptCloudFitnessFunction(cf: CloudFitnessFunction): FitnessFunction {
+  const cfg = (cf.config ?? {}) as Record<string, unknown>;
+  const fnType = cfg.function_type as FitnessFunctionType | undefined;
+  const scope = cfg.scope as FitnessScope | undefined;
+  const toEpoch = (iso: string): number => {
+    const t = Date.parse(iso);
+    return Number.isFinite(t) ? Math.floor(t / 1000) : 0;
+  };
+  return {
+    id: cf.id,
+    name: cf.name,
+    description: cf.description ?? '',
+    function_type:
+      fnType ??
+      ({ type: cf.kind as FitnessFunctionType['type'] } as FitnessFunctionType),
+    config: cfg,
+    scope: scope ?? { type: 'workspace', workspace_id: cf.workspace_id },
+    enabled: cf.enabled,
+    created_at: toEpoch(cf.created_at),
+    updated_at: toEpoch(cf.updated_at),
+  };
+}
+
 export function FitnessFunctionsPage() {
   const queryClient = useQueryClient();
   const [editingFunction, setEditingFunction] = useState<FitnessFunction | null>(null);
@@ -678,11 +712,28 @@ export function FitnessFunctionsPage() {
   const [showTestResults, setShowTestResults] = useState(false);
   const [showSummary, setShowSummary] = useState(true);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const cloudMode = isCloudMode();
 
-  // Fetch fitness functions
+  // Fetch fitness functions. In cloud mode we hit cloudContractApi
+  // (read-only) and adapt rows into the local shape; mutations are
+  // disabled until the registry exposes write endpoints.
   const { data, isLoading, refetch } = useQuery({
-    queryKey: ['fitness-functions'],
-    queryFn: () => driftApi.listFitnessFunctions(),
+    queryKey: cloudMode
+      ? ['fitness-functions', 'cloud', activeWorkspace?.id ?? '']
+      : ['fitness-functions'],
+    queryFn: async () => {
+      if (cloudMode) {
+        if (!activeWorkspace?.id) {
+          return { functions: [] as FitnessFunction[] };
+        }
+        const cloudFns = await cloudContractApi.listFitnessFunctions(
+          activeWorkspace.id,
+        );
+        return { functions: cloudFns.map(adaptCloudFitnessFunction) };
+      }
+      return driftApi.listFitnessFunctions();
+    },
   });
 
   // Fetch incidents to aggregate fitness results
@@ -782,6 +833,14 @@ export function FitnessFunctionsPage() {
         icon={<Activity className="w-6 h-6" />}
       />
 
+      {cloudMode && (
+        <Alert variant="info">
+          Cloud workspaces expose fitness functions read-only — create and
+          edit aren&apos;t wired to the registry yet. Use the local CLI or
+          contract verification config to author new functions.
+        </Alert>
+      )}
+
       <div className="flex justify-between items-center">
         <div className="text-sm text-muted-foreground">
           {functions.length} fitness function{functions.length !== 1 ? 's' : ''} registered
@@ -790,10 +849,14 @@ export function FitnessFunctionsPage() {
           <Button variant="outline" onClick={() => setShowSummary(!showSummary)}>
             {showSummary ? 'Hide' : 'Show'} Summary
           </Button>
-          <Button onClick={() => {
-            setEditingFunction(null);
-            setShowForm(true);
-          }}>
+          <Button
+            onClick={() => {
+              setEditingFunction(null);
+              setShowForm(true);
+            }}
+            disabled={cloudMode}
+            title={cloudMode ? 'Create not supported in cloud mode' : undefined}
+          >
             <Plus className="w-4 h-4 mr-2" />
             Create Fitness Function
           </Button>
@@ -826,6 +889,7 @@ export function FitnessFunctionsPage() {
                 onEdit={handleEdit}
                 onDelete={handleDelete}
                 onTest={handleTest}
+                readOnly={cloudMode}
               />
             ))}
           </div>

--- a/crates/mockforge-ui/ui/src/pages/OrchestrationBuilder.tsx
+++ b/crates/mockforge-ui/ui/src/pages/OrchestrationBuilder.tsx
@@ -37,6 +37,10 @@ import {
   Download as DownloadIcon,
   Upload as UploadIcon,
 } from '@mui/icons-material';
+import { cloudFlowsApi, type Flow as CloudFlow } from '../services/api/cloudFlows';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
+import { useEffect } from 'react';
 
 // Type definitions
 interface Variable {
@@ -112,6 +116,74 @@ export const OrchestrationBuilder: React.FC = () => {
   const [selectedStep, setSelectedStep] = useState<Step | null>(null);
   const [propertyPanelOpen, setPropertyPanelOpen] = useState(false);
   const [currentTab, setCurrentTab] = useState(0);
+
+  // Cloud-mode persistence — orchestrations live as cloudFlows with
+  // kind='orchestration'. Each save spawns a new FlowVersion; execute
+  // queues a test_run.
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const [cloudFlows, setCloudFlows] = useState<CloudFlow[]>([]);
+  const [selectedCloudFlowId, setSelectedCloudFlowId] = useState<string | null>(null);
+  const [cloudRunInfo, setCloudRunInfo] = useState<{ runId: string; status: string } | null>(null);
+
+  useEffect(() => {
+    if (!isCloudMode()) return;
+    if (!activeWorkspace?.id) {
+      setCloudFlows([]);
+      setSelectedCloudFlowId(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const flows = await cloudFlowsApi.listForWorkspace(
+          activeWorkspace.id,
+          'orchestration',
+        );
+        if (cancelled) return;
+        setCloudFlows(flows);
+      } catch (err) {
+        console.error('Failed to list cloud orchestrations', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeWorkspace?.id]);
+
+  // Hydrate the editor from a selected cloud flow's current FlowVersion.
+  useEffect(() => {
+    if (!isCloudMode() || !selectedCloudFlowId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const flow = await cloudFlowsApi.get(selectedCloudFlowId);
+        if (!flow.current_version_id) {
+          setOrchestration((prev) => ({ ...prev, name: flow.name }));
+          return;
+        }
+        const versions = await cloudFlowsApi.listVersions(selectedCloudFlowId);
+        const current =
+          versions.find((v) => v.id === flow.current_version_id) ?? versions[0];
+        const cfg = (current?.config ?? {}) as Partial<Orchestration>;
+        if (cancelled) return;
+        setOrchestration({
+          name: cfg.name ?? flow.name,
+          description: cfg.description ?? '',
+          variables: cfg.variables ?? [],
+          hooks: cfg.hooks ?? [],
+          steps: cfg.steps ?? [],
+          conditionalSteps: cfg.conditionalSteps ?? [],
+          assertions: cfg.assertions ?? [],
+          enableReporting: cfg.enableReporting ?? true,
+        });
+      } catch (err) {
+        console.error('Failed to load cloud orchestration', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedCloudFlowId]);
 
   // Step management
   const addStep = useCallback(() => {
@@ -220,6 +292,15 @@ export const OrchestrationBuilder: React.FC = () => {
   // Execute orchestration
   const executeOrchestration = useCallback(async () => {
     try {
+      if (isCloudMode()) {
+        if (!selectedCloudFlowId) {
+          alert('Save the orchestration to the cloud workspace before executing.');
+          return;
+        }
+        const run = await cloudFlowsApi.triggerRun(selectedCloudFlowId);
+        setCloudRunInfo({ runId: run.id, status: run.status });
+        return;
+      }
       const response = await fetch('/api/chaos/orchestration/execute', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -233,13 +314,92 @@ export const OrchestrationBuilder: React.FC = () => {
     } catch (error) {
       alert('Error executing orchestration');
     }
-  }, [orchestration]);
+  }, [orchestration, selectedCloudFlowId]);
+
+  // Cloud save — create a new flow if none selected, otherwise save a
+  // new FlowVersion on the selected flow.
+  const saveOrchestrationCloud = useCallback(async () => {
+    if (!isCloudMode()) return;
+    if (!activeWorkspace?.id) {
+      alert('Select a workspace before saving.');
+      return;
+    }
+    try {
+      if (selectedCloudFlowId) {
+        await cloudFlowsApi.saveVersion(selectedCloudFlowId, {
+          config: orchestration as unknown as Record<string, unknown>,
+          set_current: true,
+        });
+        return;
+      }
+      const flow = await cloudFlowsApi.create(activeWorkspace.id, {
+        kind: 'orchestration',
+        name: orchestration.name || 'Untitled orchestration',
+        description: orchestration.description || undefined,
+        initial_config: orchestration as unknown as Record<string, unknown>,
+      });
+      setCloudFlows((prev) => [...prev, flow]);
+      setSelectedCloudFlowId(flow.id);
+    } catch (err) {
+      console.error('Failed to save cloud orchestration', err);
+      alert('Failed to save orchestration to cloud workspace');
+    }
+  }, [activeWorkspace?.id, orchestration, selectedCloudFlowId]);
+
+  const handleNewCloudOrchestration = useCallback(() => {
+    setSelectedCloudFlowId(null);
+    setOrchestration({
+      name: 'New Orchestration',
+      description: '',
+      variables: [],
+      hooks: [],
+      steps: [],
+      conditionalSteps: [],
+      assertions: [],
+      enableReporting: true,
+    });
+    setCloudRunInfo(null);
+  }, []);
 
   return (
     <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
       {/* Toolbar */}
       <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
         <Grid container spacing={2} alignItems="center">
+          {isCloudMode() && (
+            <>
+              <Grid item>
+                <Select
+                  size="small"
+                  value={selectedCloudFlowId ?? ''}
+                  displayEmpty
+                  onChange={(e) =>
+                    setSelectedCloudFlowId((e.target.value as string) || null)
+                  }
+                  sx={{ minWidth: 200 }}
+                >
+                  <MenuItem value="">
+                    <em>New orchestration</em>
+                  </MenuItem>
+                  {cloudFlows.map((f) => (
+                    <MenuItem key={f.id} value={f.id}>
+                      {f.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </Grid>
+              <Grid item>
+                <Button
+                  startIcon={<AddIcon />}
+                  onClick={handleNewCloudOrchestration}
+                  variant="outlined"
+                  size="small"
+                >
+                  New
+                </Button>
+              </Grid>
+            </>
+          )}
           <Grid item xs>
             <TextField
               fullWidth
@@ -261,7 +421,16 @@ export const OrchestrationBuilder: React.FC = () => {
             </Button>
           </Grid>
           <Grid item>
-            <Button startIcon={<SaveIcon />} onClick={() => alert('Save functionality')}>
+            <Button
+              startIcon={<SaveIcon />}
+              onClick={() => {
+                if (isCloudMode()) {
+                  saveOrchestrationCloud();
+                } else {
+                  alert('Save functionality');
+                }
+              }}
+            >
               Save
             </Button>
           </Grid>
@@ -285,6 +454,14 @@ export const OrchestrationBuilder: React.FC = () => {
             </label>
           </Grid>
         </Grid>
+        {cloudRunInfo && (
+          <Box sx={{ mt: 2, p: 1.5, borderRadius: 1, bgcolor: 'info.light' }}>
+            <Typography variant="body2">
+              Run queued <strong>{cloudRunInfo.runId}</strong> ({cloudRunInfo.status}).
+              Live progress streams on the Cloud Test Runs page.
+            </Typography>
+          </Box>
+        )}
       </Box>
 
       <Grid container sx={{ flexGrow: 1, overflow: 'hidden' }}>

--- a/crates/mockforge-ui/ui/src/pages/OrchestrationExecutionView.tsx
+++ b/crates/mockforge-ui/ui/src/pages/OrchestrationExecutionView.tsx
@@ -37,6 +37,11 @@ import {
   Speed as SpeedIcon,
 } from '@mui/icons-material';
 import { useWebSocket } from '../hooks/useWebSocket';
+import { cloudFlowsApi, type Flow as CloudFlow } from '../services/api/cloudFlows';
+import { cloudTestRunsApi } from '../services/api/cloudTestRuns';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
+import { Select, MenuItem } from '@mui/material';
 
 interface ExecutionStep {
   id: string;
@@ -84,9 +89,123 @@ export const OrchestrationExecutionView: React.FC<{ orchestrationId: string }> =
     failedSteps: [],
   });
 
-  const { lastMessage, sendMessage, connected: isConnected } = useWebSocket(
-    `/api/chaos/orchestration/${orchestrationId}/ws`
+  // Local-mode WebSocket. The relative URL is stubbed in cloud mode so
+  // the connection is a no-op there; the cloud-mode SSE stream below
+  // takes over.
+  const { lastMessage, sendMessage, connected: isLocalConnected } = useWebSocket(
+    `/api/chaos/orchestration/${orchestrationId}/ws`,
   );
+
+  // Cloud-mode wiring: pick a kind='orchestration' flow from the active
+  // workspace, queue runs through cloudFlowsApi.triggerRun, and tail the
+  // resulting test_runs row via cloudTestRunsApi.streamRunEvents.
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const [cloudFlows, setCloudFlows] = useState<CloudFlow[]>([]);
+  const [selectedCloudFlowId, setSelectedCloudFlowId] = useState<string | null>(null);
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [sseConnected, setSseConnected] = useState(false);
+
+  useEffect(() => {
+    if (!isCloudMode() || !activeWorkspace?.id) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const flows = await cloudFlowsApi.listForWorkspace(
+          activeWorkspace.id,
+          'orchestration',
+        );
+        if (cancelled) return;
+        setCloudFlows(flows);
+        if (flows.length > 0 && !selectedCloudFlowId) {
+          setSelectedCloudFlowId(flows[0].id);
+          setExecutionState((prev) => ({ ...prev, name: flows[0].name }));
+        }
+      } catch (err) {
+        console.error('Failed to list cloud orchestrations', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeWorkspace?.id]);
+
+  // Open SSE for the active run; close it when the run id changes.
+  useEffect(() => {
+    if (!isCloudMode() || !activeRunId) return;
+    const es = cloudTestRunsApi.streamRunEvents(activeRunId);
+    setSseConnected(false);
+    es.onopen = () => setSseConnected(true);
+    es.onerror = () => setSseConnected(false);
+
+    // Step lifecycle events. The cloud test_run_events use snake_case
+    // event_type values; map them onto the existing ExecutionStep shape.
+    const handleStep = (status: ExecutionStep['status']) => (e: MessageEvent) => {
+      try {
+        const payload = JSON.parse(e.data);
+        const stepId: string = payload.step_id ?? payload.id ?? '';
+        if (!stepId) return;
+        setExecutionState((prev) => {
+          const existing = prev.steps.find((s) => s.id === stepId);
+          const step: ExecutionStep = {
+            id: stepId,
+            name: payload.name ?? existing?.name ?? stepId,
+            status,
+            startTime: payload.started_at
+              ? new Date(payload.started_at)
+              : existing?.startTime,
+            endTime: payload.finished_at
+              ? new Date(payload.finished_at)
+              : existing?.endTime,
+            duration: payload.duration_seconds ?? existing?.duration,
+            error: payload.error ?? existing?.error,
+            metrics: payload.metrics ?? existing?.metrics,
+          };
+          const steps = existing
+            ? prev.steps.map((s) => (s.id === stepId ? step : s))
+            : [...prev.steps, step];
+          const failedSteps =
+            status === 'failed' && !prev.failedSteps.includes(stepId)
+              ? [...prev.failedSteps, stepId]
+              : prev.failedSteps;
+          return {
+            ...prev,
+            steps,
+            failedSteps,
+            status: status === 'running' ? 'running' : prev.status,
+          };
+        });
+      } catch {
+        // ignore parse errors
+      }
+    };
+
+    es.addEventListener('step_start', handleStep('running'));
+    es.addEventListener('step_pass', handleStep('completed'));
+    es.addEventListener('step_fail', handleStep('failed'));
+    es.addEventListener('step_skip', handleStep('skipped'));
+
+    es.addEventListener('done', (e: MessageEvent) => {
+      try {
+        const payload = JSON.parse(e.data);
+        setExecutionState((prev) => ({
+          ...prev,
+          status: payload.status === 'passed' ? 'completed' : 'failed',
+          progress: 1,
+          endTime: new Date(),
+        }));
+      } catch {
+        setExecutionState((prev) => ({ ...prev, status: 'completed', progress: 1 }));
+      }
+      es.close();
+    });
+
+    return () => {
+      es.close();
+    };
+  }, [activeRunId]);
+
+  const isConnected = isCloudMode() ? sseConnected : isLocalConnected;
 
   // Handle WebSocket messages
   useEffect(() => {
@@ -129,13 +248,48 @@ export const OrchestrationExecutionView: React.FC<{ orchestrationId: string }> =
 
   const handleControl = useCallback(
     async (action: 'start' | 'stop' | 'pause' | 'resume' | 'skip') => {
+      if (isCloudMode()) {
+        if (action === 'start') {
+          if (!selectedCloudFlowId) return;
+          // Reset visual state so the SSE stream populates a fresh run.
+          setExecutionState((prev) => ({
+            ...prev,
+            status: 'running',
+            startTime: new Date(),
+            endTime: undefined,
+            progress: 0,
+            steps: [],
+            failedSteps: [],
+          }));
+          try {
+            const run = await cloudFlowsApi.triggerRun(selectedCloudFlowId);
+            setActiveRunId(run.id);
+          } catch (err) {
+            console.error('Failed to start cloud orchestration run', err);
+            setExecutionState((prev) => ({ ...prev, status: 'failed' }));
+          }
+          return;
+        }
+        if (action === 'stop' && activeRunId) {
+          try {
+            await cloudTestRunsApi.cancelRun(activeRunId);
+            setExecutionState((prev) => ({ ...prev, status: 'failed' }));
+          } catch (err) {
+            console.error('Failed to cancel cloud run', err);
+          }
+          return;
+        }
+        // Pause / resume / skip aren't supported by the cloud test_runs
+        // lifecycle yet — silently no-op rather than firing local URLs.
+        return;
+      }
       await fetch(`/api/chaos/orchestration/${orchestrationId}/control`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action }),
       });
     },
-    [orchestrationId]
+    [orchestrationId, selectedCloudFlowId, activeRunId]
   );
 
   const getStepIcon = (status: ExecutionStep['status']) => {
@@ -170,6 +324,53 @@ export const OrchestrationExecutionView: React.FC<{ orchestrationId: string }> =
 
   return (
     <Box sx={{ p: 3 }}>
+      {isCloudMode() && (
+        <Card sx={{ mb: 2 }}>
+          <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Orchestration:
+            </Typography>
+            <Select
+              size="small"
+              value={selectedCloudFlowId ?? ''}
+              onChange={(e) => {
+                const id = (e.target.value as string) || null;
+                setSelectedCloudFlowId(id);
+                const flow = cloudFlows.find((f) => f.id === id);
+                if (flow) {
+                  setExecutionState((prev) => ({
+                    ...prev,
+                    name: flow.name,
+                    status: 'idle',
+                    steps: [],
+                    failedSteps: [],
+                    progress: 0,
+                  }));
+                  setActiveRunId(null);
+                }
+              }}
+              displayEmpty
+              sx={{ minWidth: 240 }}
+              disabled={cloudFlows.length === 0}
+            >
+              {cloudFlows.length === 0 ? (
+                <MenuItem value="">No orchestrations in workspace</MenuItem>
+              ) : (
+                cloudFlows.map((f) => (
+                  <MenuItem key={f.id} value={f.id}>
+                    {f.name}
+                  </MenuItem>
+                ))
+              )}
+            </Select>
+            {activeRunId && (
+              <Typography variant="caption" color="text.secondary">
+                Run <strong>{activeRunId}</strong>
+              </Typography>
+            )}
+          </CardContent>
+        </Card>
+      )}
       {/* Header */}
       <Card sx={{ mb: 3 }}>
         <CardContent>

--- a/crates/mockforge-ui/ui/src/pages/ScenarioStateMachineEditor.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ScenarioStateMachineEditor.tsx
@@ -34,6 +34,9 @@ import { VbrEntitySelector } from '../components/state-machine/VbrEntitySelector
 import { SubScenarioEditor } from '../components/state-machine/SubScenarioEditor';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useHistory } from '../hooks/useHistory';
+import { cloudFlowsApi, type Flow as CloudFlow } from '../services/api/cloudFlows';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 
 // Types for state machine data structures
 interface StateMachineDefinition {
@@ -116,11 +119,24 @@ export const ScenarioStateMachineEditor: React.FC<StateMachineEditorProps> = ({
     edges: Edge[];
   }>({ nodes: [], edges: [] }, 50);
 
-  // WebSocket for real-time updates
+  // WebSocket for real-time updates (no-op in cloud mode — useWebSocket
+  // skips relative paths when VITE_API_BASE_URL is set).
   const { lastMessage, sendMessage, connected } = useWebSocket('/__mockforge/ws');
+
+  // Cloud-mode flow picker. In cloud mode the editor scopes to one
+  // cloudFlow (kind='state_machine') at a time; selecting a different
+  // flow rehydrates the canvas from its current FlowVersion.config.
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const [cloudFlows, setCloudFlows] = useState<CloudFlow[]>([]);
+  const [selectedCloudFlowId, setSelectedCloudFlowId] = useState<string | null>(null);
 
   // Load state machine on mount or when resourceType changes
   useEffect(() => {
+    if (isCloudMode()) {
+      // Cloud mode is driven by the cloud flow picker effect below; the
+      // resourceType prop is only used by the local API path.
+      return;
+    }
     if (resourceType) {
       loadStateMachine(resourceType);
     } else {
@@ -128,6 +144,139 @@ export const ScenarioStateMachineEditor: React.FC<StateMachineEditorProps> = ({
       initializeNewStateMachine();
     }
   }, [resourceType]);
+
+  // Cloud mode: fetch state_machine flows for the active workspace and
+  // auto-select the first one (or initialize a blank canvas if none).
+  useEffect(() => {
+    if (!isCloudMode()) return;
+    let cancelled = false;
+    (async () => {
+      if (!activeWorkspace?.id) {
+        setCloudFlows([]);
+        setSelectedCloudFlowId(null);
+        initializeNewStateMachine();
+        return;
+      }
+      try {
+        setLoading(true);
+        const flows = await cloudFlowsApi.listForWorkspace(
+          activeWorkspace.id,
+          'state_machine',
+        );
+        if (cancelled) return;
+        setCloudFlows(flows);
+        if (flows.length === 0) {
+          setSelectedCloudFlowId(null);
+          initializeNewStateMachine();
+        } else {
+          setSelectedCloudFlowId(flows[0].id);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        logger.error('Failed to list cloud state machine flows', err);
+        setError(err instanceof Error ? err.message : 'Failed to load flows');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeWorkspace?.id]);
+
+  // Hydrate the canvas from the selected cloud flow's current
+  // FlowVersion config whenever the selection changes.
+  const loadCloudStateMachine = useCallback(
+    async (flowId: string) => {
+      try {
+        setLoading(true);
+        setError(null);
+        const flow = await cloudFlowsApi.get(flowId);
+        let cfg: Record<string, unknown> = {};
+        if (flow.current_version_id) {
+          const versions = await cloudFlowsApi.listVersions(flowId);
+          const current =
+            versions.find((v) => v.id === flow.current_version_id) ??
+            versions[0];
+          cfg = (current?.config ?? {}) as Record<string, unknown>;
+        }
+        const sm = (cfg.state_machine ?? {
+          resource_type: flow.name,
+          states: ['initial'],
+          initial_state: 'initial',
+          transitions: [],
+        }) as StateMachineDefinition;
+        const layout =
+          (cfg.visual_layout as StateMachineDefinition['visual_layout']) ??
+          sm.visual_layout;
+        setStateMachine(sm);
+
+        const flowNodes: Node[] = sm.states.map((state, index) => {
+          const layoutNode = layout?.nodes?.find((n) => n.id === state);
+          const position = layoutNode
+            ? { x: layoutNode.position_x, y: layoutNode.position_y }
+            : {
+                x: (index % 5) * 200 + 100,
+                y: Math.floor(index / 5) * 150 + 100,
+              };
+          return {
+            id: state,
+            type: state === sm.initial_state ? 'initial' : 'state',
+            position,
+            data: {
+              label: state,
+              state,
+              isInitial: state === sm.initial_state,
+            },
+            style: {
+              width: layoutNode?.width || 150,
+              height: layoutNode?.height || 60,
+            },
+          };
+        });
+        const flowEdges: Edge[] = sm.transitions.map((transition, index) => {
+          const layoutEdge = layout?.edges?.find(
+            (e) =>
+              e.source === transition.from_state &&
+              e.target === transition.to_state,
+          );
+          return {
+            id: layoutEdge?.id || `edge-${index}`,
+            source: transition.from_state,
+            target: transition.to_state,
+            label: transition.condition_expression || '',
+            type: 'default',
+            animated: layoutEdge?.animated || false,
+            data: {
+              condition: transition.condition_expression,
+              subScenarioRef: transition.sub_scenario_ref,
+              probability: transition.probability,
+            },
+            markerEnd: { type: MarkerType.ArrowClosed },
+          };
+        });
+        setNodes(flowNodes);
+        setEdges(flowEdges);
+        push({ nodes: flowNodes, edges: flowEdges });
+      } catch (err) {
+        logger.error('Failed to load cloud state machine', err);
+        setError(
+          err instanceof Error ? err.message : 'Failed to load state machine',
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [setNodes, setEdges, push],
+  );
+
+  useEffect(() => {
+    if (!isCloudMode()) return;
+    if (selectedCloudFlowId) {
+      loadCloudStateMachine(selectedCloudFlowId);
+    }
+  }, [selectedCloudFlowId, loadCloudStateMachine]);
 
   // Handle WebSocket messages for real-time updates
   useEffect(() => {
@@ -297,6 +446,25 @@ export const ScenarioStateMachineEditor: React.FC<StateMachineEditorProps> = ({
         },
       };
 
+      if (isCloudMode()) {
+        if (!selectedCloudFlowId) {
+          setError(
+            'No cloud state machine selected. Use "New" to create one before saving.',
+          );
+          return;
+        }
+        await cloudFlowsApi.saveVersion(selectedCloudFlowId, {
+          config: {
+            state_machine: updatedStateMachine,
+            visual_layout: updatedStateMachine.visual_layout,
+          },
+          set_current: true,
+        });
+        setStateMachine(updatedStateMachine);
+        logger.info('State machine saved successfully');
+        return;
+      }
+
       if (resourceType) {
         await apiService.updateStateMachine(
           resourceType,
@@ -320,7 +488,58 @@ export const ScenarioStateMachineEditor: React.FC<StateMachineEditorProps> = ({
       logger.error('Failed to save state machine', err);
       setError(err instanceof Error ? err.message : 'Failed to save state machine');
     }
-  }, [stateMachine, nodes, edges, resourceType]);
+  }, [stateMachine, nodes, edges, resourceType, selectedCloudFlowId]);
+
+  // Cloud helpers — create / delete a state_machine cloud flow.
+  const handleCreateCloudFlow = useCallback(async () => {
+    if (!activeWorkspace?.id) {
+      setError('Select a workspace before creating a state machine.');
+      return;
+    }
+    try {
+      const name = window.prompt(
+        'Name this state machine',
+        `state-machine-${Math.random().toString(36).slice(2, 8)}`,
+      );
+      if (!name) return;
+      const flow = await cloudFlowsApi.create(activeWorkspace.id, {
+        kind: 'state_machine',
+        name,
+        initial_config: {
+          state_machine: {
+            resource_type: name,
+            states: ['initial'],
+            initial_state: 'initial',
+            transitions: [],
+          },
+        },
+      });
+      setCloudFlows((prev) => [...prev, flow]);
+      setSelectedCloudFlowId(flow.id);
+    } catch (err) {
+      logger.error('Failed to create cloud state machine', err);
+      setError(err instanceof Error ? err.message : 'Failed to create');
+    }
+  }, [activeWorkspace?.id]);
+
+  const handleDeleteCloudFlow = useCallback(async () => {
+    if (!selectedCloudFlowId) return;
+    if (!window.confirm('Delete this state machine? This cannot be undone.')) {
+      return;
+    }
+    try {
+      await cloudFlowsApi.delete(selectedCloudFlowId);
+      setCloudFlows((prev) => prev.filter((f) => f.id !== selectedCloudFlowId));
+      const remaining = cloudFlows.filter((f) => f.id !== selectedCloudFlowId);
+      setSelectedCloudFlowId(remaining[0]?.id ?? null);
+      if (remaining.length === 0) {
+        initializeNewStateMachine();
+      }
+    } catch (err) {
+      logger.error('Failed to delete cloud state machine', err);
+      setError(err instanceof Error ? err.message : 'Failed to delete');
+    }
+  }, [selectedCloudFlowId, cloudFlows, initializeNewStateMachine]);
 
   // Handle node creation
   const handleAddNode = useCallback(() => {
@@ -497,6 +716,40 @@ export const ScenarioStateMachineEditor: React.FC<StateMachineEditorProps> = ({
       {/* Toolbar */}
       <div className="flex items-center justify-between p-4 border-b bg-card">
         <div className="flex items-center gap-2">
+          {isCloudMode() && (
+            <>
+              <select
+                value={selectedCloudFlowId ?? ''}
+                onChange={(e) => setSelectedCloudFlowId(e.target.value || null)}
+                className="px-3 py-2 bg-card border border-border rounded-md text-sm"
+                disabled={cloudFlows.length === 0}
+              >
+                {cloudFlows.length === 0 ? (
+                  <option value="">No state machines yet</option>
+                ) : (
+                  cloudFlows.map((f) => (
+                    <option key={f.id} value={f.id}>
+                      {f.name}
+                    </option>
+                  ))
+                )}
+              </select>
+              <Button onClick={handleCreateCloudFlow} size="sm" variant="outline">
+                <Plus className="h-4 w-4 mr-2" />
+                New
+              </Button>
+              <Button
+                onClick={handleDeleteCloudFlow}
+                size="sm"
+                variant="outline"
+                disabled={!selectedCloudFlowId}
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Remove
+              </Button>
+              <div className="w-px h-6 bg-muted mx-2" />
+            </>
+          )}
           <Button onClick={handleAddNode} size="sm" variant="outline">
             <Plus className="h-4 w-4 mr-2" />
             Add State

--- a/crates/mockforge-ui/ui/src/pages/ScenarioStudioPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ScenarioStudioPage.tsx
@@ -48,6 +48,9 @@ import { FlowPropertiesPanel } from '@/components/scenario-studio/FlowProperties
 import { FlowExecutor } from '@/components/scenario-studio/FlowExecutor';
 import { useHistory } from '@/hooks/useHistory';
 import { useWebSocket } from '@/hooks/useWebSocket';
+import { cloudFlowsApi, type Flow as CloudFlow } from '@/services/api/cloudFlows';
+import { isCloudMode } from '@/utils/cloudMode';
+import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
 
 interface FlowDefinition {
   id: string;
@@ -91,6 +94,59 @@ const nodeTypes: NodeTypes = {
   parallel: ParallelNode,
 };
 
+// Cloud-mode flows store the full scenario payload (flow_type / steps /
+// connections / tags) inside the current FlowVersion.config object. We
+// build a thin sidebar stub from `metadata.flow_type` and lazily inflate
+// the editor state when the user selects a flow.
+function cloudFlowToScenarioStub(flow: CloudFlow): FlowDefinition {
+  const md = (flow.metadata ?? {}) as Record<string, unknown>;
+  return {
+    id: flow.id,
+    name: flow.name,
+    description: flow.description ?? undefined,
+    flow_type:
+      (md.flow_type as FlowDefinition['flow_type']) ?? 'happy_path',
+    steps: [],
+    connections: [],
+    tags: [],
+    created_at: flow.created_at,
+    updated_at: flow.updated_at,
+  };
+}
+
+async function inflateCloudScenarioFlow(
+  flow: CloudFlow,
+): Promise<FlowDefinition> {
+  let cfg: Record<string, unknown> = {};
+  if (flow.current_version_id) {
+    try {
+      const versions = await cloudFlowsApi.listVersions(flow.id);
+      const current =
+        versions.find((v) => v.id === flow.current_version_id) ?? versions[0];
+      cfg = (current?.config ?? {}) as Record<string, unknown>;
+    } catch {
+      // Empty config = empty editor; user can still add steps and save.
+    }
+  }
+  const md = (flow.metadata ?? {}) as Record<string, unknown>;
+  return {
+    id: flow.id,
+    name: flow.name,
+    description: flow.description ?? undefined,
+    flow_type:
+      (cfg.flow_type as FlowDefinition['flow_type']) ??
+      (md.flow_type as FlowDefinition['flow_type']) ??
+      'happy_path',
+    steps: Array.isArray(cfg.steps) ? (cfg.steps as FlowStep[]) : [],
+    connections: Array.isArray(cfg.connections)
+      ? (cfg.connections as FlowConnection[])
+      : [],
+    tags: Array.isArray(cfg.tags) ? (cfg.tags as string[]) : [],
+    created_at: flow.created_at,
+    updated_at: flow.updated_at,
+  };
+}
+
 export function ScenarioStudioPage() {
   const [flows, setFlows] = useState<FlowDefinition[]>([]);
   const [selectedFlow, setSelectedFlow] = useState<FlowDefinition | null>(null);
@@ -114,13 +170,17 @@ export function ScenarioStudioPage() {
     edges: Edge[];
   }>({ nodes: [], edges: [] }, 50);
 
-  // WebSocket for real-time updates
+  // WebSocket for real-time updates (no-op in cloud mode — useWebSocket
+  // already skips relative paths when VITE_API_BASE_URL is set).
   const { lastMessage, sendMessage, connected } = useWebSocket('/__mockforge/ws');
 
-  // Load flows on mount
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+
+  // Load flows on mount and when the active workspace changes (cloud mode).
   useEffect(() => {
     loadFlows();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeWorkspace?.id]);
 
   // Load selected flow into React Flow
   useEffect(() => {
@@ -156,6 +216,20 @@ export function ScenarioStudioPage() {
   const loadFlows = async () => {
     try {
       setLoading(true);
+      if (isCloudMode()) {
+        if (!activeWorkspace?.id) {
+          setFlows([]);
+          setError(null);
+          return;
+        }
+        const cloudFlows = await cloudFlowsApi.listForWorkspace(
+          activeWorkspace.id,
+          'scenario',
+        );
+        setFlows(cloudFlows.map(cloudFlowToScenarioStub));
+        setError(null);
+        return;
+      }
       const response = await fetch('/api/v1/scenario-studio/flows');
       if (response.ok) {
         const data = await response.json();
@@ -243,6 +317,38 @@ export function ScenarioStudioPage() {
 
   const createFlow = async () => {
     try {
+      if (isCloudMode()) {
+        if (!activeWorkspace?.id) {
+          setError('Select a workspace before creating a scenario flow.');
+          return;
+        }
+        const created = await cloudFlowsApi.create(activeWorkspace.id, {
+          kind: 'scenario',
+          name: newFlowName,
+          initial_config: {
+            flow_type: newFlowType,
+            steps: [],
+            connections: [],
+            tags: [],
+          },
+        });
+        const stub: FlowDefinition = {
+          id: created.id,
+          name: created.name,
+          description: created.description ?? undefined,
+          flow_type: newFlowType,
+          steps: [],
+          connections: [],
+          tags: [],
+          created_at: created.created_at,
+          updated_at: created.updated_at,
+        };
+        setFlows([...flows, stub]);
+        setSelectedFlow(stub);
+        setIsCreating(false);
+        setNewFlowName('');
+        return;
+      }
       const response = await fetch('/api/v1/scenario-studio/flows', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -323,6 +429,27 @@ export function ScenarioStudioPage() {
         label: edge.label as string,
       }));
 
+      if (isCloudMode()) {
+        await cloudFlowsApi.saveVersion(selectedFlow.id, {
+          config: {
+            flow_type: selectedFlow.flow_type,
+            steps,
+            connections,
+            tags: selectedFlow.tags,
+          },
+          set_current: true,
+        });
+        const updated: FlowDefinition = {
+          ...selectedFlow,
+          steps,
+          connections,
+          updated_at: new Date().toISOString(),
+        };
+        setSelectedFlow(updated);
+        setFlows(flows.map((f) => (f.id === updated.id ? updated : f)));
+        return;
+      }
+
       const response = await fetch(`/api/v1/scenario-studio/flows/${selectedFlow.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -354,6 +481,14 @@ export function ScenarioStudioPage() {
   const deleteFlow = async (flowId: string) => {
     if (!confirm('Are you sure you want to delete this flow?')) return;
     try {
+      if (isCloudMode()) {
+        await cloudFlowsApi.delete(flowId);
+        setFlows(flows.filter((f) => f.id !== flowId));
+        if (selectedFlow?.id === flowId) {
+          setSelectedFlow(null);
+        }
+        return;
+      }
       const response = await fetch(`/api/v1/scenario-studio/flows/${flowId}`, {
         method: 'DELETE',
       });
@@ -551,7 +686,22 @@ export function ScenarioStudioPage() {
                   className={`p-3 border rounded-lg cursor-pointer hover:bg-accent ${
                     selectedFlow?.id === flow.id ? 'bg-accent border-primary' : ''
                   }`}
-                  onClick={() => setSelectedFlow(flow)}
+                  onClick={async () => {
+                    if (isCloudMode()) {
+                      // Sidebar entries are stubs in cloud mode — fetch
+                      // the current FlowVersion config so the editor
+                      // canvas hydrates with real steps/connections.
+                      try {
+                        const cloudFlow = await cloudFlowsApi.get(flow.id);
+                        setSelectedFlow(await inflateCloudScenarioFlow(cloudFlow));
+                      } catch (err) {
+                        console.error('Failed to load cloud flow', err);
+                        setSelectedFlow(flow);
+                      }
+                      return;
+                    }
+                    setSelectedFlow(flow);
+                  }}
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex-1 min-w-0">

--- a/crates/mockforge-ui/ui/src/pages/ShowcasePage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ShowcasePage.tsx
@@ -43,8 +43,12 @@ import {
   NewReleases as NewIcon,
 } from '@mui/icons-material';
 import { communityApi, type ShowcaseProject, type SuccessStory } from '../services/communityApi';
+import { isCloudMode } from '../utils/cloudMode';
 
 export const ShowcasePage: React.FC = () => {
+  // Cloud backend has no success-stories endpoint; hide the tab when running
+  // against the registry so users don't get an empty/never-loading view.
+  const cloudMode = isCloudMode();
   const [projects, setProjects] = useState<ShowcaseProject[]>([]);
   const [stories, setStories] = useState<SuccessStory[]>([]);
   const [selectedProject, setSelectedProject] = useState<ShowcaseProject | null>(null);
@@ -61,9 +65,9 @@ export const ShowcasePage: React.FC = () => {
   // Load data
   useEffect(() => {
     loadProjects();
-    loadStories();
+    if (!cloudMode) loadStories();
     loadCategories();
-  }, [selectedCategory, showFeaturedOnly]);
+  }, [selectedCategory, showFeaturedOnly, cloudMode]);
 
   const loadProjects = async () => {
     setLoading(true);
@@ -144,7 +148,7 @@ export const ShowcasePage: React.FC = () => {
 
       <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ mb: 3 }}>
         <Tab label="Featured Projects" />
-        <Tab label="Success Stories" />
+        {!cloudMode && <Tab label="Success Stories" />}
       </Tabs>
 
       {activeTab === 0 && (

--- a/crates/mockforge-ui/ui/src/services/api/__tests__/cloudCommunity.test.ts
+++ b/crates/mockforge-ui/ui/src/services/api/__tests__/cloudCommunity.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Adapter tests for cloudCommunity — proves the cloud schema maps
+ * correctly into the legacy ShowcaseProject / LearningResource shapes
+ * the existing pages consume.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  showcaseEntryToProject,
+  trackToLearningResource,
+  recipeToLearningResource,
+  cloudCommunityApi,
+  type ShowcaseEntry,
+  type LearningTrack,
+  type LearningRecipe,
+} from '../cloudCommunity';
+
+const baseEntry: ShowcaseEntry = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  slug: 'awesome-mock',
+  org_id: null,
+  submitted_by: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  title: 'Awesome Mock',
+  description: 'demo',
+  body: null,
+  screenshots: ['https://example.com/a.png', 'https://example.com/b.png'],
+  demo_url: 'https://demo',
+  source_url: null,
+  tags: ['payments', 'graphql'],
+  is_featured: true,
+  is_published: true,
+  likes_count: 7,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-02T00:00:00Z',
+};
+
+describe('showcaseEntryToProject', () => {
+  it('uses slug as id and maps screenshots/featured/likes', () => {
+    const p = showcaseEntryToProject(baseEntry);
+    expect(p.id).toBe('awesome-mock');
+    expect(p.featured).toBe(true);
+    expect(p.screenshot).toBe('https://example.com/a.png');
+    expect(p.stats.stars).toBe(7);
+    expect(p.stats.downloads).toBe(0);
+    expect(p.stats.rating).toBe(0);
+    expect(p.testimonials).toEqual([]);
+    expect(p.tags).toEqual(['payments', 'graphql']);
+  });
+
+  it('uses tags[0] as category, falling back to "general" for empty tags', () => {
+    expect(showcaseEntryToProject(baseEntry).category).toBe('payments');
+    const noTags = showcaseEntryToProject({ ...baseEntry, tags: [] });
+    expect(noTags.category).toBe('general');
+  });
+
+  it('drops null demo/source urls instead of leaking null into the UI shape', () => {
+    const p = showcaseEntryToProject({ ...baseEntry, demo_url: null, source_url: null });
+    expect(p.demo_url).toBeUndefined();
+    expect(p.source_url).toBeUndefined();
+  });
+
+  it('handles missing screenshots gracefully', () => {
+    const p = showcaseEntryToProject({ ...baseEntry, screenshots: [] });
+    expect(p.screenshot).toBeUndefined();
+  });
+});
+
+describe('trackToLearningResource', () => {
+  const track: LearningTrack = {
+    id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    slug: 'getting-started',
+    title: 'Getting Started',
+    description: 'first steps',
+    body: null,
+    is_published: true,
+    sort_order: 0,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+  };
+
+  it('maps a track to a guide-typed resource keyed by slug', () => {
+    const r = trackToLearningResource(track);
+    expect(r.id).toBe('getting-started');
+    expect(r.resource_type).toBe('guide');
+    expect(r.category).toBe('tracks');
+    expect(r.description).toBe('first steps');
+    expect(r.code_examples).toEqual([]);
+  });
+
+  it('substitutes empty description for null', () => {
+    const r = trackToLearningResource({ ...track, description: null });
+    expect(r.description).toBe('');
+  });
+});
+
+describe('recipeToLearningResource', () => {
+  const recipe: LearningRecipe = {
+    id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    slug: 'rest-pagination',
+    title: 'REST Pagination',
+    description: 'cursor + offset',
+    body: '## Heading\n\nbody',
+    tags: ['rest', 'pagination'],
+    is_published: true,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+  };
+
+  it('maps a recipe to an example-typed resource and surfaces body as a code example', () => {
+    const r = recipeToLearningResource(recipe);
+    expect(r.id).toBe('rest-pagination');
+    expect(r.resource_type).toBe('example');
+    expect(r.category).toBe('recipes');
+    expect(r.tags).toEqual(['rest', 'pagination']);
+    expect(r.code_examples).toHaveLength(1);
+    expect(r.code_examples[0]).toMatchObject({
+      title: 'REST Pagination',
+      language: 'markdown',
+      code: '## Heading\n\nbody',
+    });
+  });
+
+  it('produces an empty code_examples list for a recipe with no body', () => {
+    const r = recipeToLearningResource({ ...recipe, body: '' });
+    expect(r.code_examples).toEqual([]);
+  });
+});
+
+// --- isCloudMode guard -----------------------------------------------------
+
+describe('CloudCommunityApi guard', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_MOCKFORGE_MODE', 'local');
+    vi.stubEnv('VITE_API_BASE_URL', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('rejects calls when not running in cloud mode', async () => {
+    await expect(cloudCommunityApi.getShowcaseProjects()).rejects.toThrow(/cloud mode/i);
+    await expect(cloudCommunityApi.getLearningResources()).rejects.toThrow(/cloud mode/i);
+    await expect(cloudCommunityApi.getShowcaseProject('x')).rejects.toThrow(/cloud mode/i);
+  });
+
+  it('refuses public submissions even in cloud mode (admin-only)', async () => {
+    vi.stubEnv('VITE_MOCKFORGE_MODE', 'cloud');
+    const r = await cloudCommunityApi.submitShowcaseProject({ title: 'x' });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/admin-curated/i);
+  });
+});

--- a/crates/mockforge-ui/ui/src/services/api/cloudCommunity.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudCommunity.ts
@@ -1,0 +1,337 @@
+/**
+ * Cloud-mode adapter for the Community pages (Showcase + Learning Hub).
+ *
+ * The local `communityApi` calls embedded `/__mockforge/community/*`
+ * endpoints whose data shape (`ShowcaseProject`, `LearningResource`)
+ * predates the cloud schema. The cloud registry exposes richer but
+ * differently-shaped resources at `/api/v1/showcase/*` and
+ * `/api/v1/learning/*`. This adapter speaks the cloud routes, then maps
+ * responses into the legacy shapes so `ShowcasePage` and
+ * `LearningHubPage` can render unchanged.
+ *
+ * Mappings worth flagging:
+ *   - `ShowcaseEntry.slug` → `ShowcaseProject.id` (slug is the public lookup key)
+ *   - `ShowcaseEntry.likes_count` → `stats.stars` (closest analog the cloud has)
+ *   - `tags[0]` → `category` (cloud has no separate category column)
+ *   - LearningTrack and LearningRecipe both flatten to `LearningResource[]`,
+ *     distinguished by `resource_type`: `guide` for tracks, `example` for recipes.
+ */
+import { fetchJsonWithErrorBody } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
+import type {
+  ApiResponse,
+  LearningResource,
+  ShowcaseProject,
+  SuccessStory,
+} from '../communityApi';
+
+// --- Cloud schema types (mirror registry-server) ---------------------------
+
+export interface ShowcaseEntry {
+  id: string;
+  slug: string;
+  org_id: string | null;
+  submitted_by: string | null;
+  title: string;
+  description: string;
+  body: string | null;
+  screenshots: string[];
+  demo_url: string | null;
+  source_url: string | null;
+  tags: string[];
+  is_featured: boolean;
+  is_published: boolean;
+  likes_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LearningTrack {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  body: string | null;
+  is_published: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LearningLesson {
+  id: string;
+  track_id: string;
+  slug: string;
+  title: string;
+  body: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LearningRecipe {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  body: string;
+  tags: string[];
+  is_published: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TrackDetail extends LearningTrack {
+  lessons: LearningLesson[];
+}
+
+// --- Adapters --------------------------------------------------------------
+
+export function showcaseEntryToProject(entry: ShowcaseEntry): ShowcaseProject {
+  return {
+    id: entry.slug,
+    title: entry.title,
+    author: entry.submitted_by ? 'Community' : 'MockForge',
+    description: entry.description,
+    category: entry.tags[0] ?? 'general',
+    tags: entry.tags,
+    featured: entry.is_featured,
+    screenshot: entry.screenshots[0],
+    demo_url: entry.demo_url ?? undefined,
+    source_url: entry.source_url ?? undefined,
+    stats: {
+      downloads: 0,
+      stars: entry.likes_count,
+      forks: 0,
+      rating: 0,
+    },
+    testimonials: [],
+    created_at: entry.created_at,
+    updated_at: entry.updated_at,
+  };
+}
+
+export function trackToLearningResource(track: LearningTrack): LearningResource {
+  return {
+    id: track.slug,
+    title: track.title,
+    description: track.description ?? '',
+    category: 'tracks',
+    resource_type: 'guide',
+    difficulty: 'beginner',
+    tags: [],
+    author: 'MockForge',
+    views: 0,
+    rating: 0,
+    code_examples: [],
+    created_at: track.created_at,
+    updated_at: track.updated_at,
+  };
+}
+
+export function recipeToLearningResource(recipe: LearningRecipe): LearningResource {
+  return {
+    id: recipe.slug,
+    title: recipe.title,
+    description: recipe.description ?? '',
+    category: 'recipes',
+    resource_type: 'example',
+    difficulty: 'intermediate',
+    tags: recipe.tags,
+    author: 'MockForge',
+    views: 0,
+    rating: 0,
+    code_examples: recipe.body
+      ? [{ title: recipe.title, language: 'markdown', code: recipe.body }]
+      : [],
+    created_at: recipe.created_at,
+    updated_at: recipe.updated_at,
+  };
+}
+
+function ok<T>(data: T): ApiResponse<T> {
+  return { success: true, data };
+}
+
+function fail<T>(error: string): ApiResponse<T> {
+  return { success: false, error };
+}
+
+// --- Client ----------------------------------------------------------------
+
+class CloudCommunityApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud community ${method} only works in cloud mode.`);
+    }
+  }
+
+  async getShowcaseProjects(params?: {
+    category?: string;
+    featured?: boolean;
+    limit?: number;
+  }): Promise<ApiResponse<ShowcaseProject[]>> {
+    this.guard('getShowcaseProjects');
+    try {
+      const qs = new URLSearchParams();
+      // Cloud routes filter by tag, not category. ShowcasePage uses category as
+      // a tag-like dimension (we map tags[0] → category), so it's a fair pass-through.
+      if (params?.category && params.category !== 'all') qs.set('tag', params.category);
+      if (params?.limit) qs.set('limit', String(params.limit));
+      const suffix = qs.toString() ? `?${qs}` : '';
+      const entries = (await fetchJsonWithErrorBody(
+        `/api/v1/showcase/entries${suffix}`,
+      )) as ShowcaseEntry[];
+      let projects = entries.map(showcaseEntryToProject);
+      if (params?.featured) projects = projects.filter((p) => p.featured);
+      return ok(projects);
+    } catch (e) {
+      return fail((e as Error).message);
+    }
+  }
+
+  async getShowcaseProject(slug: string): Promise<ApiResponse<ShowcaseProject>> {
+    this.guard('getShowcaseProject');
+    try {
+      const entry = (await fetchJsonWithErrorBody(
+        `/api/v1/showcase/entries/${encodeURIComponent(slug)}`,
+      )) as ShowcaseEntry;
+      return ok(showcaseEntryToProject(entry));
+    } catch (e) {
+      return fail((e as Error).message);
+    }
+  }
+
+  async getShowcaseCategories(): Promise<ApiResponse<string[]>> {
+    this.guard('getShowcaseCategories');
+    try {
+      const entries = (await fetchJsonWithErrorBody(
+        '/api/v1/showcase/entries?limit=500',
+      )) as ShowcaseEntry[];
+      const tags = new Set<string>();
+      for (const e of entries) for (const t of e.tags) tags.add(t);
+      return ok(Array.from(tags).sort());
+    } catch (e) {
+      return fail((e as Error).message);
+    }
+  }
+
+  // Cloud has no success-stories analog; the page hides the tab in cloud mode,
+  // but if anything still calls this we return an empty list rather than throw.
+  async getSuccessStories(_params?: {
+    featured?: boolean;
+    limit?: number;
+  }): Promise<ApiResponse<SuccessStory[]>> {
+    this.guard('getSuccessStories');
+    return ok([]);
+  }
+
+  async submitShowcaseProject(
+    _project: Partial<ShowcaseProject>,
+  ): Promise<ApiResponse<string>> {
+    // Public submission isn't part of the cloud surface; the admin authoring
+    // route at /api/v1/admin/showcase/entries lives behind the curator UI.
+    return fail('Showcase submissions are admin-curated in cloud mode.');
+  }
+
+  async getLearningResources(params?: {
+    category?: string;
+    type?: string;
+    difficulty?: string;
+    limit?: number;
+  }): Promise<ApiResponse<LearningResource[]>> {
+    this.guard('getLearningResources');
+    try {
+      const wantsTracks = !params?.type || params.type === 'all' || params.type === 'guide';
+      const wantsRecipes = !params?.type || params.type === 'all' || params.type === 'example';
+      const wantsByCategory = !params?.category || params.category === 'all';
+
+      const includeTracks =
+        wantsTracks && (wantsByCategory || params?.category === 'tracks');
+      const includeRecipes =
+        wantsRecipes && (wantsByCategory || params?.category === 'recipes');
+
+      const tagQs = new URLSearchParams();
+      // Recipes accept ?tag=; tracks don't filter by tag in the cloud API.
+      // We treat any non-bucket category as a recipe tag filter.
+      if (
+        params?.category &&
+        params.category !== 'all' &&
+        params.category !== 'tracks' &&
+        params.category !== 'recipes'
+      ) {
+        tagQs.set('tag', params.category);
+      }
+      const recipeSuffix = tagQs.toString() ? `?${tagQs}` : '';
+
+      const [tracks, recipes] = await Promise.all([
+        includeTracks
+          ? (fetchJsonWithErrorBody('/api/v1/learning/tracks') as Promise<LearningTrack[]>)
+          : Promise.resolve([] as LearningTrack[]),
+        includeRecipes
+          ? (fetchJsonWithErrorBody(
+              `/api/v1/learning/recipes${recipeSuffix}`,
+            ) as Promise<LearningRecipe[]>)
+          : Promise.resolve([] as LearningRecipe[]),
+      ]);
+
+      let merged: LearningResource[] = [
+        ...tracks.map(trackToLearningResource),
+        ...recipes.map(recipeToLearningResource),
+      ];
+      if (params?.difficulty && params.difficulty !== 'all') {
+        merged = merged.filter((r) => r.difficulty === params.difficulty);
+      }
+      if (params?.limit) merged = merged.slice(0, params.limit);
+      return ok(merged);
+    } catch (e) {
+      return fail((e as Error).message);
+    }
+  }
+
+  async getLearningResource(slug: string): Promise<ApiResponse<LearningResource>> {
+    this.guard('getLearningResource');
+    // We don't know up-front whether the slug is a track or recipe; try
+    // recipe first (cheaper, no lessons join), then fall back to track.
+    try {
+      const recipe = (await fetchJsonWithErrorBody(
+        `/api/v1/learning/recipes/${encodeURIComponent(slug)}`,
+      )) as LearningRecipe;
+      return ok(recipeToLearningResource(recipe));
+    } catch {
+      // fall through
+    }
+    try {
+      const detail = (await fetchJsonWithErrorBody(
+        `/api/v1/learning/tracks/${encodeURIComponent(slug)}`,
+      )) as TrackDetail;
+      const resource = trackToLearningResource(detail);
+      // Surface ordered lesson titles + bodies as code examples so the
+      // existing accordion view shows track contents.
+      resource.code_examples = (detail.lessons ?? []).map((l) => ({
+        title: l.title,
+        language: 'markdown',
+        code: l.body ?? '',
+      }));
+      return ok(resource);
+    } catch (e) {
+      return fail((e as Error).message);
+    }
+  }
+
+  async getLearningCategories(): Promise<ApiResponse<string[]>> {
+    this.guard('getLearningCategories');
+    try {
+      const recipes = (await fetchJsonWithErrorBody(
+        '/api/v1/learning/recipes',
+      )) as LearningRecipe[];
+      const tags = new Set<string>(['tracks', 'recipes']);
+      for (const r of recipes) for (const t of r.tags) tags.add(t);
+      return ok(Array.from(tags).sort());
+    } catch (e) {
+      return fail((e as Error).message);
+    }
+  }
+}
+
+export const cloudCommunityApi = new CloudCommunityApi();

--- a/crates/mockforge-ui/ui/src/services/communityApi.ts
+++ b/crates/mockforge-ui/ui/src/services/communityApi.ts
@@ -1,8 +1,16 @@
 //! Community portal API service
 //!
-//! Provides API client for showcase, learning resources, and community features
+//! Provides API client for showcase, learning resources, and community features.
+//!
+//! In cloud mode (VITE_MOCKFORGE_MODE=cloud) every method delegates to
+//! `cloudCommunityApi`, which calls `/api/v1/showcase/*` and
+//! `/api/v1/learning/*` and adapts the cloud schema to the legacy shapes
+//! defined in this file. The `/__mockforge/community/*` paths only exist
+//! on the locally embedded admin server.
 
 import { authenticatedFetch } from '../utils/apiClient';
+import { isCloudMode } from '../utils/cloudMode';
+import { cloudCommunityApi } from './api/cloudCommunity';
 
 export interface ShowcaseProject {
   id: string;
@@ -99,6 +107,7 @@ class CommunityApiService {
     limit?: number;
     offset?: number;
   }): Promise<ApiResponse<ShowcaseProject[]>> {
+    if (isCloudMode()) return cloudCommunityApi.getShowcaseProjects(params);
     const queryParams = new URLSearchParams();
     if (params?.category) queryParams.append('category', params.category);
     if (params?.featured !== undefined) queryParams.append('featured', String(params.featured));
@@ -110,10 +119,12 @@ class CommunityApiService {
   }
 
   async getShowcaseProject(id: string): Promise<ApiResponse<ShowcaseProject>> {
+    if (isCloudMode()) return cloudCommunityApi.getShowcaseProject(id);
     return this.fetchJson<ShowcaseProject>(`/__mockforge/community/showcase/projects/${id}`);
   }
 
   async getShowcaseCategories(): Promise<ApiResponse<string[]>> {
+    if (isCloudMode()) return cloudCommunityApi.getShowcaseCategories();
     return this.fetchJson<string[]>(`/__mockforge/community/showcase/categories`);
   }
 
@@ -121,6 +132,7 @@ class CommunityApiService {
     featured?: boolean;
     limit?: number;
   }): Promise<ApiResponse<SuccessStory[]>> {
+    if (isCloudMode()) return cloudCommunityApi.getSuccessStories(params);
     const queryParams = new URLSearchParams();
     if (params?.featured !== undefined) queryParams.append('featured', String(params.featured));
     if (params?.limit) queryParams.append('limit', String(params.limit));
@@ -130,6 +142,7 @@ class CommunityApiService {
   }
 
   async submitShowcaseProject(project: Partial<ShowcaseProject>): Promise<ApiResponse<string>> {
+    if (isCloudMode()) return cloudCommunityApi.submitShowcaseProject(project);
     return this.fetchJson<string>('/__mockforge/community/showcase/submit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -144,6 +157,7 @@ class CommunityApiService {
     difficulty?: string;
     limit?: number;
   }): Promise<ApiResponse<LearningResource[]>> {
+    if (isCloudMode()) return cloudCommunityApi.getLearningResources(params);
     const queryParams = new URLSearchParams();
     if (params?.category) queryParams.append('category', params.category);
     if (params?.type) queryParams.append('type', params.type);
@@ -155,10 +169,12 @@ class CommunityApiService {
   }
 
   async getLearningResource(id: string): Promise<ApiResponse<LearningResource>> {
+    if (isCloudMode()) return cloudCommunityApi.getLearningResource(id);
     return this.fetchJson<LearningResource>(`/__mockforge/community/learning/resources/${id}`);
   }
 
   async getLearningCategories(): Promise<ApiResponse<string[]>> {
+    if (isCloudMode()) return cloudCommunityApi.getLearningCategories();
     return this.fetchJson<string[]>(`/__mockforge/community/learning/categories`);
   }
 }


### PR DESCRIPTION
## Summary

Two batches of cloud-enable wiring on the same branch — both unblock pages that previously rendered as disabled "Local only" entries in cloud-mode sidebars.

### Batch 1 — Showcase + Learning Hub (already in `3fea6808`)
- `showcase` and `learning-hub` adapt `/api/v1/showcase/*` + `/api/v1/learning/*` into the legacy `ShowcaseProject` / `LearningResource` shapes via `cloudCommunityApi`.

### Batch 2 — Flows quartet + Fitness Functions + sidebar cleanup (new in `da2baf94`)

Closes the `cloudFlowsApi` story by wiring the four remaining flow-kind editor pages onto the shared workspace-scoped flows resource, plus a read-only path for fitness functions through `cloudContractApi`:

- `scenario-studio` → `cloudFlowsApi` kind=`scenario`
- `state-machine-editor` → `cloudFlowsApi` kind=`state_machine` (workspace-scoped flow picker added; local mode unchanged)
- `orchestration-builder` → `cloudFlowsApi` kind=`orchestration` (Save now persists)
- `orchestration-execution` → `cloudFlowsApi.triggerRun` + `cloudTestRunsApi.streamRunEvents` SSE — `step_start`/`step_pass`/`step_fail`/`step_skip`/`done` events map onto the existing visualization
- `fitness-functions` → `cloudContractApi.listFitnessFunctions` (read-only with banner; `readOnly` prop hides Edit/Delete/Test rows)
- `FlowExecutor` (Scenario Studio inline) → `cloudFlowsApi.triggerRun` with a "queued, follow on Cloud Test Runs" banner

`FlowVersion.config` carries the full native payload for each kind so the editors round-trip without lossy shape mapping.

### Sidebar cleanup
Added `cloudHiddenNavItemIds` to `AppShell.tsx`. Locals with cloud-* siblings are now hidden entirely in cloud mode instead of being shown disabled-with-tooltip: `chaos`, `recorder`, `incidents`, `traces`, `contract-diff`, `plugins`, `test-execution`, `analytics`.

### Reclassified HARD (not landed in this PR)

The audit's initial "TRIVIAL/SHIMMABLE" was wrong for these — each needs new backend machinery before a UI shim is meaningful:

- `verification` — interaction-verification needs request log query (registry's `verification.rs` is email verification, unrelated)
- `conformance` — no conformance executor on cloud test-runner
- `testing` — no smoke-test executor on cloud test-runner
- `behavioral-cloning` — capture-sessions vs flows shape divergence; runners still synthetic
- `analytics` — request-traffic, not conversion-funnel; covered by `pillar-analytics` already

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (0 errors, 910 pre-existing warnings)
- [x] `pnpm build` clean
- [ ] Browser-verify cloud mode for one page from each adapter family (cloudFlowsApi, cloudContractApi) before merging
- [ ] Confirm hidden locals don't break deep links (route still resolves; just no sidebar entry)