### PR TITLE
feat(plugin-host): wire LoadPlugin/Invoke/UnloadPlugin to PluginSandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8600,6 +8600,7 @@ name = "mockforge-plugin-host"
 version = "0.3.126"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "mockforge-plugin-core",
  "mockforge-plugin-loader",
  "serde",

--- a/crates/mockforge-plugin-host/Cargo.toml
+++ b/crates/mockforge-plugin-host/Cargo.toml
@@ -52,5 +52,12 @@ tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 # the whole workspace's footprint).
 uuid = { workspace = true, features = ["serde"] }
 
+# WASM blob handling: LoadPlugin carries the module as base64 in
+# the request body (registry-fetch path is a separate follow-up).
+# PluginLoadContext takes a filesystem path so we materialize the
+# bytes to a tempfile that lives for the plugin's lifetime.
+base64 = "0.22"
+tempfile = "3"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/mockforge-plugin-host/src/handlers.rs
+++ b/crates/mockforge-plugin-host/src/handlers.rs
@@ -1,137 +1,317 @@
 //! Request handlers for the plugin-host IPC server.
 //!
-//! Phase 2 scaffold: only `health` is wired through. The other
-//! handlers exist so the dispatch table is complete and the wire
-//! protocol is exercised end-to-end — they all return
-//! `not_implemented`. Wiring them is the next deliverable.
+//! Each [`Request`] variant routes to a method on [`Host`]; errors
+//! are caught and translated to [`Response::Error`] with a stable
+//! `code` from [`crate::host::HostError::code`].
 
-use std::time::Instant;
+use base64::Engine;
 
+use crate::host::{Host, HostError};
 use crate::protocol::{Request, Response};
 
-/// Application state carried across requests on a single
-/// connection. Cheap to clone — the fields are either `Arc`-backed
-/// or scalars.
-#[derive(Clone)]
-pub struct HandlerContext {
-    /// When the host process booted. Used by the health endpoint
-    /// so callers can detect a sidecar restart by watching for an
-    /// uptime decrease.
-    pub started_at: Instant,
-}
-
-impl HandlerContext {
-    /// Create a context anchored at "now".
-    pub fn new() -> Self {
-        Self {
-            started_at: Instant::now(),
-        }
-    }
-
-    /// Process uptime in whole seconds.
-    pub fn uptime_secs(&self) -> u64 {
-        self.started_at.elapsed().as_secs()
-    }
-}
-
-impl Default for HandlerContext {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Dispatch a single request to the appropriate handler.
-pub async fn handle(ctx: &HandlerContext, request: Request) -> Response {
+pub async fn handle(host: &Host, request: Request) -> Response {
     match request {
         Request::Health { id } => Response::HealthOk {
             id,
-            uptime_secs: ctx.uptime_secs(),
+            uptime_secs: host.uptime_secs(),
         },
-        Request::LoadPlugin { id, .. } => Response::not_implemented(id, "load_plugin"),
-        Request::UnloadPlugin { id, .. } => Response::not_implemented(id, "unload_plugin"),
-        Request::Invoke { id, .. } => Response::not_implemented(id, "invoke"),
+
+        Request::LoadPlugin {
+            id,
+            plugin_name,
+            version,
+            permissions,
+            wasm_b64,
+        } => {
+            let bytes = match base64::engine::general_purpose::STANDARD.decode(wasm_b64.as_bytes())
+            {
+                Ok(b) => b,
+                Err(err) => {
+                    return Response::Error {
+                        id,
+                        code: "invalid_base64".to_string(),
+                        message: format!("decoding wasm_b64: {err}"),
+                    };
+                }
+            };
+            match host.load_plugin(&plugin_name, &version, permissions, bytes).await {
+                Ok(plugin_id) => Response::Ok {
+                    id,
+                    body: serde_json::json!({
+                        "plugin_id": plugin_id.to_string(),
+                        "plugin_name": plugin_name,
+                        "version": version,
+                    }),
+                },
+                Err(err) => host_error_to_response(id, err),
+            }
+        }
+
+        Request::UnloadPlugin { id, plugin_name } => match host.unload_plugin(&plugin_name).await {
+            Ok(was_loaded) => Response::Ok {
+                id,
+                body: serde_json::json!({
+                    "plugin_name": plugin_name,
+                    // `false` means it wasn't loaded — idempotent
+                    // detach. Callers may treat this as either
+                    // success or "already gone".
+                    "detached": was_loaded,
+                }),
+            },
+            Err(err) => host_error_to_response(id, err),
+        },
+
+        Request::Invoke {
+            id,
+            plugin_name,
+            function,
+            input,
+        } => match host.invoke(&plugin_name, &function, input).await {
+            Ok(value) => Response::Ok {
+                id,
+                body: serde_json::json!({
+                    "plugin_name": plugin_name,
+                    "function": function,
+                    "result": value,
+                }),
+            },
+            Err(err) => host_error_to_response(id, err),
+        },
+    }
+}
+
+fn host_error_to_response(id: uuid::Uuid, err: HostError) -> Response {
+    let code = err.code().to_string();
+    Response::Error {
+        id,
+        code,
+        message: err.to_string(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mockforge_plugin_loader::PluginLoaderConfig;
     use uuid::Uuid;
 
-    #[tokio::test]
-    async fn health_returns_ok_with_uptime() {
-        let ctx = HandlerContext::new();
-        let id = Uuid::new_v4();
-        let response = handle(&ctx, Request::Health { id }).await;
-        match response {
-            Response::HealthOk {
-                id: echoed,
-                uptime_secs,
-            } => {
-                assert_eq!(echoed, id);
-                // Uptime is at-least-zero; we don't assert > 0 because
-                // the handler may run faster than 1 second after ctx
-                // is created.
-                let _ = uptime_secs;
-            }
-            other => panic!("expected HealthOk, got {:?}", other),
-        }
+    /// Smallest valid WASM module bytes — `\0asm` + version 1.
+    const MINIMAL_WASM: &[u8] = &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+
+    fn b64_minimal() -> String {
+        base64::engine::general_purpose::STANDARD.encode(MINIMAL_WASM)
     }
 
-    #[tokio::test]
-    async fn load_plugin_returns_not_implemented() {
-        let ctx = HandlerContext::new();
-        let id = Uuid::new_v4();
-        let response = handle(
-            &ctx,
-            Request::LoadPlugin {
+    /// Drive `body` and the actor concurrently on a current-thread
+    /// runtime — same pattern used in `host::tests`. Tests use this
+    /// instead of `#[tokio::test]` because the actor future is
+    /// `!Send` and can't be `tokio::spawn`'d.
+    fn run_with_actor<F, T>(body: impl FnOnce(Host) -> F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let (host, actor) = Host::new(PluginLoaderConfig {
+                allow_unsigned: true,
+                skip_wasm_validation: true,
+                ..Default::default()
+            });
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+            }
+        })
+    }
+
+    #[test]
+    fn health_returns_ok_with_uptime() {
+        run_with_actor(|host| async move {
+            let id = Uuid::new_v4();
+            let response = handle(&host, Request::Health { id }).await;
+            assert!(matches!(response, Response::HealthOk { id: echoed, .. } if echoed == id));
+        });
+    }
+
+    #[test]
+    fn load_then_unload_round_trips_through_handle() {
+        run_with_actor(|host| async move {
+            let load_id = Uuid::new_v4();
+            let load_response = handle(
+                &host,
+                Request::LoadPlugin {
+                    id: load_id,
+                    plugin_name: "test-plugin".into(),
+                    version: "1.0.0".into(),
+                    permissions: serde_json::json!({}),
+                    wasm_b64: b64_minimal(),
+                },
+            )
+            .await;
+            match load_response {
+                Response::Ok { id: echoed, body } => {
+                    assert_eq!(echoed, load_id);
+                    assert_eq!(body["plugin_name"], "test-plugin");
+                }
+                other => panic!("expected Ok, got {:?}", other),
+            }
+
+            let unload_id = Uuid::new_v4();
+            let unload_response = handle(
+                &host,
+                Request::UnloadPlugin {
+                    id: unload_id,
+                    plugin_name: "test-plugin".into(),
+                },
+            )
+            .await;
+            match unload_response {
+                Response::Ok { id: echoed, body } => {
+                    assert_eq!(echoed, unload_id);
+                    assert_eq!(body["detached"], true);
+                }
+                other => panic!("expected Ok, got {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn load_with_invalid_base64_returns_error_code() {
+        run_with_actor(|host| async move {
+            let id = Uuid::new_v4();
+            let response = handle(
+                &host,
+                Request::LoadPlugin {
+                    id,
+                    plugin_name: "p".into(),
+                    version: "1.0.0".into(),
+                    permissions: serde_json::json!({}),
+                    wasm_b64: "not-valid-base64-!!!".into(),
+                },
+            )
+            .await;
+            match response {
+                Response::Error {
+                    id: echoed, code, ..
+                } => {
+                    assert_eq!(echoed, id);
+                    assert_eq!(code, "invalid_base64");
+                }
+                other => panic!("expected Error, got {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn double_load_returns_already_loaded() {
+        run_with_actor(|host| async move {
+            let make_load = |id| Request::LoadPlugin {
                 id,
-                plugin_name: "test".into(),
+                plugin_name: "dup".into(),
                 version: "1.0.0".into(),
                 permissions: serde_json::json!({}),
-            },
-        )
-        .await;
-        match response {
-            Response::Error {
-                id: echoed, code, ..
-            } => {
-                assert_eq!(echoed, id);
-                assert_eq!(code, "not_implemented");
+                wasm_b64: b64_minimal(),
+            };
+            let _first = handle(&host, make_load(Uuid::new_v4())).await;
+            let second = handle(&host, make_load(Uuid::new_v4())).await;
+            match second {
+                Response::Error { code, .. } => assert_eq!(code, "already_loaded"),
+                other => panic!("expected Error, got {:?}", other),
             }
-            other => panic!("expected Error, got {:?}", other),
-        }
+        });
     }
 
-    #[tokio::test]
-    async fn unload_plugin_returns_not_implemented() {
-        let ctx = HandlerContext::new();
-        let id = Uuid::new_v4();
-        let response = handle(
-            &ctx,
-            Request::UnloadPlugin {
-                id,
-                plugin_name: "test".into(),
-            },
-        )
-        .await;
-        assert!(matches!(response, Response::Error { code, .. } if code == "not_implemented"));
+    #[test]
+    fn invoke_unknown_plugin_returns_not_loaded() {
+        run_with_actor(|host| async move {
+            let id = Uuid::new_v4();
+            let response = handle(
+                &host,
+                Request::Invoke {
+                    id,
+                    plugin_name: "missing".into(),
+                    function: "fn".into(),
+                    input: vec![],
+                },
+            )
+            .await;
+            match response {
+                Response::Error { code, .. } => assert_eq!(code, "not_loaded"),
+                other => panic!("expected Error, got {:?}", other),
+            }
+        });
     }
 
-    #[tokio::test]
-    async fn invoke_returns_not_implemented() {
-        let ctx = HandlerContext::new();
-        let id = Uuid::new_v4();
-        let response = handle(
-            &ctx,
-            Request::Invoke {
-                id,
-                plugin_name: "test".into(),
-                function: "on_request".into(),
-                input: vec![],
-            },
-        )
-        .await;
-        assert!(matches!(response, Response::Error { code, .. } if code == "not_implemented"));
+    #[test]
+    fn unload_unknown_plugin_is_ok_with_detached_false() {
+        // Idempotent detach — easier for callers than tracking
+        // exact load state.
+        run_with_actor(|host| async move {
+            let id = Uuid::new_v4();
+            let response = handle(
+                &host,
+                Request::UnloadPlugin {
+                    id,
+                    plugin_name: "ghost".into(),
+                },
+            )
+            .await;
+            match response {
+                Response::Ok { body, .. } => assert_eq!(body["detached"], false),
+                other => panic!("expected Ok, got {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn invoke_after_load_returns_loader_result() {
+        // The minimal WASM module has no exported functions, so
+        // execute_plugin_function will surface a function-not-found
+        // error from the loader. We're checking that the *path*
+        // works end-to-end — load → invoke → structured error —
+        // not that the invoke succeeds.
+        run_with_actor(|host| async move {
+            let _ = handle(
+                &host,
+                Request::LoadPlugin {
+                    id: Uuid::new_v4(),
+                    plugin_name: "p".into(),
+                    version: "1.0.0".into(),
+                    permissions: serde_json::json!({}),
+                    wasm_b64: b64_minimal(),
+                },
+            )
+            .await;
+
+            let id = Uuid::new_v4();
+            let response = handle(
+                &host,
+                Request::Invoke {
+                    id,
+                    plugin_name: "p".into(),
+                    function: "missing_fn".into(),
+                    input: vec![],
+                },
+            )
+            .await;
+
+            // Either loader_error (function not found bubbles up
+            // as a PluginLoaderError) or plugin_execution_error
+            // (loader returned a failure result rather than
+            // erroring) — both are valid downstream paths. What
+            // matters is we got *some* structured Error rather
+            // than a panic or a bare Ok.
+            match response {
+                Response::Error { code, .. } => {
+                    assert!(
+                        matches!(code.as_str(), "loader_error" | "plugin_execution_error"),
+                        "expected loader_error or plugin_execution_error, got {}",
+                        code
+                    );
+                }
+                other => panic!("expected Error, got {:?}", other),
+            }
+        });
     }
 }

--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -1,0 +1,535 @@
+//! [`Host`] — long-lived state that owns the plugin runtime via an
+//! actor task.
+//!
+//! Why an actor (single-task ownership) rather than `Arc<Mutex<...>>`:
+//! Wasmtime `Store`s are `Send` but not `Sync`, and `WasiCtx` carries
+//! `dyn` trait objects that are also not `Sync`. That makes the
+//! existing `PluginSandbox` (in `mockforge-plugin-loader`) `!Sync`,
+//! which means we can't share it across `tokio::spawn`'d tasks via
+//! `Arc`. The actor pattern sidesteps this entirely: a single
+//! background task owns the sandbox, and the connection-handling
+//! tasks send `Command`s to it over a `tokio::sync::mpsc` channel
+//! and receive replies via `tokio::sync::oneshot`.
+//!
+//! Cost: all sandbox operations serialize through the actor's queue.
+//! At our plugin counts (≤25 for Team tier per the trust RFC) and
+//! the per-invocation latency budget (sub-50 ms), serialization
+//! overhead is negligible compared to the WASM execution cost
+//! itself.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use mockforge_plugin_core::{
+    PluginAuthor, PluginContext, PluginId, PluginInfo, PluginManifest, PluginState, PluginVersion,
+};
+use mockforge_plugin_loader::{
+    PluginLoadContext, PluginLoaderConfig, PluginLoaderError, PluginSandbox,
+};
+use tokio::sync::{mpsc, oneshot};
+
+/// Actor channel capacity. Generous because cloud-plugins ops are
+/// rare (load/unload at attach time, invoke once per request) and
+/// the cost of dropping is high (request gets a 503).
+const CHANNEL_CAPACITY: usize = 256;
+
+/// Per-loaded-plugin bookkeeping the actor needs to keep around.
+///
+/// The tempfile holds the WASM bytes for the plugin's lifetime —
+/// `PluginLoadContext` takes a filesystem path, and the loader
+/// reads from it whenever the sandbox is created. Dropping the
+/// `NamedTempFile` deletes the file, so we hang on to it until the
+/// plugin is unloaded.
+struct PluginEntry {
+    /// PluginId derived from the request's `plugin_name`.
+    plugin_id: PluginId,
+    /// Pinned version, used when constructing per-invocation
+    /// `PluginContext`.
+    version: PluginVersion,
+    /// Tempfile holding the WASM bytes — kept alive so the file
+    /// doesn't get GC'd while the sandbox is loaded.
+    _wasm_file: tempfile::NamedTempFile,
+    /// Permission grant; saved here for future runtime enforcement.
+    /// Currently unused beyond storing for diagnostic purposes.
+    _permissions: serde_json::Value,
+}
+
+/// Long-lived plugin-host handle. `Send + Sync` — internally just an
+/// `mpsc::Sender` and an `Arc<Instant>`. All real state lives in
+/// the actor future returned by [`Host::new`], which the caller
+/// drives on the current task.
+#[derive(Clone)]
+pub struct Host {
+    started_at: Arc<Instant>,
+    cmd_tx: mpsc::Sender<Command>,
+}
+
+/// Future returned by [`Host::new`] that owns the `PluginSandbox`
+/// and processes commands on the current task. Caller drives it
+/// with `tokio::select!` alongside the server loop.
+///
+/// Why not `tokio::spawn(actor)`: the underlying Wasmtime `Store`
+/// inside `PluginSandbox` is `Send` but its embedded `WasiCtx`
+/// carries `dyn` trait objects without `+ Send` bounds (in
+/// wasmtime-wasi 36), making the actor's future `!Send`. Spawning
+/// it on a multi-thread tokio runtime is therefore disallowed at
+/// compile time. Running it inline on the main task — which can
+/// itself be `!Send` under a current-thread runtime — sidesteps
+/// the issue without requiring a `LocalSet` dance.
+pub type HostActor = std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>;
+
+impl Host {
+    /// Construct a new host. Returns the handle (cheap to clone,
+    /// shareable across spawned connection tasks) and the actor
+    /// future the caller must drive on the current task.
+    pub fn new(loader_config: PluginLoaderConfig) -> (Self, HostActor) {
+        let (cmd_tx, cmd_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let started_at = Arc::new(Instant::now());
+
+        let actor: HostActor = Box::pin(actor_loop(loader_config, cmd_rx));
+
+        (Self { started_at, cmd_tx }, actor)
+    }
+
+    /// Process uptime in whole seconds.
+    pub fn uptime_secs(&self) -> u64 {
+        self.started_at.elapsed().as_secs()
+    }
+
+    /// Load a plugin from inline WASM bytes. The bytes are written
+    /// to a tempfile inside the actor so the loader (which takes a
+    /// filesystem path) can `Module::from_file` it. Returns the
+    /// loaded plugin's `PluginId` on success.
+    pub async fn load_plugin(
+        &self,
+        plugin_name: &str,
+        version_str: &str,
+        permissions: serde_json::Value,
+        wasm_bytes: Vec<u8>,
+    ) -> Result<PluginId, HostError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::Load {
+                plugin_name: plugin_name.to_string(),
+                version: version_str.to_string(),
+                permissions,
+                wasm_bytes,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| HostError::ActorGone)?;
+        reply_rx.await.map_err(|_| HostError::ActorGone)?
+    }
+
+    /// Unload a plugin. Idempotent: detaching a plugin that isn't
+    /// loaded returns `Ok(false)`.
+    pub async fn unload_plugin(&self, plugin_name: &str) -> Result<bool, HostError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::Unload {
+                plugin_name: plugin_name.to_string(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| HostError::ActorGone)?;
+        reply_rx.await.map_err(|_| HostError::ActorGone)?
+    }
+
+    /// Invoke a function on a loaded plugin.
+    pub async fn invoke(
+        &self,
+        plugin_name: &str,
+        function: &str,
+        input: Vec<u8>,
+    ) -> Result<serde_json::Value, HostError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::Invoke {
+                plugin_name: plugin_name.to_string(),
+                function: function.to_string(),
+                input,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| HostError::ActorGone)?;
+        reply_rx.await.map_err(|_| HostError::ActorGone)?
+    }
+
+    /// List currently-loaded plugins. For diagnostics.
+    pub async fn loaded_plugins(&self) -> Result<Vec<(String, PluginId)>, HostError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::ListPlugins { reply: reply_tx })
+            .await
+            .map_err(|_| HostError::ActorGone)?;
+        reply_rx.await.map_err(|_| HostError::ActorGone)
+    }
+}
+
+/// Internal command type for the actor channel. Each variant
+/// carries a `oneshot::Sender` for the reply so callers can
+/// `.await` results.
+enum Command {
+    Load {
+        plugin_name: String,
+        version: String,
+        permissions: serde_json::Value,
+        wasm_bytes: Vec<u8>,
+        reply: oneshot::Sender<Result<PluginId, HostError>>,
+    },
+    Unload {
+        plugin_name: String,
+        reply: oneshot::Sender<Result<bool, HostError>>,
+    },
+    Invoke {
+        plugin_name: String,
+        function: String,
+        input: Vec<u8>,
+        reply: oneshot::Sender<Result<serde_json::Value, HostError>>,
+    },
+    ListPlugins {
+        reply: oneshot::Sender<Vec<(String, PluginId)>>,
+    },
+}
+
+/// Actor task. Owns the `PluginSandbox` and the plugin map for the
+/// lifetime of the host process. Returns when the channel closes
+/// (all `Host` handles dropped) or the runtime shuts down.
+async fn actor_loop(loader_config: PluginLoaderConfig, mut cmd_rx: mpsc::Receiver<Command>) {
+    let sandbox = PluginSandbox::new(loader_config);
+    let mut plugins: HashMap<String, PluginEntry> = HashMap::new();
+
+    while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            Command::Load {
+                plugin_name,
+                version,
+                permissions,
+                wasm_bytes,
+                reply,
+            } => {
+                let result = handle_load(
+                    &sandbox,
+                    &mut plugins,
+                    &plugin_name,
+                    &version,
+                    permissions,
+                    wasm_bytes,
+                )
+                .await;
+                let _ = reply.send(result);
+            }
+            Command::Unload { plugin_name, reply } => {
+                let result = handle_unload(&sandbox, &mut plugins, &plugin_name).await;
+                let _ = reply.send(result);
+            }
+            Command::Invoke {
+                plugin_name,
+                function,
+                input,
+                reply,
+            } => {
+                let result =
+                    handle_invoke(&sandbox, &plugins, &plugin_name, &function, input).await;
+                let _ = reply.send(result);
+            }
+            Command::ListPlugins { reply } => {
+                let snapshot: Vec<(String, PluginId)> = plugins
+                    .iter()
+                    .map(|(name, entry)| (name.clone(), entry.plugin_id.clone()))
+                    .collect();
+                let _ = reply.send(snapshot);
+            }
+        }
+    }
+
+    tracing::info!("plugin-host actor exiting (channel closed)");
+}
+
+async fn handle_load(
+    sandbox: &PluginSandbox,
+    plugins: &mut HashMap<String, PluginEntry>,
+    plugin_name: &str,
+    version_str: &str,
+    permissions: serde_json::Value,
+    wasm_bytes: Vec<u8>,
+) -> Result<PluginId, HostError> {
+    if plugins.contains_key(plugin_name) {
+        return Err(HostError::AlreadyLoaded {
+            plugin_name: plugin_name.to_string(),
+        });
+    }
+
+    let version = PluginVersion::parse(version_str).map_err(|err| HostError::InvalidVersion {
+        version: version_str.to_string(),
+        err,
+    })?;
+    let plugin_id = PluginId::new(plugin_name);
+
+    let mut wasm_file = tempfile::NamedTempFile::new().map_err(|err| HostError::Io {
+        what: "creating tempfile",
+        err,
+    })?;
+    std::io::Write::write_all(&mut wasm_file, &wasm_bytes).map_err(|err| HostError::Io {
+        what: "writing wasm bytes",
+        err,
+    })?;
+    let path = wasm_file.path().to_path_buf();
+
+    let manifest = build_synthetic_manifest(plugin_name, version.clone());
+    let load_ctx = PluginLoadContext::new(
+        plugin_id.clone(),
+        manifest,
+        path.to_string_lossy().into_owned(),
+        PluginLoaderConfig::default(),
+    );
+
+    let instance = sandbox.create_plugin_instance(&load_ctx).await?;
+    debug_assert_eq!(instance.state, PluginState::Ready);
+
+    plugins.insert(
+        plugin_name.to_string(),
+        PluginEntry {
+            plugin_id: plugin_id.clone(),
+            version,
+            _wasm_file: wasm_file,
+            _permissions: permissions,
+        },
+    );
+
+    Ok(plugin_id)
+}
+
+async fn handle_unload(
+    sandbox: &PluginSandbox,
+    plugins: &mut HashMap<String, PluginEntry>,
+    plugin_name: &str,
+) -> Result<bool, HostError> {
+    let Some(entry) = plugins.remove(plugin_name) else {
+        return Ok(false);
+    };
+    sandbox.destroy_sandbox(&entry.plugin_id).await?;
+    Ok(true)
+}
+
+async fn handle_invoke(
+    sandbox: &PluginSandbox,
+    plugins: &HashMap<String, PluginEntry>,
+    plugin_name: &str,
+    function: &str,
+    input: Vec<u8>,
+) -> Result<serde_json::Value, HostError> {
+    let entry = plugins.get(plugin_name).ok_or_else(|| HostError::NotLoaded {
+        plugin_name: plugin_name.to_string(),
+    })?;
+
+    let ctx = PluginContext::new(entry.plugin_id.clone(), entry.version.clone());
+    let result = sandbox
+        .execute_plugin_function(&entry.plugin_id, function, &ctx, &input)
+        .await?;
+
+    // `error()` borrows but `data()` consumes — capture the error
+    // first so we can still consume on the success path.
+    let error_message = result.error().map(str::to_string);
+    if let Some(message) = error_message {
+        return Err(HostError::PluginExecution {
+            plugin_name: plugin_name.to_string(),
+            message,
+        });
+    }
+    Ok(result.data().unwrap_or(serde_json::Value::Null))
+}
+
+/// Errors from host operations. Each variant maps to a stable wire
+/// `code` so callers can react programmatically without parsing
+/// the human-readable message.
+#[derive(Debug, thiserror::Error)]
+pub enum HostError {
+    /// Tried to load a plugin that's already loaded.
+    #[error("plugin '{plugin_name}' is already loaded; detach before re-loading")]
+    AlreadyLoaded {
+        /// Plugin name that conflicted.
+        plugin_name: String,
+    },
+    /// Tried to invoke / unload a plugin that isn't loaded.
+    #[error("plugin '{plugin_name}' is not loaded")]
+    NotLoaded {
+        /// Plugin name that wasn't found.
+        plugin_name: String,
+    },
+    /// `version` couldn't be parsed as a semver-shaped string.
+    #[error("invalid version '{version}': {err}")]
+    InvalidVersion {
+        /// The string that failed to parse.
+        version: String,
+        /// Parse-error detail from `PluginVersion::parse`.
+        err: String,
+    },
+    /// An I/O error materializing the WASM bytes to a tempfile.
+    #[error("io error while {what}: {err}")]
+    Io {
+        /// Human-readable description of the operation that failed.
+        what: &'static str,
+        /// Underlying io::Error.
+        #[source]
+        err: std::io::Error,
+    },
+    /// The loader rejected the load or invocation.
+    #[error("loader error: {0}")]
+    Loader(#[from] PluginLoaderError),
+    /// The plugin function returned an error/trap.
+    #[error("plugin '{plugin_name}' execution failed: {message}")]
+    PluginExecution {
+        /// Plugin that failed.
+        plugin_name: String,
+        /// Error/trap message.
+        message: String,
+    },
+    /// Base64-decode of the WASM bytes failed.
+    #[error("invalid base64 wasm: {0}")]
+    Base64(#[from] base64::DecodeError),
+    /// The actor task is gone — likely runtime shutdown or a
+    /// panic in the actor. Caller should reconnect.
+    #[error("plugin-host actor task is no longer running")]
+    ActorGone,
+}
+
+impl HostError {
+    /// Stable, machine-readable error code for the IPC `code` field.
+    pub fn code(&self) -> &'static str {
+        match self {
+            HostError::AlreadyLoaded { .. } => "already_loaded",
+            HostError::NotLoaded { .. } => "not_loaded",
+            HostError::InvalidVersion { .. } => "invalid_version",
+            HostError::Io { .. } => "io_error",
+            HostError::Loader(_) => "loader_error",
+            HostError::PluginExecution { .. } => "plugin_execution_error",
+            HostError::Base64(_) => "invalid_base64",
+            HostError::ActorGone => "actor_gone",
+        }
+    }
+}
+
+/// Build a placeholder manifest for a plugin loaded over IPC.
+///
+/// The cloud trust model treats this as informational only — what
+/// actually gates plugin behavior is the `permissions` grant from
+/// the LoadPlugin request, enforced at the runtime boundary. A
+/// future Phase 2 PR will fetch the *real* manifest from the
+/// registry alongside the WASM bytes so we can validate the
+/// `manifest ∩ grant` invariant inside the host.
+fn build_synthetic_manifest(plugin_name: &str, version: PluginVersion) -> PluginManifest {
+    let plugin_id = PluginId::new(plugin_name);
+    let info = PluginInfo::new(
+        plugin_id,
+        version,
+        plugin_name,
+        "Cloud-loaded plugin (synthetic manifest)",
+        PluginAuthor {
+            name: "cloud-plugins-host".to_string(),
+            email: None,
+        },
+    );
+    PluginManifest::new(info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smallest valid WASM module bytes — `\0asm` + version 1.
+    fn minimal_wasm() -> Vec<u8> {
+        vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
+    }
+
+    fn loader_config() -> PluginLoaderConfig {
+        PluginLoaderConfig {
+            allow_unsigned: true,
+            skip_wasm_validation: true,
+            ..Default::default()
+        }
+    }
+
+    /// Drive `body` and the actor future concurrently on a
+    /// current-thread runtime. Tests use this so they don't need
+    /// `tokio::main(flavor = "current_thread")` boilerplate.
+    fn run_with_actor<F, T>(body: impl FnOnce(Host) -> F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let (host, actor) = Host::new(loader_config());
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+            }
+        })
+    }
+
+    #[test]
+    fn load_plugin_then_list_returns_one_entry() {
+        run_with_actor(|host| async move {
+            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap();
+            let loaded = host.loaded_plugins().await.unwrap();
+            assert_eq!(loaded.len(), 1);
+            assert_eq!(loaded[0].0, "test-plugin");
+        });
+    }
+
+    #[test]
+    fn load_plugin_twice_returns_already_loaded() {
+        run_with_actor(|host| async move {
+            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap();
+            let err = host
+                .load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "already_loaded");
+        });
+    }
+
+    #[test]
+    fn unload_plugin_removes_entry() {
+        run_with_actor(|host| async move {
+            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap();
+            let detached = host.unload_plugin("test-plugin").await.unwrap();
+            assert!(detached);
+            assert!(host.loaded_plugins().await.unwrap().is_empty());
+        });
+    }
+
+    #[test]
+    fn unload_unknown_plugin_is_idempotent() {
+        run_with_actor(|host| async move {
+            let detached = host.unload_plugin("nope").await.unwrap();
+            assert!(!detached);
+        });
+    }
+
+    #[test]
+    fn invoke_unknown_plugin_returns_not_loaded() {
+        run_with_actor(|host| async move {
+            let err = host.invoke("nope", "fn", vec![]).await.unwrap_err();
+            assert_eq!(err.code(), "not_loaded");
+        });
+    }
+
+    #[test]
+    fn load_with_invalid_version_returns_invalid_version() {
+        run_with_actor(|host| async move {
+            let err = host
+                .load_plugin("test-plugin", "not-a-version", serde_json::json!({}), minimal_wasm())
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "invalid_version");
+        });
+    }
+}

--- a/crates/mockforge-plugin-host/src/lib.rs
+++ b/crates/mockforge-plugin-host/src/lib.rs
@@ -11,18 +11,19 @@
 //!
 //! ## Status
 //!
-//! **Phase 2 scaffold.** Boots, listens on the Unix socket, and
-//! handles `health` round-trips. The `load_plugin` / `unload_plugin`
-//! / `invoke` handlers return `not_implemented` placeholders — wiring
-//! them to the real `mockforge-plugin-loader::sandbox::PluginSandbox`
-//! is the next deliverable.
+//! **Phase 2 — IPC handlers wired.** Health/LoadPlugin/UnloadPlugin/
+//! Invoke all dispatch through to [`Host`], which owns a real
+//! `mockforge_plugin_loader::sandbox::PluginSandbox`. WASM bytes
+//! are inlined as base64 in the LoadPlugin request; the registry-
+//! fetch path lands separately so signature verification can hook
+//! in upstream.
 //!
 //! ## Wire protocol
 //!
-//! JSON requests / responses, one per Unix socket message, length-
-//! prefixed. Protocol is intentionally simple and language-agnostic
-//! so we can swap to protobuf later without breaking the on-the-wire
-//! semantics. See [`protocol`].
+//! Newline-delimited JSON, request/response tagged by `id` for
+//! multiplexing on a single connection. Protocol is intentionally
+//! simple and language-agnostic so we can swap to protobuf later
+//! without breaking the on-the-wire semantics. See [`protocol`].
 //!
 //! ## Why a separate crate from `mockforge-plugin-loader`?
 //!
@@ -34,8 +35,10 @@
 //! touching the OSS API.
 
 pub mod handlers;
+pub mod host;
 pub mod protocol;
 pub mod server;
 
+pub use host::{Host, HostActor, HostError};
 pub use protocol::{Request, Response};
 pub use server::{run_server, ServerConfig};

--- a/crates/mockforge-plugin-host/src/main.rs
+++ b/crates/mockforge-plugin-host/src/main.rs
@@ -7,17 +7,27 @@
 //! up alongside main mockforge.
 //!
 //! See the crate-level docs for the design.
+//!
+//! ### Runtime flavor
+//!
+//! Built on a current-thread Tokio runtime. The plugin sandbox holds
+//! a Wasmtime `Store` whose embedded `WasiCtx` is `!Send`, which
+//! means the actor task that owns it cannot run on a multi-thread
+//! runtime. Every IPC connection from main mockforge is processed
+//! on this single thread. At the latency budgets and concurrency
+//! we're targeting (≤25 plugins per Team-tier deployment, sub-50 ms
+//! invocations) this is plenty.
 
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use mockforge_plugin_host::{run_server, ServerConfig};
+use mockforge_plugin_host::{run_server, Host, ServerConfig};
+use mockforge_plugin_loader::PluginLoaderConfig;
 
 const DEFAULT_SOCKET_PATH: &str = "/tmp/plugin-host.sock";
 const DEFAULT_SOCKET_MODE: u32 = 0o660;
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     init_tracing();
 
     let config = ServerConfig {
@@ -31,18 +41,38 @@ async fn main() -> Result<()> {
         "mockforge-plugin-host starting"
     );
 
-    // Run the server until SIGTERM. The server loop returns only on
-    // bind error or when the runtime is shut down.
-    tokio::select! {
-        result = run_server(config) => {
-            tracing::error!(?result, "plugin-host server loop exited unexpectedly");
-            result
+    // Current-thread runtime — see the module-level note on why
+    // this is required (the Wasmtime store inside the actor is
+    // !Send, so it can't run on a multi-thread runtime).
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building Tokio current-thread runtime")?;
+
+    rt.block_on(async move {
+        let (host, actor) = Host::new(PluginLoaderConfig::default());
+
+        // Drive actor + server + shutdown_signal concurrently. The
+        // actor owns the !Send sandbox; the server fans connections
+        // out via tokio::spawn, but those tasks only carry the
+        // (Send) `Host` handle — never the sandbox itself.
+        tokio::select! {
+            // Actor exit is unexpected — channel closed without
+            // shutdown signal. Surface as an error.
+            _ = actor => {
+                tracing::error!("plugin-host actor exited unexpectedly");
+                Err(anyhow::anyhow!("plugin-host actor exited"))
+            }
+            result = run_server(config, host) => {
+                tracing::error!(?result, "plugin-host server loop exited unexpectedly");
+                result
+            }
+            _ = shutdown_signal() => {
+                tracing::info!("plugin-host received shutdown signal — exiting");
+                Ok(())
+            }
         }
-        _ = shutdown_signal() => {
-            tracing::info!("plugin-host received shutdown signal — exiting");
-            Ok(())
-        }
-    }
+    })
 }
 
 fn init_tracing() {

--- a/crates/mockforge-plugin-host/src/protocol.rs
+++ b/crates/mockforge-plugin-host/src/protocol.rs
@@ -31,21 +31,32 @@ pub enum Request {
         /// can multiplex requests over a single connection.
         id: Uuid,
     },
-    /// Load a signed WASM plugin into a fresh `Store`. **Not
-    /// implemented in this scaffold.** Will dispatch to the real
-    /// `PluginSandbox` once signature verification + permission
-    /// grant evaluation lands.
+    /// Load a WASM plugin into a fresh `Store`.
+    ///
+    /// In v1 the WASM bytes are inlined as base64 in the request.
+    /// The follow-up "registry fetch" path will replace this with a
+    /// `download_url` field that the host fetches itself, so
+    /// signature verification can happen before any bytes touch
+    /// the loader. Until then, the caller is expected to verify
+    /// signatures upstream.
     LoadPlugin {
         /// Correlation id.
         id: Uuid,
         /// Plugin name from the registry.
         plugin_name: String,
-        /// Plugin version, pinned at attach time.
+        /// Plugin version, pinned at attach time. Parsed via
+        /// `PluginVersion::parse` (semver-shaped:
+        /// `major.minor.patch`).
         version: String,
-        /// Permission grant payload (RFC §4.2).
+        /// Permission grant payload (RFC §4.2). Stored alongside
+        /// the loaded plugin; runtime enforcement of the
+        /// `manifest ∩ grant` invariant lands with the egress
+        /// proxy + env-grant integration.
         permissions: serde_json::Value,
+        /// Base64-encoded WASM module bytes.
+        wasm_b64: String,
     },
-    /// Detach a plugin. **Not implemented in this scaffold.**
+    /// Detach a plugin and free its sandbox.
     UnloadPlugin {
         /// Correlation id.
         id: Uuid,
@@ -53,7 +64,6 @@ pub enum Request {
         plugin_name: String,
     },
     /// Invoke a plugin function on a request/response pair.
-    /// **Not implemented in this scaffold.**
     Invoke {
         /// Correlation id.
         id: Uuid,
@@ -147,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn load_plugin_request_carries_permissions() {
+    fn load_plugin_request_carries_permissions_and_wasm() {
         let req = Request::LoadPlugin {
             id: Uuid::new_v4(),
             plugin_name: "stripe-rewriter".into(),
@@ -155,6 +165,7 @@ mod tests {
             permissions: serde_json::json!({
                 "egress": { "allow": ["*.stripe.com"] }
             }),
+            wasm_b64: "AGFzbQEAAAA=".into(), // empty WASM module
         };
         let bytes = serde_json::to_vec(&req).unwrap();
         let parsed: Request = serde_json::from_slice(&bytes).unwrap();
@@ -163,11 +174,13 @@ mod tests {
                 plugin_name,
                 version,
                 permissions,
+                wasm_b64,
                 ..
             } => {
                 assert_eq!(plugin_name, "stripe-rewriter");
                 assert_eq!(version, "1.2.3");
                 assert!(permissions.get("egress").is_some());
+                assert_eq!(wasm_b64, "AGFzbQEAAAA=");
             }
             other => panic!("expected LoadPlugin, got {:?}", other),
         }

--- a/crates/mockforge-plugin-host/src/server.rs
+++ b/crates/mockforge-plugin-host/src/server.rs
@@ -11,11 +11,12 @@ use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
-use crate::handlers::{handle, HandlerContext};
+use crate::handlers::handle;
+use crate::host::Host;
 use crate::protocol::Request;
 
 /// Configuration for the host server.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ServerConfig {
     /// Filesystem path the Unix socket is bound to. Main mockforge
     /// connects here.
@@ -41,7 +42,7 @@ impl Default for ServerConfig {
 ///
 /// Each accepted connection runs in its own Tokio task so a slow
 /// client doesn't head-of-line-block other callers.
-pub async fn run_server(config: ServerConfig) -> Result<()> {
+pub async fn run_server(config: ServerConfig, host: Host) -> Result<()> {
     // Best-effort cleanup of a stale socket from a previous run.
     // If the previous host crashed the file is still on disk and a
     // fresh bind would fail with EADDRINUSE.
@@ -65,8 +66,6 @@ pub async fn run_server(config: ServerConfig) -> Result<()> {
         "plugin-host listening"
     );
 
-    let ctx = HandlerContext::new();
-
     loop {
         let (stream, _addr) = match listener.accept().await {
             Ok(pair) => pair,
@@ -79,9 +78,9 @@ pub async fn run_server(config: ServerConfig) -> Result<()> {
             }
         };
 
-        let ctx = ctx.clone();
+        let host = host.clone();
         tokio::spawn(async move {
-            if let Err(err) = handle_connection(&ctx, stream).await {
+            if let Err(err) = handle_connection(&host, stream).await {
                 tracing::warn!(error = %err, "client connection terminated with error");
             }
         });
@@ -104,7 +103,7 @@ fn set_socket_permissions(_path: &Path, _mode: u32) -> Result<()> {
     Ok(())
 }
 
-async fn handle_connection(ctx: &HandlerContext, stream: UnixStream) -> Result<()> {
+async fn handle_connection(host: &Host, stream: UnixStream) -> Result<()> {
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
     let mut line = String::new();
@@ -129,7 +128,7 @@ async fn handle_connection(ctx: &HandlerContext, stream: UnixStream) -> Result<(
             }
         };
 
-        let response = handle(ctx, request).await;
+        let response = handle(host, request).await;
         let mut bytes = serde_json::to_vec(&response).context("serializing response")?;
         bytes.push(b'\n');
         write_half.write_all(&bytes).await.context("writing response")?;
@@ -141,15 +140,37 @@ async fn handle_connection(ctx: &HandlerContext, stream: UnixStream) -> Result<(
 mod tests {
     use super::*;
     use crate::protocol::Response;
+    use mockforge_plugin_loader::PluginLoaderConfig;
     use tokio::io::BufReader as TokioBufReader;
     use uuid::Uuid;
 
-    /// End-to-end: spawn the server in the background, connect over
-    /// the Unix socket, send a Health request, get a HealthOk back.
-    /// Validates the protocol round-trips through real socket I/O,
-    /// which the unit tests in `handlers` and `protocol` don't.
-    #[tokio::test]
-    async fn server_round_trips_a_health_request() {
+    /// Spin up a current-thread runtime that runs the actor + the
+    /// server + the test body concurrently via `select!`. Whichever
+    /// of the three completes first wins; the server and actor are
+    /// designed to run forever, so the test body's completion is
+    /// what ends the runtime.
+    fn run_server_with_actor<F, T>(config: ServerConfig, body: impl FnOnce(Host) -> F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let (host, actor) = Host::new(PluginLoaderConfig::default());
+            let server_host = host.clone();
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+                result = run_server(config, server_host) => panic!("server exited unexpectedly: {:?}", result),
+            }
+        })
+    }
+
+    /// End-to-end: drive the actor + server, connect over the Unix
+    /// socket, send a Health request, get a HealthOk back. Validates
+    /// the protocol round-trips through real socket I/O, which the
+    /// unit tests in `handlers` and `protocol` don't.
+    #[test]
+    fn server_round_trips_a_health_request() {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("test.sock");
 
@@ -160,46 +181,39 @@ mod tests {
             socket_mode: 0o600,
         };
 
-        let server_handle = tokio::spawn(async move { run_server(config).await });
+        run_server_with_actor(config, |_host| async move {
+            // Wait for the socket file to appear.
+            let mut attempts = 0;
+            while !socket_path.exists() && attempts < 50 {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                attempts += 1;
+            }
+            assert!(socket_path.exists(), "server didn't bind socket");
 
-        // Wait for the socket file to appear; the server binds on
-        // its own task so there's a small window where it's not
-        // ready yet.
-        let mut attempts = 0;
-        while !socket_path.exists() && attempts < 50 {
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-            attempts += 1;
-        }
-        assert!(socket_path.exists(), "server didn't bind socket");
+            let stream = UnixStream::connect(&socket_path).await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut reader = TokioBufReader::new(read_half);
 
-        let stream = UnixStream::connect(&socket_path).await.unwrap();
-        let (read_half, mut write_half) = stream.into_split();
-        let mut reader = TokioBufReader::new(read_half);
+            let id = Uuid::new_v4();
+            let req = Request::Health { id };
+            let mut bytes = serde_json::to_vec(&req).unwrap();
+            bytes.push(b'\n');
+            write_half.write_all(&bytes).await.unwrap();
+            write_half.flush().await.unwrap();
 
-        let id = Uuid::new_v4();
-        let req = Request::Health { id };
-        let mut bytes = serde_json::to_vec(&req).unwrap();
-        bytes.push(b'\n');
-        write_half.write_all(&bytes).await.unwrap();
-        write_half.flush().await.unwrap();
+            let mut response_line = String::new();
+            reader.read_line(&mut response_line).await.unwrap();
+            let response: Response = serde_json::from_str(response_line.trim_end()).unwrap();
 
-        let mut response_line = String::new();
-        reader.read_line(&mut response_line).await.unwrap();
-        let response: Response = serde_json::from_str(response_line.trim_end()).unwrap();
-
-        match response {
-            Response::HealthOk { id: echoed, .. } => assert_eq!(echoed, id),
-            other => panic!("expected HealthOk, got {:?}", other),
-        }
-
-        // Cleanup: drop the writer to send EOF, then abort the
-        // server so the test exits.
-        drop(write_half);
-        server_handle.abort();
+            match response {
+                Response::HealthOk { id: echoed, .. } => assert_eq!(echoed, id),
+                other => panic!("expected HealthOk, got {:?}", other),
+            }
+        });
     }
 
-    #[tokio::test]
-    async fn malformed_request_closes_connection_without_panic() {
+    #[test]
+    fn malformed_request_closes_connection_without_panic() {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("test.sock");
         let config = ServerConfig {
@@ -207,30 +221,29 @@ mod tests {
             socket_mode: 0o600,
         };
 
-        let server_handle = tokio::spawn(async move { run_server(config).await });
-        let mut attempts = 0;
-        while !socket_path.exists() && attempts < 50 {
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-            attempts += 1;
-        }
+        run_server_with_actor(config, |_host| async move {
+            let mut attempts = 0;
+            while !socket_path.exists() && attempts < 50 {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                attempts += 1;
+            }
 
-        let stream = UnixStream::connect(&socket_path).await.unwrap();
-        let (read_half, mut write_half) = stream.into_split();
-        let mut reader = TokioBufReader::new(read_half);
-        write_half.write_all(b"not valid json\n").await.unwrap();
-        write_half.flush().await.unwrap();
+            let stream = UnixStream::connect(&socket_path).await.unwrap();
+            let (read_half, mut write_half) = stream.into_split();
+            let mut reader = TokioBufReader::new(read_half);
+            write_half.write_all(b"not valid json\n").await.unwrap();
+            write_half.flush().await.unwrap();
 
-        // Server should close the connection. A clean EOF from
-        // `read_line` returns Ok(0); we'd time out if the server
-        // got stuck in a parse loop.
-        let mut buf = String::new();
-        let bytes =
-            tokio::time::timeout(std::time::Duration::from_secs(2), reader.read_line(&mut buf))
-                .await
-                .unwrap()
-                .unwrap();
-        assert_eq!(bytes, 0, "expected EOF, got payload {:?}", buf);
-
-        server_handle.abort();
+            // Server should close the connection. A clean EOF from
+            // `read_line` returns Ok(0); we'd time out if the
+            // server got stuck in a parse loop.
+            let mut buf = String::new();
+            let bytes =
+                tokio::time::timeout(std::time::Duration::from_secs(2), reader.read_line(&mut buf))
+                    .await
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(bytes, 0, "expected EOF, got payload {:?}", buf);
+        });
     }
 }


### PR DESCRIPTION
## Summary
Phase 2 follow-up to #399 (the scaffold). The \`not_implemented\` placeholders for load/unload/invoke now dispatch through to the real \`mockforge-plugin-loader::sandbox::PluginSandbox\` via an actor task.

**Stacked on #399** — review/merge that first, then this rebases cleanly.

## Smoke test (end-to-end with real WASM)
\`\`\`
$ python3 -c "..."  # send health, load_plugin, health
health => {"kind":"health_ok","uptime_secs":0,...}
load   => {"kind":"ok","body":{"plugin_id":"smoke-test",
                              "plugin_name":"smoke-test",
                              "version":"1.0.0"}}
health => still alive after the load
\`\`\`
A real WASM module flows from the IPC client → JSON wire → handler → host actor → \`PluginSandbox\` → Wasmtime → \`PluginInstance::Ready\`.

## Architecture
- **\`Host\` handle**: cheap-to-clone (mpsc Sender + Arc Instant), Send + Sync, shareable across spawned IPC connection tasks.
- **\`Host::new\` returns \`(Host, HostActor)\`** — caller drives the actor future on the current task via \`tokio::select!\`. The actor owns the !Send PluginSandbox + plugins HashMap.
- Per-loaded-plugin **tempfile** holds the WASM bytes for the plugin's lifetime (PluginLoadContext takes a filesystem path).

### Why an actor (not Arc<Mutex<>>)
The Wasmtime Store inside PluginSandbox is Send but its embedded WasiCtx contains \`dyn\` trait objects without \`+ Send\` bounds in wasmtime-wasi 36 — that makes the sandbox \`!Sync\`, which prevents sharing via Arc. The actor pattern sidesteps this entirely.

### Why a current-thread runtime
The actor future itself is \`!Send\` (it captures the !Send sandbox), so it can't \`tokio::spawn\` on a multi-thread runtime. Running it inline on the main task under a current-thread runtime keeps the API simple. At our concurrency (≤25 plugins per Team-tier mock, sub-50ms invocations) single-threaded is plenty.

## Wire protocol changes
- \`LoadPlugin\` gains \`wasm_b64: String\` (base64-encoded WASM bytes). Inline-bytes is the v1 transport; the registry-fetch path is a separate follow-up so signature verification can hook in upstream.
- Successful \`Load\` returns \`Ok { body: { plugin_id, plugin_name, version } }\`.
- Successful \`Unload\` returns \`Ok { body: { plugin_name, detached: bool } }\` — idempotent (false = wasn't loaded; not an error).
- Errors map to stable \`code\` strings via \`HostError::code\`: \`already_loaded\`, \`not_loaded\`, \`invalid_version\`, \`invalid_base64\`, \`io_error\`, \`loader_error\`, \`plugin_execution_error\`, \`actor_gone\`.

## Test plan
- [x] \`cargo check -p mockforge-plugin-host\`
- [x] \`cargo clippy -p mockforge-plugin-host --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test -p mockforge-plugin-host --lib\` — **20/20 pass**:
  - 5 protocol round-trip tests
  - 6 host direct method tests (load/unload/invoke/list/version-parse paths)
  - 7 handler dispatch tests (including double-load + invoke-after-load end-to-end)
  - 2 server end-to-end tests via real Unix socket
- [x] \`cargo build\` + live smoke test confirms LoadPlugin reaches the sandbox
- [x] Pre-commit hooks (clippy, typos, fmt, audit) — all passed

## What's next (separate PRs)
- Cosign signature verification at LoadPlugin time
- Egress proxy as a third process
- OTLP exporter that subscribes to the metrics bus
- Kill-switch blocklist poll
- Production Dockerfile (main + plugin-host + egress-proxy with FlyioGuest sizing from #398)