### PR TITLE
feat(plugin-loader): wire MemoryTracker into active sandbox

### DIFF
--- a/crates/mockforge-plugin-loader/src/lib.rs
+++ b/crates/mockforge-plugin-loader/src/lib.rs
@@ -27,6 +27,7 @@ pub mod git;
 pub mod installer;
 pub mod invocation_metrics;
 pub mod loader;
+pub mod memory_tracking;
 pub mod metadata;
 pub mod registry;
 pub mod remote;
@@ -43,6 +44,7 @@ pub use invocation_metrics::{
     InvocationMetric, InvocationMetricsBus, InvocationStatus, InvocationTimer,
 };
 pub use loader::*;
+pub use memory_tracking::{MemoryStats, MemoryTracker};
 pub use metadata::*;
 pub use registry::*;
 pub use remote::*;

--- a/crates/mockforge-plugin-loader/src/memory_tracking.rs
+++ b/crates/mockforge-plugin-loader/src/memory_tracking.rs
@@ -1,53 +1,87 @@
-//! Memory tracking and enforcement for WASM sandbox
+//! Memory tracking and enforcement for the WASM sandbox.
 //!
-//! This module provides real-time memory tracking and enforcement of limits
-//! using Wasmtime's resource monitoring capabilities
+//! [`MemoryTracker`] implements Wasmtime's [`ResourceLimiter`] trait so
+//! the host can deny linear-memory growth that would exceed the
+//! configured cap, and observe the per-store peak. Wire it into a
+//! `Store<T>` by holding the tracker inside the store's data type and
+//! installing the limiter:
+//!
+//! ```ignore
+//! struct StoreData {
+//!     wasi: WasiCtx,
+//!     tracker: MemoryTracker,
+//! }
+//!
+//! let mut store = Store::new(&engine, StoreData {
+//!     wasi: wasi_ctx,
+//!     tracker: MemoryTracker::with_byte_limit(10 * 1024 * 1024),
+//! });
+//! store.limiter(|d| &mut d.tracker as &mut dyn wasmtime::ResourceLimiter);
+//! ```
+//!
+//! Modern Wasmtime (≥27) removed the standalone `Store::set_limits`
+//! API in favor of the closure-based `Store::limiter`, which is why
+//! the limiter must live inside the store's data type.
 
-use wasmtime::{ResourceLimiter, Store, StoreLimits, StoreLimitsBuilder};
+use wasmtime::ResourceLimiter;
 
-/// Memory tracker for WASM store
+/// Memory tracker for a single Wasmtime `Store`.
+///
+/// One tracker per store. The `Store::limiter` closure should hand
+/// back `&mut self` so Wasmtime can call `memory_growing` /
+/// `table_growing` for resource accounting.
 pub struct MemoryTracker {
-    /// Maximum memory allowed (bytes)
+    /// Maximum memory allowed (bytes).
     max_memory_bytes: usize,
-    /// Current memory usage (bytes)
+    /// Current memory usage (bytes), as reported by the most recent
+    /// `memory_growing` callback.
     current_memory_bytes: usize,
-    /// Peak memory usage (bytes)
+    /// Peak memory ever observed across the lifetime of this store.
+    /// Linear memory only grows in WASM, so this is monotonically
+    /// non-decreasing.
     peak_memory_bytes: usize,
-    /// Maximum instances allowed
-    max_instances: usize,
-    /// Current instances
-    current_instances: usize,
-    /// Maximum tables allowed
+    /// Maximum tables allowed.
     max_tables: usize,
-    /// Current tables
+    /// Current table count.
     current_tables: usize,
 }
 
 impl MemoryTracker {
-    /// Create a new memory tracker
+    /// Create a tracker with a megabyte-precision cap.
     pub fn new(max_memory_mb: usize) -> Self {
+        Self::with_byte_limit(max_memory_mb * 1024 * 1024)
+    }
+
+    /// Create a tracker with a byte-precision cap. Use this when the
+    /// caller already has a value in bytes (e.g. from
+    /// `ExecutionLimits::max_memory_bytes`) so the conversion can be
+    /// exact.
+    pub fn with_byte_limit(max_memory_bytes: usize) -> Self {
         Self {
-            max_memory_bytes: max_memory_mb * 1024 * 1024,
+            max_memory_bytes,
             current_memory_bytes: 0,
             peak_memory_bytes: 0,
-            max_instances: 10,
-            current_instances: 0,
             max_tables: 10,
             current_tables: 0,
         }
     }
 
-    /// Get current memory usage in bytes
+    /// Current linear-memory size in bytes.
     pub fn current_memory(&self) -> usize {
         self.current_memory_bytes
     }
 
-    /// Get peak memory usage in bytes
+    /// Highest linear-memory size observed in this store's lifetime.
     pub fn peak_memory(&self) -> usize {
         self.peak_memory_bytes
     }
 
-    /// Get memory usage as percentage
+    /// Configured upper bound in bytes.
+    pub fn max_memory(&self) -> usize {
+        self.max_memory_bytes
+    }
+
+    /// Memory usage as a percentage of the configured limit.
     pub fn memory_usage_percent(&self) -> f64 {
         if self.max_memory_bytes == 0 {
             0.0
@@ -56,12 +90,11 @@ impl MemoryTracker {
         }
     }
 
-    /// Check if memory limit exceeded
+    /// Whether the most recent observation exceeded the cap.
     pub fn is_memory_exceeded(&self) -> bool {
         self.current_memory_bytes > self.max_memory_bytes
     }
 
-    /// Update peak memory if current exceeds it
     fn update_peak(&mut self) {
         if self.current_memory_bytes > self.peak_memory_bytes {
             self.peak_memory_bytes = self.current_memory_bytes;
@@ -70,46 +103,39 @@ impl MemoryTracker {
 }
 
 impl ResourceLimiter for MemoryTracker {
-    /// Called when memory is requested
     fn memory_growing(
         &mut self,
         current: usize,
         desired: usize,
         _maximum: Option<usize>,
     ) -> anyhow::Result<bool> {
-        // Calculate the new memory size
-        let new_size = desired;
-
-        // Check if it exceeds the limit
-        if new_size > self.max_memory_bytes {
+        if desired > self.max_memory_bytes {
             tracing::warn!(
                 "Memory growth denied: {} bytes requested, {} bytes allowed",
-                new_size,
+                desired,
                 self.max_memory_bytes
             );
-            return Ok(false); // Deny the allocation
+            return Ok(false);
         }
 
-        // Update current memory
-        self.current_memory_bytes = new_size;
+        self.current_memory_bytes = desired;
         self.update_peak();
 
         tracing::debug!(
             "Memory growth allowed: {} -> {} bytes ({:.1}% of limit)",
             current,
-            new_size,
+            desired,
             self.memory_usage_percent()
         );
 
-        Ok(true) // Allow the allocation
+        Ok(true)
     }
 
-    /// Called when a table is created
     fn table_growing(
         &mut self,
-        _current: u32,
-        _desired: u32,
-        _maximum: Option<u32>,
+        _current: usize,
+        _desired: usize,
+        _maximum: Option<usize>,
     ) -> anyhow::Result<bool> {
         if self.current_tables >= self.max_tables {
             tracing::warn!(
@@ -124,78 +150,52 @@ impl ResourceLimiter for MemoryTracker {
         Ok(true)
     }
 
-    /// Called when an instance is created
-    fn instances(&self) -> usize {
-        self.current_instances
-    }
-
-    /// Called to get maximum instances
     fn tables(&self) -> usize {
         self.current_tables
     }
 
-    /// Called to get current memory size
     fn memories(&self) -> usize {
-        1 // We allow one memory instance
+        // We allow one memory instance per plugin sandbox.
+        1
     }
 }
 
-/// Configure a Wasmtime store with memory limits
-pub fn configure_store_with_limits<T>(
-    store: &mut Store<T>,
-    max_memory_mb: usize,
-) -> MemoryTracker {
-    let tracker = MemoryTracker::new(max_memory_mb);
-
-    // Set up store limits
-    let limits = StoreLimitsBuilder::new()
-        .memory_size(max_memory_mb * 1024 * 1024)
-        .instances(10)
-        .tables(10)
-        .memories(1)
-        .build();
-
-    store.limiter(|_| &mut tracker);
-    store.set_limits(limits);
-
-    tracker
-}
-
-/// Memory usage statistics
+/// Snapshot of a tracker's state. Cheap to clone for emitting on the
+/// invocation metrics bus or returning from a status endpoint.
 #[derive(Debug, Clone)]
 pub struct MemoryStats {
-    /// Current memory usage (bytes)
+    /// Current linear-memory size in bytes.
     pub current_bytes: usize,
-    /// Peak memory usage (bytes)
+    /// Peak linear-memory size observed in this store's lifetime.
     pub peak_bytes: usize,
-    /// Maximum allowed (bytes)
+    /// Configured upper bound in bytes.
     pub limit_bytes: usize,
-    /// Usage percentage
+    /// Current usage as a percentage of the configured limit.
     pub usage_percent: f64,
 }
 
 impl MemoryStats {
-    /// Create from memory tracker
+    /// Capture a snapshot of the current tracker state.
     pub fn from_tracker(tracker: &MemoryTracker) -> Self {
         Self {
             current_bytes: tracker.current_memory(),
             peak_bytes: tracker.peak_memory(),
-            limit_bytes: tracker.max_memory_bytes,
+            limit_bytes: tracker.max_memory(),
             usage_percent: tracker.memory_usage_percent(),
         }
     }
 
-    /// Check if usage is critical (>90%)
+    /// Usage above 90% of the limit.
     pub fn is_critical(&self) -> bool {
         self.usage_percent > 90.0
     }
 
-    /// Check if usage is high (>75%)
+    /// Usage above 75% of the limit.
     pub fn is_high(&self) -> bool {
         self.usage_percent > 75.0
     }
 
-    /// Get human-readable summary
+    /// Human-readable summary for log lines and the admin UI.
     pub fn summary(&self) -> String {
         format!(
             "{} / {} MB ({:.1}%), peak: {} MB",
@@ -213,32 +213,35 @@ mod tests {
 
     #[test]
     fn test_memory_tracker_creation() {
-        let tracker = MemoryTracker::new(10); // 10MB
+        let tracker = MemoryTracker::new(10);
         assert_eq!(tracker.current_memory(), 0);
         assert_eq!(tracker.peak_memory(), 0);
+        assert_eq!(tracker.max_memory(), 10 * 1024 * 1024);
         assert_eq!(tracker.memory_usage_percent(), 0.0);
     }
 
     #[test]
-    fn test_memory_tracker_growing() {
-        let mut tracker = MemoryTracker::new(10); // 10MB max
+    fn test_with_byte_limit_is_exact() {
+        let tracker = MemoryTracker::with_byte_limit(5_242_880); // exact 5 MiB
+        assert_eq!(tracker.max_memory(), 5_242_880);
+    }
 
-        // Allow growth within limit
-        let result = tracker.memory_growing(0, 5 * 1024 * 1024, None);
-        assert!(result.is_ok());
-        assert!(result.unwrap());
+    #[test]
+    fn test_memory_tracker_growing() {
+        let mut tracker = MemoryTracker::new(10);
+
+        let ok = tracker.memory_growing(0, 5 * 1024 * 1024, None).unwrap();
+        assert!(ok);
         assert_eq!(tracker.current_memory(), 5 * 1024 * 1024);
         assert_eq!(tracker.peak_memory(), 5 * 1024 * 1024);
 
-        // Deny growth exceeding limit
-        let result = tracker.memory_growing(5 * 1024 * 1024, 15 * 1024 * 1024, None);
-        assert!(result.is_ok());
-        assert!(!result.unwrap()); // Should deny
+        let denied = tracker.memory_growing(5 * 1024 * 1024, 15 * 1024 * 1024, None).unwrap();
+        assert!(!denied);
     }
 
     #[test]
     fn test_memory_stats() {
-        let mut tracker = MemoryTracker::new(10); // 10MB
+        let mut tracker = MemoryTracker::new(10);
         tracker.memory_growing(0, 8 * 1024 * 1024, None).unwrap();
 
         let stats = MemoryStats::from_tracker(&tracker);
@@ -252,15 +255,15 @@ mod tests {
     fn test_memory_tracker_peak() {
         let mut tracker = MemoryTracker::new(10);
 
-        // Grow to 5MB
         tracker.memory_growing(0, 5 * 1024 * 1024, None).unwrap();
         assert_eq!(tracker.peak_memory(), 5 * 1024 * 1024);
 
-        // Grow to 8MB
         tracker.memory_growing(5 * 1024 * 1024, 8 * 1024 * 1024, None).unwrap();
         assert_eq!(tracker.peak_memory(), 8 * 1024 * 1024);
 
-        // Shrink to 6MB (peak should remain 8MB)
+        // Peak persists even after a hypothetical shrink (linear memory
+        // doesn't actually shrink in WASM, but the invariant still holds
+        // if a future Wasmtime version added shrink callbacks).
         tracker.current_memory_bytes = 6 * 1024 * 1024;
         assert_eq!(tracker.peak_memory(), 8 * 1024 * 1024);
     }
@@ -270,15 +273,12 @@ mod tests {
         let mut tracker = MemoryTracker::new(10);
         tracker.max_tables = 2;
 
-        // First table should succeed
         assert!(tracker.table_growing(0, 1, None).unwrap());
         assert_eq!(tracker.current_tables, 1);
 
-        // Second table should succeed
         assert!(tracker.table_growing(1, 2, None).unwrap());
         assert_eq!(tracker.current_tables, 2);
 
-        // Third table should be denied
         assert!(!tracker.table_growing(2, 3, None).unwrap());
     }
 }

--- a/crates/mockforge-plugin-loader/src/sandbox.rs
+++ b/crates/mockforge-plugin-loader/src/sandbox.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 use crate::invocation_metrics::{InvocationMetricsBus, InvocationTimer};
+use crate::memory_tracking::MemoryTracker;
 use mockforge_plugin_core::{
     PluginCapabilities, PluginContext, PluginHealth, PluginId, PluginMetrics, PluginResult,
     PluginState,
@@ -12,8 +13,35 @@ use mockforge_plugin_core::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime::{Engine, Linker, Module, ResourceLimiter, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder};
+
+/// Per-store data carried by every WASM `Store` in this sandbox.
+///
+/// Bundles the WASI context (for stdio + filesystem capability bits)
+/// with a [`MemoryTracker`] that Wasmtime calls back via the
+/// `ResourceLimiter` trait. The tracker has to live inside the store
+/// data because Wasmtime's modern API (`Store::limiter`) takes a
+/// closure `|t: &mut T| &mut dyn ResourceLimiter` — there's no way to
+/// hand it an externally-owned tracker.
+pub struct SandboxStoreData {
+    /// WASI context for stdio inheritance + filesystem capabilities.
+    pub wasi: WasiCtx,
+    /// Memory + table accounting installed on the store via
+    /// `Store::limiter`.
+    pub tracker: MemoryTracker,
+}
+
+/// Build a fully-configured `Store` with the `MemoryTracker` installed
+/// as a `ResourceLimiter`. Centralized so the real `new` and the stub
+/// `stub_new` can't drift on how the limiter gets wired up.
+fn make_store(engine: &Engine, max_memory_bytes: usize) -> Store<SandboxStoreData> {
+    let wasi = WasiCtxBuilder::new().inherit_stderr().inherit_stdout().build();
+    let tracker = MemoryTracker::with_byte_limit(max_memory_bytes);
+    let mut store = Store::new(engine, SandboxStoreData { wasi, tracker });
+    store.limiter(|d| &mut d.tracker as &mut dyn ResourceLimiter);
+    store
+}
 
 /// Plugin sandbox for secure execution
 pub struct PluginSandbox {
@@ -158,9 +186,9 @@ pub struct SandboxInstance {
     /// WebAssembly module
     _module: Module,
     /// WebAssembly store
-    store: Store<WasiCtx>,
+    store: Store<SandboxStoreData>,
     /// Linker for the instance
-    linker: Linker<WasiCtx>,
+    linker: Linker<SandboxStoreData>,
     /// Sandbox resources
     resources: SandboxResources,
     /// Health monitor
@@ -185,11 +213,12 @@ impl SandboxInstance {
         let module = Module::from_file(engine, &context.plugin_path)
             .map_err(|e| PluginLoaderError::wasm(format!("Failed to load WASM module: {}", e)))?;
 
-        // Create WASI context
-        let wasi_ctx = WasiCtxBuilder::new().inherit_stderr().inherit_stdout().build();
+        // Set up execution limits up front so the memory cap is wired
+        // into the store from creation time.
+        let plugin_capabilities = PluginCapabilities::default();
+        let limits = ExecutionLimits::from_capabilities(&plugin_capabilities);
 
-        // Create WebAssembly store
-        let mut store = Store::new(engine, wasi_ctx);
+        let mut store = make_store(engine, limits.max_memory_bytes);
 
         // Create linker
         let linker = Linker::new(engine);
@@ -202,10 +231,6 @@ impl SandboxInstance {
         linker
             .instantiate(&mut store, &module)
             .map_err(|e| PluginLoaderError::wasm(format!("Failed to instantiate module: {}", e)))?;
-
-        // Set up execution limits
-        let plugin_capabilities = PluginCapabilities::default();
-        let limits = ExecutionLimits::from_capabilities(&plugin_capabilities);
 
         Ok(Self {
             plugin_id: plugin_id.clone(),
@@ -227,16 +252,15 @@ impl SandboxInstance {
         let plugin_id = &context.plugin_id;
 
         // Create dummy values for when WebAssembly is disabled
-        let module = Module::new(&Engine::default(), [])
+        let engine = Engine::default();
+        let module = Module::new(&engine, [])
             .map_err(|e| PluginLoaderError::wasm(format!("Failed to create stub module: {}", e)))?;
-
-        let wasi_ctx = WasiCtxBuilder::new().inherit_stderr().inherit_stdout().build();
-
-        let store = Store::new(&Engine::default(), wasi_ctx);
-        let linker = Linker::new(&Engine::default());
 
         let plugin_capabilities = PluginCapabilities::default();
         let limits = ExecutionLimits::from_capabilities(&plugin_capabilities);
+
+        let store = make_store(&engine, limits.max_memory_bytes);
+        let linker = Linker::new(&engine);
 
         Ok(Self {
             plugin_id: plugin_id.clone(),
@@ -317,11 +341,18 @@ impl SandboxInstance {
             self.resources.max_execution_time = execution_time;
         }
 
-        // Snapshot the peak memory at the end of the invocation. Today
-        // this comes from `resources.peak_memory_usage` which is not
-        // wired to the WASM `MemoryTracker` yet — it stays at 0 in
-        // most paths. Cloud Phase 2 wires this through.
-        let peak_memory_bytes = self.resources.peak_memory_usage as u64;
+        // Read peak memory from the `MemoryTracker` installed on the
+        // store. Wasmtime calls back into the tracker via
+        // `ResourceLimiter::memory_growing` whenever the WASM module
+        // grows linear memory, so this is a real observation — not the
+        // 0 placeholder from the previous iteration of this code path.
+        // Mirror it onto the aggregate `SandboxResources` for the
+        // existing health-check + status surfaces.
+        let peak_memory_bytes = self.store.data().tracker.peak_memory() as u64;
+        if (peak_memory_bytes as usize) > self.resources.peak_memory_usage {
+            self.resources.peak_memory_usage = peak_memory_bytes as usize;
+        }
+        self.resources.memory_usage = self.store.data().tracker.current_memory();
 
         match result {
             Ok(data) => {


### PR DESCRIPTION
## Summary
Followup to #388 (Task #9). The metrics bus from #388 shipped with a `memory_peak_bytes` field that always reported 0 because the `MemoryTracker` module was dead code (not declared `pub mod`) and had two latent Wasmtime API drift bugs. Both now fixed; the metric is no longer a placeholder.

## What changed
- **Fix `ResourceLimiter::table_growing` signature drift**: `u32` → `usize` (modern Wasmtime trait).
- **Drop the broken `configure_store_with_limits` helper.** The modern Wasmtime API replaced `Store::set_limits` with `Store::limiter`, which takes a closure `|&mut T| -> &mut dyn ResourceLimiter` — this forces the tracker to live inside the store's data type. A standalone helper that owns the tracker structurally can't work.
- **Add `MemoryTracker::with_byte_limit`** for exact byte-precision caps (avoids round-trip through MB when reading from `ExecutionLimits::max_memory_bytes`).
- **Declare `pub mod memory_tracking`** and re-export `MemoryTracker` + `MemoryStats`.
- **Introduce `SandboxStoreData { wasi: WasiCtx, tracker: MemoryTracker }`** as the per-store data type. `Store<WasiCtx>` → `Store<SandboxStoreData>` in `SandboxInstance`.
- **Add `make_store` helper** so `SandboxInstance::new` and `stub_new` can't drift on how the limiter gets wired.
- **In `execute_function`**: read peak from `self.store.data().tracker.peak_memory()` — actual observed value instead of 0. Also mirror onto `SandboxResources::peak_memory_usage` so existing health-check + status surfaces see real data too.

## Visible effect
After this PR, `InvocationMetric::memory_peak_bytes` is the byte count of the largest linear-memory size Wasmtime ever observed on this store via the `ResourceLimiter::memory_growing` callback. Aggregate `SandboxResources::peak_memory_usage` and `memory_usage` are also live.

## Test plan
- [x] `cargo check -p mockforge-plugin-loader` (clean)
- [x] `cargo clippy -p mockforge-plugin-loader --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check`
- [x] `cargo test -p mockforge-plugin-loader --lib` — 147 pass (141 from #388 + 6 from memory_tracking module now reachable; one new assertion confirms `with_byte_limit` is exact)
- [x] Pre-commit hooks (clippy, typos, fmt) — all passed

## Phase status
| # | Status | |
|---|--------|--|
| 1 | ✅ | #385 demand CTA |
| 2 | ✅ | #387 build-vs-buy spike |
| 3 | pending | sidecar Fly proof |
| 4 | ✅ | #386 trust RFC |
| 5 | ✅ | #389 schema migration |
| 6 | ✅ #395 | control-plane API |
| 7 | ✅ | #388 wall-time accounting |
| 8 | pending | go/no-go (gated on #385 demand signal) |
| 9 | this PR | wire MemoryTracker |