### PR TITLE
feat(plugin-loader): per-invocation metrics bus with wall-time + status

### DIFF
--- a/crates/mockforge-plugin-loader/src/invocation_metrics.rs
+++ b/crates/mockforge-plugin-loader/src/invocation_metrics.rs
@@ -1,0 +1,357 @@
+//! Per-invocation metrics for plugin execution.
+//!
+//! Each call into a plugin emits an [`InvocationMetric`] on a
+//! broadcast channel ([`InvocationMetricsBus`]). Observers — the admin
+//! UI's plugin status page, an OTLP exporter for cloud metering, a
+//! billing aggregator — subscribe and consume.
+//!
+//! This is the foundation for cloud-plugins Phase 2 metering: the bus
+//! shape is the same whether we're emitting locally for the OSS admin
+//! UI or shipping events to a SaaS billing pipeline. Local first,
+//! cloud second.
+//!
+//! # Why a broadcast channel
+//!
+//! Multiple subscribers each get every event without coordinating.
+//! Slow consumers don't slow down the producer — `tokio::sync::broadcast`
+//! drops messages for laggers and surfaces it as a `RecvError::Lagged`,
+//! which is the right semantics for telemetry (better to miss a sample
+//! than to backpressure the request path).
+//!
+//! # Why RAII for the timer
+//!
+//! The producer side is wrapped in [`InvocationTimer`], which records
+//! the start instant on construction and emits the metric on `finish_*`.
+//! Forgetting to finish a timer is a (warned) bug; the `Drop` impl emits
+//! a "dropped" metric so we don't silently lose calls.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use mockforge_plugin_core::PluginId;
+use tokio::sync::broadcast::{self, Receiver, Sender};
+
+/// Default capacity for the broadcast channel. 256 is generous for a
+/// single mockforge process — laggers up to ~256 events behind still
+/// receive; beyond that the receiver gets `RecvError::Lagged`.
+const DEFAULT_CHANNEL_CAPACITY: usize = 256;
+
+/// One plugin invocation's measured cost + outcome.
+#[derive(Debug, Clone)]
+pub struct InvocationMetric {
+    /// The plugin whose function was invoked.
+    pub plugin_id: PluginId,
+    /// The exported function the host called. For most plugins this is
+    /// `"on_request"` / `"on_response"` / similar.
+    pub function_name: String,
+    /// Wall-clock start, useful for correlation with request traces.
+    pub started_at: DateTime<Utc>,
+    /// Wall-time spent inside the plugin call. Microseconds for fine
+    /// resolution; sub-millisecond invocations are common for transform
+    /// plugins.
+    pub wall_time_us: u64,
+    /// Peak memory usage observed during this invocation, in bytes.
+    /// Reported as 0 when the underlying tracker isn't wired up
+    /// (current state — see `memory_tracking.rs` for the limiter that
+    /// will populate this in cloud Phase 2).
+    pub memory_peak_bytes: u64,
+    /// Outcome.
+    pub status: InvocationStatus,
+}
+
+/// Outcome of a plugin invocation, attached to each [`InvocationMetric`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvocationStatus {
+    /// The plugin function returned normally.
+    Success,
+    /// The plugin function returned an error or trapped.
+    Failure {
+        /// Error message captured from the failed invocation.
+        error: String,
+    },
+    /// The timer was dropped without `finish_*` being called. Indicates
+    /// a host-side bug — the call path didn't see the work through.
+    Dropped,
+}
+
+/// Broadcast bus that fans an [`InvocationMetric`] out to subscribers.
+///
+/// Construct one per [`PluginSandbox`] and clone the `Arc` to pass it
+/// into each [`SandboxInstance`]. External code calls [`subscribe`] to
+/// get a [`Receiver`] for live events.
+///
+/// [`PluginSandbox`]: crate::sandbox::PluginSandbox
+/// [`SandboxInstance`]: crate::sandbox::SandboxInstance
+/// [`subscribe`]: InvocationMetricsBus::subscribe
+#[derive(Debug, Clone)]
+pub struct InvocationMetricsBus {
+    tx: Sender<InvocationMetric>,
+}
+
+impl InvocationMetricsBus {
+    /// Construct a bus with the default channel capacity
+    /// ([`DEFAULT_CHANNEL_CAPACITY`]).
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CHANNEL_CAPACITY)
+    }
+
+    /// Construct a bus with a custom channel capacity. Larger values
+    /// tolerate slower subscribers without dropping events; smaller
+    /// values use less memory per bus.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (tx, _rx) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    /// Subscribe to live metrics. Each subscriber sees every event sent
+    /// after the call to `subscribe`; events emitted before are not
+    /// replayed.
+    pub fn subscribe(&self) -> Receiver<InvocationMetric> {
+        self.tx.subscribe()
+    }
+
+    /// Send a metric. Non-blocking. If the channel is full, the oldest
+    /// undelivered event is dropped (broadcast semantics) — that
+    /// subscriber gets `RecvError::Lagged` on the next `recv`. If
+    /// nobody is subscribed, the metric is silently dropped.
+    pub fn record(&self, metric: InvocationMetric) {
+        // `send` returns `Err` if there are no subscribers. That's
+        // expected (e.g. self-hosted user without admin UI open) — not
+        // an error, so we ignore it.
+        let _ = self.tx.send(metric);
+    }
+
+    /// Current number of subscribers. Useful for tests and for skipping
+    /// metric construction when nobody's listening.
+    pub fn subscriber_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+}
+
+impl Default for InvocationMetricsBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII guard that times a plugin invocation and emits one
+/// [`InvocationMetric`] when finished.
+///
+/// Construct with [`start`], then call exactly one of
+/// [`finish_success`] or [`finish_failure`]. Dropping the timer
+/// without calling `finish_*` emits a [`InvocationStatus::Dropped`]
+/// metric — this is a bug, but a visible one rather than a silent
+/// omission.
+///
+/// [`start`]: InvocationTimer::start
+/// [`finish_success`]: InvocationTimer::finish_success
+/// [`finish_failure`]: InvocationTimer::finish_failure
+pub struct InvocationTimer {
+    bus: Arc<InvocationMetricsBus>,
+    plugin_id: PluginId,
+    function_name: String,
+    started_at: DateTime<Utc>,
+    started_instant: std::time::Instant,
+    /// Set to `true` when `finish_*` consumes the timer, so the `Drop`
+    /// impl knows to skip the dropped-metric emit.
+    finished: bool,
+}
+
+impl InvocationTimer {
+    /// Start timing an invocation. The wall-clock and `Instant` are
+    /// captured here; nothing is sent on the bus until `finish_*`.
+    pub fn start(
+        bus: Arc<InvocationMetricsBus>,
+        plugin_id: PluginId,
+        function_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            bus,
+            plugin_id,
+            function_name: function_name.into(),
+            started_at: Utc::now(),
+            started_instant: std::time::Instant::now(),
+            finished: false,
+        }
+    }
+
+    /// Emit a successful invocation metric.
+    pub fn finish_success(mut self, memory_peak_bytes: u64) {
+        self.emit(InvocationStatus::Success, memory_peak_bytes);
+    }
+
+    /// Emit a failed invocation metric.
+    pub fn finish_failure(mut self, error: impl Into<String>, memory_peak_bytes: u64) {
+        self.emit(
+            InvocationStatus::Failure {
+                error: error.into(),
+            },
+            memory_peak_bytes,
+        );
+    }
+
+    fn emit(&mut self, status: InvocationStatus, memory_peak_bytes: u64) {
+        self.finished = true;
+        let wall_time_us = self.started_instant.elapsed().as_micros().min(u64::MAX as u128) as u64;
+        let metric = InvocationMetric {
+            plugin_id: self.plugin_id.clone(),
+            function_name: std::mem::take(&mut self.function_name),
+            started_at: self.started_at,
+            wall_time_us,
+            memory_peak_bytes,
+            status,
+        };
+        self.bus.record(metric);
+    }
+}
+
+impl Drop for InvocationTimer {
+    fn drop(&mut self) {
+        if !self.finished {
+            tracing::warn!(
+                plugin_id = %self.plugin_id,
+                function_name = %self.function_name,
+                "InvocationTimer dropped without finish_* — emitting Dropped metric"
+            );
+            // Re-use `emit`. We have to provide a memory_peak; we don't
+            // know it at drop time, so 0 is the honest value.
+            self.emit(InvocationStatus::Dropped, 0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn test_plugin_id() -> PluginId {
+        PluginId::new("test-plugin")
+    }
+
+    #[tokio::test]
+    async fn record_with_no_subscribers_is_silent() {
+        let bus = InvocationMetricsBus::new();
+        assert_eq!(bus.subscriber_count(), 0);
+
+        // Should not panic, should not error.
+        bus.record(InvocationMetric {
+            plugin_id: test_plugin_id(),
+            function_name: "fn1".into(),
+            started_at: Utc::now(),
+            wall_time_us: 100,
+            memory_peak_bytes: 0,
+            status: InvocationStatus::Success,
+        });
+    }
+
+    #[tokio::test]
+    async fn subscribe_then_receive() {
+        let bus = InvocationMetricsBus::new();
+        let mut rx = bus.subscribe();
+        assert_eq!(bus.subscriber_count(), 1);
+
+        bus.record(InvocationMetric {
+            plugin_id: test_plugin_id(),
+            function_name: "fn1".into(),
+            started_at: Utc::now(),
+            wall_time_us: 42,
+            memory_peak_bytes: 0,
+            status: InvocationStatus::Success,
+        });
+
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received.function_name, "fn1");
+        assert_eq!(received.wall_time_us, 42);
+        assert_eq!(received.status, InvocationStatus::Success);
+    }
+
+    #[tokio::test]
+    async fn multiple_subscribers_each_get_every_event() {
+        let bus = InvocationMetricsBus::new();
+        let mut rx1 = bus.subscribe();
+        let mut rx2 = bus.subscribe();
+        assert_eq!(bus.subscriber_count(), 2);
+
+        bus.record(InvocationMetric {
+            plugin_id: test_plugin_id(),
+            function_name: "fn-broadcast".into(),
+            started_at: Utc::now(),
+            wall_time_us: 7,
+            memory_peak_bytes: 0,
+            status: InvocationStatus::Success,
+        });
+
+        let m1 = rx1.recv().await.unwrap();
+        let m2 = rx2.recv().await.unwrap();
+        assert_eq!(m1.function_name, "fn-broadcast");
+        assert_eq!(m2.function_name, "fn-broadcast");
+    }
+
+    #[tokio::test]
+    async fn timer_finish_success_emits_metric() {
+        let bus = Arc::new(InvocationMetricsBus::new());
+        let mut rx = bus.subscribe();
+
+        let timer = InvocationTimer::start(bus.clone(), test_plugin_id(), "do_thing");
+        // Sleep a tiny amount so wall_time_us is meaningfully > 0.
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        timer.finish_success(1024);
+
+        let metric = rx.recv().await.unwrap();
+        assert_eq!(metric.function_name, "do_thing");
+        assert_eq!(metric.status, InvocationStatus::Success);
+        assert_eq!(metric.memory_peak_bytes, 1024);
+        assert!(metric.wall_time_us >= 1_000, "expected ≥1ms, got {}us", metric.wall_time_us);
+    }
+
+    #[tokio::test]
+    async fn timer_finish_failure_includes_error() {
+        let bus = Arc::new(InvocationMetricsBus::new());
+        let mut rx = bus.subscribe();
+
+        let timer = InvocationTimer::start(bus.clone(), test_plugin_id(), "do_thing");
+        timer.finish_failure("boom", 0);
+
+        let metric = rx.recv().await.unwrap();
+        match metric.status {
+            InvocationStatus::Failure { error } => assert_eq!(error, "boom"),
+            other => panic!("expected Failure, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn timer_dropped_without_finish_emits_dropped_metric() {
+        let bus = Arc::new(InvocationMetricsBus::new());
+        let mut rx = bus.subscribe();
+
+        {
+            let _timer = InvocationTimer::start(bus.clone(), test_plugin_id(), "leaked");
+            // Dropped here without calling finish_*.
+        }
+
+        let metric = rx.recv().await.unwrap();
+        assert_eq!(metric.function_name, "leaked");
+        assert_eq!(metric.status, InvocationStatus::Dropped);
+    }
+
+    #[tokio::test]
+    async fn started_at_is_set_at_start_not_finish() {
+        let bus = Arc::new(InvocationMetricsBus::new());
+        let mut rx = bus.subscribe();
+
+        let timer = InvocationTimer::start(bus.clone(), test_plugin_id(), "fn");
+        let started = timer.started_at;
+
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        timer.finish_success(0);
+
+        let metric = rx.recv().await.unwrap();
+        assert_eq!(metric.started_at, started);
+        let elapsed_via_metric = Utc::now()
+            .signed_duration_since(metric.started_at)
+            .num_microseconds()
+            .unwrap_or(i64::MAX);
+        assert!(elapsed_via_metric >= 5_000);
+    }
+}

--- a/crates/mockforge-plugin-loader/src/lib.rs
+++ b/crates/mockforge-plugin-loader/src/lib.rs
@@ -25,6 +25,7 @@ use mockforge_plugin_core::{
 
 pub mod git;
 pub mod installer;
+pub mod invocation_metrics;
 pub mod loader;
 pub mod metadata;
 pub mod registry;
@@ -38,6 +39,9 @@ pub mod validator;
 /// Re-export commonly used types
 pub use git::*;
 pub use installer::*;
+pub use invocation_metrics::{
+    InvocationMetric, InvocationMetricsBus, InvocationStatus, InvocationTimer,
+};
 pub use loader::*;
 pub use metadata::*;
 pub use registry::*;

--- a/crates/mockforge-plugin-loader/src/sandbox.rs
+++ b/crates/mockforge-plugin-loader/src/sandbox.rs
@@ -4,6 +4,7 @@
 //! including resource limits, security boundaries, and isolation.
 
 use super::*;
+use crate::invocation_metrics::{InvocationMetricsBus, InvocationTimer};
 use mockforge_plugin_core::{
     PluginCapabilities, PluginContext, PluginHealth, PluginId, PluginMetrics, PluginResult,
     PluginState,
@@ -22,6 +23,10 @@ pub struct PluginSandbox {
     _config: PluginLoaderConfig,
     /// Active sandboxes
     active_sandboxes: RwLock<HashMap<PluginId, SandboxInstance>>,
+    /// Per-invocation metrics bus. One per sandbox; cloned `Arc` is
+    /// stamped onto each `SandboxInstance` so `execute_function` can
+    /// record without round-tripping through the parent.
+    metrics_bus: Arc<InvocationMetricsBus>,
 }
 
 impl PluginSandbox {
@@ -34,7 +39,17 @@ impl PluginSandbox {
             engine,
             _config: config,
             active_sandboxes: RwLock::new(HashMap::new()),
+            metrics_bus: Arc::new(InvocationMetricsBus::new()),
         }
+    }
+
+    /// Get the per-invocation metrics bus. Subscribe to receive a live
+    /// stream of [`InvocationMetric`] events. Suitable for the admin UI
+    /// or an OTLP exporter.
+    ///
+    /// [`InvocationMetric`]: crate::invocation_metrics::InvocationMetric
+    pub fn metrics_bus(&self) -> Arc<InvocationMetricsBus> {
+        self.metrics_bus.clone()
     }
 
     /// Create a plugin instance in the sandbox
@@ -54,10 +69,10 @@ impl PluginSandbox {
 
         // Create sandbox instance
         let sandbox = if let Some(ref engine) = self.engine {
-            SandboxInstance::new(engine, context).await?
+            SandboxInstance::new(engine, context, self.metrics_bus.clone()).await?
         } else {
             // Create a stub sandbox instance when WebAssembly is disabled
-            SandboxInstance::stub_new(context).await?
+            SandboxInstance::stub_new(context, self.metrics_bus.clone()).await?
         };
 
         // Store sandbox instance
@@ -139,7 +154,7 @@ impl PluginSandbox {
 /// Individual sandbox instance
 pub struct SandboxInstance {
     /// Plugin ID
-    _plugin_id: PluginId,
+    plugin_id: PluginId,
     /// WebAssembly module
     _module: Module,
     /// WebAssembly store
@@ -152,11 +167,18 @@ pub struct SandboxInstance {
     health: SandboxHealth,
     /// Execution limits
     limits: ExecutionLimits,
+    /// Bus for emitting per-invocation metrics. Shared with the parent
+    /// `PluginSandbox`.
+    metrics_bus: Arc<InvocationMetricsBus>,
 }
 
 impl SandboxInstance {
     /// Create a new sandbox instance
-    async fn new(engine: &Engine, context: &PluginLoadContext) -> LoaderResult<Self> {
+    async fn new(
+        engine: &Engine,
+        context: &PluginLoadContext,
+        metrics_bus: Arc<InvocationMetricsBus>,
+    ) -> LoaderResult<Self> {
         let plugin_id = &context.plugin_id;
 
         // Load WASM module
@@ -186,18 +208,22 @@ impl SandboxInstance {
         let limits = ExecutionLimits::from_capabilities(&plugin_capabilities);
 
         Ok(Self {
-            _plugin_id: plugin_id.clone(),
+            plugin_id: plugin_id.clone(),
             _module: module,
             store,
             linker,
             resources: SandboxResources::default(),
             health: SandboxHealth::healthy(),
             limits,
+            metrics_bus,
         })
     }
 
     /// Create a stub sandbox instance (when WebAssembly is disabled)
-    async fn stub_new(context: &PluginLoadContext) -> LoaderResult<Self> {
+    async fn stub_new(
+        context: &PluginLoadContext,
+        metrics_bus: Arc<InvocationMetricsBus>,
+    ) -> LoaderResult<Self> {
         let plugin_id = &context.plugin_id;
 
         // Create dummy values for when WebAssembly is disabled
@@ -213,13 +239,14 @@ impl SandboxInstance {
         let limits = ExecutionLimits::from_capabilities(&plugin_capabilities);
 
         Ok(Self {
-            _plugin_id: plugin_id.clone(),
+            plugin_id: plugin_id.clone(),
             _module: module,
             store,
             linker,
             resources: SandboxResources::default(),
             health: SandboxHealth::healthy(),
             limits,
+            metrics_bus,
         })
     }
 
@@ -254,13 +281,29 @@ impl SandboxInstance {
             )));
         }
 
+        // Start the per-invocation metrics timer. Finished on either
+        // success or failure path below; the limit-check early-returns
+        // above happen before this point and don't emit a metric (no
+        // plugin code ran).
+        let timer = InvocationTimer::start(
+            self.metrics_bus.clone(),
+            self.plugin_id.clone(),
+            function_name.to_string(),
+        );
+
         // Prepare function call
         let start_time = std::time::Instant::now();
 
         // Get function from linker
-        let _func = self.linker.get(&mut self.store, "", function_name).ok_or_else(|| {
-            PluginLoaderError::execution(format!("Function '{}' not found", function_name))
-        })?;
+        let func_lookup = self.linker.get(&mut self.store, "", function_name);
+        if func_lookup.is_none() {
+            // Function-not-found: count as a failed invocation in both
+            // the aggregate counters and the per-invocation bus.
+            self.resources.error_count += 1;
+            let err_msg = format!("Function '{}' not found", function_name);
+            timer.finish_failure(err_msg.clone(), self.resources.peak_memory_usage as u64);
+            return Err(PluginLoaderError::execution(err_msg));
+        }
 
         // Execute function (simplified - real implementation would handle WASM calling conventions)
         let result = self.call_wasm_function(function_name, context, input).await;
@@ -274,14 +317,22 @@ impl SandboxInstance {
             self.resources.max_execution_time = execution_time;
         }
 
+        // Snapshot the peak memory at the end of the invocation. Today
+        // this comes from `resources.peak_memory_usage` which is not
+        // wired to the WASM `MemoryTracker` yet — it stays at 0 in
+        // most paths. Cloud Phase 2 wires this through.
+        let peak_memory_bytes = self.resources.peak_memory_usage as u64;
+
         match result {
             Ok(data) => {
                 self.resources.success_count += 1;
+                timer.finish_success(peak_memory_bytes);
                 Ok(PluginResult::success(data, execution_time.as_millis() as u64))
             }
             Err(e) => {
                 self.resources.error_count += 1;
-                Ok(PluginResult::failure(e.to_string(), execution_time.as_millis() as u64))
+                timer.finish_failure(e.clone(), peak_memory_bytes);
+                Ok(PluginResult::failure(e, execution_time.as_millis() as u64))
             }
         }
     }


### PR DESCRIPTION
## Summary
Cloud-plugins Phase 2 prep (Task #7). Adds a structured per-invocation metrics surface to `mockforge-plugin-loader` so that:
- The OSS admin UI can show per-call wall-time + status today.
- The cloud build can hook an OTLP exporter to the same channel for billing tomorrow.

The "build" recommendation in #387 means we own the metering layer fully — this PR is the foundation.

## What's in the box
- **New module `invocation_metrics`**:
  - `InvocationMetric` — `{ plugin_id, function_name, started_at, wall_time_us, memory_peak_bytes, status }`.
  - `InvocationStatus` — `Success` | `Failure { error }` | `Dropped` (the timer was dropped without `finish_*` — a host-side bug, but we emit a visible metric instead of silently losing the call).
  - `InvocationMetricsBus` — wraps `tokio::sync::broadcast` with subscriber count + non-erroring `record` (no subscribers = silently dropped).
  - `InvocationTimer` — RAII guard that captures `Instant` on `start` and emits via `finish_success` / `finish_failure`.
- **Wiring**: `PluginSandbox` owns one bus, clones the `Arc` into each `SandboxInstance` at construction. `execute_function` instruments the success/failure paths. Function-not-found also emits a failure metric — early-return limit checks (which mean no plugin code ran) deliberately don't emit.
- **Public accessor**: `PluginSandbox::metrics_bus() -> Arc<InvocationMetricsBus>` so observers can subscribe externally.

## What's deliberately not in this PR
- **Memory peak is plumbed but reports 0 in most paths.** `memory_tracking.rs` is dead code (not declared `pub mod`) and the WASM `ResourceLimiter` isn't wired into the active `Store`. The metric field's shape is correct so wiring it later is a one-line patch — but doing it now would expand scope and surfaces two latent Wasmtime API drift errors in `memory_tracking.rs` (the `table_growing` signature changed from `u32` to `usize`, and `Store::set_limits` was removed). That's a separate cleanup for someone with cycles.
- **Cloud bus subscription / OTLP exporter.** Out of scope; this PR ships the surface, Phase 2 ships the consumer.
- **Admin UI integration.** Surface is now subscribable; the UI side is its own PR.

## Why broadcast (vs. mpsc / metrics crate)
Multiple subscribers each get every event without coordinating. Slow consumers don't backpressure the request path — `tokio::sync::broadcast` drops messages for laggers and surfaces it as `RecvError::Lagged`, which is the right semantics for telemetry (better to miss a sample than to slow a hot path). Aligns with how the existing OTLP and SSE surfaces are structured.

## Test plan
- [x] `cargo check -p mockforge-plugin-loader`
- [x] `cargo clippy -p mockforge-plugin-loader --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p mockforge-plugin-loader --lib` — 141 pass (134 pre-existing + 7 new):
  - bus subscribe / publish basic flow
  - multi-subscriber fan-out
  - no-subscriber silence (no panic, no error)
  - timer wall-time captured correctly across an `await`
  - timer success path
  - timer failure path includes error string
  - timer dropped without `finish_*` emits `Dropped` status
- [x] Pre-commit hooks (clippy, typos, fmt) — all passed

## Phase tracker
| # | Status | |
|---|--------|--|
| 1 | ✅ | #385 demand CTA |
| 2 | ✅ | #387 build-vs-buy spike |
| 3 | pending | sidecar Fly proof |
| 4 | ✅ | #386 trust RFC |
| 5 | pending | schema migration |
| 6 | pending | API spec |
| 7 | this PR | wall-time accounting |
| 8 | pending | go/no-go |