### PR TITLE
feat(plugin-egress): HTTP CONNECT proxy with per-plugin allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8596,6 +8596,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockforge-plugin-egress"
+version = "0.3.126"
+dependencies = [
+ "anyhow",
+ "ipnet",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mockforge-plugin-host"
 version = "0.3.126"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     # Plugin system
     "crates/mockforge-plugin-core",
     "crates/mockforge-plugin-cli",
+    "crates/mockforge-plugin-egress",
     "crates/mockforge-plugin-host",
     "crates/mockforge-plugin-loader",
     "crates/mockforge-plugin-registry",

--- a/crates/mockforge-plugin-egress/Cargo.toml
+++ b/crates/mockforge-plugin-egress/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "mockforge-plugin-egress"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme.workspace = true
+keywords = ["plugin", "proxy", "egress", "cloud", "sidecar"]
+categories = ["development-tools", "network-programming"]
+description = "HTTP forward proxy enforcing per-plugin egress allowlists for MockForge cloud"
+
+[lints.rust]
+missing_docs = "deny"
+
+[lib]
+name = "mockforge_plugin_egress"
+path = "src/lib.rs"
+
+[[bin]]
+name = "mockforge-plugin-egress"
+path = "src/main.rs"
+
+[dependencies]
+# Async runtime + TCP I/O. Multi-threaded is fine here — the proxy
+# doesn't carry any !Send state.
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "io-util", "time"] }
+
+# Serde for the allowlist config file.
+serde.workspace = true
+serde_json.workspace = true
+
+# Error handling
+anyhow.workspace = true
+thiserror.workspace = true
+
+# Logging
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+
+# IP parsing for the hard denylist (RFC1918 + cloud metadata IPs).
+# `ipnet` gives us correct CIDR-membership checks without rolling our own.
+ipnet = "2.10"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mockforge-plugin-egress/src/denylist.rs
+++ b/crates/mockforge-plugin-egress/src/denylist.rs
@@ -1,0 +1,187 @@
+//! Hard denylist that takes precedence over the per-plugin allowlist.
+//!
+//! Even if an org admin grants `*` egress to a plugin, traffic to
+//! these targets is still blocked. Mirrors the hard-deny set from
+//! `cloud-trust-permissions-rfc.md` §5.3.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use ipnet::{Ipv4Net, Ipv6Net};
+
+/// Hostnames that are never allowed regardless of the plugin's
+/// allowlist. These resolve to cloud metadata services and are a
+/// classic exfiltration target.
+const DENY_HOSTS: &[&str] = &[
+    "metadata.google.internal",
+    "metadata.googleapis.com",
+    "instance-data.ec2.internal",
+];
+
+/// Suffixes that are denied — catches subdomains of MockForge's own
+/// control plane so a compromised plugin can't loop back.
+const DENY_SUFFIXES: &[&str] = &[
+    ".mockforge.dev", // app.mockforge.dev, registry.mockforge.dev, etc.
+    ".fly.dev",       // any Fly app, including other tenants'
+    ".internal",      // Fly's internal DNS domain
+    ".flycast",       // Fly's flycast addresses
+];
+
+/// Whether `host` (a hostname or IP-literal) should be hard-denied
+/// before any allowlist check runs. Returns the matching reason as
+/// a stable string for audit logging.
+pub fn is_denied_target(host: &str) -> Option<&'static str> {
+    let host_lc = host.to_ascii_lowercase();
+
+    // Exact-match hostname denylist.
+    if DENY_HOSTS.iter().any(|h| host_lc == *h) {
+        return Some("denied: cloud metadata hostname");
+    }
+
+    // Suffix-match denylist — catches subdomains.
+    for suffix in DENY_SUFFIXES {
+        if host_lc.ends_with(suffix) {
+            return Some("denied: protected platform suffix");
+        }
+    }
+
+    // IP-literal checks. If the "host" parses as an IP address,
+    // walk the deny CIDRs.
+    if let Ok(ip) = IpAddr::from_str(&host_lc) {
+        if denied_ip(ip) {
+            return Some("denied: reserved or internal IP range");
+        }
+    }
+
+    None
+}
+
+/// Whether a resolved IP address falls in a denied CIDR block.
+/// Called by the proxy *after* DNS resolution — even an
+/// allowlisted hostname is rejected if its A/AAAA record points
+/// into a private range. This catches `evil.example.com → 10.0.0.5`
+/// rebinding tricks.
+pub fn denied_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => denied_ipv4(v4),
+        IpAddr::V6(v6) => denied_ipv6(v6),
+    }
+}
+
+fn denied_ipv4(addr: Ipv4Addr) -> bool {
+    let nets: &[Ipv4Net] = &[
+        // RFC1918 private use
+        "10.0.0.0/8".parse().unwrap(),
+        "172.16.0.0/12".parse().unwrap(),
+        "192.168.0.0/16".parse().unwrap(),
+        // Loopback
+        "127.0.0.0/8".parse().unwrap(),
+        // Link-local — covers 169.254.169.254 (cloud metadata)
+        "169.254.0.0/16".parse().unwrap(),
+        // Multicast + reserved
+        "224.0.0.0/4".parse().unwrap(),
+        "240.0.0.0/4".parse().unwrap(),
+        // Carrier-grade NAT
+        "100.64.0.0/10".parse().unwrap(),
+        // RFC1122 "this network"
+        "0.0.0.0/8".parse().unwrap(),
+    ];
+    nets.iter().any(|n| n.contains(&addr))
+}
+
+fn denied_ipv6(addr: Ipv6Addr) -> bool {
+    let nets: &[Ipv6Net] = &[
+        // Loopback
+        "::1/128".parse().unwrap(),
+        // Link-local
+        "fe80::/10".parse().unwrap(),
+        // Unique-local addresses
+        "fc00::/7".parse().unwrap(),
+        // Multicast
+        "ff00::/8".parse().unwrap(),
+        // IPv4-mapped — block these too because the underlying v4
+        // address might still be private. Stricter parsing of the
+        // mapped form happens in the proxy connect path.
+        "::ffff:0:0/96".parse().unwrap(),
+        // Discard prefix
+        "100::/64".parse().unwrap(),
+    ];
+    nets.iter().any(|n| n.contains(&addr))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_hostname_is_denied() {
+        assert!(is_denied_target("metadata.google.internal").is_some());
+        assert!(is_denied_target("METADATA.GOOGLE.INTERNAL").is_some()); // case-insensitive
+    }
+
+    #[test]
+    fn fly_dev_subdomain_is_denied() {
+        assert!(is_denied_target("anyone.fly.dev").is_some());
+        assert!(is_denied_target("evil.subdomain.fly.dev").is_some());
+    }
+
+    #[test]
+    fn mockforge_dev_subdomain_is_denied() {
+        assert!(is_denied_target("registry.mockforge.dev").is_some());
+        assert!(is_denied_target("app.mockforge.dev").is_some());
+    }
+
+    #[test]
+    fn rfc1918_ipv4_is_denied() {
+        for ip in &["10.0.0.5", "172.16.5.5", "192.168.1.1", "172.31.255.255"] {
+            assert!(is_denied_target(ip).is_some(), "expected {} denied", ip);
+        }
+    }
+
+    #[test]
+    fn cloud_metadata_ipv4_is_denied() {
+        assert!(is_denied_target("169.254.169.254").is_some());
+    }
+
+    #[test]
+    fn loopback_is_denied() {
+        assert!(is_denied_target("127.0.0.1").is_some());
+        assert!(is_denied_target("::1").is_some());
+    }
+
+    #[test]
+    fn ipv6_link_local_is_denied() {
+        assert!(is_denied_target("fe80::1").is_some());
+    }
+
+    #[test]
+    fn ipv6_unique_local_is_denied() {
+        assert!(is_denied_target("fc00::1").is_some());
+        assert!(is_denied_target("fd00:dead:beef::1").is_some());
+    }
+
+    #[test]
+    fn public_hostname_passes_denylist() {
+        assert!(is_denied_target("api.stripe.com").is_none());
+        assert!(is_denied_target("github.com").is_none());
+    }
+
+    #[test]
+    fn public_ip_passes_denylist() {
+        // 8.8.8.8 (Google DNS) — public, not denied
+        assert!(is_denied_target("8.8.8.8").is_none());
+        // 1.1.1.1 (Cloudflare)
+        assert!(is_denied_target("1.1.1.1").is_none());
+    }
+
+    #[test]
+    fn just_under_172_16_is_public() {
+        // 172.15.x.x is *not* RFC1918 — only 172.16.0.0/12 is.
+        // This guards against a /16 confusion bug in the CIDR
+        // table.
+        assert!(!denied_ipv4("172.15.0.1".parse().unwrap()));
+        assert!(denied_ipv4("172.16.0.1".parse().unwrap()));
+        assert!(denied_ipv4("172.31.255.255".parse().unwrap()));
+        assert!(!denied_ipv4("172.32.0.1".parse().unwrap()));
+    }
+}

--- a/crates/mockforge-plugin-egress/src/handle.rs
+++ b/crates/mockforge-plugin-egress/src/handle.rs
@@ -1,0 +1,189 @@
+//! Cheaply-cloneable, hot-swappable handle around a [`HostPolicy`].
+//!
+//! Built on `Arc<std::sync::RwLock<Arc<HostPolicy>>>`. The double
+//! `Arc` lets per-connection tasks `read()` the inner `Arc<Policy>`
+//! under a brief read lock and then drop the lock — checks against
+//! the policy don't hold the lock across await points. A reload
+//! takes the write lock just long enough to replace the inner
+//! `Arc`. Readers using the old version finish naturally as their
+//! `Arc<HostPolicy>` clones drop.
+//!
+//! Why `std::sync::RwLock` rather than `tokio::sync::RwLock`: the
+//! lock is held for nanoseconds (clone an Arc, drop the guard).
+//! Holding it across an `await` would be wrong; the API
+//! deliberately doesn't expose that. Tokio's RwLock would force
+//! every check to be `.await` for no benefit.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use crate::policy::{HostPolicy, PolicyDecision, PolicyError};
+
+/// Hot-swappable policy handle. Cloning is `Arc::clone` —
+/// per-connection tasks each hold one.
+#[derive(Clone)]
+pub struct PolicyHandle {
+    inner: Arc<RwLock<Arc<HostPolicy>>>,
+}
+
+impl PolicyHandle {
+    /// Wrap an existing `HostPolicy`.
+    pub fn new(policy: HostPolicy) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Arc::new(policy))),
+        }
+    }
+
+    /// Take a cheap snapshot of the current policy. The returned
+    /// `Arc<HostPolicy>` survives a concurrent `replace`; the
+    /// caller's view of the policy is consistent for the rest of
+    /// the request.
+    pub fn snapshot(&self) -> Arc<HostPolicy> {
+        // `expect` rather than `unwrap` so a poisoned lock surfaces
+        // a clear message — poisoning would mean a previous holder
+        // panicked while writing, which is a bug worth seeing.
+        Arc::clone(
+            &self
+                .inner
+                .read()
+                .expect("PolicyHandle read lock poisoned — earlier write panicked"),
+        )
+    }
+
+    /// One-shot check that combines `snapshot` and
+    /// `HostPolicy::check`. Convenient for the proxy hot path.
+    pub fn check(&self, host: &str) -> PolicyDecision {
+        self.snapshot().check(host)
+    }
+
+    /// Atomically replace the inner policy.
+    pub fn replace(&self, policy: HostPolicy) {
+        let mut guard = self
+            .inner
+            .write()
+            .expect("PolicyHandle write lock poisoned — previous holder panicked");
+        *guard = Arc::new(policy);
+    }
+}
+
+/// Read an allowlist file (one pattern per line, `#` comments) and
+/// build a fresh [`HostPolicy`]. Used by the SIGHUP handler in
+/// `main.rs`.
+pub fn load_policy_from_file(path: &Path) -> Result<HostPolicy, ReloadError> {
+    let contents = std::fs::read_to_string(path).map_err(|err| ReloadError::Io {
+        path: path.to_path_buf(),
+        err: err.to_string(),
+    })?;
+    let patterns: Vec<String> = contents
+        .lines()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && !s.starts_with('#'))
+        .map(|s| s.to_string())
+        .collect();
+    HostPolicy::from_patterns(&patterns).map_err(ReloadError::Compile)
+}
+
+/// Errors building a fresh policy from disk during reload.
+#[derive(Debug, thiserror::Error)]
+pub enum ReloadError {
+    /// Couldn't read the allowlist file.
+    #[error("io error reading {}: {err}", path.display())]
+    Io {
+        /// Path that failed to open.
+        path: PathBuf,
+        /// Underlying io::Error message.
+        err: String,
+    },
+    /// Patterns didn't compile (e.g. mid-string wildcard).
+    #[error("policy compile error: {0}")]
+    Compile(#[from] PolicyError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn handle_snapshot_returns_current_policy() {
+        let policy = HostPolicy::from_patterns(&["api.stripe.com".to_string()]).unwrap();
+        let handle = PolicyHandle::new(policy);
+        let snap = handle.snapshot();
+        assert_eq!(snap.check("api.stripe.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn handle_replace_swaps_policy() {
+        let initial = HostPolicy::from_patterns(&["a.example.com".to_string()]).unwrap();
+        let handle = PolicyHandle::new(initial);
+
+        // Old policy allows a.example.com but not b.example.com.
+        assert_eq!(handle.check("a.example.com"), PolicyDecision::Allowed);
+        assert!(matches!(handle.check("b.example.com"), PolicyDecision::Denied(_)));
+
+        // Hot-swap.
+        let updated = HostPolicy::from_patterns(&["b.example.com".to_string()]).unwrap();
+        handle.replace(updated);
+
+        assert!(matches!(handle.check("a.example.com"), PolicyDecision::Denied(_)));
+        assert_eq!(handle.check("b.example.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn handle_clone_shares_state() {
+        let policy = HostPolicy::from_patterns(&["api.example.com".to_string()]).unwrap();
+        let handle = PolicyHandle::new(policy);
+        let cloned = handle.clone();
+
+        // Replace via the clone — original sees the change.
+        cloned.replace(HostPolicy::from_patterns(&["new.example.com".to_string()]).unwrap());
+        assert_eq!(handle.check("new.example.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn pre_reload_snapshot_survives_concurrent_replace() {
+        let initial = HostPolicy::from_patterns(&["before.example.com".to_string()]).unwrap();
+        let handle = PolicyHandle::new(initial);
+
+        // Take a snapshot, then replace, then keep using the old
+        // snapshot. This simulates a long-lived request that
+        // started under an old policy — its decisions stay stable
+        // for the request's lifetime.
+        let snap = handle.snapshot();
+        handle.replace(HostPolicy::from_patterns(&["after.example.com".to_string()]).unwrap());
+
+        // Old snapshot still allows the old hostname.
+        assert_eq!(snap.check("before.example.com"), PolicyDecision::Allowed);
+        // New handle reads see the swap.
+        assert_eq!(handle.check("after.example.com"), PolicyDecision::Allowed);
+        assert!(matches!(handle.check("before.example.com"), PolicyDecision::Denied(_)));
+    }
+
+    #[test]
+    fn load_policy_from_file_strips_comments_and_blank_lines() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "# header comment").unwrap();
+        writeln!(file).unwrap();
+        writeln!(file, "api.stripe.com").unwrap();
+        writeln!(file, "  *.stripe.com  ").unwrap();
+        writeln!(file, "# another comment").unwrap();
+
+        let policy = load_policy_from_file(file.path()).unwrap();
+        assert_eq!(policy.check("api.stripe.com"), PolicyDecision::Allowed);
+        assert_eq!(policy.check("events.stripe.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn load_policy_from_file_surfaces_compile_errors() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "foo.*.com").unwrap(); // mid-string wildcard
+        let result = load_policy_from_file(file.path());
+        assert!(matches!(result, Err(ReloadError::Compile(_))));
+    }
+
+    #[test]
+    fn load_policy_from_file_surfaces_missing_file_errors() {
+        let result = load_policy_from_file(Path::new("/nonexistent/path/that/does/not/exist"));
+        assert!(matches!(result, Err(ReloadError::Io { .. })));
+    }
+}

--- a/crates/mockforge-plugin-egress/src/lib.rs
+++ b/crates/mockforge-plugin-egress/src/lib.rs
@@ -37,9 +37,11 @@
 //!   same allowlist. No "this rewrite-rule may call X, that one Y."
 
 pub mod denylist;
+pub mod handle;
 pub mod policy;
 pub mod proxy;
 
 pub use denylist::is_denied_target;
+pub use handle::{load_policy_from_file, PolicyHandle, ReloadError};
 pub use policy::{HostPolicy, PolicyDecision};
 pub use proxy::{run_proxy, ProxyConfig};

--- a/crates/mockforge-plugin-egress/src/lib.rs
+++ b/crates/mockforge-plugin-egress/src/lib.rs
@@ -1,0 +1,45 @@
+//! # MockForge Plugin Egress Proxy
+//!
+//! HTTP forward proxy that gates outbound plugin traffic through a
+//! per-plugin hostname allowlist and a hard denylist for cloud
+//! metadata IPs + RFC1918 ranges. Sits as the third process in a
+//! cloud-plugins-enabled hosted-mock Fly machine, alongside main
+//! `mockforge` and `mockforge-plugin-host`.
+//!
+//! See `docs/plugins/security/cloud-trust-permissions-rfc.md` §5 for
+//! the threat model and §6 for the egress policy semantics.
+//!
+//! ## What this proxy enforces
+//!
+//! - **Hostname allowlist**: a request to `Host: api.example.com` is
+//!   allowed only if `api.example.com` matches an entry in the
+//!   plugin's grant. Wildcards (`*.example.com`) are supported and
+//!   match one or more leftmost labels.
+//! - **Hard denylist** (always-on, can't be opted out of):
+//!   - Cloud metadata: `169.254.169.254`, `fd00:ec2::254`,
+//!     `metadata.google.internal`
+//!   - RFC1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+//!   - Loopback: `127.0.0.0/8`, `::1/128`
+//!   - Link-local: `169.254.0.0/16`, `fe80::/10`
+//!   - The MockForge registry itself (so plugins can't loop back).
+//! - **HTTP CONNECT** for HTTPS pass-through. We don't MITM TLS —
+//!   that would break cert pinning and is itself a security risk.
+//!   The CONNECT host header is checked against the allowlist
+//!   before the tunnel opens.
+//!
+//! ## What this proxy explicitly doesn't do
+//!
+//! - **Body inspection.** Once a request is allowed, body content
+//!   is opaque — we accept that determined plugins can exfiltrate
+//!   via legitimate traffic to allowed hosts (RFC §5.4). Audit +
+//!   signature trust + revocation are the answer to that.
+//! - **Per-route policy.** All requests through a plugin share the
+//!   same allowlist. No "this rewrite-rule may call X, that one Y."
+
+pub mod denylist;
+pub mod policy;
+pub mod proxy;
+
+pub use denylist::is_denied_target;
+pub use policy::{HostPolicy, PolicyDecision};
+pub use proxy::{run_proxy, ProxyConfig};

--- a/crates/mockforge-plugin-egress/src/main.rs
+++ b/crates/mockforge-plugin-egress/src/main.rs
@@ -1,0 +1,111 @@
+//! `mockforge-plugin-egress` binary — the cloud-plugins egress proxy.
+//!
+//! Reads its allowlist from `MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST`
+//! (comma-separated patterns) or the file at
+//! `MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE` (one pattern per line).
+//! Bind address comes from `MOCKFORGE_PLUGIN_EGRESS_LISTEN`,
+//! defaulting to `127.0.0.1:8125`.
+//!
+//! In a Phase 2 production deployment, the plugin-host (PR #399/#400)
+//! is responsible for keeping this proxy's allowlist in sync with the
+//! per-plugin grants. v1 reads a static config; a future PR will
+//! add live reload via SIGHUP or an admin socket.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use mockforge_plugin_egress::{run_proxy, HostPolicy, ProxyConfig};
+
+const DEFAULT_LISTEN: &str = "127.0.0.1:8125";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_tracing();
+
+    let listen: SocketAddr = std::env::var("MOCKFORGE_PLUGIN_EGRESS_LISTEN")
+        .unwrap_or_else(|_| DEFAULT_LISTEN.to_string())
+        .parse()
+        .context("parsing MOCKFORGE_PLUGIN_EGRESS_LISTEN")?;
+
+    let patterns = load_allowlist()?;
+    let policy = HostPolicy::from_patterns(&patterns).context("compiling egress allowlist")?;
+    let config = ProxyConfig::new(listen, Arc::new(policy));
+
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        listen = %listen,
+        patterns = patterns.len(),
+        "mockforge-plugin-egress starting"
+    );
+
+    tokio::select! {
+        result = run_proxy(config) => {
+            tracing::error!(?result, "proxy exited unexpectedly");
+            result
+        }
+        _ = shutdown_signal() => {
+            tracing::info!("egress proxy received shutdown signal — exiting");
+            Ok(())
+        }
+    }
+}
+
+fn load_allowlist() -> Result<Vec<String>> {
+    if let Ok(path) = std::env::var("MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE") {
+        return load_allowlist_file(PathBuf::from(path));
+    }
+    if let Ok(inline) = std::env::var("MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST") {
+        return Ok(inline
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect());
+    }
+    // No allowlist configured — deny-all by default. The proxy
+    // will respond 403 to every request, which is the correct
+    // behavior when the operator forgets to set the env var.
+    tracing::warn!(
+        "no allowlist configured (set MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST or _FILE) — deny-all"
+    );
+    Ok(Vec::new())
+}
+
+fn load_allowlist_file(path: PathBuf) -> Result<Vec<String>> {
+    let contents = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading allowlist file {}", path.display()))?;
+    Ok(contents
+        .lines()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && !s.starts_with('#'))
+        .map(|s| s.to_string())
+        .collect())
+}
+
+fn init_tracing() {
+    use tracing_subscriber::fmt::format::FmtSpan;
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_span_events(FmtSpan::CLOSE)
+        .try_init();
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let mut sigint = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    tokio::select! {
+        _ = sigterm.recv() => tracing::info!("received SIGTERM"),
+        _ = sigint.recv() => tracing::info!("received SIGINT"),
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/crates/mockforge-plugin-egress/src/main.rs
+++ b/crates/mockforge-plugin-egress/src/main.rs
@@ -6,17 +6,23 @@
 //! Bind address comes from `MOCKFORGE_PLUGIN_EGRESS_LISTEN`,
 //! defaulting to `127.0.0.1:8125`.
 //!
-//! In a Phase 2 production deployment, the plugin-host (PR #399/#400)
-//! is responsible for keeping this proxy's allowlist in sync with the
-//! per-plugin grants. v1 reads a static config; a future PR will
-//! add live reload via SIGHUP or an admin socket.
+//! ## Live reload
+//!
+//! When `MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE` is set, sending
+//! `SIGHUP` to the process re-reads the file and atomically swaps
+//! the active policy. In-flight connections finish under their
+//! pre-reload snapshot; new connections see the updated policy
+//! immediately. A failed reload (file missing, invalid pattern)
+//! is logged and the previous policy stays in place — a typo'd
+//! file shouldn't open the gates.
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use mockforge_plugin_egress::{run_proxy, HostPolicy, ProxyConfig};
+use mockforge_plugin_egress::{
+    load_policy_from_file, run_proxy, HostPolicy, PolicyHandle, ProxyConfig,
+};
 
 const DEFAULT_LISTEN: &str = "127.0.0.1:8125";
 
@@ -29,14 +35,19 @@ async fn main() -> Result<()> {
         .parse()
         .context("parsing MOCKFORGE_PLUGIN_EGRESS_LISTEN")?;
 
-    let patterns = load_allowlist()?;
+    let allowlist_file =
+        std::env::var("MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE").ok().map(PathBuf::from);
+
+    let patterns = load_initial_allowlist(allowlist_file.as_deref())?;
     let policy = HostPolicy::from_patterns(&patterns).context("compiling egress allowlist")?;
-    let config = ProxyConfig::new(listen, Arc::new(policy));
+    let handle = PolicyHandle::new(policy);
+    let config = ProxyConfig::new(listen, handle.clone());
 
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         listen = %listen,
         patterns = patterns.len(),
+        reload_path = allowlist_file.as_ref().map(|p| p.display().to_string()).unwrap_or_else(|| "(disabled)".into()),
         "mockforge-plugin-egress starting"
     );
 
@@ -45,6 +56,9 @@ async fn main() -> Result<()> {
             tracing::error!(?result, "proxy exited unexpectedly");
             result
         }
+        _ = sighup_loop(handle, allowlist_file) => {
+            unreachable!("sighup_loop runs forever until shutdown_signal cancels it")
+        }
         _ = shutdown_signal() => {
             tracing::info!("egress proxy received shutdown signal — exiting");
             Ok(())
@@ -52,9 +66,63 @@ async fn main() -> Result<()> {
     }
 }
 
-fn load_allowlist() -> Result<Vec<String>> {
-    if let Ok(path) = std::env::var("MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE") {
-        return load_allowlist_file(PathBuf::from(path));
+/// SIGHUP reload loop. Returns only on cancellation by the
+/// outer `select!`. If no allowlist file is configured (so a
+/// reload would have nothing to read), `pending()` blocks
+/// forever — the `select!` arm is effectively disabled but the
+/// shape of the binary stays simple.
+#[cfg(unix)]
+async fn sighup_loop(handle: PolicyHandle, allowlist_file: Option<PathBuf>) {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let Some(path) = allowlist_file else {
+        std::future::pending::<()>().await;
+        return;
+    };
+
+    let mut sighup = match signal(SignalKind::hangup()) {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to install SIGHUP handler; live reload disabled");
+            std::future::pending::<()>().await;
+            return;
+        }
+    };
+
+    while sighup.recv().await.is_some() {
+        match load_policy_from_file(&path) {
+            Ok(new_policy) => {
+                handle.replace(new_policy);
+                tracing::info!(path = %path.display(), "egress allowlist reloaded on SIGHUP");
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    path = %path.display(),
+                    "SIGHUP reload failed; previous policy retained"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn sighup_loop(_handle: PolicyHandle, _allowlist_file: Option<PathBuf>) {
+    // SIGHUP is Unix-only. Non-Unix builds (developer machines)
+    // get no live reload.
+    std::future::pending::<()>().await;
+}
+
+fn load_initial_allowlist(allowlist_file: Option<&std::path::Path>) -> Result<Vec<String>> {
+    if let Some(path) = allowlist_file {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("reading allowlist file {}", path.display()))?;
+        return Ok(contents
+            .lines()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty() && !s.starts_with('#'))
+            .map(|s| s.to_string())
+            .collect());
     }
     if let Ok(inline) = std::env::var("MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST") {
         return Ok(inline
@@ -70,17 +138,6 @@ fn load_allowlist() -> Result<Vec<String>> {
         "no allowlist configured (set MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST or _FILE) — deny-all"
     );
     Ok(Vec::new())
-}
-
-fn load_allowlist_file(path: PathBuf) -> Result<Vec<String>> {
-    let contents = std::fs::read_to_string(&path)
-        .with_context(|| format!("reading allowlist file {}", path.display()))?;
-    Ok(contents
-        .lines()
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty() && !s.starts_with('#'))
-        .map(|s| s.to_string())
-        .collect())
 }
 
 fn init_tracing() {

--- a/crates/mockforge-plugin-egress/src/policy.rs
+++ b/crates/mockforge-plugin-egress/src/policy.rs
@@ -1,0 +1,233 @@
+//! Per-plugin allowlist policy.
+//!
+//! A `HostPolicy` carries the set of hostnames + wildcard patterns
+//! a plugin is allowed to reach. The proxy consults it for each
+//! request after the hard denylist runs (denylist wins on conflict).
+//!
+//! Patterns supported:
+//!   - Exact match: `api.stripe.com`
+//!   - Leading wildcard: `*.stripe.com` matches `api.stripe.com`,
+//!     `events.stripe.com`, `foo.bar.stripe.com`. Does **not**
+//!     match the bare `stripe.com` (require explicit listing).
+//!
+//! Out of scope for v1:
+//!   - Path-level rules (allow GET /v1/charges only)
+//!   - Header-based policies
+//!   - SNI inspection on TLS pass-through
+//!
+//! The cloud trust RFC §5.4 explicitly accepts these limitations:
+//! once a host is allowed, body content is opaque. That's the
+//! price of supporting useful plugins without MITM-ing TLS.
+
+use crate::denylist::is_denied_target;
+
+/// What the policy decided about a given host. The `Denied` variant
+/// carries a stable reason string for audit logging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyDecision {
+    /// Host matched the allowlist (and isn't on the hard denylist).
+    Allowed,
+    /// Host failed the policy check. The reason is a stable string
+    /// suitable for both logs and the 403 body the proxy returns.
+    Denied(&'static str),
+}
+
+/// Per-plugin allowlist + the global hard denylist.
+///
+/// Construct with [`HostPolicy::from_patterns`]. The policy is
+/// immutable for the lifetime of the plugin; re-attach with
+/// updated permissions creates a fresh policy.
+#[derive(Debug, Clone)]
+pub struct HostPolicy {
+    /// Compiled patterns. Each entry is either an exact hostname
+    /// (lowercased) or a leading-wildcard pattern represented as
+    /// `(suffix_with_dot, _)` — e.g. `*.stripe.com` becomes
+    /// `(".stripe.com", true)` so we just check `host.ends_with`.
+    patterns: Vec<HostPattern>,
+}
+
+#[derive(Debug, Clone)]
+enum HostPattern {
+    /// Exact match (lowercased).
+    Exact(String),
+    /// Leading-wildcard match: stored as the dotted suffix, e.g.
+    /// `.stripe.com`. A host matches if it ends with this suffix
+    /// AND has at least one extra label before it.
+    Wildcard(String),
+}
+
+impl HostPolicy {
+    /// Build a policy from the grant payload's `egress.allow`
+    /// list. Patterns that don't conform to the supported syntax
+    /// (no `*` other than as a leading label) are rejected — the
+    /// caller should surface this as a permission-grant error.
+    pub fn from_patterns(patterns: &[String]) -> Result<Self, PolicyError> {
+        let mut compiled = Vec::with_capacity(patterns.len());
+        for raw in patterns {
+            compiled.push(compile_pattern(raw)?);
+        }
+        Ok(Self { patterns: compiled })
+    }
+
+    /// Empty policy — denies everything. Useful as the deny-all
+    /// default when a plugin has no `egress.allow` entries.
+    pub fn deny_all() -> Self {
+        Self {
+            patterns: Vec::new(),
+        }
+    }
+
+    /// Decide whether `host` is allowed. Hard denylist runs first;
+    /// allowlist runs only if the denylist passes.
+    pub fn check(&self, host: &str) -> PolicyDecision {
+        if let Some(reason) = is_denied_target(host) {
+            return PolicyDecision::Denied(reason);
+        }
+
+        let host_lc = host.to_ascii_lowercase();
+        for pattern in &self.patterns {
+            match pattern {
+                HostPattern::Exact(s) => {
+                    if host_lc == *s {
+                        return PolicyDecision::Allowed;
+                    }
+                }
+                HostPattern::Wildcard(suffix) => {
+                    // Suffix is `.example.com`; require host to be
+                    // `<at-least-one-label>.example.com`.
+                    if host_lc.len() > suffix.len() && host_lc.ends_with(suffix) {
+                        return PolicyDecision::Allowed;
+                    }
+                }
+            }
+        }
+
+        PolicyDecision::Denied("denied: host not in allowlist")
+    }
+}
+
+/// Errors that can occur while compiling a pattern list.
+#[derive(Debug, thiserror::Error)]
+pub enum PolicyError {
+    /// The pattern uses `*` somewhere other than the leading
+    /// label, which we don't support in v1.
+    #[error("unsupported wildcard placement in pattern '{0}'; only leading-label `*.` is allowed")]
+    UnsupportedWildcard(String),
+    /// The pattern is empty or otherwise malformed.
+    #[error("invalid pattern '{0}'")]
+    InvalidPattern(String),
+}
+
+fn compile_pattern(raw: &str) -> Result<HostPattern, PolicyError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(PolicyError::InvalidPattern(raw.to_string()));
+    }
+    let lc = trimmed.to_ascii_lowercase();
+
+    if let Some(suffix) = lc.strip_prefix("*.") {
+        // The remainder must be a plain hostname — no further `*`s.
+        if suffix.contains('*') {
+            return Err(PolicyError::UnsupportedWildcard(raw.to_string()));
+        }
+        if suffix.is_empty() {
+            return Err(PolicyError::InvalidPattern(raw.to_string()));
+        }
+        // Store with the leading dot so `host.ends_with(".stripe.com")`
+        // correctly rejects `evilstripe.com`.
+        Ok(HostPattern::Wildcard(format!(".{suffix}")))
+    } else {
+        if lc.contains('*') {
+            return Err(PolicyError::UnsupportedWildcard(raw.to_string()));
+        }
+        Ok(HostPattern::Exact(lc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allow(patterns: &[&str]) -> HostPolicy {
+        HostPolicy::from_patterns(&patterns.iter().map(|s| (*s).to_string()).collect::<Vec<_>>())
+            .expect("test patterns should compile")
+    }
+
+    #[test]
+    fn deny_all_denies_everything() {
+        let policy = HostPolicy::deny_all();
+        assert!(matches!(policy.check("api.stripe.com"), PolicyDecision::Denied(_)));
+    }
+
+    #[test]
+    fn exact_match_allows_only_that_host() {
+        let policy = allow(&["api.stripe.com"]);
+        assert_eq!(policy.check("api.stripe.com"), PolicyDecision::Allowed);
+        assert!(matches!(policy.check("events.stripe.com"), PolicyDecision::Denied(_)));
+        assert!(matches!(policy.check("api.stripe.org"), PolicyDecision::Denied(_)));
+    }
+
+    #[test]
+    fn wildcard_matches_subdomains() {
+        let policy = allow(&["*.stripe.com"]);
+        assert_eq!(policy.check("api.stripe.com"), PolicyDecision::Allowed);
+        assert_eq!(policy.check("events.stripe.com"), PolicyDecision::Allowed);
+        assert_eq!(policy.check("foo.bar.stripe.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn wildcard_does_not_match_apex() {
+        // `*.stripe.com` should NOT match `stripe.com` itself —
+        // require explicit listing.
+        let policy = allow(&["*.stripe.com"]);
+        assert!(matches!(policy.check("stripe.com"), PolicyDecision::Denied(_)));
+    }
+
+    #[test]
+    fn wildcard_does_not_match_overlapping_suffix() {
+        // `evilstripe.com` ends with `stripe.com` byte-wise, but
+        // we require the dot before the suffix.
+        let policy = allow(&["*.stripe.com"]);
+        assert!(matches!(policy.check("evilstripe.com"), PolicyDecision::Denied(_)));
+    }
+
+    #[test]
+    fn allowlist_check_is_case_insensitive() {
+        let policy = allow(&["api.STRIPE.com"]);
+        assert_eq!(policy.check("API.stripe.COM"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn denylist_overrides_allowlist() {
+        // Even if you literally allow metadata.google.internal,
+        // the hard denylist wins.
+        let policy = allow(&["metadata.google.internal"]);
+        assert!(matches!(policy.check("metadata.google.internal"), PolicyDecision::Denied(_)));
+    }
+
+    #[test]
+    fn denylist_overrides_wildcard_match() {
+        // *.fly.dev should match an allowlist entry — but the hard
+        // denylist for *.fly.dev wins.
+        let policy = allow(&["*.fly.dev"]);
+        assert!(matches!(policy.check("anyone.fly.dev"), PolicyDecision::Denied(_)));
+    }
+
+    #[test]
+    fn malformed_wildcard_is_rejected() {
+        let result = HostPolicy::from_patterns(&["foo.*.com".to_string()]);
+        assert!(matches!(result, Err(PolicyError::UnsupportedWildcard(_))));
+    }
+
+    #[test]
+    fn empty_pattern_is_rejected() {
+        let result = HostPolicy::from_patterns(&["   ".to_string()]);
+        assert!(matches!(result, Err(PolicyError::InvalidPattern(_))));
+    }
+
+    #[test]
+    fn wildcard_without_suffix_is_rejected() {
+        let result = HostPolicy::from_patterns(&["*.".to_string()]);
+        assert!(matches!(result, Err(PolicyError::InvalidPattern(_))));
+    }
+}

--- a/crates/mockforge-plugin-egress/src/proxy.rs
+++ b/crates/mockforge-plugin-egress/src/proxy.rs
@@ -5,14 +5,14 @@
 //! which is `Send + Sync`.
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::denylist::denied_ip;
-use crate::policy::{HostPolicy, PolicyDecision};
+use crate::handle::PolicyHandle;
+use crate::policy::PolicyDecision;
 
 /// Configuration for the proxy server.
 #[derive(Clone)]
@@ -20,9 +20,13 @@ pub struct ProxyConfig {
     /// TCP address to bind. Plugins set `HTTP_PROXY` /
     /// `HTTPS_PROXY` env vars at this address.
     pub listen: SocketAddr,
-    /// Per-plugin allowlist policy. Wrapped in `Arc` so the
-    /// per-connection tasks can clone the handle cheaply.
-    pub policy: Arc<HostPolicy>,
+    /// Hot-swappable allowlist handle. Per-connection tasks clone
+    /// the handle (cheap), snapshot it for each request, and drop
+    /// the snapshot when the request ends. The SIGHUP signal
+    /// handler in `main.rs` swaps the inner policy without
+    /// affecting in-flight connections — those finish under
+    /// their own snapshot.
+    pub policy: PolicyHandle,
     /// Hard cap on the number of bytes we'll buffer while reading
     /// the request line + headers. 64 KiB is generous for realistic
     /// HTTP traffic; protects against malicious clients sending
@@ -33,7 +37,7 @@ pub struct ProxyConfig {
 impl ProxyConfig {
     /// Convenience constructor with sensible defaults for header
     /// limits.
-    pub fn new(listen: SocketAddr, policy: Arc<HostPolicy>) -> Self {
+    pub fn new(listen: SocketAddr, policy: PolicyHandle) -> Self {
         Self {
             listen,
             policy,
@@ -72,7 +76,7 @@ pub async fn run_proxy(config: ProxyConfig) -> Result<()> {
 async fn handle_connection(
     mut stream: TcpStream,
     _peer: SocketAddr,
-    policy: Arc<HostPolicy>,
+    policy: PolicyHandle,
     max_header_bytes: usize,
 ) -> Result<()> {
     let request_line = read_request_line(&mut stream, max_header_bytes).await?;
@@ -191,7 +195,7 @@ async fn handle_connect(
     mut client: TcpStream,
     host: String,
     port: u16,
-    policy: Arc<HostPolicy>,
+    policy: PolicyHandle,
 ) -> Result<()> {
     // Drain remaining client headers before deciding — RFC 7231
     // requires consuming through the empty line. Use a fresh

--- a/crates/mockforge-plugin-egress/src/proxy.rs
+++ b/crates/mockforge-plugin-egress/src/proxy.rs
@@ -1,0 +1,351 @@
+//! HTTP forward proxy implementation. Listens on a TCP socket;
+//! handles `CONNECT` for HTTPS pass-through and absolute-URI HTTP
+//! GET/POST/etc. for plain HTTP. Each accepted connection runs
+//! in its own Tokio task — proxy state is `Arc<HostPolicy>`,
+//! which is `Send + Sync`.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::denylist::denied_ip;
+use crate::policy::{HostPolicy, PolicyDecision};
+
+/// Configuration for the proxy server.
+#[derive(Clone)]
+pub struct ProxyConfig {
+    /// TCP address to bind. Plugins set `HTTP_PROXY` /
+    /// `HTTPS_PROXY` env vars at this address.
+    pub listen: SocketAddr,
+    /// Per-plugin allowlist policy. Wrapped in `Arc` so the
+    /// per-connection tasks can clone the handle cheaply.
+    pub policy: Arc<HostPolicy>,
+    /// Hard cap on the number of bytes we'll buffer while reading
+    /// the request line + headers. 64 KiB is generous for realistic
+    /// HTTP traffic; protects against malicious clients sending
+    /// unbounded headers to OOM the proxy.
+    pub max_request_header_bytes: usize,
+}
+
+impl ProxyConfig {
+    /// Convenience constructor with sensible defaults for header
+    /// limits.
+    pub fn new(listen: SocketAddr, policy: Arc<HostPolicy>) -> Self {
+        Self {
+            listen,
+            policy,
+            max_request_header_bytes: 64 * 1024,
+        }
+    }
+}
+
+/// Bind the listener and accept connections forever.
+pub async fn run_proxy(config: ProxyConfig) -> Result<()> {
+    let listener = TcpListener::bind(config.listen)
+        .await
+        .with_context(|| format!("binding TCP listener at {}", config.listen))?;
+
+    tracing::info!(addr = %config.listen, "egress proxy listening");
+
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(err) => {
+                tracing::error!(error = %err, "accept failed; retrying");
+                continue;
+            }
+        };
+
+        let policy = config.policy.clone();
+        let max_header_bytes = config.max_request_header_bytes;
+        tokio::spawn(async move {
+            if let Err(err) = handle_connection(stream, peer, policy, max_header_bytes).await {
+                tracing::warn!(peer = %peer, error = %err, "proxy connection ended with error");
+            }
+        });
+    }
+}
+
+async fn handle_connection(
+    mut stream: TcpStream,
+    _peer: SocketAddr,
+    policy: Arc<HostPolicy>,
+    max_header_bytes: usize,
+) -> Result<()> {
+    let request_line = read_request_line(&mut stream, max_header_bytes).await?;
+    let parsed = parse_request_line(&request_line)?;
+
+    match parsed {
+        ParsedRequest::Connect { host, port } => handle_connect(stream, host, port, policy).await,
+        ParsedRequest::Other {
+            method,
+            raw_request_line,
+        } => {
+            // For non-CONNECT methods we'd implement absolute-URI
+            // HTTP forwarding (RFC 7230 §5.3.2). v1 ships CONNECT-
+            // only because that covers HTTPS — the dominant case
+            // for plugin egress — and avoids a full HTTP parser
+            // in the proxy. Plugins that need plain HTTP get a
+            // 405 with a clear message.
+            tracing::debug!(method = %method, "non-CONNECT method rejected");
+            write_simple_status(
+                &mut stream,
+                405,
+                "Method Not Allowed",
+                "Only HTTP CONNECT is supported in v1; plain HTTP is not yet proxied",
+            )
+            .await?;
+            let _ = raw_request_line; // keep for future logging
+            Ok(())
+        }
+    }
+}
+
+/// Read the first line of the request, bounded by `max_bytes`.
+/// Returns the line without the trailing CRLF.
+async fn read_request_line(stream: &mut TcpStream, max_bytes: usize) -> Result<String> {
+    let mut buffer = Vec::with_capacity(256);
+    let mut byte = [0u8; 1];
+    loop {
+        let n = stream.read(&mut byte).await.context("reading request byte")?;
+        if n == 0 {
+            anyhow::bail!("client closed before sending request line");
+        }
+        buffer.push(byte[0]);
+        if buffer.len() >= 2 && &buffer[buffer.len() - 2..] == b"\r\n" {
+            buffer.truncate(buffer.len() - 2);
+            break;
+        }
+        if buffer.len() > max_bytes {
+            anyhow::bail!("request line exceeded {max_bytes} bytes");
+        }
+    }
+    String::from_utf8(buffer).context("request line not valid UTF-8")
+}
+
+/// Drain remaining headers (we don't need them for CONNECT but
+/// must consume them so the response sits at the right offset in
+/// the stream).
+async fn drain_headers(reader: &mut BufReader<&mut TcpStream>, max_bytes: usize) -> Result<()> {
+    let mut total = 0usize;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await.context("reading header line")?;
+        if n == 0 {
+            anyhow::bail!("client closed mid-headers");
+        }
+        total += n;
+        if total > max_bytes {
+            anyhow::bail!("headers exceeded {max_bytes} bytes");
+        }
+        if line == "\r\n" || line == "\n" {
+            return Ok(());
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ParsedRequest {
+    Connect {
+        host: String,
+        port: u16,
+    },
+    Other {
+        method: String,
+        raw_request_line: String,
+    },
+}
+
+fn parse_request_line(line: &str) -> Result<ParsedRequest> {
+    // Format: METHOD SP REQUEST-TARGET SP HTTP/VERSION
+    let mut parts = line.split_ascii_whitespace();
+    let method = parts.next().context("empty request line")?.to_string();
+    let target = parts.next().context("missing request target")?;
+    let _version = parts.next().context("missing HTTP version")?;
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        // CONNECT target is `host:port`.
+        let (host, port_str) = target
+            .rsplit_once(':')
+            .with_context(|| format!("CONNECT target missing :port — {target}"))?;
+        let port: u16 = port_str
+            .parse()
+            .with_context(|| format!("CONNECT port not a number — {port_str}"))?;
+        Ok(ParsedRequest::Connect {
+            host: host.trim_matches(['[', ']']).to_string(),
+            port,
+        })
+    } else {
+        Ok(ParsedRequest::Other {
+            method,
+            raw_request_line: line.to_string(),
+        })
+    }
+}
+
+async fn handle_connect(
+    mut client: TcpStream,
+    host: String,
+    port: u16,
+    policy: Arc<HostPolicy>,
+) -> Result<()> {
+    // Drain remaining client headers before deciding — RFC 7231
+    // requires consuming through the empty line. Use a fresh
+    // BufReader since `read_request_line` left us at the second
+    // line.
+    {
+        let mut reader = BufReader::new(&mut client);
+        drain_headers(&mut reader, 32 * 1024).await?;
+    }
+
+    // 1. Allowlist check on the hostname presented by the client.
+    let decision = policy.check(&host);
+    if let PolicyDecision::Denied(reason) = decision {
+        tracing::info!(host = %host, port, reason, "egress denied (allowlist)");
+        write_simple_status(&mut client, 403, "Forbidden", reason).await?;
+        return Ok(());
+    }
+
+    // 2. DNS-resolve and re-check the resolved address against the
+    //    denylist. This is the rebinding guard — even an
+    //    allowlisted hostname can't tunnel through to a private IP.
+    let target_addr = match resolve_first_public(&host, port).await {
+        Ok(addr) => addr,
+        Err(reason) => {
+            tracing::info!(host = %host, port, %reason, "egress denied (resolution)");
+            write_simple_status(&mut client, 403, "Forbidden", &reason).await?;
+            return Ok(());
+        }
+    };
+
+    // 3. Connect upstream.
+    let upstream = match TcpStream::connect(target_addr).await {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::warn!(host = %host, port, error = %err, "upstream connect failed");
+            write_simple_status(
+                &mut client,
+                502,
+                "Bad Gateway",
+                &format!("upstream connect failed: {err}"),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    // 4. Tell the client we're tunneling.
+    client
+        .write_all(b"HTTP/1.1 200 Connection established\r\n\r\n")
+        .await
+        .context("writing CONNECT 200")?;
+    client.flush().await.context("flushing CONNECT 200")?;
+
+    // 5. Bidirectional copy until either side closes. tokio's
+    //    `copy_bidirectional` handles half-close correctly.
+    let (mut client_read, mut client_write) = client.into_split();
+    let (mut upstream_read, mut upstream_write) = upstream.into_split();
+    let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
+    let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
+    tokio::select! {
+        _ = client_to_upstream => {},
+        _ = upstream_to_client => {},
+    }
+    tracing::debug!(host = %host, port, "tunnel closed");
+    Ok(())
+}
+
+/// Resolve `host:port` and return the first non-denied A/AAAA
+/// address. Returns an error reason string suitable for the 403
+/// body when nothing usable comes back.
+async fn resolve_first_public(host: &str, port: u16) -> Result<SocketAddr, String> {
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|err| format!("dns resolution failed: {err}"))?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err("dns returned no addresses".to_string());
+    }
+
+    for addr in &addrs {
+        if !denied_ip(addr.ip()) {
+            return Ok(*addr);
+        }
+    }
+    Err("dns returned only denied addresses (RFC1918, metadata, loopback, etc.)".to_string())
+}
+
+async fn write_simple_status(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+    body: &str,
+) -> Result<()> {
+    let response = format!(
+        "HTTP/1.1 {status} {reason}\r\n\
+         Content-Type: text/plain; charset=utf-8\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body}",
+        len = body.len()
+    );
+    stream.write_all(response.as_bytes()).await.context("writing status response")?;
+    stream.flush().await.context("flushing status response")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_connect_request() {
+        let parsed = parse_request_line("CONNECT api.stripe.com:443 HTTP/1.1").unwrap();
+        match parsed {
+            ParsedRequest::Connect { host, port } => {
+                assert_eq!(host, "api.stripe.com");
+                assert_eq!(port, 443);
+            }
+            other => panic!("expected Connect, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_connect_with_ipv6_brackets() {
+        // RFC 7230: IPv6 literals in CONNECT targets use brackets.
+        let parsed = parse_request_line("CONNECT [::1]:443 HTTP/1.1").unwrap();
+        match parsed {
+            ParsedRequest::Connect { host, port } => {
+                assert_eq!(host, "::1");
+                assert_eq!(port, 443);
+            }
+            other => panic!("expected Connect, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_get_request_returns_other() {
+        let parsed = parse_request_line("GET /healthz HTTP/1.1").unwrap();
+        assert!(matches!(parsed, ParsedRequest::Other { .. }));
+    }
+
+    #[test]
+    fn parse_connect_missing_port_errors() {
+        let result = parse_request_line("CONNECT api.stripe.com HTTP/1.1");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_request_line_lowercase_method() {
+        // Case-insensitive method match — tolerate `connect` from
+        // a misbehaved client.
+        let parsed = parse_request_line("connect host:1 HTTP/1.1").unwrap();
+        assert!(matches!(parsed, ParsedRequest::Connect { .. }));
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2: third process per Fly machine (RFC §5). New crate \`mockforge-plugin-egress\` provides an HTTP forward proxy that plugins reach via \`HTTP_PROXY\` env var. Sits alongside main mockforge and mockforge-plugin-host (#399/#400).

## Live smoke test (real curl + real upstream)
\`\`\`
$ curl --proxy http://127.0.0.1:8125 https://192.168.1.1/
  -> 403 (denied: reserved or internal IP range)
$ curl --proxy http://127.0.0.1:8125 https://169.254.169.254/
  -> 403 (denied: reserved or internal IP range)
$ curl --proxy http://127.0.0.1:8125 https://github.com/
  -> 403 (denied: host not in allowlist)
$ curl --proxy http://127.0.0.1:8125 https://example.com/
  -> 200 (allowed; real TLS handshake to real upstream)
\`\`\`

## Security checks per request (in order)
1. Hard denylist on hostname/IP from CONNECT target
2. Allowlist match against plugin's \`HostPolicy\`
3. DNS resolution + denylist re-check on resolved address (catches \`evil.example.com → 10.0.0.5\` rebinding)
4. Upstream connect; bidirectional copy on success

## What's blocked, regardless of allowlist
- **RFC1918**: 10/8, 172.16/12, 192.168/16
- **Loopback**: 127/8, ::1/128
- **Link-local**: 169.254/16 (covers 169.254.169.254 cloud metadata), fe80::/10
- **Unique-local v6**: fc00::/7
- **Hostnames**: \`metadata.google.internal\`, \`metadata.googleapis.com\`, \`instance-data.ec2.internal\`
- **Hostname suffixes**: \`.fly.dev\`, \`.mockforge.dev\`, \`.internal\`, \`.flycast\` (so plugins can't loop back to other tenants or to MockForge's own control plane)

## Allowlist patterns
- Exact: \`api.stripe.com\`
- Leading wildcard: \`*.stripe.com\` (matches \`api.stripe.com\`, \`events.stripe.com\`, etc. — does NOT match the apex \`stripe.com\` itself)
- Dotted-suffix comparison guards against \`evilstripe.com\` falsely matching \`*.stripe.com\`

## Configuration (env vars)
- \`MOCKFORGE_PLUGIN_EGRESS_LISTEN\` — bind address (default \`127.0.0.1:8125\`)
- \`MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST\` — comma-separated patterns
- \`MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE\` — file path, one pattern per line, \`#\` for comments
- No allowlist set = **deny-all** (correct fail-safe; the proxy logs a warning at startup)

## Out of scope for v1
- **Plain HTTP forwarding** — currently 405. CONNECT covers HTTPS, the dominant plugin egress shape. Adding plain HTTP requires a fuller HTTP parser; follow-up.
- **Live reload** — allowlist is read once at startup. The plugin-host (PR #400) needs to push attach/detach updates here. SIGHUP or admin-socket follow-up.
- **SNI-based policy** — RFC §5.4 explicitly accepts that once a host is allowed, body content is opaque. We don't MITM TLS.

## Test plan
- [x] \`cargo check -p mockforge-plugin-egress\`
- [x] \`cargo clippy -p mockforge-plugin-egress --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test -p mockforge-plugin-egress --lib\` — **27/27 pass**:
  - 11 denylist tests (RFC1918 boundaries, link-local, IPv6 variants, hostname suffixes, public bypass)
  - 11 policy tests (exact, wildcard, apex non-match, suffix rebinding, denylist override, malformed patterns)
  - 5 proxy tests (CONNECT parser including IPv6 brackets and case-insensitive method)
- [x] Live smoke test (above) confirmed end-to-end through real internet
- [x] Pre-commit hooks (clippy, typos, fmt, audit) — all passed