### PR TITLE
feat(cloud-plugins): Phase 0 demand-validation CTA on cloud plugin-registry

### DIFF
--- a/crates/mockforge-registry-core/src/models/cloud_plugin_beta_interest.rs
+++ b/crates/mockforge-registry-core/src/models/cloud_plugin_beta_interest.rs
@@ -1,0 +1,83 @@
+//! Cloud Plugins beta interest signups (Phase 0 demand validation).
+//!
+//! Each row captures one user's "Request beta access" submission for the
+//! cloud-hosted plugin runtime. Unique on `user_id` so repeat submissions
+//! UPSERT (latest `use_case` wins). See migration
+//! 20250101000073_cloud_plugin_beta_interest.sql.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[cfg(feature = "postgres")]
+use sqlx::{FromRow, PgPool};
+
+#[cfg_attr(feature = "postgres", derive(FromRow))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudPluginBetaInterest {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub org_id: Option<Uuid>,
+    pub use_case: Option<String>,
+    pub plan_at_signup: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[cfg(feature = "postgres")]
+pub struct UpsertCloudPluginBetaInterest<'a> {
+    pub user_id: Uuid,
+    pub org_id: Option<Uuid>,
+    pub use_case: Option<&'a str>,
+    pub plan_at_signup: Option<&'a str>,
+}
+
+#[cfg(feature = "postgres")]
+impl CloudPluginBetaInterest {
+    pub async fn upsert(
+        pool: &PgPool,
+        input: UpsertCloudPluginBetaInterest<'_>,
+    ) -> sqlx::Result<Self> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            INSERT INTO cloud_plugin_beta_interest (user_id, org_id, use_case, plan_at_signup)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (user_id) DO UPDATE SET
+                org_id = EXCLUDED.org_id,
+                use_case = EXCLUDED.use_case,
+                plan_at_signup = EXCLUDED.plan_at_signup,
+                updated_at = NOW()
+            RETURNING *
+            "#,
+        )
+        .bind(input.user_id)
+        .bind(input.org_id)
+        .bind(input.use_case)
+        .bind(input.plan_at_signup)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn find_by_user(pool: &PgPool, user_id: Uuid) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>("SELECT * FROM cloud_plugin_beta_interest WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_optional(pool)
+            .await
+    }
+
+    /// Aggregate counts for the go/no-go review. Returns
+    /// `(total_signups, distinct_orgs)`.
+    pub async fn aggregate_counts(pool: &PgPool) -> sqlx::Result<(i64, i64)> {
+        let row: (Option<i64>, Option<i64>) = sqlx::query_as(
+            r#"
+            SELECT
+                COUNT(*)::BIGINT AS total,
+                COUNT(DISTINCT org_id)::BIGINT AS distinct_orgs
+            FROM cloud_plugin_beta_interest
+            "#,
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok((row.0.unwrap_or(0), row.1.unwrap_or(0)))
+    }
+}

--- a/crates/mockforge-registry-core/src/models/mod.rs
+++ b/crates/mockforge-registry-core/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod audit_log;
 pub mod capture;
 pub mod chaos;
 pub mod cloud_fixture;
+pub mod cloud_plugin_beta_interest;
 pub mod cloud_service;
 pub mod cloud_workspace;
 pub mod contract_verification;
@@ -64,6 +65,7 @@ pub use audit_log::record_audit_event;
 pub use audit_log::AuditEventType;
 pub use capture::{CaptureSession, CloneModel};
 pub use chaos::{ChaosCampaign, ChaosCampaignReport, ResiliencePattern};
+pub use cloud_plugin_beta_interest::CloudPluginBetaInterest;
 pub use cloud_workspace::Workspace as CloudWorkspace;
 pub use contract_verification::{
     ContractDiffFinding, ContractDiffRun, FitnessFunction, MonitoredService, VerificationSuite,

--- a/crates/mockforge-registry-server/migrations/20250101000073_cloud_plugin_beta_interest.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000073_cloud_plugin_beta_interest.sql
@@ -1,0 +1,28 @@
+-- Cloud Plugins beta interest signups (Phase 0 demand validation).
+--
+-- A row is inserted when an authenticated user clicks the "Request beta
+-- access" CTA on the cloud plugin-registry page. UNIQUE (user_id) makes
+-- repeat submissions an UPSERT — the latest use_case wins. The org_id
+-- column captures which org context the user was in at signup time so
+-- the go/no-go review can ask "how many distinct orgs (and at which
+-- plan tiers) want this".
+
+CREATE TABLE cloud_plugin_beta_interest (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- Nullable so a user with no current org context can still register.
+    org_id UUID REFERENCES organizations(id) ON DELETE SET NULL,
+    -- Free-text "what would you build with cloud plugins?". Optional.
+    use_case TEXT,
+    -- Snapshot of the org plan at signup ('free' | 'pro' | 'team' | NULL).
+    -- Stored verbatim to avoid joins during analysis and to preserve the
+    -- value even if the org later upgrades.
+    plan_at_signup VARCHAR(50),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id)
+);
+
+CREATE INDEX idx_cloud_plugin_beta_interest_org ON cloud_plugin_beta_interest(org_id);
+CREATE INDEX idx_cloud_plugin_beta_interest_created
+    ON cloud_plugin_beta_interest(created_at DESC);

--- a/crates/mockforge-registry-server/src/handlers/cloud_plugins.rs
+++ b/crates/mockforge-registry-server/src/handlers/cloud_plugins.rs
@@ -1,0 +1,166 @@
+//! Cloud Plugins beta interest endpoints (Phase 0 demand validation).
+//!
+//! These endpoints back the "Request beta access" CTA on the cloud
+//! `/plugin-registry` page. They are deliberately tiny: a single UPSERT
+//! and a single point-read. Aggregate analysis for the go/no-go review
+//! is done off-line via SQL against `cloud_plugin_beta_interest`.
+//!
+//! Routes:
+//!   POST /api/v1/cloud-plugins/beta-interest
+//!   GET  /api/v1/cloud-plugins/beta-interest/me
+//!
+//! The endpoint is NOT org-scoped on purpose: registering interest is a
+//! per-user action, not a per-org one. We still snapshot the user's
+//! current org_id + plan so the go/no-go review can segment by tier.
+
+use axum::{extract::State, http::HeaderMap, Json};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    models::CloudPluginBetaInterest,
+    AppState,
+};
+
+/// Free-text caps. Trimmed and length-limited server-side so a runaway
+/// client can't dump unlimited text into the table.
+const MAX_USE_CASE_LEN: usize = 2_000;
+
+#[derive(Debug, Deserialize)]
+pub struct BetaInterestRequest {
+    /// Optional "what would you build with cloud plugins?" answer.
+    #[serde(default)]
+    pub use_case: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BetaInterestResponse {
+    pub id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BetaInterestStatusResponse {
+    pub signed_up: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+    /// Echo back the user's last submitted use case so the form can
+    /// pre-populate when they revisit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_case: Option<String>,
+}
+
+/// `POST /api/v1/cloud-plugins/beta-interest`
+///
+/// UPSERT — second submission updates `use_case` instead of erroring.
+pub async fn submit_interest(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Json(request): Json<BetaInterestRequest>,
+) -> ApiResult<Json<BetaInterestResponse>> {
+    let use_case = sanitize_use_case(request.use_case.as_deref())?;
+
+    // Best-effort org context — we don't fail the signup if the user has
+    // no current org, we just store NULL.
+    let (org_id, plan_at_signup) = match resolve_org_context(&state, user_id, &headers, None).await
+    {
+        Ok(ctx) => (Some(ctx.org_id), Some(ctx.org.plan)),
+        Err(_) => (None, None),
+    };
+
+    let row = CloudPluginBetaInterest::upsert(
+        state.db.pool(),
+        crate::models::cloud_plugin_beta_interest::UpsertCloudPluginBetaInterest {
+            user_id,
+            org_id,
+            use_case: use_case.as_deref(),
+            plan_at_signup: plan_at_signup.as_deref(),
+        },
+    )
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(BetaInterestResponse {
+        id: row.id.to_string(),
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    }))
+}
+
+/// `GET /api/v1/cloud-plugins/beta-interest/me`
+pub async fn get_my_interest(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+) -> ApiResult<Json<BetaInterestStatusResponse>> {
+    let existing = CloudPluginBetaInterest::find_by_user(state.db.pool(), user_id)
+        .await
+        .map_err(ApiError::Database)?;
+
+    Ok(Json(match existing {
+        Some(row) => BetaInterestStatusResponse {
+            signed_up: true,
+            created_at: Some(row.created_at),
+            use_case: row.use_case,
+        },
+        None => BetaInterestStatusResponse {
+            signed_up: false,
+            created_at: None,
+            use_case: None,
+        },
+    }))
+}
+
+fn sanitize_use_case(raw: Option<&str>) -> ApiResult<Option<String>> {
+    let Some(text) = raw else {
+        return Ok(None);
+    };
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.chars().count() > MAX_USE_CASE_LEN {
+        return Err(ApiError::InvalidRequest(format!(
+            "use_case must be {} characters or fewer",
+            MAX_USE_CASE_LEN
+        )));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_trims_and_drops_empty() {
+        assert_eq!(sanitize_use_case(None).unwrap(), None);
+        assert_eq!(sanitize_use_case(Some("")).unwrap(), None);
+        assert_eq!(sanitize_use_case(Some("   ")).unwrap(), None);
+        assert_eq!(sanitize_use_case(Some("  hello  ")).unwrap(), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn sanitize_rejects_too_long() {
+        let too_long: String = "x".repeat(MAX_USE_CASE_LEN + 1);
+        let err = sanitize_use_case(Some(&too_long)).unwrap_err();
+        assert!(matches!(err, ApiError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn sanitize_accepts_max_length() {
+        let exact: String = "x".repeat(MAX_USE_CASE_LEN);
+        assert_eq!(sanitize_use_case(Some(&exact)).unwrap(), Some(exact));
+    }
+
+    #[test]
+    fn sanitize_counts_chars_not_bytes() {
+        // Multi-byte UTF-8 char — 4 bytes, 1 grapheme. We count chars to
+        // be lenient with non-ASCII input.
+        let s: String = "🚀".repeat(MAX_USE_CASE_LEN);
+        assert_eq!(sanitize_use_case(Some(&s)).unwrap(), Some(s));
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod captures;
 pub mod chaos;
 pub mod cloud_dashboard;
 pub mod cloud_fixtures;
+pub mod cloud_plugins;
 pub mod cloud_services;
 pub mod cloud_workspaces;
 pub mod contract_verification;

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -664,6 +664,17 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             patch(handlers::routing_rules::update_rule)
                 .delete(handlers::routing_rules::delete_rule),
         )
+        // Cloud Plugins beta interest (Phase 0 demand validation).
+        // Tiny pair of endpoints behind the "Request beta access" CTA on
+        // the cloud /plugin-registry page. Per-user, not org-scoped.
+        .route(
+            "/api/v1/cloud-plugins/beta-interest",
+            post(handlers::cloud_plugins::submit_interest),
+        )
+        .route(
+            "/api/v1/cloud-plugins/beta-interest/me",
+            get(handlers::cloud_plugins::get_my_interest),
+        )
         // Usage tracking routes
         .route("/api/v1/usage", get(handlers::usage::get_usage))
         .route("/api/v1/usage/history", get(handlers::usage::get_usage_history))

--- a/crates/mockforge-ui/ui/src/components/plugins/CloudPluginsBetaCta.tsx
+++ b/crates/mockforge-ui/ui/src/components/plugins/CloudPluginsBetaCta.tsx
@@ -1,0 +1,232 @@
+/**
+ * CloudPluginsBetaCta — demand-validation CTA for cloud-runtime plugins.
+ *
+ * Phase 0 of the cloud-plugins initiative: before committing to the
+ * 4–6 weeks of runtime + metering work, ship a "Request beta access"
+ * banner on the cloud /plugin-registry page and gate the engineering
+ * spend on signups. A user submits once (UPSERT on user_id) with an
+ * optional free-text use case. After submitting, the banner switches
+ * to a thank-you state so the page doesn't keep prompting.
+ *
+ * Hides itself entirely in self-hosted (local) mode — there is no
+ * cloud runtime to attach plugins to in that build.
+ */
+import React, { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Snackbar,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  Cloud as CloudIcon,
+  Close as CloseIcon,
+  CheckCircle as CheckCircleIcon,
+} from '@mui/icons-material';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { isCloudMode } from '../../utils/cloudMode';
+import {
+  cloudPluginsApi,
+  type BetaInterestStatus,
+} from '../../services/api/cloudPlugins';
+
+const QUERY_KEY = ['cloud-plugins', 'beta-interest', 'me'];
+const USE_CASE_MAX = 2_000;
+
+export const CloudPluginsBetaCta: React.FC = () => {
+  if (!isCloudMode()) return null;
+  return <Inner />;
+};
+
+const Inner: React.FC = () => {
+  const queryClient = useQueryClient();
+  const statusQuery = useQuery<BetaInterestStatus>({
+    queryKey: QUERY_KEY,
+    queryFn: () => cloudPluginsApi.getMyBetaInterest(),
+    staleTime: 5 * 60_000,
+  });
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [useCase, setUseCase] = useState('');
+  const [snackbarMsg, setSnackbarMsg] = useState<string | null>(null);
+
+  const submit = useMutation({
+    mutationFn: (text: string) =>
+      cloudPluginsApi.submitBetaInterest({
+        use_case: text.trim() ? text.trim() : undefined,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      setDialogOpen(false);
+      setSnackbarMsg("You're on the beta list. We'll be in touch.");
+    },
+  });
+
+  const openDialog = () => {
+    setUseCase(statusQuery.data?.use_case ?? '');
+    setDialogOpen(true);
+  };
+
+  // Don't render until we know whether the user has signed up — avoids
+  // a flash of the CTA followed by the thank-you state on every page
+  // load. Errors are soft-failed (banner just doesn't show).
+  if (statusQuery.isLoading || statusQuery.isError || !statusQuery.data) {
+    return null;
+  }
+
+  const status = statusQuery.data;
+
+  return (
+    <>
+      {status.signed_up ? (
+        <SignedUpBanner onUpdate={openDialog} />
+      ) : (
+        <CtaBanner onClick={openDialog} />
+      )}
+
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+        aria-labelledby="cloud-plugins-beta-dialog-title"
+      >
+        <DialogTitle id="cloud-plugins-beta-dialog-title">
+          Cloud Plugins — beta access
+        </DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              We're exploring a per-tenant plugin runtime that would let you
+              attach signed WASM extensions to your hosted mocks — request
+              transformers, custom auth, response shaping, etc. — without
+              self-hosting MockForge.
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              If that sounds useful, tell us roughly what you'd build. It
+              shapes which capabilities ship first and who we invite to the
+              private beta.
+            </Typography>
+            <TextField
+              label="What would you build with cloud plugins? (optional)"
+              multiline
+              minRows={3}
+              maxRows={8}
+              fullWidth
+              value={useCase}
+              onChange={(e) => setUseCase(e.target.value.slice(0, USE_CASE_MAX))}
+              helperText={`${useCase.length} / ${USE_CASE_MAX}`}
+              inputProps={{ 'data-testid': 'beta-use-case-input' }}
+            />
+            {submit.isError && (
+              <Alert severity="error">
+                Something went wrong. Try again in a moment.
+              </Alert>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)} disabled={submit.isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            disabled={submit.isPending}
+            onClick={() => submit.mutate(useCase)}
+            data-testid="beta-submit-button"
+          >
+            {status.signed_up ? 'Update' : 'Request beta access'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbarMsg !== null}
+        autoHideDuration={4000}
+        onClose={() => setSnackbarMsg(null)}
+        message={snackbarMsg}
+      />
+    </>
+  );
+};
+
+const CtaBanner: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 2,
+      p: 2,
+      mb: 3,
+      borderRadius: 2,
+      background: 'linear-gradient(90deg, rgba(59,130,246,0.08), rgba(168,85,247,0.08))',
+      border: '1px solid',
+      borderColor: 'divider',
+    }}
+    data-testid="cloud-plugins-beta-cta"
+  >
+    <CloudIcon sx={{ color: 'primary.main' }} />
+    <Box sx={{ flex: 1 }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+        Coming soon: run plugins in your cloud workspace
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Help us decide what ships first — request beta access in 30 seconds.
+      </Typography>
+    </Box>
+    <Button variant="contained" size="small" onClick={onClick}>
+      Request beta access
+    </Button>
+  </Box>
+);
+
+const SignedUpBanner: React.FC<{ onUpdate: () => void }> = ({ onUpdate }) => {
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed) return null;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        p: 1.5,
+        mb: 3,
+        borderRadius: 2,
+        background: (theme) =>
+          theme.palette.mode === 'dark'
+            ? 'rgba(34,197,94,0.08)'
+            : 'rgba(34,197,94,0.06)',
+        border: '1px solid',
+        borderColor: 'success.light',
+      }}
+      data-testid="cloud-plugins-beta-signed-up"
+    >
+      <CheckCircleIcon sx={{ color: 'success.main' }} />
+      <Box sx={{ flex: 1 }}>
+        <Typography variant="body2">
+          You're on the cloud-plugins beta list. We'll reach out as the runtime
+          ships.
+        </Typography>
+      </Box>
+      <Button size="small" onClick={onUpdate}>
+        Update
+      </Button>
+      <IconButton
+        size="small"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+      >
+        <CloseIcon fontSize="small" />
+      </IconButton>
+    </Box>
+  );
+};

--- a/crates/mockforge-ui/ui/src/components/plugins/__tests__/CloudPluginsBetaCta.test.tsx
+++ b/crates/mockforge-ui/ui/src/components/plugins/__tests__/CloudPluginsBetaCta.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const cloudModeMock = vi.hoisted(() => ({ isCloudMode: vi.fn(() => true) }));
+vi.mock('../../../utils/cloudMode', () => cloudModeMock);
+
+const apiMock = vi.hoisted(() => ({
+  getMyBetaInterest: vi.fn(),
+  submitBetaInterest: vi.fn(),
+}));
+vi.mock('../../../services/api/cloudPlugins', () => ({
+  cloudPluginsApi: apiMock,
+}));
+
+import { CloudPluginsBetaCta } from '../CloudPluginsBetaCta';
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+describe('CloudPluginsBetaCta', () => {
+  beforeEach(() => {
+    // Reset (not just clear) wipes the mockResolvedValue queue so each
+    // test starts from a known-empty state.
+    apiMock.getMyBetaInterest.mockReset();
+    apiMock.submitBetaInterest.mockReset();
+    cloudModeMock.isCloudMode.mockReset();
+    cloudModeMock.isCloudMode.mockReturnValue(true);
+  });
+
+  it('renders nothing in self-hosted (local) mode', () => {
+    cloudModeMock.isCloudMode.mockReturnValue(false);
+    apiMock.getMyBetaInterest.mockResolvedValue({ signed_up: false });
+
+    const { container } = renderWithProviders(<CloudPluginsBetaCta />);
+
+    expect(container.firstChild).toBeNull();
+    expect(apiMock.getMyBetaInterest).not.toHaveBeenCalled();
+  });
+
+  it('shows the request-access banner when the user has not signed up', async () => {
+    apiMock.getMyBetaInterest.mockResolvedValue({ signed_up: false });
+
+    renderWithProviders(<CloudPluginsBetaCta />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cloud-plugins-beta-cta')).toBeInTheDocument();
+    });
+    // Use role-based query so "Request beta access" matches only the button,
+    // not the subtitle text that also contains the phrase.
+    expect(
+      screen.getByRole('button', { name: /Request beta access/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the signed-up banner when the user already registered interest', async () => {
+    apiMock.getMyBetaInterest.mockResolvedValue({
+      signed_up: true,
+      created_at: '2026-05-05T12:00:00Z',
+      use_case: 'request transformer for compliance redaction',
+    });
+
+    renderWithProviders(<CloudPluginsBetaCta />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('cloud-plugins-beta-signed-up'),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('cloud-plugins-beta-cta')).not.toBeInTheDocument();
+  });
+
+  it('submits the use case and switches to the signed-up state', async () => {
+    // First call (initial load) → not signed up. After submit, the
+    // mutation invalidates the query and we expect the next call to
+    // return signed_up = true.
+    apiMock.getMyBetaInterest
+      .mockResolvedValueOnce({ signed_up: false })
+      .mockResolvedValue({
+        signed_up: true,
+        created_at: '2026-05-05T12:00:00Z',
+        use_case: 'webhook signing plugin',
+      });
+    apiMock.submitBetaInterest.mockResolvedValue({
+      id: '00000000-0000-0000-0000-000000000001',
+      created_at: '2026-05-05T12:00:00Z',
+      updated_at: '2026-05-05T12:00:00Z',
+    });
+
+    renderWithProviders(<CloudPluginsBetaCta />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Request beta access/i }),
+    );
+
+    const textarea = await screen.findByTestId('beta-use-case-input');
+    fireEvent.change(textarea, { target: { value: 'webhook signing plugin' } });
+
+    fireEvent.click(screen.getByTestId('beta-submit-button'));
+
+    await waitFor(() => {
+      expect(apiMock.submitBetaInterest).toHaveBeenCalledWith({
+        use_case: 'webhook signing plugin',
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('cloud-plugins-beta-signed-up'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('omits use_case from the payload when the textarea is empty', async () => {
+    apiMock.getMyBetaInterest
+      .mockResolvedValueOnce({ signed_up: false })
+      .mockResolvedValue({ signed_up: true });
+    apiMock.submitBetaInterest.mockResolvedValue({
+      id: '00000000-0000-0000-0000-000000000001',
+      created_at: '2026-05-05T12:00:00Z',
+      updated_at: '2026-05-05T12:00:00Z',
+    });
+
+    renderWithProviders(<CloudPluginsBetaCta />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Request beta access/i }),
+    );
+    fireEvent.click(await screen.findByTestId('beta-submit-button'));
+
+    await waitFor(() => {
+      expect(apiMock.submitBetaInterest).toHaveBeenCalledWith({
+        use_case: undefined,
+      });
+    });
+  });
+
+  it('renders nothing on API error to avoid blocking the page', async () => {
+    apiMock.getMyBetaInterest.mockRejectedValue(new Error('boom'));
+
+    const { container } = renderWithProviders(<CloudPluginsBetaCta />);
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid^="cloud-plugins-beta"]'),
+      ).toBeNull();
+    });
+  });
+});

--- a/crates/mockforge-ui/ui/src/pages/PluginRegistryPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PluginRegistryPage.tsx
@@ -61,6 +61,7 @@ import { authenticatedFetch } from '../utils/apiClient';
 import { useAuthStore } from '../stores/useAuthStore';
 import { PublishPluginModal } from '../components/marketplace/PublishPluginModal';
 import { MarketplaceTabs } from '../components/marketplace/MarketplaceTabs';
+import { CloudPluginsBetaCta } from '../components/plugins/CloudPluginsBetaCta';
 
 interface Plugin {
   name: string;
@@ -627,6 +628,9 @@ export const PluginRegistryPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       <MarketplaceTabs />
+
+      {/* Phase 0 demand-validation CTA — only renders in cloud mode. */}
+      <CloudPluginsBetaCta />
 
       {/* Header */}
       <Box

--- a/crates/mockforge-ui/ui/src/services/api/cloudPlugins.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudPlugins.ts
@@ -1,0 +1,43 @@
+/**
+ * Cloud Plugins beta interest API (Phase 0 demand validation).
+ *
+ * Wraps `/api/v1/cloud-plugins/beta-interest{,/me}`. The endpoints are
+ * per-user (not org-scoped) — registering interest is an individual
+ * action, even if we snapshot the user's current org context server
+ * side for analysis.
+ */
+import { fetchJsonWithErrorBody } from './client';
+
+export interface BetaInterestStatus {
+  signed_up: boolean;
+  created_at?: string;
+  use_case?: string;
+}
+
+export interface BetaInterestSubmission {
+  id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SubmitBetaInterestRequest {
+  use_case?: string;
+}
+
+export const cloudPluginsApi = {
+  async getMyBetaInterest(): Promise<BetaInterestStatus> {
+    return (await fetchJsonWithErrorBody(
+      '/api/v1/cloud-plugins/beta-interest/me',
+    )) as BetaInterestStatus;
+  },
+
+  async submitBetaInterest(
+    body: SubmitBetaInterestRequest,
+  ): Promise<BetaInterestSubmission> {
+    return (await fetchJsonWithErrorBody('/api/v1/cloud-plugins/beta-interest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })) as BetaInterestSubmission;
+  },
+};


### PR DESCRIPTION
## Summary
- Kicks off the cloud-plugins initiative — a tenant-scoped runtime for plugins attached to hosted mocks. **No competitor in the mock-API space ships this**, so it's a real moat opportunity, but ambiguous category-level evidence means we should validate demand before committing 4–6 weeks to runtime + metering.
- This PR is the validate step: ships a "Request beta access" CTA on the cloud `/plugin-registry` page, captures signups + a free-text use-case answer into `cloud_plugin_beta_interest`, and gates downstream phases on a pre-set threshold (≥25 signups from Pro+ orgs in 4 weeks, ≥5 unique use cases).
- Self-hosted bundle is untouched — banner only renders when `isCloudMode()` is true.

## What's in the box
**Backend** — two endpoints, deliberately tiny:
- `POST /api/v1/cloud-plugins/beta-interest` — UPSERT on `user_id`, optional `use_case` field (server-side trim + 2k char cap, char-counted not byte-counted so non-ASCII is lenient).
- `GET /api/v1/cloud-plugins/beta-interest/me` — returns `{ signed_up, created_at?, use_case? }` so the UI can show a thank-you state instead of re-prompting on every visit.
- New table `cloud_plugin_beta_interest` snapshots `org_id` + `plan_at_signup` so the go/no-go review can segment by tier.

**Frontend** — `CloudPluginsBetaCta` component on `PluginRegistryPage`:
- Soft-fails on API error (no banner instead of error noise).
- Banner switches to a dismissible thank-you state once submitted; "Update" lets the user revise their use-case answer.

## Why now
The cloud surface today already runs per-tenant Fly machines for hosted mocks — we just haven't projected runtime control surfaces (plugins, recorder, chaos, config overrides) onto them. Plugins is the highest-value first projection because no one else does it. This PR is **only** the demand signal; runtime/metering work is gated on it.

## Phase plan (linked context)
1. **Phase 0 — this PR** — demand CTA + capture
2. Phase 1 — trust/permission RFC + control-plane API + schema
3. Phase 2 — runtime delivery + metering paired (sidecar on the same Fly machine, signature-required loads, egress allowlist)
4. Phase 3 — `cloud-plugins` UI route (separate from local `/plugins`)
5. Phase 4 — beta → GA + tiered pricing

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p mockforge-registry-core -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test handlers::cloud_plugins` — 4/4 pass
- [x] `pnpm type-check` — clean
- [x] `pnpm test src/components/plugins/__tests__/CloudPluginsBetaCta.test.tsx` — 6/6 pass (local-mode hide, signed-up vs not rendering, submit + state flip, empty-text payload, soft-fail on API error)
- [x] Adjacent plugin tests (`Plugins.test.tsx`, `PluginsPage.test.tsx`) — 21/21 pass, no regressions
- [x] Pre-commit hooks (migration-collisions, clippy, typos, rust fmt) — all passed
- [ ] Smoke-test the migration on a staging registry instance before production rollout