### PR TITLE
feat(plugin-host): scaffold sidecar binary for cloud-plugins Phase 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8600,6 +8600,7 @@ name = "mockforge-plugin-host"
 version = "0.3.126"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "mockforge-plugin-core",
  "mockforge-plugin-loader",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8596,6 +8596,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockforge-plugin-host"
+version = "0.3.126"
+dependencies = [
+ "anyhow",
+ "mockforge-plugin-core",
+ "mockforge-plugin-loader",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "mockforge-plugin-loader"
 version = "0.3.126"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     # Plugin system
     "crates/mockforge-plugin-core",
     "crates/mockforge-plugin-cli",
+    "crates/mockforge-plugin-host",
     "crates/mockforge-plugin-loader",
     "crates/mockforge-plugin-registry",
     "crates/mockforge-plugin-sdk",

--- a/crates/mockforge-plugin-host/Cargo.toml
+++ b/crates/mockforge-plugin-host/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "mockforge-plugin-host"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme.workspace = true
+keywords = ["plugin", "wasm", "sandbox", "cloud", "sidecar"]
+categories = ["development-tools"]
+description = "Sidecar plugin runtime host for MockForge cloud — Phase 2 scaffold"
+
+[lints.rust]
+missing_docs = "deny"
+
+[lib]
+name = "mockforge_plugin_host"
+path = "src/lib.rs"
+
+[[bin]]
+name = "mockforge-plugin-host"
+path = "src/main.rs"
+
+[dependencies]
+# Reuse the existing plugin-loader's Wasmtime integration:
+# MemoryTracker (PR #396) and InvocationMetricsBus (PR #388).
+mockforge-plugin-loader = { version = "0.3.70", path = "../mockforge-plugin-loader" }
+mockforge-plugin-core = { version = "0.3.70", path = "../mockforge-plugin-core" }
+
+# Async runtime + Unix socket I/O
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "time", "sync", "io-util"] }
+
+# Serialization (JSON-over-Unix-socket protocol — easy to migrate to
+# protobuf later without breaking out the wire format separately)
+serde.workspace = true
+serde_json.workspace = true
+
+# Error handling
+anyhow.workspace = true
+thiserror.workspace = true
+
+# Logging — extend the workspace tracing-subscriber feature set
+# locally so the bin can use `EnvFilter` for runtime log-level
+# control (workspace default is `fmt` only).
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+
+# Utility (need `serde` for the JSON IPC protocol; the workspace
+# default is `v4` only, so we extend it locally rather than bumping
+# the whole workspace's footprint).
+uuid = { workspace = true, features = ["serde"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mockforge-plugin-host/Cargo.toml
+++ b/crates/mockforge-plugin-host/Cargo.toml
@@ -52,5 +52,12 @@ tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 # the whole workspace's footprint).
 uuid = { workspace = true, features = ["serde"] }
 
+# WASM blob handling: LoadPlugin carries the module as base64 in
+# the request body (registry-fetch path is a separate follow-up).
+# PluginLoadContext takes a filesystem path so we materialize the
+# bytes to a tempfile that lives for the plugin's lifetime.
+base64 = "0.22"
+tempfile = "3"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/mockforge-plugin-host/src/handlers.rs
+++ b/crates/mockforge-plugin-host/src/handlers.rs
@@ -1,0 +1,137 @@
+//! Request handlers for the plugin-host IPC server.
+//!
+//! Phase 2 scaffold: only `health` is wired through. The other
+//! handlers exist so the dispatch table is complete and the wire
+//! protocol is exercised end-to-end — they all return
+//! `not_implemented`. Wiring them is the next deliverable.
+
+use std::time::Instant;
+
+use crate::protocol::{Request, Response};
+
+/// Application state carried across requests on a single
+/// connection. Cheap to clone — the fields are either `Arc`-backed
+/// or scalars.
+#[derive(Clone)]
+pub struct HandlerContext {
+    /// When the host process booted. Used by the health endpoint
+    /// so callers can detect a sidecar restart by watching for an
+    /// uptime decrease.
+    pub started_at: Instant,
+}
+
+impl HandlerContext {
+    /// Create a context anchored at "now".
+    pub fn new() -> Self {
+        Self {
+            started_at: Instant::now(),
+        }
+    }
+
+    /// Process uptime in whole seconds.
+    pub fn uptime_secs(&self) -> u64 {
+        self.started_at.elapsed().as_secs()
+    }
+}
+
+impl Default for HandlerContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Dispatch a single request to the appropriate handler.
+pub async fn handle(ctx: &HandlerContext, request: Request) -> Response {
+    match request {
+        Request::Health { id } => Response::HealthOk {
+            id,
+            uptime_secs: ctx.uptime_secs(),
+        },
+        Request::LoadPlugin { id, .. } => Response::not_implemented(id, "load_plugin"),
+        Request::UnloadPlugin { id, .. } => Response::not_implemented(id, "unload_plugin"),
+        Request::Invoke { id, .. } => Response::not_implemented(id, "invoke"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn health_returns_ok_with_uptime() {
+        let ctx = HandlerContext::new();
+        let id = Uuid::new_v4();
+        let response = handle(&ctx, Request::Health { id }).await;
+        match response {
+            Response::HealthOk {
+                id: echoed,
+                uptime_secs,
+            } => {
+                assert_eq!(echoed, id);
+                // Uptime is at-least-zero; we don't assert > 0 because
+                // the handler may run faster than 1 second after ctx
+                // is created.
+                let _ = uptime_secs;
+            }
+            other => panic!("expected HealthOk, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn load_plugin_returns_not_implemented() {
+        let ctx = HandlerContext::new();
+        let id = Uuid::new_v4();
+        let response = handle(
+            &ctx,
+            Request::LoadPlugin {
+                id,
+                plugin_name: "test".into(),
+                version: "1.0.0".into(),
+                permissions: serde_json::json!({}),
+            },
+        )
+        .await;
+        match response {
+            Response::Error {
+                id: echoed, code, ..
+            } => {
+                assert_eq!(echoed, id);
+                assert_eq!(code, "not_implemented");
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn unload_plugin_returns_not_implemented() {
+        let ctx = HandlerContext::new();
+        let id = Uuid::new_v4();
+        let response = handle(
+            &ctx,
+            Request::UnloadPlugin {
+                id,
+                plugin_name: "test".into(),
+            },
+        )
+        .await;
+        assert!(matches!(response, Response::Error { code, .. } if code == "not_implemented"));
+    }
+
+    #[tokio::test]
+    async fn invoke_returns_not_implemented() {
+        let ctx = HandlerContext::new();
+        let id = Uuid::new_v4();
+        let response = handle(
+            &ctx,
+            Request::Invoke {
+                id,
+                plugin_name: "test".into(),
+                function: "on_request".into(),
+                input: vec![],
+            },
+        )
+        .await;
+        assert!(matches!(response, Response::Error { code, .. } if code == "not_implemented"));
+    }
+}

--- a/crates/mockforge-plugin-host/src/handlers.rs
+++ b/crates/mockforge-plugin-host/src/handlers.rs
@@ -1,137 +1,317 @@
 //! Request handlers for the plugin-host IPC server.
 //!
-//! Phase 2 scaffold: only `health` is wired through. The other
-//! handlers exist so the dispatch table is complete and the wire
-//! protocol is exercised end-to-end — they all return
-//! `not_implemented`. Wiring them is the next deliverable.
+//! Each [`Request`] variant routes to a method on [`Host`]; errors
+//! are caught and translated to [`Response::Error`] with a stable
+//! `code` from [`crate::host::HostError::code`].
 
-use std::time::Instant;
+use base64::Engine;
 
+use crate::host::{Host, HostError};
 use crate::protocol::{Request, Response};
 
-/// Application state carried across requests on a single
-/// connection. Cheap to clone — the fields are either `Arc`-backed
-/// or scalars.
-#[derive(Clone)]
-pub struct HandlerContext {
-    /// When the host process booted. Used by the health endpoint
-    /// so callers can detect a sidecar restart by watching for an
-    /// uptime decrease.
-    pub started_at: Instant,
-}
-
-impl HandlerContext {
-    /// Create a context anchored at "now".
-    pub fn new() -> Self {
-        Self {
-            started_at: Instant::now(),
-        }
-    }
-
-    /// Process uptime in whole seconds.
-    pub fn uptime_secs(&self) -> u64 {
-        self.started_at.elapsed().as_secs()
-    }
-}
-
-impl Default for HandlerContext {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Dispatch a single request to the appropriate handler.
-pub async fn handle(ctx: &HandlerContext, request: Request) -> Response {
+pub async fn handle(host: &Host, request: Request) -> Response {
     match request {
         Request::Health { id } => Response::HealthOk {
             id,
-            uptime_secs: ctx.uptime_secs(),
+            uptime_secs: host.uptime_secs(),
         },
-        Request::LoadPlugin { id, .. } => Response::not_implemented(id, "load_plugin"),
-        Request::UnloadPlugin { id, .. } => Response::not_implemented(id, "unload_plugin"),
-        Request::Invoke { id, .. } => Response::not_implemented(id, "invoke"),
+
+        Request::LoadPlugin {
+            id,
+            plugin_name,
+            version,
+            permissions,
+            wasm_b64,
+        } => {
+            let bytes = match base64::engine::general_purpose::STANDARD.decode(wasm_b64.as_bytes())
+            {
+                Ok(b) => b,
+                Err(err) => {
+                    return Response::Error {
+                        id,
+                        code: "invalid_base64".to_string(),
+                        message: format!("decoding wasm_b64: {err}"),
+                    };
+                }
+            };
+            match host.load_plugin(&plugin_name, &version, permissions, bytes).await {
+                Ok(plugin_id) => Response::Ok {
+                    id,
+                    body: serde_json::json!({
+                        "plugin_id": plugin_id.to_string(),
+                        "plugin_name": plugin_name,
+                        "version": version,
+                    }),
+                },
+                Err(err) => host_error_to_response(id, err),
+            }
+        }
+
+        Request::UnloadPlugin { id, plugin_name } => match host.unload_plugin(&plugin_name).await {
+            Ok(was_loaded) => Response::Ok {
+                id,
+                body: serde_json::json!({
+                    "plugin_name": plugin_name,
+                    // `false` means it wasn't loaded — idempotent
+                    // detach. Callers may treat this as either
+                    // success or "already gone".
+                    "detached": was_loaded,
+                }),
+            },
+            Err(err) => host_error_to_response(id, err),
+        },
+
+        Request::Invoke {
+            id,
+            plugin_name,
+            function,
+            input,
+        } => match host.invoke(&plugin_name, &function, input).await {
+            Ok(value) => Response::Ok {
+                id,
+                body: serde_json::json!({
+                    "plugin_name": plugin_name,
+                    "function": function,
+                    "result": value,
+                }),
+            },
+            Err(err) => host_error_to_response(id, err),
+        },
+    }
+}
+
+fn host_error_to_response(id: uuid::Uuid, err: HostError) -> Response {
+    let code = err.code().to_string();
+    Response::Error {
+        id,
+        code,
+        message: err.to_string(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mockforge_plugin_loader::PluginLoaderConfig;
     use uuid::Uuid;
 
-    #[tokio::test]
-    async fn health_returns_ok_with_uptime() {
-        let ctx = HandlerContext::new();
-        let id = Uuid::new_v4();
-        let response = handle(&ctx, Request::Health { id }).await;
-        match response {
-            Response::HealthOk {
-                id: echoed,
-                uptime_secs,
-            } => {
-                assert_eq!(echoed, id);
-                // Uptime is at-least-zero; we don't assert > 0 because
-                // the handler may run faster than 1 second after ctx
-                // is created.
-                let _ = uptime_secs;
-            }
-            other => panic!("expected HealthOk, got {:?}", other),
-        }
+    /// Smallest valid WASM module bytes — `\0asm` + version 1.
+    const MINIMAL_WASM: &[u8] = &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+
+    fn b64_minimal() -> String {
+        base64::engine::general_purpose::STANDARD.encode(MINIMAL_WASM)
     }
 
-    #[tokio::test]
-    async fn load_plugin_returns_not_implemented() {
-        let ctx = HandlerContext::new();
-        let id = Uuid::new_v4();
-        let response = handle(
-            &ctx,
-            Request::LoadPlugin {
+    /// Drive `body` and the actor concurrently on a current-thread
+    /// runtime — same pattern used in `host::tests`. Tests use this
+    /// instead of `#[tokio::test]` because the actor future is
+    /// `!Send` and can't be `tokio::spawn`'d.
+    fn run_with_actor<F, T>(body: impl FnOnce(Host) -> F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let (host, actor) = Host::new(PluginLoaderConfig {
+                allow_unsigned: true,
+                skip_wasm_validation: true,
+                ..Default::default()
+            });
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+            }
+        })
+    }
+
+    #[test]
+    fn health_returns_ok_with_uptime() {
+        run_with_actor(|host| async move {
+            let id = Uuid::new_v4();
+            let response = handle(&host, Request::Health { id }).await;
+            assert!(matches!(response, Response::HealthOk { id: echoed, .. } if echoed == id));
+        });
+    }
+
+    #[test]
+    fn load_then_unload_round_trips_through_handle() {
+        run_with_actor(|host| async move {
+            let load_id = Uuid::new_v4();
+            let load_response = handle(
+                &host,
+                Request::LoadPlugin {
+                    id: load_id,
+                    plugin_name: "test-plugin".into(),
+                    version: "1.0.0".into(),
+                    permissions: serde_json::json!({}),
+                    wasm_b64: b64_minimal(),
+                },
+            )
+            .await;
+            match load_response {
+                Response::Ok { id: echoed, body } => {
+                    assert_eq!(echoed, load_id);
+                    assert_eq!(body["plugin_name"], "test-plugin");
+                }
+                other => panic!("expected Ok, got {:?}", other),
+            }
+
+            let unload_id = Uuid::new_v4();
+            let unload_response = handle(
+                &host,
+                Request::UnloadPlugin {
+                    id: unload_id,
+                    plugin_name: "test-plugin".into(),
+                },
+            )
+            .await;
+            match unload_response {
+                Response::Ok { id: echoed, body } => {
+                    assert_eq!(echoed, unload_id);
+                    assert_eq!(body["detached"], true);
+                }
+                other => panic!("expected Ok, got {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn load_with_invalid_base64_returns_error_code() {
+        run_with_actor(|host| async move {
+            let id = Uuid::new_v4();
+            let response = handle(
+                &host,
+                Request::LoadPlugin {
+                    id,
+                    plugin_name: "p".into(),
+                    version: "1.0.0".into(),
+                    permissions: serde_json::json!({}),
+                    wasm_b64: "not-valid-base64-!!!".into(),
+                },
+            )
+            .await;
+            match response {
+                Response::Error {
+                    id: echoed, code, ..
+                } => {
+                    assert_eq!(echoed, id);
+                    assert_eq!(code, "invalid_base64");
+                }
+                other => panic!("expected Error, got {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn double_load_returns_already_loaded() {
+        run_with_actor(|host| async move {
+            let make_load = |id| Request::LoadPlugin {
                 id,
-                plugin_name: "test".into(),
+                plugin_name: "dup".into(),
                 version: "1.0.0".into(),
                 permissions: serde_json::json!({}),
-            },
-        )
-        .await;
-        match response {
-            Response::Error {
-                id: echoed, code, ..
-            } => {
-                assert_eq!(echoed, id);
-                assert_eq!(code, "not_implemented");
+                wasm_b64: b64_minimal(),
+            };
+            let _first = handle(&host, make_load(Uuid::new_v4())).await;
+            let second = handle(&host, make_load(Uuid::new_v4())).await;
+            match second {
+                Response::Error { code, .. } => assert_eq!(code, "already_loaded"),
+                other => panic!("expected Error, got {:?}", other),
             }
-            other => panic!("expected Error, got {:?}", other),
-        }
+        });
     }
 
-    #[tokio::test]
-    async fn unload_plugin_returns_not_implemented() {
-        let ctx = HandlerContext::new();
-        let id = Uuid::new_v4();
-        let response = handle(
-            &ctx,
-            Request::UnloadPlugin {
-                id,
-                plugin_name: "test".into(),
-            },
-        )
-        .await;
-        assert!(matches!(response, Response::Error { code, .. } if code == "not_implemented"));
+    #[test]
+    fn invoke_unknown_plugin_returns_not_loaded() {
+        run_with_actor(|host| async move {
+            let id = Uuid::new_v4();
+            let response = handle(
+                &host,
+                Request::Invoke {
+                    id,
+                    plugin_name: "missing".into(),
+                    function: "fn".into(),
+                    input: vec![],
+                },
+            )
+            .await;
+            match response {
+                Response::Error { code, .. } => assert_eq!(code, "not_loaded"),
+                other => panic!("expected Error, got {:?}", other),
+            }
+        });
     }
 
-    #[tokio::test]
-    async fn invoke_returns_not_implemented() {
-        let ctx = HandlerContext::new();
-        let id = Uuid::new_v4();
-        let response = handle(
-            &ctx,
-            Request::Invoke {
-                id,
-                plugin_name: "test".into(),
-                function: "on_request".into(),
-                input: vec![],
-            },
-        )
-        .await;
-        assert!(matches!(response, Response::Error { code, .. } if code == "not_implemented"));
+    #[test]
+    fn unload_unknown_plugin_is_ok_with_detached_false() {
+        // Idempotent detach — easier for callers than tracking
+        // exact load state.
+        run_with_actor(|host| async move {
+            let id = Uuid::new_v4();
+            let response = handle(
+                &host,
+                Request::UnloadPlugin {
+                    id,
+                    plugin_name: "ghost".into(),
+                },
+            )
+            .await;
+            match response {
+                Response::Ok { body, .. } => assert_eq!(body["detached"], false),
+                other => panic!("expected Ok, got {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn invoke_after_load_returns_loader_result() {
+        // The minimal WASM module has no exported functions, so
+        // execute_plugin_function will surface a function-not-found
+        // error from the loader. We're checking that the *path*
+        // works end-to-end — load → invoke → structured error —
+        // not that the invoke succeeds.
+        run_with_actor(|host| async move {
+            let _ = handle(
+                &host,
+                Request::LoadPlugin {
+                    id: Uuid::new_v4(),
+                    plugin_name: "p".into(),
+                    version: "1.0.0".into(),
+                    permissions: serde_json::json!({}),
+                    wasm_b64: b64_minimal(),
+                },
+            )
+            .await;
+
+            let id = Uuid::new_v4();
+            let response = handle(
+                &host,
+                Request::Invoke {
+                    id,
+                    plugin_name: "p".into(),
+                    function: "missing_fn".into(),
+                    input: vec![],
+                },
+            )
+            .await;
+
+            // Either loader_error (function not found bubbles up
+            // as a PluginLoaderError) or plugin_execution_error
+            // (loader returned a failure result rather than
+            // erroring) — both are valid downstream paths. What
+            // matters is we got *some* structured Error rather
+            // than a panic or a bare Ok.
+            match response {
+                Response::Error { code, .. } => {
+                    assert!(
+                        matches!(code.as_str(), "loader_error" | "plugin_execution_error"),
+                        "expected loader_error or plugin_execution_error, got {}",
+                        code
+                    );
+                }
+                other => panic!("expected Error, got {:?}", other),
+            }
+        });
     }
 }

--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -1,0 +1,535 @@
+//! [`Host`] — long-lived state that owns the plugin runtime via an
+//! actor task.
+//!
+//! Why an actor (single-task ownership) rather than `Arc<Mutex<...>>`:
+//! Wasmtime `Store`s are `Send` but not `Sync`, and `WasiCtx` carries
+//! `dyn` trait objects that are also not `Sync`. That makes the
+//! existing `PluginSandbox` (in `mockforge-plugin-loader`) `!Sync`,
+//! which means we can't share it across `tokio::spawn`'d tasks via
+//! `Arc`. The actor pattern sidesteps this entirely: a single
+//! background task owns the sandbox, and the connection-handling
+//! tasks send `Command`s to it over a `tokio::sync::mpsc` channel
+//! and receive replies via `tokio::sync::oneshot`.
+//!
+//! Cost: all sandbox operations serialize through the actor's queue.
+//! At our plugin counts (≤25 for Team tier per the trust RFC) and
+//! the per-invocation latency budget (sub-50 ms), serialization
+//! overhead is negligible compared to the WASM execution cost
+//! itself.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use mockforge_plugin_core::{
+    PluginAuthor, PluginContext, PluginId, PluginInfo, PluginManifest, PluginState, PluginVersion,
+};
+use mockforge_plugin_loader::{
+    PluginLoadContext, PluginLoaderConfig, PluginLoaderError, PluginSandbox,
+};
+use tokio::sync::{mpsc, oneshot};
+
+/// Actor channel capacity. Generous because cloud-plugins ops are
+/// rare (load/unload at attach time, invoke once per request) and
+/// the cost of dropping is high (request gets a 503).
+const CHANNEL_CAPACITY: usize = 256;
+
+/// Per-loaded-plugin bookkeeping the actor needs to keep around.
+///
+/// The tempfile holds the WASM bytes for the plugin's lifetime —
+/// `PluginLoadContext` takes a filesystem path, and the loader
+/// reads from it whenever the sandbox is created. Dropping the
+/// `NamedTempFile` deletes the file, so we hang on to it until the
+/// plugin is unloaded.
+struct PluginEntry {
+    /// PluginId derived from the request's `plugin_name`.
+    plugin_id: PluginId,
+    /// Pinned version, used when constructing per-invocation
+    /// `PluginContext`.
+    version: PluginVersion,
+    /// Tempfile holding the WASM bytes — kept alive so the file
+    /// doesn't get GC'd while the sandbox is loaded.
+    _wasm_file: tempfile::NamedTempFile,
+    /// Permission grant; saved here for future runtime enforcement.
+    /// Currently unused beyond storing for diagnostic purposes.
+    _permissions: serde_json::Value,
+}
+
+/// Long-lived plugin-host handle. `Send + Sync` — internally just an
+/// `mpsc::Sender` and an `Arc<Instant>`. All real state lives in
+/// the actor future returned by [`Host::new`], which the caller
+/// drives on the current task.
+#[derive(Clone)]
+pub struct Host {
+    started_at: Arc<Instant>,
+    cmd_tx: mpsc::Sender<Command>,
+}
+
+/// Future returned by [`Host::new`] that owns the `PluginSandbox`
+/// and processes commands on the current task. Caller drives it
+/// with `tokio::select!` alongside the server loop.
+///
+/// Why not `tokio::spawn(actor)`: the underlying Wasmtime `Store`
+/// inside `PluginSandbox` is `Send` but its embedded `WasiCtx`
+/// carries `dyn` trait objects without `+ Send` bounds (in
+/// wasmtime-wasi 36), making the actor's future `!Send`. Spawning
+/// it on a multi-thread tokio runtime is therefore disallowed at
+/// compile time. Running it inline on the main task — which can
+/// itself be `!Send` under a current-thread runtime — sidesteps
+/// the issue without requiring a `LocalSet` dance.
+pub type HostActor = std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>;
+
+impl Host {
+    /// Construct a new host. Returns the handle (cheap to clone,
+    /// shareable across spawned connection tasks) and the actor
+    /// future the caller must drive on the current task.
+    pub fn new(loader_config: PluginLoaderConfig) -> (Self, HostActor) {
+        let (cmd_tx, cmd_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let started_at = Arc::new(Instant::now());
+
+        let actor: HostActor = Box::pin(actor_loop(loader_config, cmd_rx));
+
+        (Self { started_at, cmd_tx }, actor)
+    }
+
+    /// Process uptime in whole seconds.
+    pub fn uptime_secs(&self) -> u64 {
+        self.started_at.elapsed().as_secs()
+    }
+
+    /// Load a plugin from inline WASM bytes. The bytes are written
+    /// to a tempfile inside the actor so the loader (which takes a
+    /// filesystem path) can `Module::from_file` it. Returns the
+    /// loaded plugin's `PluginId` on success.
+    pub async fn load_plugin(
+        &self,
+        plugin_name: &str,
+        version_str: &str,
+        permissions: serde_json::Value,
+        wasm_bytes: Vec<u8>,
+    ) -> Result<PluginId, HostError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::Load {
+                plugin_name: plugin_name.to_string(),
+                version: version_str.to_string(),
+                permissions,
+                wasm_bytes,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| HostError::ActorGone)?;
+        reply_rx.await.map_err(|_| HostError::ActorGone)?
+    }
+
+    /// Unload a plugin. Idempotent: detaching a plugin that isn't
+    /// loaded returns `Ok(false)`.
+    pub async fn unload_plugin(&self, plugin_name: &str) -> Result<bool, HostError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::Unload {
+                plugin_name: plugin_name.to_string(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| HostError::ActorGone)?;
+        reply_rx.await.map_err(|_| HostError::ActorGone)?
+    }
+
+    /// Invoke a function on a loaded plugin.
+    pub async fn invoke(
+        &self,
+        plugin_name: &str,
+        function: &str,
+        input: Vec<u8>,
+    ) -> Result<serde_json::Value, HostError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::Invoke {
+                plugin_name: plugin_name.to_string(),
+                function: function.to_string(),
+                input,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| HostError::ActorGone)?;
+        reply_rx.await.map_err(|_| HostError::ActorGone)?
+    }
+
+    /// List currently-loaded plugins. For diagnostics.
+    pub async fn loaded_plugins(&self) -> Result<Vec<(String, PluginId)>, HostError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::ListPlugins { reply: reply_tx })
+            .await
+            .map_err(|_| HostError::ActorGone)?;
+        reply_rx.await.map_err(|_| HostError::ActorGone)
+    }
+}
+
+/// Internal command type for the actor channel. Each variant
+/// carries a `oneshot::Sender` for the reply so callers can
+/// `.await` results.
+enum Command {
+    Load {
+        plugin_name: String,
+        version: String,
+        permissions: serde_json::Value,
+        wasm_bytes: Vec<u8>,
+        reply: oneshot::Sender<Result<PluginId, HostError>>,
+    },
+    Unload {
+        plugin_name: String,
+        reply: oneshot::Sender<Result<bool, HostError>>,
+    },
+    Invoke {
+        plugin_name: String,
+        function: String,
+        input: Vec<u8>,
+        reply: oneshot::Sender<Result<serde_json::Value, HostError>>,
+    },
+    ListPlugins {
+        reply: oneshot::Sender<Vec<(String, PluginId)>>,
+    },
+}
+
+/// Actor task. Owns the `PluginSandbox` and the plugin map for the
+/// lifetime of the host process. Returns when the channel closes
+/// (all `Host` handles dropped) or the runtime shuts down.
+async fn actor_loop(loader_config: PluginLoaderConfig, mut cmd_rx: mpsc::Receiver<Command>) {
+    let sandbox = PluginSandbox::new(loader_config);
+    let mut plugins: HashMap<String, PluginEntry> = HashMap::new();
+
+    while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            Command::Load {
+                plugin_name,
+                version,
+                permissions,
+                wasm_bytes,
+                reply,
+            } => {
+                let result = handle_load(
+                    &sandbox,
+                    &mut plugins,
+                    &plugin_name,
+                    &version,
+                    permissions,
+                    wasm_bytes,
+                )
+                .await;
+                let _ = reply.send(result);
+            }
+            Command::Unload { plugin_name, reply } => {
+                let result = handle_unload(&sandbox, &mut plugins, &plugin_name).await;
+                let _ = reply.send(result);
+            }
+            Command::Invoke {
+                plugin_name,
+                function,
+                input,
+                reply,
+            } => {
+                let result =
+                    handle_invoke(&sandbox, &plugins, &plugin_name, &function, input).await;
+                let _ = reply.send(result);
+            }
+            Command::ListPlugins { reply } => {
+                let snapshot: Vec<(String, PluginId)> = plugins
+                    .iter()
+                    .map(|(name, entry)| (name.clone(), entry.plugin_id.clone()))
+                    .collect();
+                let _ = reply.send(snapshot);
+            }
+        }
+    }
+
+    tracing::info!("plugin-host actor exiting (channel closed)");
+}
+
+async fn handle_load(
+    sandbox: &PluginSandbox,
+    plugins: &mut HashMap<String, PluginEntry>,
+    plugin_name: &str,
+    version_str: &str,
+    permissions: serde_json::Value,
+    wasm_bytes: Vec<u8>,
+) -> Result<PluginId, HostError> {
+    if plugins.contains_key(plugin_name) {
+        return Err(HostError::AlreadyLoaded {
+            plugin_name: plugin_name.to_string(),
+        });
+    }
+
+    let version = PluginVersion::parse(version_str).map_err(|err| HostError::InvalidVersion {
+        version: version_str.to_string(),
+        err,
+    })?;
+    let plugin_id = PluginId::new(plugin_name);
+
+    let mut wasm_file = tempfile::NamedTempFile::new().map_err(|err| HostError::Io {
+        what: "creating tempfile",
+        err,
+    })?;
+    std::io::Write::write_all(&mut wasm_file, &wasm_bytes).map_err(|err| HostError::Io {
+        what: "writing wasm bytes",
+        err,
+    })?;
+    let path = wasm_file.path().to_path_buf();
+
+    let manifest = build_synthetic_manifest(plugin_name, version.clone());
+    let load_ctx = PluginLoadContext::new(
+        plugin_id.clone(),
+        manifest,
+        path.to_string_lossy().into_owned(),
+        PluginLoaderConfig::default(),
+    );
+
+    let instance = sandbox.create_plugin_instance(&load_ctx).await?;
+    debug_assert_eq!(instance.state, PluginState::Ready);
+
+    plugins.insert(
+        plugin_name.to_string(),
+        PluginEntry {
+            plugin_id: plugin_id.clone(),
+            version,
+            _wasm_file: wasm_file,
+            _permissions: permissions,
+        },
+    );
+
+    Ok(plugin_id)
+}
+
+async fn handle_unload(
+    sandbox: &PluginSandbox,
+    plugins: &mut HashMap<String, PluginEntry>,
+    plugin_name: &str,
+) -> Result<bool, HostError> {
+    let Some(entry) = plugins.remove(plugin_name) else {
+        return Ok(false);
+    };
+    sandbox.destroy_sandbox(&entry.plugin_id).await?;
+    Ok(true)
+}
+
+async fn handle_invoke(
+    sandbox: &PluginSandbox,
+    plugins: &HashMap<String, PluginEntry>,
+    plugin_name: &str,
+    function: &str,
+    input: Vec<u8>,
+) -> Result<serde_json::Value, HostError> {
+    let entry = plugins.get(plugin_name).ok_or_else(|| HostError::NotLoaded {
+        plugin_name: plugin_name.to_string(),
+    })?;
+
+    let ctx = PluginContext::new(entry.plugin_id.clone(), entry.version.clone());
+    let result = sandbox
+        .execute_plugin_function(&entry.plugin_id, function, &ctx, &input)
+        .await?;
+
+    // `error()` borrows but `data()` consumes — capture the error
+    // first so we can still consume on the success path.
+    let error_message = result.error().map(str::to_string);
+    if let Some(message) = error_message {
+        return Err(HostError::PluginExecution {
+            plugin_name: plugin_name.to_string(),
+            message,
+        });
+    }
+    Ok(result.data().unwrap_or(serde_json::Value::Null))
+}
+
+/// Errors from host operations. Each variant maps to a stable wire
+/// `code` so callers can react programmatically without parsing
+/// the human-readable message.
+#[derive(Debug, thiserror::Error)]
+pub enum HostError {
+    /// Tried to load a plugin that's already loaded.
+    #[error("plugin '{plugin_name}' is already loaded; detach before re-loading")]
+    AlreadyLoaded {
+        /// Plugin name that conflicted.
+        plugin_name: String,
+    },
+    /// Tried to invoke / unload a plugin that isn't loaded.
+    #[error("plugin '{plugin_name}' is not loaded")]
+    NotLoaded {
+        /// Plugin name that wasn't found.
+        plugin_name: String,
+    },
+    /// `version` couldn't be parsed as a semver-shaped string.
+    #[error("invalid version '{version}': {err}")]
+    InvalidVersion {
+        /// The string that failed to parse.
+        version: String,
+        /// Parse-error detail from `PluginVersion::parse`.
+        err: String,
+    },
+    /// An I/O error materializing the WASM bytes to a tempfile.
+    #[error("io error while {what}: {err}")]
+    Io {
+        /// Human-readable description of the operation that failed.
+        what: &'static str,
+        /// Underlying io::Error.
+        #[source]
+        err: std::io::Error,
+    },
+    /// The loader rejected the load or invocation.
+    #[error("loader error: {0}")]
+    Loader(#[from] PluginLoaderError),
+    /// The plugin function returned an error/trap.
+    #[error("plugin '{plugin_name}' execution failed: {message}")]
+    PluginExecution {
+        /// Plugin that failed.
+        plugin_name: String,
+        /// Error/trap message.
+        message: String,
+    },
+    /// Base64-decode of the WASM bytes failed.
+    #[error("invalid base64 wasm: {0}")]
+    Base64(#[from] base64::DecodeError),
+    /// The actor task is gone — likely runtime shutdown or a
+    /// panic in the actor. Caller should reconnect.
+    #[error("plugin-host actor task is no longer running")]
+    ActorGone,
+}
+
+impl HostError {
+    /// Stable, machine-readable error code for the IPC `code` field.
+    pub fn code(&self) -> &'static str {
+        match self {
+            HostError::AlreadyLoaded { .. } => "already_loaded",
+            HostError::NotLoaded { .. } => "not_loaded",
+            HostError::InvalidVersion { .. } => "invalid_version",
+            HostError::Io { .. } => "io_error",
+            HostError::Loader(_) => "loader_error",
+            HostError::PluginExecution { .. } => "plugin_execution_error",
+            HostError::Base64(_) => "invalid_base64",
+            HostError::ActorGone => "actor_gone",
+        }
+    }
+}
+
+/// Build a placeholder manifest for a plugin loaded over IPC.
+///
+/// The cloud trust model treats this as informational only — what
+/// actually gates plugin behavior is the `permissions` grant from
+/// the LoadPlugin request, enforced at the runtime boundary. A
+/// future Phase 2 PR will fetch the *real* manifest from the
+/// registry alongside the WASM bytes so we can validate the
+/// `manifest ∩ grant` invariant inside the host.
+fn build_synthetic_manifest(plugin_name: &str, version: PluginVersion) -> PluginManifest {
+    let plugin_id = PluginId::new(plugin_name);
+    let info = PluginInfo::new(
+        plugin_id,
+        version,
+        plugin_name,
+        "Cloud-loaded plugin (synthetic manifest)",
+        PluginAuthor {
+            name: "cloud-plugins-host".to_string(),
+            email: None,
+        },
+    );
+    PluginManifest::new(info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smallest valid WASM module bytes — `\0asm` + version 1.
+    fn minimal_wasm() -> Vec<u8> {
+        vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
+    }
+
+    fn loader_config() -> PluginLoaderConfig {
+        PluginLoaderConfig {
+            allow_unsigned: true,
+            skip_wasm_validation: true,
+            ..Default::default()
+        }
+    }
+
+    /// Drive `body` and the actor future concurrently on a
+    /// current-thread runtime. Tests use this so they don't need
+    /// `tokio::main(flavor = "current_thread")` boilerplate.
+    fn run_with_actor<F, T>(body: impl FnOnce(Host) -> F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let (host, actor) = Host::new(loader_config());
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+            }
+        })
+    }
+
+    #[test]
+    fn load_plugin_then_list_returns_one_entry() {
+        run_with_actor(|host| async move {
+            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap();
+            let loaded = host.loaded_plugins().await.unwrap();
+            assert_eq!(loaded.len(), 1);
+            assert_eq!(loaded[0].0, "test-plugin");
+        });
+    }
+
+    #[test]
+    fn load_plugin_twice_returns_already_loaded() {
+        run_with_actor(|host| async move {
+            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap();
+            let err = host
+                .load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "already_loaded");
+        });
+    }
+
+    #[test]
+    fn unload_plugin_removes_entry() {
+        run_with_actor(|host| async move {
+            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap();
+            let detached = host.unload_plugin("test-plugin").await.unwrap();
+            assert!(detached);
+            assert!(host.loaded_plugins().await.unwrap().is_empty());
+        });
+    }
+
+    #[test]
+    fn unload_unknown_plugin_is_idempotent() {
+        run_with_actor(|host| async move {
+            let detached = host.unload_plugin("nope").await.unwrap();
+            assert!(!detached);
+        });
+    }
+
+    #[test]
+    fn invoke_unknown_plugin_returns_not_loaded() {
+        run_with_actor(|host| async move {
+            let err = host.invoke("nope", "fn", vec![]).await.unwrap_err();
+            assert_eq!(err.code(), "not_loaded");
+        });
+    }
+
+    #[test]
+    fn load_with_invalid_version_returns_invalid_version() {
+        run_with_actor(|host| async move {
+            let err = host
+                .load_plugin("test-plugin", "not-a-version", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "invalid_version");
+        });
+    }
+}

--- a/crates/mockforge-plugin-host/src/lib.rs
+++ b/crates/mockforge-plugin-host/src/lib.rs
@@ -1,0 +1,41 @@
+//! # MockForge Plugin Host
+//!
+//! Sidecar binary that runs alongside `mockforge` in the same Fly
+//! machine, hosts the WASM plugin runtime, and exposes a Unix-socket
+//! IPC interface that main mockforge calls into for each plugin
+//! invocation.
+//!
+//! See `docs/plugins/security/cloud-trust-permissions-rfc.md` and
+//! `docs/plugins/security/cloud-runtime-build-vs-buy-spike.md` for
+//! the design.
+//!
+//! ## Status
+//!
+//! **Phase 2 scaffold.** Boots, listens on the Unix socket, and
+//! handles `health` round-trips. The `load_plugin` / `unload_plugin`
+//! / `invoke` handlers return `not_implemented` placeholders — wiring
+//! them to the real `mockforge-plugin-loader::sandbox::PluginSandbox`
+//! is the next deliverable.
+//!
+//! ## Wire protocol
+//!
+//! JSON requests / responses, one per Unix socket message, length-
+//! prefixed. Protocol is intentionally simple and language-agnostic
+//! so we can swap to protobuf later without breaking the on-the-wire
+//! semantics. See [`protocol`].
+//!
+//! ## Why a separate crate from `mockforge-plugin-loader`?
+//!
+//! The loader is OSS — it ships in the local mockforge binary for
+//! self-hosted users. The host is cloud-only: it owns IPC, signature
+//! verification at boot, OTLP export to the cloud aggregator, and
+//! the kill-switch poll. Keeping them split lets the OSS surface
+//! stay small and lets us iterate on cloud-only concerns without
+//! touching the OSS API.
+
+pub mod handlers;
+pub mod protocol;
+pub mod server;
+
+pub use protocol::{Request, Response};
+pub use server::{run_server, ServerConfig};

--- a/crates/mockforge-plugin-host/src/lib.rs
+++ b/crates/mockforge-plugin-host/src/lib.rs
@@ -11,18 +11,19 @@
 //!
 //! ## Status
 //!
-//! **Phase 2 scaffold.** Boots, listens on the Unix socket, and
-//! handles `health` round-trips. The `load_plugin` / `unload_plugin`
-//! / `invoke` handlers return `not_implemented` placeholders — wiring
-//! them to the real `mockforge-plugin-loader::sandbox::PluginSandbox`
-//! is the next deliverable.
+//! **Phase 2 — IPC handlers wired.** Health/LoadPlugin/UnloadPlugin/
+//! Invoke all dispatch through to [`Host`], which owns a real
+//! `mockforge_plugin_loader::sandbox::PluginSandbox`. WASM bytes
+//! are inlined as base64 in the LoadPlugin request; the registry-
+//! fetch path lands separately so signature verification can hook
+//! in upstream.
 //!
 //! ## Wire protocol
 //!
-//! JSON requests / responses, one per Unix socket message, length-
-//! prefixed. Protocol is intentionally simple and language-agnostic
-//! so we can swap to protobuf later without breaking the on-the-wire
-//! semantics. See [`protocol`].
+//! Newline-delimited JSON, request/response tagged by `id` for
+//! multiplexing on a single connection. Protocol is intentionally
+//! simple and language-agnostic so we can swap to protobuf later
+//! without breaking the on-the-wire semantics. See [`protocol`].
 //!
 //! ## Why a separate crate from `mockforge-plugin-loader`?
 //!
@@ -34,8 +35,10 @@
 //! touching the OSS API.
 
 pub mod handlers;
+pub mod host;
 pub mod protocol;
 pub mod server;
 
+pub use host::{Host, HostActor, HostError};
 pub use protocol::{Request, Response};
 pub use server::{run_server, ServerConfig};

--- a/crates/mockforge-plugin-host/src/main.rs
+++ b/crates/mockforge-plugin-host/src/main.rs
@@ -1,0 +1,101 @@
+//! `mockforge-plugin-host` binary — the cloud-plugins sidecar.
+//!
+//! Reads `MOCKFORGE_PLUGIN_HOST_SOCKET` for the bind path (default
+//! `/tmp/plugin-host.sock`) and `MOCKFORGE_PLUGIN_HOST_SOCKET_MODE`
+//! for the file mode (default `0o660`). Logs to stdout with the
+//! standard `tracing` subscriber so Fly's log aggregation picks it
+//! up alongside main mockforge.
+//!
+//! See the crate-level docs for the design.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use mockforge_plugin_host::{run_server, ServerConfig};
+
+const DEFAULT_SOCKET_PATH: &str = "/tmp/plugin-host.sock";
+const DEFAULT_SOCKET_MODE: u32 = 0o660;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_tracing();
+
+    let config = ServerConfig {
+        socket_path: env_socket_path()?,
+        socket_mode: env_socket_mode()?,
+    };
+
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        socket = %config.socket_path.display(),
+        "mockforge-plugin-host starting"
+    );
+
+    // Run the server until SIGTERM. The server loop returns only on
+    // bind error or when the runtime is shut down.
+    tokio::select! {
+        result = run_server(config) => {
+            tracing::error!(?result, "plugin-host server loop exited unexpectedly");
+            result
+        }
+        _ = shutdown_signal() => {
+            tracing::info!("plugin-host received shutdown signal — exiting");
+            Ok(())
+        }
+    }
+}
+
+fn init_tracing() {
+    use tracing_subscriber::fmt::format::FmtSpan;
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_span_events(FmtSpan::CLOSE)
+        .try_init();
+}
+
+fn env_socket_path() -> Result<PathBuf> {
+    Ok(std::env::var("MOCKFORGE_PLUGIN_HOST_SOCKET")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_SOCKET_PATH)))
+}
+
+fn env_socket_mode() -> Result<u32> {
+    match std::env::var("MOCKFORGE_PLUGIN_HOST_SOCKET_MODE") {
+        Ok(s) => {
+            // Accept "0o660", "660", "0660", "0x1B0" — be lenient
+            // to keep deploy configs readable.
+            let trimmed = s.trim();
+            let (radix, digits) = if let Some(rest) = trimmed.strip_prefix("0o") {
+                (8, rest)
+            } else if let Some(rest) = trimmed.strip_prefix("0x") {
+                (16, rest)
+            } else if trimmed.starts_with('0') && trimmed.len() > 1 {
+                (8, &trimmed[1..])
+            } else {
+                (8, trimmed)
+            };
+            u32::from_str_radix(digits, radix)
+                .with_context(|| format!("parsing MOCKFORGE_PLUGIN_HOST_SOCKET_MODE={}", s))
+        }
+        Err(_) => Ok(DEFAULT_SOCKET_MODE),
+    }
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let mut sigint = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    tokio::select! {
+        _ = sigterm.recv() => tracing::info!("received SIGTERM"),
+        _ = sigint.recv() => tracing::info!("received SIGINT"),
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/crates/mockforge-plugin-host/src/main.rs
+++ b/crates/mockforge-plugin-host/src/main.rs
@@ -7,17 +7,27 @@
 //! up alongside main mockforge.
 //!
 //! See the crate-level docs for the design.
+//!
+//! ### Runtime flavor
+//!
+//! Built on a current-thread Tokio runtime. The plugin sandbox holds
+//! a Wasmtime `Store` whose embedded `WasiCtx` is `!Send`, which
+//! means the actor task that owns it cannot run on a multi-thread
+//! runtime. Every IPC connection from main mockforge is processed
+//! on this single thread. At the latency budgets and concurrency
+//! we're targeting (≤25 plugins per Team-tier deployment, sub-50 ms
+//! invocations) this is plenty.
 
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use mockforge_plugin_host::{run_server, ServerConfig};
+use mockforge_plugin_host::{run_server, Host, ServerConfig};
+use mockforge_plugin_loader::PluginLoaderConfig;
 
 const DEFAULT_SOCKET_PATH: &str = "/tmp/plugin-host.sock";
 const DEFAULT_SOCKET_MODE: u32 = 0o660;
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     init_tracing();
 
     let config = ServerConfig {
@@ -31,18 +41,38 @@ async fn main() -> Result<()> {
         "mockforge-plugin-host starting"
     );
 
-    // Run the server until SIGTERM. The server loop returns only on
-    // bind error or when the runtime is shut down.
-    tokio::select! {
-        result = run_server(config) => {
-            tracing::error!(?result, "plugin-host server loop exited unexpectedly");
-            result
+    // Current-thread runtime — see the module-level note on why
+    // this is required (the Wasmtime store inside the actor is
+    // !Send, so it can't run on a multi-thread runtime).
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building Tokio current-thread runtime")?;
+
+    rt.block_on(async move {
+        let (host, actor) = Host::new(PluginLoaderConfig::default());
+
+        // Drive actor + server + shutdown_signal concurrently. The
+        // actor owns the !Send sandbox; the server fans connections
+        // out via tokio::spawn, but those tasks only carry the
+        // (Send) `Host` handle — never the sandbox itself.
+        tokio::select! {
+            // Actor exit is unexpected — channel closed without
+            // shutdown signal. Surface as an error.
+            _ = actor => {
+                tracing::error!("plugin-host actor exited unexpectedly");
+                Err(anyhow::anyhow!("plugin-host actor exited"))
+            }
+            result = run_server(config, host) => {
+                tracing::error!(?result, "plugin-host server loop exited unexpectedly");
+                result
+            }
+            _ = shutdown_signal() => {
+                tracing::info!("plugin-host received shutdown signal — exiting");
+                Ok(())
+            }
         }
-        _ = shutdown_signal() => {
-            tracing::info!("plugin-host received shutdown signal — exiting");
-            Ok(())
-        }
-    }
+    })
 }
 
 fn init_tracing() {

--- a/crates/mockforge-plugin-host/src/protocol.rs
+++ b/crates/mockforge-plugin-host/src/protocol.rs
@@ -1,0 +1,213 @@
+//! Wire protocol for main-mockforge ↔ plugin-host IPC.
+//!
+//! Newline-delimited JSON. Every request gets exactly one response,
+//! tagged by `id` so callers can multiplex without ordering
+//! guarantees. Chosen over protobuf for v1 because: (a) the message
+//! set is tiny, (b) JSON is debuggable with `nc -U`, (c) we can
+//! swap to protobuf later without changing semantics — only the
+//! framing.
+//!
+//! Compared with `wasi:http` for plugin↔host (the build-vs-buy spike
+//! recommendation): that's the *plugin's* interface inside the
+//! host, exposed via Wasmtime imports. This protocol is the **host
+//! ↔ host** interface — between mockforge's request handler and
+//! the sidecar's plugin runtime — and is unrelated.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Request from main mockforge to the plugin host.
+///
+/// Each request carries a client-chosen `id` that the matching
+/// [`Response`] echoes. IDs need only be unique within a single
+/// connection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Request {
+    /// Liveness check. Cheap, no side effects. Used by both the
+    /// startup probe and the steady-state heartbeat.
+    Health {
+        /// Correlation id — echoed back in the response so callers
+        /// can multiplex requests over a single connection.
+        id: Uuid,
+    },
+    /// Load a signed WASM plugin into a fresh `Store`. **Not
+    /// implemented in this scaffold.** Will dispatch to the real
+    /// `PluginSandbox` once signature verification + permission
+    /// grant evaluation lands.
+    LoadPlugin {
+        /// Correlation id.
+        id: Uuid,
+        /// Plugin name from the registry.
+        plugin_name: String,
+        /// Plugin version, pinned at attach time.
+        version: String,
+        /// Permission grant payload (RFC §4.2).
+        permissions: serde_json::Value,
+    },
+    /// Detach a plugin. **Not implemented in this scaffold.**
+    UnloadPlugin {
+        /// Correlation id.
+        id: Uuid,
+        /// Plugin name from the registry.
+        plugin_name: String,
+    },
+    /// Invoke a plugin function on a request/response pair.
+    /// **Not implemented in this scaffold.**
+    Invoke {
+        /// Correlation id.
+        id: Uuid,
+        /// Plugin name from the registry.
+        plugin_name: String,
+        /// Exported function to call (e.g. `on_request`,
+        /// `on_response`).
+        function: String,
+        /// Opaque input bytes — the loader handles serialization
+        /// of the host context + input together.
+        input: Vec<u8>,
+    },
+}
+
+impl Request {
+    /// The correlation id this request was tagged with. The
+    /// matching [`Response`] echoes it.
+    pub fn id(&self) -> Uuid {
+        match self {
+            Request::Health { id }
+            | Request::LoadPlugin { id, .. }
+            | Request::UnloadPlugin { id, .. }
+            | Request::Invoke { id, .. } => *id,
+        }
+    }
+}
+
+/// Response from the plugin host back to main mockforge.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Response {
+    /// Health check answered. Returns the host's startup time so
+    /// callers can detect a restart.
+    HealthOk {
+        /// Echoed correlation id from the matching request.
+        id: Uuid,
+        /// Process uptime in seconds.
+        uptime_secs: u64,
+    },
+    /// Plugin operation succeeded. Body is operation-specific.
+    Ok {
+        /// Echoed correlation id from the matching request.
+        id: Uuid,
+        /// Operation-specific result payload.
+        body: serde_json::Value,
+    },
+    /// Operation failed. `code` is a stable string callers can
+    /// match against; `message` is human-readable detail.
+    Error {
+        /// Echoed correlation id from the matching request.
+        id: Uuid,
+        /// Stable machine-readable error code.
+        code: String,
+        /// Human-readable detail.
+        message: String,
+    },
+}
+
+impl Response {
+    /// Convenience: build a `not_implemented` error for handlers
+    /// that haven't shipped yet (load/unload/invoke).
+    pub fn not_implemented(id: Uuid, what: &str) -> Self {
+        Response::Error {
+            id,
+            code: "not_implemented".to_string(),
+            message: format!("{} is not yet implemented in this plugin-host scaffold", what),
+        }
+    }
+
+    /// Correlation id this response is tagged with.
+    pub fn id(&self) -> Uuid {
+        match self {
+            Response::HealthOk { id, .. }
+            | Response::Ok { id, .. }
+            | Response::Error { id, .. } => *id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_round_trips_through_json() {
+        let id = Uuid::new_v4();
+        let req = Request::Health { id };
+        let bytes = serde_json::to_vec(&req).unwrap();
+        let parsed: Request = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed.id(), id);
+    }
+
+    #[test]
+    fn load_plugin_request_carries_permissions() {
+        let req = Request::LoadPlugin {
+            id: Uuid::new_v4(),
+            plugin_name: "stripe-rewriter".into(),
+            version: "1.2.3".into(),
+            permissions: serde_json::json!({
+                "egress": { "allow": ["*.stripe.com"] }
+            }),
+        };
+        let bytes = serde_json::to_vec(&req).unwrap();
+        let parsed: Request = serde_json::from_slice(&bytes).unwrap();
+        match parsed {
+            Request::LoadPlugin {
+                plugin_name,
+                version,
+                permissions,
+                ..
+            } => {
+                assert_eq!(plugin_name, "stripe-rewriter");
+                assert_eq!(version, "1.2.3");
+                assert!(permissions.get("egress").is_some());
+            }
+            other => panic!("expected LoadPlugin, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn not_implemented_helper_carries_correlation_id() {
+        let id = Uuid::new_v4();
+        let resp = Response::not_implemented(id, "invoke");
+        match resp {
+            Response::Error {
+                id: echoed,
+                code,
+                message,
+            } => {
+                assert_eq!(echoed, id);
+                assert_eq!(code, "not_implemented");
+                assert!(message.contains("invoke"));
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn response_serialization_uses_snake_case_kind() {
+        let resp = Response::HealthOk {
+            id: Uuid::new_v4(),
+            uptime_secs: 42,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"kind\":\"health_ok\""));
+    }
+
+    #[test]
+    fn unknown_request_kind_fails_to_parse() {
+        // Forward compatibility check: requests with new kinds get
+        // a clean parse error rather than silently mismatching to a
+        // similar variant.
+        let bytes = br#"{"kind":"future_op","id":"00000000-0000-0000-0000-000000000000"}"#;
+        let result: Result<Request, _> = serde_json::from_slice(bytes);
+        assert!(result.is_err());
+    }
+}

--- a/crates/mockforge-plugin-host/src/protocol.rs
+++ b/crates/mockforge-plugin-host/src/protocol.rs
@@ -31,21 +31,32 @@ pub enum Request {
         /// can multiplex requests over a single connection.
         id: Uuid,
     },
-    /// Load a signed WASM plugin into a fresh `Store`. **Not
-    /// implemented in this scaffold.** Will dispatch to the real
-    /// `PluginSandbox` once signature verification + permission
-    /// grant evaluation lands.
+    /// Load a WASM plugin into a fresh `Store`.
+    ///
+    /// In v1 the WASM bytes are inlined as base64 in the request.
+    /// The follow-up "registry fetch" path will replace this with a
+    /// `download_url` field that the host fetches itself, so
+    /// signature verification can happen before any bytes touch
+    /// the loader. Until then, the caller is expected to verify
+    /// signatures upstream.
     LoadPlugin {
         /// Correlation id.
         id: Uuid,
         /// Plugin name from the registry.
         plugin_name: String,
-        /// Plugin version, pinned at attach time.
+        /// Plugin version, pinned at attach time. Parsed via
+        /// `PluginVersion::parse` (semver-shaped:
+        /// `major.minor.patch`).
         version: String,
-        /// Permission grant payload (RFC §4.2).
+        /// Permission grant payload (RFC §4.2). Stored alongside
+        /// the loaded plugin; runtime enforcement of the
+        /// `manifest ∩ grant` invariant lands with the egress
+        /// proxy + env-grant integration.
         permissions: serde_json::Value,
+        /// Base64-encoded WASM module bytes.
+        wasm_b64: String,
     },
-    /// Detach a plugin. **Not implemented in this scaffold.**
+    /// Detach a plugin and free its sandbox.
     UnloadPlugin {
         /// Correlation id.
         id: Uuid,
@@ -53,7 +64,6 @@ pub enum Request {
         plugin_name: String,
     },
     /// Invoke a plugin function on a request/response pair.
-    /// **Not implemented in this scaffold.**
     Invoke {
         /// Correlation id.
         id: Uuid,
@@ -147,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn load_plugin_request_carries_permissions() {
+    fn load_plugin_request_carries_permissions_and_wasm() {
         let req = Request::LoadPlugin {
             id: Uuid::new_v4(),
             plugin_name: "stripe-rewriter".into(),
@@ -155,6 +165,7 @@ mod tests {
             permissions: serde_json::json!({
                 "egress": { "allow": ["*.stripe.com"] }
             }),
+            wasm_b64: "AGFzbQEAAAA=".into(), // empty WASM module
         };
         let bytes = serde_json::to_vec(&req).unwrap();
         let parsed: Request = serde_json::from_slice(&bytes).unwrap();
@@ -163,11 +174,13 @@ mod tests {
                 plugin_name,
                 version,
                 permissions,
+                wasm_b64,
                 ..
             } => {
                 assert_eq!(plugin_name, "stripe-rewriter");
                 assert_eq!(version, "1.2.3");
                 assert!(permissions.get("egress").is_some());
+                assert_eq!(wasm_b64, "AGFzbQEAAAA=");
             }
             other => panic!("expected LoadPlugin, got {:?}", other),
         }

--- a/crates/mockforge-plugin-host/src/server.rs
+++ b/crates/mockforge-plugin-host/src/server.rs
@@ -11,11 +11,12 @@ use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
-use crate::handlers::{handle, HandlerContext};
+use crate::handlers::handle;
+use crate::host::Host;
 use crate::protocol::Request;
 
 /// Configuration for the host server.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ServerConfig {
     /// Filesystem path the Unix socket is bound to. Main mockforge
     /// connects here.
@@ -41,7 +42,7 @@ impl Default for ServerConfig {
 ///
 /// Each accepted connection runs in its own Tokio task so a slow
 /// client doesn't head-of-line-block other callers.
-pub async fn run_server(config: ServerConfig) -> Result<()> {
+pub async fn run_server(config: ServerConfig, host: Host) -> Result<()> {
     // Best-effort cleanup of a stale socket from a previous run.
     // If the previous host crashed the file is still on disk and a
     // fresh bind would fail with EADDRINUSE.
@@ -65,8 +66,6 @@ pub async fn run_server(config: ServerConfig) -> Result<()> {
         "plugin-host listening"
     );
 
-    let ctx = HandlerContext::new();
-
     loop {
         let (stream, _addr) = match listener.accept().await {
             Ok(pair) => pair,
@@ -79,9 +78,9 @@ pub async fn run_server(config: ServerConfig) -> Result<()> {
             }
         };
 
-        let ctx = ctx.clone();
+        let host = host.clone();
         tokio::spawn(async move {
-            if let Err(err) = handle_connection(&ctx, stream).await {
+            if let Err(err) = handle_connection(&host, stream).await {
                 tracing::warn!(error = %err, "client connection terminated with error");
             }
         });
@@ -104,7 +103,7 @@ fn set_socket_permissions(_path: &Path, _mode: u32) -> Result<()> {
     Ok(())
 }
 
-async fn handle_connection(ctx: &HandlerContext, stream: UnixStream) -> Result<()> {
+async fn handle_connection(host: &Host, stream: UnixStream) -> Result<()> {
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
     let mut line = String::new();
@@ -129,7 +128,7 @@ async fn handle_connection(ctx: &HandlerContext, stream: UnixStream) -> Result<(
             }
         };
 
-        let response = handle(ctx, request).await;
+        let response = handle(host, request).await;
         let mut bytes = serde_json::to_vec(&response).context("serializing response")?;
         bytes.push(b'\n');
         write_half.write_all(&bytes).await.context("writing response")?;
@@ -141,15 +140,37 @@ async fn handle_connection(ctx: &HandlerContext, stream: UnixStream) -> Result<(
 mod tests {
     use super::*;
     use crate::protocol::Response;
+    use mockforge_plugin_loader::PluginLoaderConfig;
     use tokio::io::BufReader as TokioBufReader;
     use uuid::Uuid;
 
-    /// End-to-end: spawn the server in the background, connect over
-    /// the Unix socket, send a Health request, get a HealthOk back.
-    /// Validates the protocol round-trips through real socket I/O,
-    /// which the unit tests in `handlers` and `protocol` don't.
-    #[tokio::test]
-    async fn server_round_trips_a_health_request() {
+    /// Spin up a current-thread runtime that runs the actor + the
+    /// server + the test body concurrently via `select!`. Whichever
+    /// of the three completes first wins; the server and actor are
+    /// designed to run forever, so the test body's completion is
+    /// what ends the runtime.
+    fn run_server_with_actor<F, T>(config: ServerConfig, body: impl FnOnce(Host) -> F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let (host, actor) = Host::new(PluginLoaderConfig::default());
+            let server_host = host.clone();
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+                result = run_server(config, server_host) => panic!("server exited unexpectedly: {:?}", result),
+            }
+        })
+    }
+
+    /// End-to-end: drive the actor + server, connect over the Unix
+    /// socket, send a Health request, get a HealthOk back. Validates
+    /// the protocol round-trips through real socket I/O, which the
+    /// unit tests in `handlers` and `protocol` don't.
+    #[test]
+    fn server_round_trips_a_health_request() {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("test.sock");
 
@@ -160,46 +181,39 @@ mod tests {
             socket_mode: 0o600,
         };
 
-        let server_handle = tokio::spawn(async move { run_server(config).await });
+        run_server_with_actor(config, |_host| async move {
+            // Wait for the socket file to appear.
+            let mut attempts = 0;
+            while !socket_path.exists() && attempts < 50 {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                attempts += 1;
+            }
+            assert!(socket_path.exists(), "server didn't bind socket");
 
-        // Wait for the socket file to appear; the server binds on
-        // its own task so there's a small window where it's not
-        // ready yet.
-        let mut attempts = 0;
-        while !socket_path.exists() && attempts < 50 {
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-            attempts += 1;
-        }
-        assert!(socket_path.exists(), "server didn't bind socket");
+            let stream = UnixStream::connect(&socket_path).await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut reader = TokioBufReader::new(read_half);
 
-        let stream = UnixStream::connect(&socket_path).await.unwrap();
-        let (read_half, mut write_half) = stream.into_split();
-        let mut reader = TokioBufReader::new(read_half);
+            let id = Uuid::new_v4();
+            let req = Request::Health { id };
+            let mut bytes = serde_json::to_vec(&req).unwrap();
+            bytes.push(b'\n');
+            write_half.write_all(&bytes).await.unwrap();
+            write_half.flush().await.unwrap();
 
-        let id = Uuid::new_v4();
-        let req = Request::Health { id };
-        let mut bytes = serde_json::to_vec(&req).unwrap();
-        bytes.push(b'\n');
-        write_half.write_all(&bytes).await.unwrap();
-        write_half.flush().await.unwrap();
+            let mut response_line = String::new();
+            reader.read_line(&mut response_line).await.unwrap();
+            let response: Response = serde_json::from_str(response_line.trim_end()).unwrap();
 
-        let mut response_line = String::new();
-        reader.read_line(&mut response_line).await.unwrap();
-        let response: Response = serde_json::from_str(response_line.trim_end()).unwrap();
-
-        match response {
-            Response::HealthOk { id: echoed, .. } => assert_eq!(echoed, id),
-            other => panic!("expected HealthOk, got {:?}", other),
-        }
-
-        // Cleanup: drop the writer to send EOF, then abort the
-        // server so the test exits.
-        drop(write_half);
-        server_handle.abort();
+            match response {
+                Response::HealthOk { id: echoed, .. } => assert_eq!(echoed, id),
+                other => panic!("expected HealthOk, got {:?}", other),
+            }
+        });
     }
 
-    #[tokio::test]
-    async fn malformed_request_closes_connection_without_panic() {
+    #[test]
+    fn malformed_request_closes_connection_without_panic() {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("test.sock");
         let config = ServerConfig {
@@ -207,30 +221,29 @@ mod tests {
             socket_mode: 0o600,
         };
 
-        let server_handle = tokio::spawn(async move { run_server(config).await });
-        let mut attempts = 0;
-        while !socket_path.exists() && attempts < 50 {
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-            attempts += 1;
-        }
+        run_server_with_actor(config, |_host| async move {
+            let mut attempts = 0;
+            while !socket_path.exists() && attempts < 50 {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                attempts += 1;
+            }
 
-        let stream = UnixStream::connect(&socket_path).await.unwrap();
-        let (read_half, mut write_half) = stream.into_split();
-        let mut reader = TokioBufReader::new(read_half);
-        write_half.write_all(b"not valid json\n").await.unwrap();
-        write_half.flush().await.unwrap();
+            let stream = UnixStream::connect(&socket_path).await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut reader = TokioBufReader::new(read_half);
+            write_half.write_all(b"not valid json\n").await.unwrap();
+            write_half.flush().await.unwrap();
 
-        // Server should close the connection. A clean EOF from
-        // `read_line` returns Ok(0); we'd time out if the server
-        // got stuck in a parse loop.
-        let mut buf = String::new();
-        let bytes =
-            tokio::time::timeout(std::time::Duration::from_secs(2), reader.read_line(&mut buf))
-                .await
-                .unwrap()
-                .unwrap();
-        assert_eq!(bytes, 0, "expected EOF, got payload {:?}", buf);
-
-        server_handle.abort();
+            // Server should close the connection. A clean EOF from
+            // `read_line` returns Ok(0); we'd time out if the
+            // server got stuck in a parse loop.
+            let mut buf = String::new();
+            let bytes =
+                tokio::time::timeout(std::time::Duration::from_secs(2), reader.read_line(&mut buf))
+                    .await
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(bytes, 0, "expected EOF, got payload {:?}", buf);
+        });
     }
 }

--- a/crates/mockforge-plugin-host/src/server.rs
+++ b/crates/mockforge-plugin-host/src/server.rs
@@ -1,0 +1,236 @@
+//! Unix-socket server loop. Accepts connections from main mockforge,
+//! reads newline-delimited JSON requests, dispatches via
+//! [`handlers::handle`], writes back the JSON response.
+//!
+//! [`handlers::handle`]: crate::handlers::handle
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+use crate::handlers::{handle, HandlerContext};
+use crate::protocol::Request;
+
+/// Configuration for the host server.
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// Filesystem path the Unix socket is bound to. Main mockforge
+    /// connects here.
+    pub socket_path: PathBuf,
+    /// Permissions to set on the socket file after bind. The
+    /// production deployment uses `0o660` + a shared group between
+    /// the mockforge user and the plugin-host user; the spike uses
+    /// `0o666` for simplicity.
+    pub socket_mode: u32,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            socket_path: PathBuf::from("/tmp/plugin-host.sock"),
+            socket_mode: 0o660,
+        }
+    }
+}
+
+/// Bind the socket, accept connections forever. Returns only on
+/// fatal error (the bind itself failing, or shutdown signal).
+///
+/// Each accepted connection runs in its own Tokio task so a slow
+/// client doesn't head-of-line-block other callers.
+pub async fn run_server(config: ServerConfig) -> Result<()> {
+    // Best-effort cleanup of a stale socket from a previous run.
+    // If the previous host crashed the file is still on disk and a
+    // fresh bind would fail with EADDRINUSE.
+    if let Err(err) = tokio::fs::remove_file(&config.socket_path).await {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(
+                path = %config.socket_path.display(),
+                error = %err,
+                "could not remove stale socket file; bind may fail"
+            );
+        }
+    }
+
+    let listener = UnixListener::bind(&config.socket_path)
+        .with_context(|| format!("binding Unix socket at {}", config.socket_path.display()))?;
+    set_socket_permissions(&config.socket_path, config.socket_mode)?;
+
+    tracing::info!(
+        path = %config.socket_path.display(),
+        mode = format!("0o{:o}", config.socket_mode),
+        "plugin-host listening"
+    );
+
+    let ctx = HandlerContext::new();
+
+    loop {
+        let (stream, _addr) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(err) => {
+                // Transient accept failures (EMFILE, etc.) are
+                // worth surfacing but not fatal — keep the loop
+                // running so the next client can connect.
+                tracing::error!(error = %err, "accept failed; retrying");
+                continue;
+            }
+        };
+
+        let ctx = ctx.clone();
+        tokio::spawn(async move {
+            if let Err(err) = handle_connection(&ctx, stream).await {
+                tracing::warn!(error = %err, "client connection terminated with error");
+            }
+        });
+    }
+}
+
+#[cfg(unix)]
+fn set_socket_permissions(path: &Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(mode);
+    std::fs::set_permissions(path, perms)
+        .with_context(|| format!("setting {:o} on {}", mode, path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_socket_permissions(_path: &Path, _mode: u32) -> Result<()> {
+    // Unix sockets are Unix-only; this branch is unreachable in
+    // practice but keeps the crate buildable on non-Unix targets
+    // (e.g., for `cargo check` on a developer's Windows machine).
+    Ok(())
+}
+
+async fn handle_connection(ctx: &HandlerContext, stream: UnixStream) -> Result<()> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes = reader.read_line(&mut line).await.context("reading IPC frame")?;
+        if bytes == 0 {
+            // Clean EOF — client closed the connection.
+            return Ok(());
+        }
+
+        let request: Request = match serde_json::from_str(line.trim_end()) {
+            Ok(req) => req,
+            Err(err) => {
+                tracing::warn!(error = %err, raw = %line, "malformed request — closing");
+                // We don't have a request id to echo, so we close
+                // the connection rather than send a tagged error.
+                // Clients should treat dropped connections as a
+                // signal to retry with fresh state.
+                return Ok(());
+            }
+        };
+
+        let response = handle(ctx, request).await;
+        let mut bytes = serde_json::to_vec(&response).context("serializing response")?;
+        bytes.push(b'\n');
+        write_half.write_all(&bytes).await.context("writing response")?;
+        write_half.flush().await.context("flushing response")?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::Response;
+    use tokio::io::BufReader as TokioBufReader;
+    use uuid::Uuid;
+
+    /// End-to-end: spawn the server in the background, connect over
+    /// the Unix socket, send a Health request, get a HealthOk back.
+    /// Validates the protocol round-trips through real socket I/O,
+    /// which the unit tests in `handlers` and `protocol` don't.
+    #[tokio::test]
+    async fn server_round_trips_a_health_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("test.sock");
+
+        let config = ServerConfig {
+            socket_path: socket_path.clone(),
+            // Tests run under the user's account; 0o660 needs a
+            // matching group. 0o600 keeps the test self-contained.
+            socket_mode: 0o600,
+        };
+
+        let server_handle = tokio::spawn(async move { run_server(config).await });
+
+        // Wait for the socket file to appear; the server binds on
+        // its own task so there's a small window where it's not
+        // ready yet.
+        let mut attempts = 0;
+        while !socket_path.exists() && attempts < 50 {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            attempts += 1;
+        }
+        assert!(socket_path.exists(), "server didn't bind socket");
+
+        let stream = UnixStream::connect(&socket_path).await.unwrap();
+        let (read_half, mut write_half) = stream.into_split();
+        let mut reader = TokioBufReader::new(read_half);
+
+        let id = Uuid::new_v4();
+        let req = Request::Health { id };
+        let mut bytes = serde_json::to_vec(&req).unwrap();
+        bytes.push(b'\n');
+        write_half.write_all(&bytes).await.unwrap();
+        write_half.flush().await.unwrap();
+
+        let mut response_line = String::new();
+        reader.read_line(&mut response_line).await.unwrap();
+        let response: Response = serde_json::from_str(response_line.trim_end()).unwrap();
+
+        match response {
+            Response::HealthOk { id: echoed, .. } => assert_eq!(echoed, id),
+            other => panic!("expected HealthOk, got {:?}", other),
+        }
+
+        // Cleanup: drop the writer to send EOF, then abort the
+        // server so the test exits.
+        drop(write_half);
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn malformed_request_closes_connection_without_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("test.sock");
+        let config = ServerConfig {
+            socket_path: socket_path.clone(),
+            socket_mode: 0o600,
+        };
+
+        let server_handle = tokio::spawn(async move { run_server(config).await });
+        let mut attempts = 0;
+        while !socket_path.exists() && attempts < 50 {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            attempts += 1;
+        }
+
+        let stream = UnixStream::connect(&socket_path).await.unwrap();
+        let (read_half, mut write_half) = stream.into_split();
+        let mut reader = TokioBufReader::new(read_half);
+        write_half.write_all(b"not valid json\n").await.unwrap();
+        write_half.flush().await.unwrap();
+
+        // Server should close the connection. A clean EOF from
+        // `read_line` returns Ok(0); we'd time out if the server
+        // got stuck in a parse loop.
+        let mut buf = String::new();
+        let bytes =
+            tokio::time::timeout(std::time::Duration::from_secs(2), reader.read_line(&mut buf))
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(bytes, 0, "expected EOF, got payload {:?}", buf);
+
+        server_handle.abort();
+    }
+}


### PR DESCRIPTION
## Summary
**First Phase 2 deliverable.** New crate \`mockforge-plugin-host\` that replaces the Python stub from the sidecar spike (#397) with a real Rust binary. Lays down the IPC interface that main mockforge calls into for plugin operations. Future PRs wire the handlers through to the existing \`mockforge-plugin-loader::sandbox::PluginSandbox\`.

## Crate layout
- \`src/protocol.rs\` — JSON-over-Unix-socket Request/Response enums (\`Health\`, \`LoadPlugin\`, \`UnloadPlugin\`, \`Invoke\`)
- \`src/handlers.rs\` — dispatch table; **\`Health\` wired**, others return \`{ code: "not_implemented" }\` placeholders
- \`src/server.rs\` — \`UnixListener\` loop with per-connection Tokio tasks, mode-controlled socket permissions
- \`src/main.rs\` — bin entrypoint with SIGTERM/SIGINT handling, \`MOCKFORGE_PLUGIN_HOST_SOCKET\` + \`_MODE\` env vars

## Why a separate crate from \`mockforge-plugin-loader\`?
The loader is OSS — ships in the local mockforge binary for self-hosted users. The host is cloud-only: it owns IPC framing, signature verification at boot, OTLP export to the cloud aggregator, and the kill-switch poll. Splitting them keeps the OSS surface small and lets us iterate on cloud-only concerns without touching the OSS API.

## Why JSON not protobuf for v1?
The message set is tiny (4 variants), JSON is debuggable with \`nc -U\` and \`jq\`, and the framing can swap to protobuf later without changing semantics. The build-vs-buy spike's \`wasi:http\` recommendation is unrelated — that's the *plugin's* interface inside the host (Wasmtime imports), not the host↔host IPC this protocol covers.

## Smoke test
The binary boots, listens, handles a real socket round-trip, and shuts down cleanly:
\`\`\`
$ MOCKFORGE_PLUGIN_HOST_SOCKET=/tmp/test.sock \\
  target/release/mockforge-plugin-host &
$ echo '{"kind":"health","id":"<uuid>"}' | nc -U /tmp/test.sock
{"kind":"health_ok","id":"<uuid>","uptime_secs":0}
\`\`\`

Confirmed locally with a Python client over a real Unix socket — request went out, response came back, SIGTERM cleaned up.

## Test plan
- [x] \`cargo check -p mockforge-plugin-host\`
- [x] \`cargo clippy -p mockforge-plugin-host --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test -p mockforge-plugin-host --lib\` — 11/11 pass:
  - 5 protocol tests (round-trip, helper carries id, snake_case kind, unknown kinds fail-parse for forward-compat)
  - 4 handler dispatch tests (health + 3 not_implemented paths)
  - 2 server end-to-end tests via tempfile UnixStream (round-trip + malformed-request-doesn't-panic)
- [x] \`cargo build --release\` produces a working bin
- [x] Live smoke test confirmed wire-format round-trips
- [x] Pre-commit hooks (clippy, typos, fmt, audit) — all passed

## What's deliberately not in this PR
Each of these is a follow-up Phase 2 deliverable, scoped separately so this PR stays reviewable:
- Wire \`LoadPlugin\` → \`PluginSandbox::create_plugin_instance\`
- Wire \`Invoke\` → \`PluginSandbox::execute_plugin_function\`
- Cosign signature verification at \`LoadPlugin\` time (RFC §7.2 step 3)
- OTLP exporter that subscribes to \`InvocationMetricsBus\` (#388)
- Kill-switch blocklist poll (RFC §8.2)
- Egress proxy as a third process (RFC §5.3)
- Production Dockerfile pairing main mockforge + plugin-host + egress-proxy with the \`FlyioGuest\` sizing from #398

## Phase tracker
| # | Status | |
|---|--------|--|
| 1 | ✅ | #385 demand CTA |
| 2 | ✅ | #387 build-vs-buy spike |
| 3 | ✅ #397 | sidecar Fly proof |
| 4 | ✅ | #386 trust RFC |
| 5 | ✅ | #389 schema migration |
| 6 | ✅ #395 | control-plane API |
| 7 | ✅ | #388 wall-time accounting |
| 8 | pending | go/no-go (gated on demand signal) |
| 9 | ✅ #396 | wire MemoryTracker |
| 10 | ✅ #398 | FlyioMachineConfig.guest |
| 11 | this PR | plugin-host scaffold |

This is the first concrete Phase 2 delivery. Multiple follow-up PRs will fill in the not_implemented handlers — but the IPC shape, lifecycle, and ops story are now established and tested.