### PR TITLE
feat(cloud-plugins): FlyioMachineConfig.guest + plan-tier sizing

### DIFF
--- a/crates/mockforge-registry-server/src/deployment/flyio.rs
+++ b/crates/mockforge-registry-server/src/deployment/flyio.rs
@@ -56,6 +56,102 @@ pub struct FlyioMachineConfig {
     pub env: HashMap<String, String>,
     pub services: Vec<FlyioService>,
     pub checks: Option<HashMap<String, FlyioCheck>>,
+    /// VM resource sizing. `None` means accept Fly's API default
+    /// (currently `shared-cpu-1x:256MB`); existing deployments and
+    /// non-plugin-enabled machines stay on that default. Cloud
+    /// plugins requires explicit sizing — see
+    /// `docs/plugins/security/cloud-runtime-sidecar-spike.md` for
+    /// the measured-on-Fly numbers and tier table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guest: Option<FlyioGuest>,
+}
+
+/// VM sizing block sent to Fly Machines API as `config.guest`.
+/// Mirrors the API's expected JSON shape:
+/// <https://fly.io/docs/machines/api/machines-resource/#machine-config-object-properties>
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlyioGuest {
+    /// `"shared"` or `"performance"`.
+    pub cpu_kind: String,
+    pub cpus: u32,
+    pub memory_mb: u32,
+}
+
+impl FlyioGuest {
+    /// `shared-cpu-1x:256MB` — Fly's default for the registry today.
+    /// Used when no plugins are attached so existing hosted-mocks
+    /// keep their current footprint.
+    pub fn shared_256() -> Self {
+        Self {
+            cpu_kind: "shared".into(),
+            cpus: 1,
+            memory_mb: 256,
+        }
+    }
+
+    /// `shared-cpu-1x:512MB` — Pro tier with cloud plugins. Real-Fly
+    /// measurement on the spike showed mockforge + sidecar idle at
+    /// ~166 MB / 256 MB (65%), with only 71 MB headroom; bumping to
+    /// 512 MB gives 316 MB headroom — comfortable for ≤5 plugins
+    /// at typical sizes.
+    pub fn shared_512() -> Self {
+        Self {
+            cpu_kind: "shared".into(),
+            cpus: 1,
+            memory_mb: 512,
+        }
+    }
+
+    /// `shared-cpu-1x:1024MB` — Team tier with cloud plugins
+    /// (≤25 plugins per mock).
+    pub fn shared_1024() -> Self {
+        Self {
+            cpu_kind: "shared".into(),
+            cpus: 1,
+            memory_mb: 1024,
+        }
+    }
+
+    /// `shared-cpu-2x:2048MB` — Enterprise tier with metered
+    /// pass-through. Two cores so heavy plugin workloads don't
+    /// starve mockforge's request path.
+    pub fn shared_2x_2048() -> Self {
+        Self {
+            cpu_kind: "shared".into(),
+            cpus: 2,
+            memory_mb: 2048,
+        }
+    }
+
+    /// Pick the right Fly machine size for a hosted-mock deployment
+    /// based on org plan + whether cloud plugins are attached.
+    ///
+    /// Without plugins, every tier stays on the existing 256 MB
+    /// default — no behavior change for legacy deployments.
+    ///
+    /// With plugins, the floor bumps according to the
+    /// real-microVM measurements in
+    /// `docs/plugins/security/cloud-runtime-sidecar-spike.md`:
+    /// idle on 256 MB sits at ~166 MB / 65% utilization with only
+    /// ~71 MB headroom. That's not enough for the plugin runtime to
+    /// grow into without OOM-killing mockforge. 512 MB gives 316 MB
+    /// headroom which fits ≤5 plugins comfortably; Team's larger
+    /// plugin count needs 1024 MB.
+    pub fn for_hosted_mock(plan: &str, plugins_enabled: bool) -> Self {
+        if !plugins_enabled {
+            return Self::shared_256();
+        }
+        match plan.to_lowercase().as_str() {
+            "free" => Self::shared_256(), // Plugins not available on Free.
+            "pro" => Self::shared_512(),
+            "team" => Self::shared_1024(),
+            // Unknown / future plans (e.g. "enterprise") get the
+            // largest currently-available shape. The handler should
+            // refuse plugin attachment for unknown plans before
+            // ever reaching this; defaulting big is fail-safe.
+            _ => Self::shared_2x_2048(),
+        }
+    }
 }
 
 /// Registry authentication for pulling private Docker images
@@ -508,5 +604,94 @@ impl FlyioClient {
             response.json().await.context("Failed to parse Fly.io machines response")?;
 
         Ok(machines)
+    }
+}
+
+#[cfg(test)]
+mod guest_tests {
+    use super::*;
+
+    #[test]
+    fn for_hosted_mock_no_plugins_uses_legacy_256() {
+        // Existing hosted-mocks without cloud plugins must keep
+        // their current 256 MB footprint — no surprise pricing
+        // bumps for legacy deployments.
+        for plan in ["free", "pro", "team", "enterprise", "weird-future-plan"] {
+            let g = FlyioGuest::for_hosted_mock(plan, false);
+            assert_eq!(g.memory_mb, 256, "plan {} without plugins must stay at 256MB", plan);
+            assert_eq!(g.cpu_kind, "shared");
+            assert_eq!(g.cpus, 1);
+        }
+    }
+
+    #[test]
+    fn for_hosted_mock_pro_with_plugins_bumps_to_512() {
+        let g = FlyioGuest::for_hosted_mock("pro", true);
+        assert_eq!(g.memory_mb, 512);
+        assert_eq!(g.cpus, 1);
+    }
+
+    #[test]
+    fn for_hosted_mock_team_with_plugins_bumps_to_1024() {
+        let g = FlyioGuest::for_hosted_mock("team", true);
+        assert_eq!(g.memory_mb, 1024);
+        assert_eq!(g.cpus, 1);
+    }
+
+    #[test]
+    fn for_hosted_mock_free_with_plugins_stays_256() {
+        // Plugins aren't available on Free — handler rejects before
+        // we get here — but if we do, don't accidentally upsize
+        // a Free org's machine.
+        let g = FlyioGuest::for_hosted_mock("free", true);
+        assert_eq!(g.memory_mb, 256);
+    }
+
+    #[test]
+    fn for_hosted_mock_unknown_plan_with_plugins_fails_safe_high() {
+        // Unknown plans (e.g. future "enterprise") get the largest
+        // shape rather than under-provisioning.
+        let g = FlyioGuest::for_hosted_mock("enterprise", true);
+        assert_eq!(g.memory_mb, 2048);
+        assert_eq!(g.cpus, 2);
+    }
+
+    #[test]
+    fn for_hosted_mock_plan_string_is_case_insensitive() {
+        let g = FlyioGuest::for_hosted_mock("PRO", true);
+        assert_eq!(g.memory_mb, 512);
+        let g = FlyioGuest::for_hosted_mock("Team", true);
+        assert_eq!(g.memory_mb, 1024);
+    }
+
+    #[test]
+    fn machine_config_serialization_omits_guest_when_none() {
+        // Existing call sites that pass `guest: None` (or use the
+        // legacy struct without the field via Default) must produce
+        // JSON without a `guest` key — so Fly's API default kicks in.
+        let cfg = FlyioMachineConfig {
+            image: "img".into(),
+            env: HashMap::new(),
+            services: vec![],
+            checks: None,
+            guest: None,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(!json.contains("guest"), "guest=None must be omitted, got {}", json);
+    }
+
+    #[test]
+    fn machine_config_serializes_guest_when_set() {
+        let cfg = FlyioMachineConfig {
+            image: "img".into(),
+            env: HashMap::new(),
+            services: vec![],
+            checks: None,
+            guest: Some(FlyioGuest::shared_512()),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(json.contains("\"guest\""));
+        assert!(json.contains("\"memory_mb\":512"));
+        assert!(json.contains("\"cpu_kind\":\"shared\""));
     }
 }

--- a/crates/mockforge-registry-server/src/deployment/orchestrator.rs
+++ b/crates/mockforge-registry-server/src/deployment/orchestrator.rs
@@ -370,6 +370,11 @@ impl DeploymentOrchestrator {
             env,
             services,
             checks: Some(checks),
+            // None = accept Fly's API default (shared-cpu-1x:256MB)
+            // for legacy hosted-mocks. Cloud-plugin-enabled deploys
+            // will set this via FlyioGuest::for_hosted_mock when the
+            // plugin runtime ships in Phase 2.
+            guest: None,
         };
 
         DeploymentLog::create(pool, deployment.id, "info", "Creating Fly.io machine", None).await?;
@@ -594,6 +599,11 @@ impl DeploymentOrchestrator {
             env,
             services,
             checks: Some(checks),
+            // None = accept Fly's API default (shared-cpu-1x:256MB)
+            // for legacy hosted-mocks. Cloud-plugin-enabled deploys
+            // will set this via FlyioGuest::for_hosted_mock when the
+            // plugin runtime ships in Phase 2.
+            guest: None,
         };
 
         // Build registry auth

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -752,6 +752,11 @@ pub async fn redeploy_deployment(
                     env,
                     services,
                     checks: Some(checks),
+                    // None = accept Fly's API default
+                    // (shared-cpu-1x:256MB) — same as other call
+                    // sites. Plugin-enabled redeploys will set this
+                    // via FlyioGuest::for_hosted_mock in Phase 2.
+                    guest: None,
                 };
 
                 // Build registry auth

--- a/docs/plugins/security/cloud-runtime-sidecar-spike.md
+++ b/docs/plugins/security/cloud-runtime-sidecar-spike.md
@@ -147,8 +147,80 @@ The orchestrator picks the right `guest` based on `org.plan` + whether the deplo
 - **An actual Fly deploy.** The Fly microVM adds ~30 MB of kernel + init + DNS resolver overhead on top of the cgroup count. Adjusted estimate: idle ≈ 99 MB on a real Fly machine, still 39% of 256 MB. Comfortable, but the on-Fly number is one cycle off real. A 5-minute Fly deploy with this spike's image would close that gap; treat it as the next operational check before Phase 2 build, not as an open question.
 - **Egress proxy as a third process.** RFC §5.1 proposes a small HTTP forward-proxy as a *third* process for egress allowlist enforcement. Adding it to this measurement is a follow-up; expect ~5-10 MB overhead.
 
+## Addendum: real Fly microVM measurement (2026-05-06)
+
+Closing the "did NOT validate" gap above by deploying the spike image to an actual Fly machine (`mockforge-cp-spike` in `iad`, since destroyed) and re-measuring. **The local docker numbers were too optimistic; 256 MB is *not* sufficient for plugin-enabled deployments.**
+
+### Measurements
+
+```
+$ flyctl ssh console --app mockforge-cp-spike --command 'ps -eo pid,rss,comm --sort=-rss; cat /sys/fs/cgroup/memory.current'
+
+  PID   RSS COMMAND
+  657 61804 python3        ← plugin-host stub
+  644 52424 mockforge      ← main mockforge
+  636 20448 hallpass       ← Fly's SSH/RPC daemon
+    1  6444 init           ← Fly's microVM init
+  667  1816 sh
+  643  1728 entrypoint-spik
+  635  1452 tini
+
+cgroup memory: 174153728 bytes  (166 MB)
+MemTotal:      212236 kB        (Fly reserves ~44 MB on a 256 MB tier for kernel)
+MemAvailable:   72492 kB        (only 71 MB free)
+```
+
+After scaling the same machine to `shared-cpu-1x:512MB`:
+
+```
+cgroup memory: 202166272 bytes  (193 MB / 512 MB = 38%)
+MemAvailable: 323664 kB         (316 MB free)
+```
+
+### What changed vs. local docker
+
+| Tier | Local docker (cgroup) | Real Fly (cgroup) | Δ |
+|---|---:|---:|---:|
+| 256 MB | 69 MB / 27% | 166 MB / 65% | **+97 MB** |
+| 512 MB | (not measured) | 193 MB / 38% | — |
+
+The +97 MB delta is **larger than the +30 MB** I'd estimated. Sources:
+- `init` (Fly microVM PID 1, before our tini): ~6 MB
+- `hallpass` (Fly's exec/SSH daemon): ~20 MB
+- Kernel reserve: 256 MB tier reports `MemTotal: 212 MB`, so ~44 MB is reserved before user space sees it
+- Cgroup accounting differences between docker and Fly's microVM
+
+### Revised tier table
+
+The original headroom analysis assumed local-docker numbers; here are the corrected per-Fly-tier numbers:
+
+| Tier | Idle cgroup | Headroom | Fits ≤5 plugins (Pro)? | Fits ≤25 plugins (Team)? |
+|---|---:|---:|---|---|
+| `shared-cpu-1x:256MB` | 166 MB / 65% | 71 MB | tight; small plugins only | no |
+| `shared-cpu-1x:512MB` | 193 MB / 38% | 316 MB | yes, comfortably | yes, with care |
+| `shared-cpu-1x:1024MB` | (extrapolated ~205 MB / 20%) | ~800 MB | yes | yes, comfortably |
+
+### Revised recommendation
+
+**Pro tier with cloud plugins requires `shared-cpu-1x:512MB` (not 256MB).** The original "Pro stays on 256MB" note from the docker-only measurement was incorrect — the on-Fly headroom isn't enough for plugin runtime growth without OOM-killing mockforge.
+
+| Plan | Plugins enabled? | Floor |
+|---|---|---|
+| Free | (plugins not available) | `shared-cpu-1x:256MB` |
+| Pro | no | `shared-cpu-1x:256MB` |
+| Pro | yes | `shared-cpu-1x:512MB` |
+| Team | yes | `shared-cpu-1x:1024MB` |
+| Future Enterprise | yes | `shared-cpu-2x:2048MB` |
+
+The pricing implication is real: a Pro-tier customer who attaches plugins is on a more expensive Fly machine. Budget that into the cloud-plugins pricing table from the build-vs-buy spike.
+
+### Action taken
+
+`FlyioGuest::for_hosted_mock(plan, plugins_enabled)` ships in this PR with these numbers as defaults. Existing hosted-mocks (no plugins) keep `guest: None` → Fly's API default, so this is non-disruptive.
+
 ## Decision log
 
 | Date | Decision | By |
 | ---- | -------- | -- |
-| 2026-05-05 | Sidecar architecture validated for `shared-cpu-1x:256MB`. Pro tier proceeds with current floor; Team tier needs `512MB`; `FlyioMachineConfig` needs a `guest` field. | Ray Clanan |
+| 2026-05-05 | Sidecar architecture validated for `shared-cpu-1x:256MB` (local docker). Pro tier proceeds with current floor; Team tier needs `512MB`; `FlyioMachineConfig` needs a `guest` field. | Ray Clanan |
+| 2026-05-06 | Real Fly deploy revised the floor: Pro w/ plugins needs `512MB`, Team w/ plugins needs `1024MB`. `FlyioGuest::for_hosted_mock` codifies this. | Ray Clanan |


### PR DESCRIPTION
## Summary
Closes the two open items from the sidecar Fly spike (#397):
1. **Real Fly deploy** of the spike image (not just local docker)
2. **Add the \`guest\` field to \`FlyioMachineConfig\`** that the spike memo flagged was missing

**Stacked on #397** — review/merge that first, then this rebases cleanly.

## What the real Fly deploy showed
Deployed the spike image to a one-off Fly app (since destroyed). The local docker measurement was **too optimistic by ~+97 MB**:

| Tier | Local docker | Real Fly | Δ |
|---|---:|---:|---:|
| 256 MB | 27% / 69 MB cgroup | **65% / 166 MB cgroup** | +97 MB |
| 512 MB | not measured | 38% / 193 MB cgroup | — |

Sources of the gap: Fly's \`init\` (~6 MB), \`hallpass\` SSH/RPC daemon (~20 MB), kernel reserve (~44 MB on a 256 MB tier — \`MemTotal\` shows only 212 MB). Cgroup accounting also differs subtly between docker and Fly's microVM.

**Implication: 256 MB is *not* sufficient for plugin-enabled hosted-mocks.** The original spike's "Pro tier proceeds with current floor" recommendation was wrong. Revised: Pro w/ plugins needs **512 MB**, Team w/ plugins needs **1024 MB**.

## What this PR adds
- \`FlyioGuest\` struct mirroring Fly's \`config.guest\` JSON shape (cpu_kind, cpus, memory_mb)
- Four named-tier constructors: \`shared_256\`, \`shared_512\`, \`shared_1024\`, \`shared_2x_2048\`
- \`FlyioGuest::for_hosted_mock(plan, plugins_enabled)\` — the one-call entry point the orchestrator will use when plugin-enabled deployments ship
- \`FlyioMachineConfig.guest: Option<FlyioGuest>\` with \`#[serde(default, skip_serializing_if = "Option::is_none")]\` — \`None\` produces JSON without the key, so existing API calls accept Fly's default (no behavior change)
- All 3 production call sites (orchestrator ×2, hosted_mocks ×1) pass \`guest: None\` — same behavior as before this PR

## What this PR does *not* do
- **Doesn't change deployment behavior for any existing hosted-mock.** Every current call site stays on \`guest: None\`. Cloud-plugin-enabled deployments will opt into a sized guest when the runtime ships in Phase 2 (the attach handler in #395 doesn't trigger redeploys yet — that wiring is Phase 2 work).
- **Doesn't change pricing today.** This is the structural enablement for the right floor; the actual customer-facing tier change rolls out with Phase 2.

## Test plan
- [x] \`cargo check -p mockforge-registry-server\` (clean)
- [x] \`cargo clippy -p mockforge-registry-server --all-targets -- -D warnings\`
- [x] \`cargo test deployment::flyio::guest_tests\` — 8/8 pass:
  - no plugins → 256 MB (every plan)
  - Pro w/ plugins → 512 MB
  - Team w/ plugins → 1024 MB
  - Free w/ plugins stays 256 MB (handler should reject earlier)
  - unknown/future plan falls safe to 2048 MB
  - case-insensitive plan match
  - JSON serialization omits \`guest\` when None
  - JSON serialization includes \`guest\` when set
- [x] \`cargo fmt --check\`
- [x] Real Fly deploy (spike app, destroyed) confirmed the numbers

## Memo update
Adds a "Real Fly microVM measurement" addendum to \`cloud-runtime-sidecar-spike.md\` with the corrected tier table and decision-log entry.

## Phase status
With this + #397, all "operational findings" from Task #3 are closed. Phase 1 is fully done modulo Task #8 (go/no-go, gated on demand signal).

The natural Phase 2 kickoff piece — scaffolding the production Rust plugin-host crate that replaces the Python stub from the spike — is the next logical PR. Happy to take it next.