### PR TITLE
feat(cloud-plugins): production Dockerfile + multi-process entrypoint

### DIFF
--- a/Dockerfile.cloud-plugins
+++ b/Dockerfile.cloud-plugins
@@ -1,0 +1,111 @@
+# MockForge Cloud Plugins — multi-process container image.
+#
+# Bundles the three processes called for by the trust RFC §5 into
+# one container suitable for a Fly machine:
+#   - mockforge        (main, user-facing HTTP/admin)
+#   - mockforge-plugin-host (sidecar; owns the WASM runtime)
+#   - mockforge-plugin-egress (HTTP CONNECT proxy enforcing the
+#                              per-plugin allowlist)
+#
+# Use this image only on plugin-enabled hosted-mock deployments —
+# the existing mockforge:latest image (see ./Dockerfile) is still
+# correct for non-plugin deployments and stays smaller.
+#
+# Sizing per the build-vs-buy spike (#387) and the real-Fly
+# measurement (#398): this image needs at least
+# `shared-cpu-1x:512MB` for Pro tier and `shared-cpu-1x:1024MB`
+# for Team tier. See FlyioGuest::for_hosted_mock for the chooser.
+
+# ─── Stage 0: UI bundle ─────────────────────────────────────────────
+# Same pattern as the main Dockerfile — Vite + pnpm produce the
+# admin UI assets the Rust binary embeds.
+FROM node:22-slim AS ui-builder
+
+WORKDIR /ui
+RUN corepack enable
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+COPY crates/mockforge-ui/ui/package.json crates/mockforge-ui/ui/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY crates/mockforge-ui/ui/ ./
+RUN pnpm build
+
+# ─── Stage 1: Rust builder ──────────────────────────────────────────
+FROM rust:1.90-slim AS builder
+
+RUN apt-get update && apt-get install -y \
+        pkg-config \
+        libssl-dev \
+        protobuf-compiler \
+        build-essential \
+        g++ \
+        cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+# Strip the same workspace members the main Dockerfile strips —
+# they don't contribute to the runtime binaries.
+RUN sed -i '/\s*"test_openapi_demo"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"tests"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/\s*"desktop-app"\s*,\?\s*$/d' Cargo.toml && \
+    sed -i '/# Integration tests package/d' Cargo.toml
+
+COPY crates/ ./crates/
+COPY proto/ ./proto/
+COPY templates/ ./templates/
+
+# Copy the pre-built UI bundle into the position the Rust build
+# expects to embed it from.
+COPY --from=ui-builder /ui/dist ./crates/mockforge-ui/ui/dist
+
+# Build all three binaries in one cargo invocation so they share
+# the dependency graph cache.
+RUN cargo build --release \
+        --bin mockforge \
+        --bin mockforge-plugin-host \
+        --bin mockforge-plugin-egress
+
+# ─── Stage 2: Runtime image ─────────────────────────────────────────
+# Debian slim with just the libraries the binaries dlopen at
+# runtime + tini for PID 1 reaping. No build toolchain.
+FROM debian:trixie-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        tini \
+        ca-certificates \
+        libssl3 \
+        procps \
+        netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user for the runtime processes. tini stays root so it
+# can reap children regardless of UID; the application binaries
+# drop down to this UID via the entrypoint.
+RUN useradd --system --create-home --shell /sbin/nologin --uid 1000 mockforge
+
+# Copy the three binaries.
+COPY --from=builder /app/target/release/mockforge /usr/local/bin/mockforge
+COPY --from=builder /app/target/release/mockforge-plugin-host /usr/local/bin/mockforge-plugin-host
+COPY --from=builder /app/target/release/mockforge-plugin-egress /usr/local/bin/mockforge-plugin-egress
+
+# Entrypoint script orchestrates the three processes.
+COPY scripts/cloud-plugins-entrypoint.sh /usr/local/bin/cloud-plugins-entrypoint.sh
+RUN chmod +x /usr/local/bin/cloud-plugins-entrypoint.sh
+
+# Default plugin-host socket path lives under /run so it doesn't
+# pollute /tmp and is auto-created with appropriate perms.
+RUN mkdir -p /run/mockforge && chown mockforge:mockforge /run/mockforge
+
+# Expose the standard mockforge ports. The egress proxy stays on
+# loopback (it's only meant for the plugin-host, not external
+# callers) so we don't expose it.
+EXPOSE 3000 3001 9080
+
+# Health check — main mockforge's admin liveness endpoint covers
+# all three because the entrypoint takes the whole container down
+# if any child dies.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD nc -z 127.0.0.1 9080 || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/cloud-plugins-entrypoint.sh"]

--- a/scripts/cloud-plugins-entrypoint.sh
+++ b/scripts/cloud-plugins-entrypoint.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# Cloud Plugins multi-process entrypoint.
+#
+# Starts main mockforge + plugin-host sidecar + egress proxy
+# under tini PID 1, traps SIGTERM, kills all children if any
+# child exits unexpectedly so Fly restarts the machine cleanly.
+#
+# Mirrors the architecture validated in PR #397 (the sidecar
+# spike) but with real Rust binaries instead of the Python stub.
+# tini handles PID 1 reaping; this script is the supervisor.
+#
+# Process roles:
+#   main          — the user-facing mockforge (HTTP, admin UI,
+#                   gRPC, etc.). Reads plugin-enabled config from
+#                   env vars.
+#   plugin-host   — Wasmtime sidecar. Listens on the Unix socket;
+#                   loads/invokes WASM plugins on behalf of main.
+#   egress-proxy  — HTTP CONNECT proxy on loopback. Plugins reach
+#                   the internet only via HTTP_PROXY pointed here.
+
+set -eu
+
+# ─── Configurable defaults ─────────────────────────────────────────
+PLUGIN_HOST_SOCKET="${MOCKFORGE_PLUGIN_HOST_SOCKET:-/run/mockforge/plugin-host.sock}"
+EGRESS_LISTEN="${MOCKFORGE_PLUGIN_EGRESS_LISTEN:-127.0.0.1:8125}"
+
+# Make sure the plugin-host's Unix socket directory exists with
+# the right ownership before either process tries to bind.
+PLUGIN_HOST_SOCKET_DIR="$(dirname "$PLUGIN_HOST_SOCKET")"
+mkdir -p "$PLUGIN_HOST_SOCKET_DIR"
+chown mockforge:mockforge "$PLUGIN_HOST_SOCKET_DIR" 2>/dev/null || true
+
+cleanup() {
+    echo "[cloud-plugins-entrypoint] received signal — terminating children" >&2
+    if [ -n "${MAIN_PID:-}" ]; then
+        kill -TERM "$MAIN_PID" 2>/dev/null || true
+    fi
+    if [ -n "${PLUGIN_HOST_PID:-}" ]; then
+        kill -TERM "$PLUGIN_HOST_PID" 2>/dev/null || true
+    fi
+    if [ -n "${EGRESS_PID:-}" ]; then
+        kill -TERM "$EGRESS_PID" 2>/dev/null || true
+    fi
+    wait
+    exit 0
+}
+trap cleanup TERM INT HUP
+
+# ─── Start order ──────────────────────────────────────────────────
+# Egress proxy first — main and plugin-host both depend on it
+# being up before they accept user traffic.
+echo "[cloud-plugins-entrypoint] starting egress proxy on $EGRESS_LISTEN" >&2
+MOCKFORGE_PLUGIN_EGRESS_LISTEN="$EGRESS_LISTEN" \
+    su mockforge -s /bin/sh -c '/usr/local/bin/mockforge-plugin-egress' &
+EGRESS_PID=$!
+
+# Plugin host next so main can connect to its socket on first
+# request. Brief stagger to avoid disk-read contention.
+sleep 1
+echo "[cloud-plugins-entrypoint] starting plugin-host on $PLUGIN_HOST_SOCKET" >&2
+MOCKFORGE_PLUGIN_HOST_SOCKET="$PLUGIN_HOST_SOCKET" \
+    su mockforge -s /bin/sh -c '/usr/local/bin/mockforge-plugin-host' &
+PLUGIN_HOST_PID=$!
+
+# Wait for the plugin-host socket to actually appear before
+# starting main — main's request handler will try to dial it on
+# the first plugin invocation, and a missing socket = 503 stamp.
+WAIT_TRIES=0
+while [ ! -S "$PLUGIN_HOST_SOCKET" ] && [ "$WAIT_TRIES" -lt 50 ]; do
+    sleep 0.2
+    WAIT_TRIES=$((WAIT_TRIES + 1))
+done
+if [ ! -S "$PLUGIN_HOST_SOCKET" ]; then
+    echo "[cloud-plugins-entrypoint] plugin-host socket failed to appear at $PLUGIN_HOST_SOCKET" >&2
+    cleanup
+fi
+
+# Finally main. Default args are appropriate for hosted-mock
+# deployments (admin UI, all protocols enabled). Operators can
+# override the entrypoint or pass extra args via the COMMAND.
+echo "[cloud-plugins-entrypoint] starting main mockforge" >&2
+su mockforge -s /bin/sh -c '/usr/local/bin/mockforge serve --admin' &
+MAIN_PID=$!
+
+echo "[cloud-plugins-entrypoint] all children up — main=$MAIN_PID host=$PLUGIN_HOST_PID egress=$EGRESS_PID" >&2
+
+# Wait for any child to exit. If any of the three dies, take
+# them all down — Fly restarts the whole machine, which is the
+# correct response to a partial failure: we can't run plugins
+# without all three processes alive.
+while kill -0 "$MAIN_PID" 2>/dev/null \
+   && kill -0 "$PLUGIN_HOST_PID" 2>/dev/null \
+   && kill -0 "$EGRESS_PID" 2>/dev/null; do
+    sleep 5
+done
+
+echo "[cloud-plugins-entrypoint] one child exited — tearing down" >&2
+cleanup


### PR DESCRIPTION
## Summary
Phase 2 deployment piece. Packages all three runtime binaries — main mockforge, mockforge-plugin-host (#400), mockforge-plugin-egress (#401) — into one container suitable for a Fly machine.

## Files
- **\`Dockerfile.cloud-plugins\`** — multi-stage build:
  - Stage 0: Vite + pnpm UI bundle (matches the main Dockerfile)
  - Stage 1: \`cargo build --release\` for all 3 binaries in one invocation so they share the dep-graph cache
  - Stage 2: \`debian:trixie-slim\` runtime with tini, ca-certs, libssl3, procps, netcat. Non-root \`mockforge\` user (uid 1000). Health check via netcat against admin port.
- **\`scripts/cloud-plugins-entrypoint.sh\`** — supervisor script under tini PID 1. Start order: egress proxy → plugin-host (waits for socket to appear) → main mockforge. SIGTERM trap cascades; if any child exits, all three come down so Fly restarts the whole machine.

## Why one container, not three
Per the build-vs-buy spike (#387) and sidecar Fly proof (#397/#398), the three processes share a Fly microVM rather than running as separate machines: same trust boundary (one tenant per machine), simpler ops (one deploy unit), shared kernel page cache for the binaries.

## Why this image is separate from the existing Dockerfile
Non-plugin-enabled hosted-mocks should keep using the existing \`mockforge:latest\` image (smaller, no extra processes). The orchestrator (\`FlyioMachineConfig\` + \`FlyioGuest::for_hosted_mock\` from #398) picks which image to deploy based on whether the deployment has any plugins attached.

## Sizing
Per the trust RFC (#386) and real-Fly measurements (#398):
- Pro tier with plugins: \`shared-cpu-1x:512MB\`
- Team tier with plugins: \`shared-cpu-1x:1024MB\`

Tier-aware sizing already lives in \`FlyioGuest::for_hosted_mock\`.

## Test plan
- [x] \`sh -n cloud-plugins-entrypoint.sh\` — shell syntax clean
- [x] Dockerfile structure mirrors existing \`./Dockerfile\` so the build pattern is known-good
- [x] Pre-commit hooks (executable-bit, line-endings, typos) — passed
- [ ] Actual \`docker build\` — skipped here (10+ min full-workspace compile). Real build is the next operational check when we wire this into the orchestrator's image picker (separate PR).

## What's next
- Wire \`FlyioMachineConfig::image\` to pick this image when plugins are attached (pairs with \`FlyioGuest::for_hosted_mock\`)
- Live reload: SIGHUP path on egress-proxy so plugin-host can push allowlist updates
- Cosign signature verification at LoadPlugin time
- Kill-switch blocklist poll
- OTLP exporter wiring \`InvocationMetricsBus\` → cloud aggregator