### PR TITLE
feat(plugin-host): Ed25519 signature verification at LoadPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8601,6 +8601,7 @@ version = "0.3.126"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "ed25519-dalek",
  "mockforge-plugin-core",
  "mockforge-plugin-loader",
  "serde",

--- a/crates/mockforge-plugin-host/Cargo.toml
+++ b/crates/mockforge-plugin-host/Cargo.toml
@@ -59,5 +59,11 @@ uuid = { workspace = true, features = ["serde"] }
 base64 = "0.22"
 tempfile = "3"
 
+# Ed25519 signature verification on the WASM bytes (RFC §7.2 step 3).
+# Matches the scheme used by the registry's UserPublicKey +
+# verify_sbom_attestation so trust roots can be shared once the
+# registry-fetch path lands.
+ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/mockforge-plugin-host/src/handlers.rs
+++ b/crates/mockforge-plugin-host/src/handlers.rs
@@ -23,6 +23,8 @@ pub async fn handle(host: &Host, request: Request) -> Response {
             version,
             permissions,
             wasm_b64,
+            signature_b64,
+            publisher_key_id,
         } => {
             let bytes = match base64::engine::general_purpose::STANDARD.decode(wasm_b64.as_bytes())
             {
@@ -35,7 +37,17 @@ pub async fn handle(host: &Host, request: Request) -> Response {
                     };
                 }
             };
-            match host.load_plugin(&plugin_name, &version, permissions, bytes).await {
+            match host
+                .load_plugin(
+                    &plugin_name,
+                    &version,
+                    permissions,
+                    bytes,
+                    signature_b64,
+                    publisher_key_id,
+                )
+                .await
+            {
                 Ok(plugin_id) => Response::Ok {
                     id,
                     body: serde_json::json!({
@@ -113,11 +125,18 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let (host, actor) = Host::new(PluginLoaderConfig {
-                allow_unsigned: true,
-                skip_wasm_validation: true,
-                ..Default::default()
-            });
+            let verifier = crate::signing::SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Optional,
+            );
+            let (host, actor) = Host::new(
+                PluginLoaderConfig {
+                    allow_unsigned: true,
+                    skip_wasm_validation: true,
+                    ..Default::default()
+                },
+                verifier,
+            );
             tokio::select! {
                 result = body(host) => result,
                 _ = actor => panic!("actor exited before test body finished"),
@@ -146,6 +165,8 @@ mod tests {
                     version: "1.0.0".into(),
                     permissions: serde_json::json!({}),
                     wasm_b64: b64_minimal(),
+                    signature_b64: None,
+                    publisher_key_id: None,
                 },
             )
             .await;
@@ -188,6 +209,8 @@ mod tests {
                     version: "1.0.0".into(),
                     permissions: serde_json::json!({}),
                     wasm_b64: "not-valid-base64-!!!".into(),
+                    signature_b64: None,
+                    publisher_key_id: None,
                 },
             )
             .await;
@@ -212,6 +235,8 @@ mod tests {
                 version: "1.0.0".into(),
                 permissions: serde_json::json!({}),
                 wasm_b64: b64_minimal(),
+                signature_b64: None,
+                publisher_key_id: None,
             };
             let _first = handle(&host, make_load(Uuid::new_v4())).await;
             let second = handle(&host, make_load(Uuid::new_v4())).await;
@@ -280,6 +305,8 @@ mod tests {
                     version: "1.0.0".into(),
                     permissions: serde_json::json!({}),
                     wasm_b64: b64_minimal(),
+                    signature_b64: None,
+                    publisher_key_id: None,
                 },
             )
             .await;

--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -29,6 +29,8 @@ use mockforge_plugin_loader::{
 };
 use tokio::sync::{mpsc, oneshot};
 
+use crate::signing::{SignatureVerifier, VerificationError};
+
 /// Actor channel capacity. Generous because cloud-plugins ops are
 /// rare (load/unload at attach time, invoke once per request) and
 /// the cost of dropping is high (request gets a 503).
@@ -83,11 +85,23 @@ impl Host {
     /// Construct a new host. Returns the handle (cheap to clone,
     /// shareable across spawned connection tasks) and the actor
     /// future the caller must drive on the current task.
-    pub fn new(loader_config: PluginLoaderConfig) -> (Self, HostActor) {
+    ///
+    /// The verifier is consulted on every LoadPlugin to enforce
+    /// the policy from `cloud-trust-permissions-rfc.md` §7.2 step
+    /// 3. Pass [`SignatureVerifier::new(TrustStore::new(),
+    /// SignatureMode::Optional)`] for the loosest behavior — the
+    /// existing test fixtures use that to keep the tests focused
+    /// on lifecycle rather than signing.
+    ///
+    /// [`SignatureVerifier::new(TrustStore::new(), SignatureMode::Optional)`]: crate::signing::SignatureVerifier::new
+    pub fn new(
+        loader_config: PluginLoaderConfig,
+        verifier: SignatureVerifier,
+    ) -> (Self, HostActor) {
         let (cmd_tx, cmd_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let started_at = Arc::new(Instant::now());
 
-        let actor: HostActor = Box::pin(actor_loop(loader_config, cmd_rx));
+        let actor: HostActor = Box::pin(actor_loop(loader_config, verifier, cmd_rx));
 
         (Self { started_at, cmd_tx }, actor)
     }
@@ -101,12 +115,19 @@ impl Host {
     /// to a tempfile inside the actor so the loader (which takes a
     /// filesystem path) can `Module::from_file` it. Returns the
     /// loaded plugin's `PluginId` on success.
+    ///
+    /// The actor verifies the signature (if any) against its
+    /// `SignatureVerifier` before any bytes touch the loader.
+    /// `signature_b64` and `publisher_key_id` must be passed
+    /// together or both `None`.
     pub async fn load_plugin(
         &self,
         plugin_name: &str,
         version_str: &str,
         permissions: serde_json::Value,
         wasm_bytes: Vec<u8>,
+        signature_b64: Option<String>,
+        publisher_key_id: Option<String>,
     ) -> Result<PluginId, HostError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx
@@ -115,6 +136,8 @@ impl Host {
                 version: version_str.to_string(),
                 permissions,
                 wasm_bytes,
+                signature_b64,
+                publisher_key_id,
                 reply: reply_tx,
             })
             .await
@@ -176,6 +199,8 @@ enum Command {
         version: String,
         permissions: serde_json::Value,
         wasm_bytes: Vec<u8>,
+        signature_b64: Option<String>,
+        publisher_key_id: Option<String>,
         reply: oneshot::Sender<Result<PluginId, HostError>>,
     },
     Unload {
@@ -196,9 +221,18 @@ enum Command {
 /// Actor task. Owns the `PluginSandbox` and the plugin map for the
 /// lifetime of the host process. Returns when the channel closes
 /// (all `Host` handles dropped) or the runtime shuts down.
-async fn actor_loop(loader_config: PluginLoaderConfig, mut cmd_rx: mpsc::Receiver<Command>) {
+async fn actor_loop(
+    loader_config: PluginLoaderConfig,
+    verifier: SignatureVerifier,
+    mut cmd_rx: mpsc::Receiver<Command>,
+) {
     let sandbox = PluginSandbox::new(loader_config);
     let mut plugins: HashMap<String, PluginEntry> = HashMap::new();
+    tracing::info!(
+        mode = ?verifier.mode(),
+        trusted_keys = verifier.trusted_key_count(),
+        "plugin-host actor started"
+    );
 
     while let Some(cmd) = cmd_rx.recv().await {
         match cmd {
@@ -207,15 +241,20 @@ async fn actor_loop(loader_config: PluginLoaderConfig, mut cmd_rx: mpsc::Receive
                 version,
                 permissions,
                 wasm_bytes,
+                signature_b64,
+                publisher_key_id,
                 reply,
             } => {
                 let result = handle_load(
                     &sandbox,
+                    &verifier,
                     &mut plugins,
                     &plugin_name,
                     &version,
                     permissions,
                     wasm_bytes,
+                    signature_b64.as_deref(),
+                    publisher_key_id.as_deref(),
                 )
                 .await;
                 let _ = reply.send(result);
@@ -247,14 +286,38 @@ async fn actor_loop(loader_config: PluginLoaderConfig, mut cmd_rx: mpsc::Receive
     tracing::info!("plugin-host actor exiting (channel closed)");
 }
 
+// Many arguments because the function is the
+// destructured-Command equivalent — splitting into a struct
+// would just shift names around without saving a line.
+#[allow(clippy::too_many_arguments)]
 async fn handle_load(
     sandbox: &PluginSandbox,
+    verifier: &SignatureVerifier,
     plugins: &mut HashMap<String, PluginEntry>,
     plugin_name: &str,
     version_str: &str,
     permissions: serde_json::Value,
     wasm_bytes: Vec<u8>,
+    signature_b64: Option<&str>,
+    publisher_key_id: Option<&str>,
 ) -> Result<PluginId, HostError> {
+    // Verify the signature *before* the loader sees the bytes.
+    // Bypass-via-loader-bug is impossible if the bytes never
+    // reach the loader on a verification failure.
+    let outcome = verifier.verify(&wasm_bytes, signature_b64, publisher_key_id)?;
+    match &outcome {
+        crate::signing::VerificationOutcome::Verified { key_id } => {
+            tracing::info!(plugin_name, version = version_str, key_id, "plugin signature verified");
+        }
+        crate::signing::VerificationOutcome::SkippedUnsigned => {
+            tracing::warn!(
+                plugin_name,
+                version = version_str,
+                "plugin loaded without signature (Optional mode)"
+            );
+        }
+    }
+
     if plugins.contains_key(plugin_name) {
         return Err(HostError::AlreadyLoaded {
             plugin_name: plugin_name.to_string(),
@@ -389,6 +452,9 @@ pub enum HostError {
     /// Base64-decode of the WASM bytes failed.
     #[error("invalid base64 wasm: {0}")]
     Base64(#[from] base64::DecodeError),
+    /// Signature verification rejected the load.
+    #[error("signature verification failed: {0}")]
+    Signature(#[from] VerificationError),
     /// The actor task is gone — likely runtime shutdown or a
     /// panic in the actor. Caller should reconnect.
     #[error("plugin-host actor task is no longer running")]
@@ -406,6 +472,9 @@ impl HostError {
             HostError::Loader(_) => "loader_error",
             HostError::PluginExecution { .. } => "plugin_execution_error",
             HostError::Base64(_) => "invalid_base64",
+            // Forward the verifier's specific code so callers can
+            // distinguish "missing signature" from "wrong key" etc.
+            HostError::Signature(err) => err.code(),
             HostError::ActorGone => "actor_gone",
         }
     }
@@ -460,7 +529,11 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let (host, actor) = Host::new(loader_config());
+            let verifier = SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Optional,
+            );
+            let (host, actor) = Host::new(loader_config(), verifier);
             tokio::select! {
                 result = body(host) => result,
                 _ = actor => panic!("actor exited before test body finished"),
@@ -471,9 +544,16 @@ mod tests {
     #[test]
     fn load_plugin_then_list_returns_one_entry() {
         run_with_actor(|host| async move {
-            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
-                .await
-                .unwrap();
+            host.load_plugin(
+                "test-plugin",
+                "1.0.0",
+                serde_json::json!({}),
+                minimal_wasm(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             let loaded = host.loaded_plugins().await.unwrap();
             assert_eq!(loaded.len(), 1);
             assert_eq!(loaded[0].0, "test-plugin");
@@ -483,11 +563,25 @@ mod tests {
     #[test]
     fn load_plugin_twice_returns_already_loaded() {
         run_with_actor(|host| async move {
-            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
-                .await
-                .unwrap();
+            host.load_plugin(
+                "test-plugin",
+                "1.0.0",
+                serde_json::json!({}),
+                minimal_wasm(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             let err = host
-                .load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .load_plugin(
+                    "test-plugin",
+                    "1.0.0",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    None,
+                    None,
+                )
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), "already_loaded");
@@ -497,9 +591,16 @@ mod tests {
     #[test]
     fn unload_plugin_removes_entry() {
         run_with_actor(|host| async move {
-            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
-                .await
-                .unwrap();
+            host.load_plugin(
+                "test-plugin",
+                "1.0.0",
+                serde_json::json!({}),
+                minimal_wasm(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             let detached = host.unload_plugin("test-plugin").await.unwrap();
             assert!(detached);
             assert!(host.loaded_plugins().await.unwrap().is_empty());
@@ -522,11 +623,79 @@ mod tests {
         });
     }
 
+    /// Drive a Host wired to a Required-mode verifier so we can
+    /// observe end-to-end signature-rejection behavior.
+    fn run_with_required_actor<F, T>(body: impl FnOnce(Host) -> F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let verifier = SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Required,
+            );
+            let (host, actor) = Host::new(loader_config(), verifier);
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+            }
+        })
+    }
+
+    #[test]
+    fn load_in_required_mode_without_signature_is_rejected() {
+        run_with_required_actor(|host| async move {
+            let err = host
+                .load_plugin(
+                    "test-plugin",
+                    "1.0.0",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "signature_required");
+        });
+    }
+
+    #[test]
+    fn load_in_required_mode_with_unknown_publisher_key_is_rejected() {
+        run_with_required_actor(|host| async move {
+            // 64 zero bytes — base64-encoded — is the right shape
+            // for an Ed25519 signature, but the publisher_key_id
+            // isn't in the (empty) trust store.
+            use base64::Engine;
+            let sig_b64 = base64::engine::general_purpose::STANDARD.encode([0u8; 64]);
+            let err = host
+                .load_plugin(
+                    "test-plugin",
+                    "1.0.0",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    Some(sig_b64),
+                    Some("unknown-key".to_string()),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "unknown_publisher_key");
+        });
+    }
+
     #[test]
     fn load_with_invalid_version_returns_invalid_version() {
         run_with_actor(|host| async move {
             let err = host
-                .load_plugin("test-plugin", "not-a-version", serde_json::json!({}), minimal_wasm())
+                .load_plugin(
+                    "test-plugin",
+                    "not-a-version",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    None,
+                    None,
+                )
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), "invalid_version");

--- a/crates/mockforge-plugin-host/src/lib.rs
+++ b/crates/mockforge-plugin-host/src/lib.rs
@@ -38,7 +38,12 @@ pub mod handlers;
 pub mod host;
 pub mod protocol;
 pub mod server;
+pub mod signing;
 
 pub use host::{Host, HostActor, HostError};
 pub use protocol::{Request, Response};
 pub use server::{run_server, ServerConfig};
+pub use signing::{
+    SignatureMode, SignatureVerifier, TrustStore, TrustStoreError, VerificationError,
+    VerificationOutcome,
+};

--- a/crates/mockforge-plugin-host/src/main.rs
+++ b/crates/mockforge-plugin-host/src/main.rs
@@ -21,7 +21,9 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use mockforge_plugin_host::{run_server, Host, ServerConfig};
+use mockforge_plugin_host::{
+    run_server, Host, ServerConfig, SignatureMode, SignatureVerifier, TrustStore,
+};
 use mockforge_plugin_loader::PluginLoaderConfig;
 
 const DEFAULT_SOCKET_PATH: &str = "/tmp/plugin-host.sock";
@@ -34,10 +36,15 @@ fn main() -> Result<()> {
         socket_path: env_socket_path()?,
         socket_mode: env_socket_mode()?,
     };
+    let trust_store = env_trust_store()?;
+    let signature_mode = env_signature_mode();
+    let verifier = SignatureVerifier::new(trust_store, signature_mode);
 
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         socket = %config.socket_path.display(),
+        signature_mode = ?signature_mode,
+        trusted_keys = verifier.trusted_key_count(),
         "mockforge-plugin-host starting"
     );
 
@@ -50,7 +57,7 @@ fn main() -> Result<()> {
         .context("building Tokio current-thread runtime")?;
 
     rt.block_on(async move {
-        let (host, actor) = Host::new(PluginLoaderConfig::default());
+        let (host, actor) = Host::new(PluginLoaderConfig::default(), verifier);
 
         // Drive actor + server + shutdown_signal concurrently. The
         // actor owns the !Send sandbox; the server fans connections
@@ -111,6 +118,46 @@ fn env_socket_mode() -> Result<u32> {
                 .with_context(|| format!("parsing MOCKFORGE_PLUGIN_HOST_SOCKET_MODE={}", s))
         }
         Err(_) => Ok(DEFAULT_SOCKET_MODE),
+    }
+}
+
+/// Read the trust store from one of:
+///
+/// - `MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS_FILE` (path to JSON file)
+/// - `MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS` (inline JSON)
+///
+/// or return an empty store if neither is set. The store is a
+/// JSON object `{ "publisher-id": "<base64-pubkey>", ... }`.
+fn env_trust_store() -> Result<TrustStore> {
+    if let Ok(path) = std::env::var("MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS_FILE") {
+        return TrustStore::from_file(std::path::Path::new(&path)).map_err(anyhow::Error::from);
+    }
+    if let Ok(inline) = std::env::var("MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS") {
+        return TrustStore::from_json_str(&inline).map_err(anyhow::Error::from);
+    }
+    Ok(TrustStore::new())
+}
+
+/// Read `MOCKFORGE_PLUGIN_HOST_SIGNATURE_MODE` (`required` |
+/// `optional`). Cloud production sets this to `required` via the
+/// orchestrator's env var; self-hosted leaves it unset and gets
+/// the default (`optional`).
+fn env_signature_mode() -> SignatureMode {
+    match std::env::var("MOCKFORGE_PLUGIN_HOST_SIGNATURE_MODE")
+        .ok()
+        .map(|s| s.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("required") => SignatureMode::Required,
+        Some("optional") => SignatureMode::Optional,
+        Some(other) => {
+            tracing::warn!(
+                value = other,
+                "unrecognized MOCKFORGE_PLUGIN_HOST_SIGNATURE_MODE; falling back to Optional"
+            );
+            SignatureMode::Optional
+        }
+        None => SignatureMode::Optional,
     }
 }
 

--- a/crates/mockforge-plugin-host/src/protocol.rs
+++ b/crates/mockforge-plugin-host/src/protocol.rs
@@ -33,12 +33,15 @@ pub enum Request {
     },
     /// Load a WASM plugin into a fresh `Store`.
     ///
-    /// In v1 the WASM bytes are inlined as base64 in the request.
-    /// The follow-up "registry fetch" path will replace this with a
-    /// `download_url` field that the host fetches itself, so
-    /// signature verification can happen before any bytes touch
-    /// the loader. Until then, the caller is expected to verify
-    /// signatures upstream.
+    /// The optional `signature_b64` + `publisher_key_id` fields
+    /// carry an Ed25519 signature over `wasm_bytes` (the decoded
+    /// `wasm_b64`). Whether they're required is governed by the
+    /// host's `SignatureMode`:
+    ///   - `Required` (cloud default): both fields must be present
+    ///     and the signature must verify against an active trust
+    ///     root, or the load is rejected.
+    ///   - `Optional` (self-hosted/dev): unsigned loads are
+    ///     allowed (and logged).
     LoadPlugin {
         /// Correlation id.
         id: Uuid,
@@ -55,6 +58,16 @@ pub enum Request {
         permissions: serde_json::Value,
         /// Base64-encoded WASM module bytes.
         wasm_b64: String,
+        /// Base64-encoded Ed25519 signature over the decoded WASM
+        /// bytes (64 bytes raw, ~88 chars after base64). Required
+        /// in cloud mode. Pairs with `publisher_key_id`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature_b64: Option<String>,
+        /// Trust-root id naming the public key the signature is
+        /// expected to verify against. Pairs with
+        /// `signature_b64` — both or neither.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        publisher_key_id: Option<String>,
     },
     /// Detach a plugin and free its sandbox.
     UnloadPlugin {
@@ -166,6 +179,8 @@ mod tests {
                 "egress": { "allow": ["*.stripe.com"] }
             }),
             wasm_b64: "AGFzbQEAAAA=".into(), // empty WASM module
+            signature_b64: None,
+            publisher_key_id: None,
         };
         let bytes = serde_json::to_vec(&req).unwrap();
         let parsed: Request = serde_json::from_slice(&bytes).unwrap();
@@ -175,15 +190,64 @@ mod tests {
                 version,
                 permissions,
                 wasm_b64,
+                signature_b64,
+                publisher_key_id,
                 ..
             } => {
                 assert_eq!(plugin_name, "stripe-rewriter");
                 assert_eq!(version, "1.2.3");
                 assert!(permissions.get("egress").is_some());
                 assert_eq!(wasm_b64, "AGFzbQEAAAA=");
+                assert!(signature_b64.is_none());
+                assert!(publisher_key_id.is_none());
             }
             other => panic!("expected LoadPlugin, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn load_plugin_request_with_signature_round_trips() {
+        let req = Request::LoadPlugin {
+            id: Uuid::new_v4(),
+            plugin_name: "p".into(),
+            version: "1.0.0".into(),
+            permissions: serde_json::json!({}),
+            wasm_b64: "AGFzbQEAAAA=".into(),
+            signature_b64: Some("BBBB".repeat(22)), // 88-char base64-shaped value
+            publisher_key_id: Some("publisher-1".into()),
+        };
+        let bytes = serde_json::to_vec(&req).unwrap();
+        let parsed: Request = serde_json::from_slice(&bytes).unwrap();
+        match parsed {
+            Request::LoadPlugin {
+                signature_b64,
+                publisher_key_id,
+                ..
+            } => {
+                assert!(signature_b64.is_some());
+                assert_eq!(publisher_key_id.as_deref(), Some("publisher-1"));
+            }
+            other => panic!("expected LoadPlugin, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn load_plugin_request_signature_fields_omitted_when_none() {
+        let req = Request::LoadPlugin {
+            id: Uuid::new_v4(),
+            plugin_name: "p".into(),
+            version: "1.0.0".into(),
+            permissions: serde_json::json!({}),
+            wasm_b64: "AGFzbQEAAAA=".into(),
+            signature_b64: None,
+            publisher_key_id: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        // skip_serializing_if drops the keys entirely so older
+        // wire-format consumers (and the `nc -U` debug path)
+        // don't see surprising `null`s.
+        assert!(!json.contains("signature_b64"), "expected omitted, got {}", json);
+        assert!(!json.contains("publisher_key_id"));
     }
 
     #[test]

--- a/crates/mockforge-plugin-host/src/server.rs
+++ b/crates/mockforge-plugin-host/src/server.rs
@@ -155,7 +155,11 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let (host, actor) = Host::new(PluginLoaderConfig::default());
+            let verifier = crate::signing::SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Optional,
+            );
+            let (host, actor) = Host::new(PluginLoaderConfig::default(), verifier);
             let server_host = host.clone();
             tokio::select! {
                 result = body(host) => result,

--- a/crates/mockforge-plugin-host/src/signing.rs
+++ b/crates/mockforge-plugin-host/src/signing.rs
@@ -1,0 +1,488 @@
+//! Ed25519 signature verification for cloud plugins.
+//!
+//! Implements RFC §7.2 step 3 — runtime verification at LoadPlugin
+//! time. The publish-time check (§7.2 step 1) and the attach-time
+//! check (§7.2 step 2) are upstream concerns; this is the last
+//! line of defense before the WASM bytes touch the loader.
+//!
+//! ## Trust roots
+//!
+//! Trust is configured via [`TrustStore`]: a map from publisher
+//! key id (string) to Ed25519 public key (32 bytes). The host
+//! reads this from one of:
+//!
+//!   - `MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS` — JSON object like
+//!     `{"publisher-1": "<base64-pubkey>", ...}` inline
+//!   - `MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS_FILE` — same JSON in
+//!     a file
+//!
+//! Empty trust store → reject every signed plugin. Combined with
+//! [`SignatureMode::Required`] the proxy is fail-safe by default.
+//!
+//! ## Modes
+//!
+//! - [`SignatureMode::Required`] — every LoadPlugin must carry a
+//!   valid signature against an active trust root. Default for
+//!   cloud deployments.
+//! - [`SignatureMode::Optional`] — LoadPlugin without a signature
+//!   is allowed (but logged). Default for self-hosted / dev. The
+//!   plugin-host bin currently flips to Required in cloud mode
+//!   via env var; see `main.rs`.
+//!
+//! ## Signed payload
+//!
+//! Signature is over the **WASM bytes alone** — the canonical hash
+//! used for storage and signing. We don't include the manifest in
+//! the signed payload yet; that's a Phase 2 follow-up that pairs
+//! with fetching the real manifest from the registry instead of
+//! using the synthetic one in `host.rs::build_synthetic_manifest`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use base64::Engine;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+/// What signature policy the host enforces at LoadPlugin time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SignatureMode {
+    /// Every LoadPlugin must carry `(signature_b64, publisher_key_id)`
+    /// and the signature must verify against an active trust root.
+    /// Cloud-mode default.
+    Required,
+    /// LoadPlugin without a signature is allowed (and logged).
+    /// Self-hosted / dev default — preserves the current OSS
+    /// behavior of accepting unsigned plugins for local
+    /// development. Default so a stub deployment that forgets to
+    /// configure trust roots can still load a plugin; cloud
+    /// production explicitly sets Required.
+    #[default]
+    Optional,
+}
+
+/// Map from publisher key id → 32-byte Ed25519 public key.
+#[derive(Debug, Clone, Default)]
+pub struct TrustStore {
+    keys: HashMap<String, VerifyingKey>,
+}
+
+impl TrustStore {
+    /// Build an empty trust store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of currently-active trust roots.
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// Whether this store has any trust roots.
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    /// Insert a key. Returns the previous binding for `key_id` if
+    /// any (rotation case).
+    pub fn insert(&mut self, key_id: String, key: VerifyingKey) -> Option<VerifyingKey> {
+        self.keys.insert(key_id, key)
+    }
+
+    /// Look up a key by id.
+    pub fn get(&self, key_id: &str) -> Option<&VerifyingKey> {
+        self.keys.get(key_id)
+    }
+
+    /// Build from a JSON object `{ "key_id": "<base64-pubkey>", ... }`.
+    pub fn from_json_str(json: &str) -> Result<Self, TrustStoreError> {
+        let raw: HashMap<String, String> =
+            serde_json::from_str(json).map_err(|err| TrustStoreError::InvalidJson {
+                err: err.to_string(),
+            })?;
+        let mut store = Self::new();
+        for (key_id, b64_value) in raw {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(b64_value.as_bytes())
+                .map_err(|err| TrustStoreError::InvalidBase64 {
+                    key_id: key_id.clone(),
+                    err: err.to_string(),
+                })?;
+            let key_bytes: [u8; 32] =
+                bytes.as_slice().try_into().map_err(|_| TrustStoreError::InvalidKeyLength {
+                    key_id: key_id.clone(),
+                    actual_bytes: bytes.len(),
+                })?;
+            let key = VerifyingKey::from_bytes(&key_bytes).map_err(|err| {
+                TrustStoreError::InvalidKey {
+                    key_id: key_id.clone(),
+                    err: err.to_string(),
+                }
+            })?;
+            store.insert(key_id, key);
+        }
+        Ok(store)
+    }
+
+    /// Read trust roots from a file containing the same JSON shape
+    /// as [`from_json_str`].
+    pub fn from_file(path: &Path) -> Result<Self, TrustStoreError> {
+        let contents = std::fs::read_to_string(path).map_err(|err| TrustStoreError::Io {
+            what: "reading trust store file",
+            err: err.to_string(),
+        })?;
+        Self::from_json_str(&contents)
+    }
+}
+
+/// Errors building a trust store from external input.
+#[derive(Debug, thiserror::Error)]
+pub enum TrustStoreError {
+    /// The JSON didn't parse as `{string: string}`.
+    #[error("trust store JSON failed to parse: {err}")]
+    InvalidJson {
+        /// Parser error detail.
+        err: String,
+    },
+    /// A value wasn't valid base64.
+    #[error("trust store key '{key_id}' has invalid base64: {err}")]
+    InvalidBase64 {
+        /// The key id that failed.
+        key_id: String,
+        /// Decode error detail.
+        err: String,
+    },
+    /// A decoded key wasn't 32 bytes.
+    #[error("trust store key '{key_id}' is {actual_bytes} bytes; expected 32")]
+    InvalidKeyLength {
+        /// The key id that failed.
+        key_id: String,
+        /// Actual byte length seen.
+        actual_bytes: usize,
+    },
+    /// The 32 bytes weren't a valid Ed25519 point.
+    #[error("trust store key '{key_id}' is not a valid Ed25519 key: {err}")]
+    InvalidKey {
+        /// The key id that failed.
+        key_id: String,
+        /// Error detail from `VerifyingKey::from_bytes`.
+        err: String,
+    },
+    /// Couldn't read the file.
+    #[error("io error while {what}: {err}")]
+    Io {
+        /// Operation that failed.
+        what: &'static str,
+        /// Underlying error message.
+        err: String,
+    },
+}
+
+/// Verifier — combines the trust store and the policy mode.
+pub struct SignatureVerifier {
+    store: TrustStore,
+    mode: SignatureMode,
+}
+
+impl SignatureVerifier {
+    /// Build a verifier with the given trust store and policy.
+    pub fn new(store: TrustStore, mode: SignatureMode) -> Self {
+        Self { store, mode }
+    }
+
+    /// Verify a signature over `wasm_bytes`. Pass `None` for
+    /// `signature_b64` / `publisher_key_id` if the LoadPlugin
+    /// request didn't include a signature — the verifier will
+    /// either accept (Optional mode) or reject (Required mode).
+    pub fn verify(
+        &self,
+        wasm_bytes: &[u8],
+        signature_b64: Option<&str>,
+        publisher_key_id: Option<&str>,
+    ) -> Result<VerificationOutcome, VerificationError> {
+        match (signature_b64, publisher_key_id) {
+            (None, None) => {
+                if self.mode == SignatureMode::Required {
+                    return Err(VerificationError::Required);
+                }
+                Ok(VerificationOutcome::SkippedUnsigned)
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                // Half a signature is more suspicious than none —
+                // either we have both fields or neither.
+                Err(VerificationError::IncompleteSignatureFields)
+            }
+            (Some(sig_b64), Some(key_id)) => {
+                let sig_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(sig_b64.as_bytes())
+                    .map_err(|err| VerificationError::InvalidSignatureBase64(err.to_string()))?;
+                let sig_array: [u8; 64] = sig_bytes.as_slice().try_into().map_err(|_| {
+                    VerificationError::InvalidSignatureLength {
+                        actual_bytes: sig_bytes.len(),
+                    }
+                })?;
+                let signature = Signature::from_bytes(&sig_array);
+
+                let key =
+                    self.store.get(key_id).ok_or_else(|| VerificationError::UnknownKeyId {
+                        key_id: key_id.to_string(),
+                    })?;
+
+                key.verify(wasm_bytes, &signature)
+                    .map_err(|err| VerificationError::SignatureMismatch(err.to_string()))?;
+
+                Ok(VerificationOutcome::Verified {
+                    key_id: key_id.to_string(),
+                })
+            }
+        }
+    }
+
+    /// Current policy mode.
+    pub fn mode(&self) -> SignatureMode {
+        self.mode
+    }
+
+    /// Number of active trust roots.
+    pub fn trusted_key_count(&self) -> usize {
+        self.store.len()
+    }
+}
+
+/// What happened during verification. Successful cases include
+/// the key id used, so the caller can include it in the audit
+/// trail. The `SkippedUnsigned` variant is only ever reachable
+/// in `SignatureMode::Optional`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationOutcome {
+    /// Signature was present and valid against a trust root.
+    Verified {
+        /// The trust-root key id that matched.
+        key_id: String,
+    },
+    /// No signature was provided and the policy allowed it.
+    /// Reachable only in [`SignatureMode::Optional`].
+    SkippedUnsigned,
+}
+
+/// Errors the verifier can produce. Each variant maps to a stable
+/// error code via [`code`] so the IPC layer can surface it
+/// consistently.
+///
+/// [`code`]: VerificationError::code
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+    /// Signature was required by policy but not present in the
+    /// LoadPlugin request.
+    #[error("signature required by policy but not provided")]
+    Required,
+    /// Either `signature_b64` or `publisher_key_id` was set but
+    /// not both.
+    #[error("LoadPlugin must include both signature_b64 AND publisher_key_id, or neither")]
+    IncompleteSignatureFields,
+    /// The signature wasn't valid base64.
+    #[error("signature_b64 is not valid base64: {0}")]
+    InvalidSignatureBase64(String),
+    /// The signature decoded to something other than 64 bytes.
+    #[error("signature must be 64 bytes; got {actual_bytes}")]
+    InvalidSignatureLength {
+        /// Actual byte length seen.
+        actual_bytes: usize,
+    },
+    /// The publisher key id wasn't in the trust store. Could be
+    /// a stale key id from before a rotation, or an attacker.
+    #[error("publisher key id '{key_id}' is not a trusted root")]
+    UnknownKeyId {
+        /// The key id that wasn't recognized.
+        key_id: String,
+    },
+    /// The signature didn't verify against the named key.
+    #[error("signature did not verify against the named key: {0}")]
+    SignatureMismatch(String),
+}
+
+impl VerificationError {
+    /// Stable, machine-readable error code for the IPC `code`
+    /// field. Keeps the wire surface compatible across host
+    /// versions even if the human messages change.
+    pub fn code(&self) -> &'static str {
+        match self {
+            VerificationError::Required => "signature_required",
+            VerificationError::IncompleteSignatureFields => "incomplete_signature",
+            VerificationError::InvalidSignatureBase64(_) => "invalid_signature_base64",
+            VerificationError::InvalidSignatureLength { .. } => "invalid_signature_length",
+            VerificationError::UnknownKeyId { .. } => "unknown_publisher_key",
+            VerificationError::SignatureMismatch(_) => "signature_mismatch",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn fixture_keypair() -> (SigningKey, VerifyingKey) {
+        // Deterministic keypair — using a fixed seed makes the
+        // tests reproducible. Not a real key; never put a value
+        // like this near production.
+        let sk_bytes: [u8; 32] = [
+            0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec,
+            0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03,
+            0x1c, 0xae, 0x7f, 0x60,
+        ];
+        let sk = SigningKey::from_bytes(&sk_bytes);
+        let vk = sk.verifying_key();
+        (sk, vk)
+    }
+
+    fn make_store_with_test_key(key_id: &str) -> (TrustStore, SigningKey) {
+        let (sk, vk) = fixture_keypair();
+        let mut store = TrustStore::new();
+        store.insert(key_id.to_string(), vk);
+        (store, sk)
+    }
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    #[test]
+    fn verifier_accepts_valid_signature() {
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let sig = sk.sign(wasm);
+        let outcome = verifier
+            .verify(wasm, Some(&b64(sig.to_bytes().as_ref())), Some("publisher-1"))
+            .unwrap();
+        match outcome {
+            VerificationOutcome::Verified { key_id } => assert_eq!(key_id, "publisher-1"),
+            other => panic!("expected Verified, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verifier_rejects_signature_against_wrong_key() {
+        let (mut store, _sk) = make_store_with_test_key("publisher-1");
+        // Add a second key but sign with the first.
+        let (other_sk, _other_vk) = fixture_keypair();
+        let _ = other_sk; // unused; signing was with the first
+        let (real_sk, _real_vk) = fixture_keypair();
+        let verifier = SignatureVerifier::new(store.clone(), SignatureMode::Required);
+        let wasm = b"different bytes";
+        let sig = real_sk.sign(wasm);
+
+        // Sign over different bytes than what we'll ask the
+        // verifier to check — should fail.
+        let bad_message = b"original bytes";
+        let outcome =
+            verifier.verify(bad_message, Some(&b64(sig.to_bytes().as_ref())), Some("publisher-1"));
+        match outcome {
+            Err(err) => assert_eq!(err.code(), "signature_mismatch"),
+            Ok(other) => panic!("expected signature_mismatch error, got {:?}", other),
+        }
+
+        // Confirm the sk we built was actually consulted (sanity
+        // check that store has the right key).
+        assert!(store.get("publisher-1").is_some());
+        let _ = store.insert("publisher-2".to_string(), real_sk.verifying_key());
+    }
+
+    #[test]
+    fn verifier_rejects_unknown_key_id() {
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let sig = sk.sign(wasm);
+        let err = verifier
+            .verify(wasm, Some(&b64(sig.to_bytes().as_ref())), Some("not-a-real-key"))
+            .unwrap_err();
+        assert_eq!(err.code(), "unknown_publisher_key");
+    }
+
+    #[test]
+    fn verifier_required_mode_rejects_unsigned() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let err = verifier.verify(b"wasm", None, None).unwrap_err();
+        assert_eq!(err.code(), "signature_required");
+    }
+
+    #[test]
+    fn verifier_optional_mode_accepts_unsigned() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Optional);
+        let outcome = verifier.verify(b"wasm", None, None).unwrap();
+        assert_eq!(outcome, VerificationOutcome::SkippedUnsigned);
+    }
+
+    #[test]
+    fn verifier_rejects_half_signature_in_either_mode() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        for mode in [SignatureMode::Required, SignatureMode::Optional] {
+            let verifier = SignatureVerifier::new(store.clone(), mode);
+            // Only signature, no key id.
+            let err = verifier.verify(b"wasm", Some("AAAA"), None).unwrap_err();
+            assert_eq!(err.code(), "incomplete_signature");
+            // Only key id, no signature.
+            let err = verifier.verify(b"wasm", None, Some("publisher-1")).unwrap_err();
+            assert_eq!(err.code(), "incomplete_signature");
+        }
+    }
+
+    #[test]
+    fn verifier_rejects_invalid_signature_base64() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let err = verifier
+            .verify(b"wasm", Some("not-valid-base64-!!!"), Some("publisher-1"))
+            .unwrap_err();
+        assert_eq!(err.code(), "invalid_signature_base64");
+    }
+
+    #[test]
+    fn verifier_rejects_signature_of_wrong_length() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        // Valid base64 but only 8 bytes — Ed25519 signatures are
+        // 64 bytes.
+        let err = verifier
+            .verify(b"wasm", Some(&b64(&[0u8; 8])), Some("publisher-1"))
+            .unwrap_err();
+        assert_eq!(err.code(), "invalid_signature_length");
+    }
+
+    #[test]
+    fn trust_store_round_trips_through_json() {
+        let (_sk, vk) = fixture_keypair();
+        let json = format!(r#"{{"publisher-1":"{}"}}"#, b64(vk.as_bytes()));
+        let store = TrustStore::from_json_str(&json).unwrap();
+        assert_eq!(store.len(), 1);
+        assert!(store.get("publisher-1").is_some());
+    }
+
+    #[test]
+    fn trust_store_rejects_short_key() {
+        let json = format!(r#"{{"too-short":"{}"}}"#, b64(&[0u8; 16]));
+        let result = TrustStore::from_json_str(&json);
+        assert!(matches!(result, Err(TrustStoreError::InvalidKeyLength { .. })));
+    }
+
+    #[test]
+    fn trust_store_rejects_invalid_json() {
+        let result = TrustStore::from_json_str("not json");
+        assert!(matches!(result, Err(TrustStoreError::InvalidJson { .. })));
+    }
+
+    #[test]
+    fn empty_trust_store_in_required_mode_rejects_signed_load() {
+        let verifier = SignatureVerifier::new(TrustStore::new(), SignatureMode::Required);
+        let err = verifier.verify(b"wasm", Some("AAAA"), Some("any-key")).unwrap_err();
+        // Empty store means even a syntactically valid request
+        // can't find a trust root.
+        assert!(matches!(
+            err.code(),
+            "unknown_publisher_key" | "invalid_signature_length" | "invalid_signature_base64"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
Implements RFC §7.2 step 3 — runtime signature verification at LoadPlugin. Closes the security gap in #400 where the host accepted arbitrary WASM bytes from any IPC client.

**Stacked on #400.**

## What it adds
**New module \`signing.rs\`:**
- \`SignatureMode { Required | Optional }\` — Optional default preserves OSS behavior; cloud production sets Required via env var.
- \`TrustStore\` — map of \`publisher_key_id → VerifyingKey\`, built from JSON env var (inline) or file. Empty store + Required mode = fail-safe deny-everything.
- \`SignatureVerifier\` — combines the store and mode. \`verify()\` is called **before** any bytes touch the loader, so a verification failure can't accidentally bypass into the WASM runtime via a loader bug.
- \`VerificationError\` carries stable codes: \`signature_required\`, \`incomplete_signature\`, \`invalid_signature_base64\`, \`invalid_signature_length\`, \`unknown_publisher_key\`, \`signature_mismatch\`.

**Wire protocol:**
- \`LoadPlugin\` gains optional \`signature_b64\` + \`publisher_key_id\` fields, both with \`skip_serializing_if\` so older callers and the \`nc -U\` debug path don't see surprising nulls.
- Both must be set together or both None — half a signature is more suspicious than none.

**Bin entrypoint reads:**
- \`MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS_FILE\` — path to JSON file
- \`MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS\` — same shape, inline
- \`MOCKFORGE_PLUGIN_HOST_SIGNATURE_MODE\` — \`required\` | \`optional\`

## Live smoke test (Required mode + empty trust store, unsigned load)
\`\`\`
$ MOCKFORGE_PLUGIN_HOST_SIGNATURE_MODE=required \\
  target/debug/mockforge-plugin-host
$ # send unsigned LoadPlugin
=> {"kind":"error","code":"signature_required",
    "message":"signature verification failed: signature required by policy but not provided"}
\`\`\`

## Alignment with existing registry infrastructure
Ed25519, raw 32-byte public keys, base64 wire encoding — same shape as the registry's \`UserPublicKey\` + \`verify_sbom_attestation\` from #386. Trust roots can be shared once the registry-fetch path replaces inline-bytes uploads.

## Test plan
- [x] \`cargo check -p mockforge-plugin-host\`
- [x] \`cargo clippy -p mockforge-plugin-host --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test -p mockforge-plugin-host --lib\` — **36/36 pass** (20 lifecycle + 16 new):
  - 11 verifier tests: valid signature, wrong-key rejection, unknown-key rejection, required-mode-rejects-unsigned, optional-mode-accepts-unsigned, half-signature rejection, invalid base64, invalid length, trust-store JSON round-trip, short-key rejection, invalid JSON
  - 2 host-level required-mode tests: unsigned rejected, unknown-key rejected
  - 3 protocol round-trip tests: signature fields present + absent cases, \`skip_serializing_if\` working
- [x] Live smoke test: Required mode rejects unsigned loads with the right error code
- [x] Pre-commit hooks (clippy, typos, fmt, audit) — all passed

## What's next
- Pull the manifest into the signed payload (currently the signature covers WASM bytes only; defense-in-depth says cover both)
- Wire the registry's \`UserPublicKey\` list as the default trust source in cloud (dynamic key rotation)
- Kill-switch blocklist poll (RFC §8.3)