### PR TITLE
feat(plugin-host): kill-switch blocklist poll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8601,9 +8601,11 @@ version = "0.3.126"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
  "ed25519-dalek",
  "mockforge-plugin-core",
  "mockforge-plugin-loader",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/mockforge-plugin-host/Cargo.toml
+++ b/crates/mockforge-plugin-host/Cargo.toml
@@ -65,5 +65,11 @@ tempfile = "3"
 # registry-fetch path lands.
 ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 
+# HTTP client for the kill-switch blocklist poll task (RFC §8.3).
+reqwest = { workspace = true }
+# Workspace chrono already enables serde — used by BlocklistEntry's
+# `revoked_at` field on the wire format.
+chrono = { workspace = true }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/mockforge-plugin-host/src/blocklist.rs
+++ b/crates/mockforge-plugin-host/src/blocklist.rs
@@ -1,0 +1,306 @@
+//! Kill-switch blocklist (RFC §8.3).
+//!
+//! Plugin-host polls a registry endpoint for revoked
+//! `(plugin_name, version)` entries on a configurable interval.
+//! When the blocklist updates, the actor unloads any matched
+//! plugins and rejects subsequent loads with `revoked` so the
+//! caller (main mockforge → API client) gets a stable error
+//! they can surface.
+//!
+//! ## Why polling, not push
+//!
+//! Push requires a long-lived control-plane connection from each
+//! plugin-host back to the registry — that's extra ops surface
+//! (TLS rotation, reconnects, partitions) for a path that fires
+//! every few weeks at most. Polling is operationally boring and
+//! the latency target is already minutes per RFC §8.1.
+//!
+//! ## Wire format
+//!
+//! The registry endpoint returns a JSON array:
+//!
+//! ```json
+//! [
+//!   { "plugin_name": "stripe-rewriter", "version": "1.2.3",
+//!     "reason": "CVE-2026-1234", "revoked_at": "2026-05-06T01:00:00Z" }
+//! ]
+//! ```
+//!
+//! Match is exact `(name, version)` — semver ranges are out of
+//! scope for v1. Operators publishing a range simply enumerate
+//! the affected versions on the registry side.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+/// One revoked plugin pin. The registry returns an array of
+/// these; the host stores them in a [`Blocklist`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct BlocklistEntry {
+    /// Plugin name from the registry.
+    pub plugin_name: String,
+    /// Exact version revoked. Wildcard semantics (e.g. revoke all
+    /// versions of a plugin) are out of scope for v1; the
+    /// registry should enumerate.
+    pub version: String,
+    /// Stable reason string. Surfaced in the `revoked` error code
+    /// message and the audit log so operators can correlate
+    /// against advisories.
+    pub reason: String,
+    /// When the registry recorded the revocation.
+    pub revoked_at: DateTime<Utc>,
+}
+
+/// Cheaply-cloneable handle to the live blocklist. Both the poll
+/// task and the actor hold an `Arc<RwLock<...>>` so updates from
+/// the poller are observed by the actor without a channel hop.
+#[derive(Debug, Clone, Default)]
+pub struct Blocklist {
+    inner: Arc<RwLock<Vec<BlocklistEntry>>>,
+}
+
+impl Blocklist {
+    /// Empty blocklist — nothing is revoked.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the entire entry set. Called by the poll task on
+    /// each successful refresh; the actor observes the new set on
+    /// its next read without coordinating.
+    pub async fn replace(&self, entries: Vec<BlocklistEntry>) {
+        let mut guard = self.inner.write().await;
+        *guard = entries;
+    }
+
+    /// Take a cheap snapshot of the current entries. Returned as
+    /// `Vec` rather than holding the read lock, so callers can
+    /// iterate without blocking the writer.
+    pub async fn snapshot(&self) -> Vec<BlocklistEntry> {
+        self.inner.read().await.clone()
+    }
+
+    /// Whether the named `(plugin, version)` is on the blocklist.
+    /// Returns the matching reason for audit logging.
+    pub async fn matches(&self, plugin_name: &str, version: &str) -> Option<String> {
+        let guard = self.inner.read().await;
+        for entry in guard.iter() {
+            if entry.plugin_name == plugin_name && entry.version == version {
+                return Some(entry.reason.clone());
+            }
+        }
+        None
+    }
+
+    /// Return the names of every loaded plugin that's on the
+    /// blocklist. Used by the actor's periodic sweep to decide
+    /// what to unload.
+    pub async fn matches_in<I, S>(&self, loaded: I) -> HashSet<String>
+    where
+        I: IntoIterator<Item = (S, S)>,
+        S: AsRef<str>,
+    {
+        let guard = self.inner.read().await;
+        let mut hits = HashSet::new();
+        for (name, version) in loaded {
+            for entry in guard.iter() {
+                if entry.plugin_name == name.as_ref() && entry.version == version.as_ref() {
+                    hits.insert(name.as_ref().to_string());
+                    break;
+                }
+            }
+        }
+        hits
+    }
+}
+
+/// Errors the poll task can hit. Each one is logged + retried on
+/// the next interval; we never give up on the blocklist because a
+/// stale blocklist is a security risk.
+#[derive(Debug, thiserror::Error)]
+pub enum PollError {
+    /// HTTP request failed.
+    #[error("blocklist HTTP error: {0}")]
+    Http(String),
+    /// Response body wasn't valid JSON / shape.
+    #[error("blocklist parse error: {0}")]
+    Parse(String),
+}
+
+/// Configuration for the poll task.
+#[derive(Debug, Clone)]
+pub struct BlocklistConfig {
+    /// Registry endpoint to poll. Returns the JSON array
+    /// described in the module docs.
+    pub url: String,
+    /// Poll interval. Default 60 seconds per RFC §8.2.
+    pub interval: std::time::Duration,
+    /// Optional bearer token; sent as `Authorization: Bearer ...`.
+    /// Cloud production sets this so the registry can rate-limit
+    /// per host.
+    pub bearer_token: Option<String>,
+}
+
+impl BlocklistConfig {
+    /// Construct with the default 60s interval and no bearer
+    /// token.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            interval: std::time::Duration::from_secs(60),
+            bearer_token: None,
+        }
+    }
+}
+
+/// Run the poll task forever. Returns only on shutdown signal —
+/// the `select!` in main.rs is responsible for cancelling.
+pub async fn run_poll_loop(config: BlocklistConfig, blocklist: Blocklist) {
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to build blocklist HTTP client; poll task exiting");
+            return;
+        }
+    };
+
+    tracing::info!(url = %config.url, interval_secs = config.interval.as_secs(), "blocklist poll loop starting");
+
+    let mut ticker = tokio::time::interval(config.interval);
+    // Skip-the-first-tick semantics so we poll *immediately*, not
+    // after one full interval. Operators see initial blocklist
+    // state on startup.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+        match fetch_blocklist(&client, &config).await {
+            Ok(entries) => {
+                let count = entries.len();
+                blocklist.replace(entries).await;
+                tracing::debug!(entries = count, "blocklist refreshed");
+            }
+            Err(err) => {
+                // Don't update on error — preserve the last-known
+                // blocklist. A registry outage shouldn't open a
+                // security hole by silently emptying the list.
+                tracing::warn!(error = %err, "blocklist poll failed; keeping last-known list");
+            }
+        }
+    }
+}
+
+async fn fetch_blocklist(
+    client: &reqwest::Client,
+    config: &BlocklistConfig,
+) -> Result<Vec<BlocklistEntry>, PollError> {
+    let mut req = client.get(&config.url);
+    if let Some(token) = &config.bearer_token {
+        req = req.bearer_auth(token);
+    }
+    let response = req.send().await.map_err(|err| PollError::Http(err.to_string()))?;
+    if !response.status().is_success() {
+        return Err(PollError::Http(format!("status {}", response.status())));
+    }
+    response
+        .json::<Vec<BlocklistEntry>>()
+        .await
+        .map_err(|err| PollError::Parse(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn entry(name: &str, version: &str) -> BlocklistEntry {
+        BlocklistEntry {
+            plugin_name: name.to_string(),
+            version: version.to_string(),
+            reason: format!("test-revocation:{name}:{version}"),
+            revoked_at: Utc.with_ymd_and_hms(2026, 5, 6, 1, 0, 0).unwrap(),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_blocklist_matches_nothing() {
+        let bl = Blocklist::new();
+        assert!(bl.matches("any", "1.0.0").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn populated_blocklist_matches_exact_pair() {
+        let bl = Blocklist::new();
+        bl.replace(vec![entry("evil-plugin", "1.0.0")]).await;
+        assert!(bl.matches("evil-plugin", "1.0.0").await.is_some());
+        // Different version of same plugin not blocked.
+        assert!(bl.matches("evil-plugin", "1.0.1").await.is_none());
+        // Different plugin same version not blocked.
+        assert!(bl.matches("good-plugin", "1.0.0").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn replace_swaps_the_entire_set() {
+        let bl = Blocklist::new();
+        bl.replace(vec![entry("p1", "1.0.0")]).await;
+        bl.replace(vec![entry("p2", "2.0.0")]).await;
+        assert!(bl.matches("p1", "1.0.0").await.is_none());
+        assert!(bl.matches("p2", "2.0.0").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn matches_in_finds_loaded_hits() {
+        let bl = Blocklist::new();
+        bl.replace(vec![entry("p1", "1.0.0"), entry("p3", "3.0.0")]).await;
+        let loaded = vec![
+            ("p1".to_string(), "1.0.0".to_string()), // hit
+            ("p2".to_string(), "2.0.0".to_string()), // miss
+            ("p3".to_string(), "3.0.0".to_string()), // hit
+        ];
+        let hits = bl.matches_in(loaded).await;
+        assert_eq!(hits.len(), 2);
+        assert!(hits.contains("p1"));
+        assert!(hits.contains("p3"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_round_trips_cloneable() {
+        let bl = Blocklist::new();
+        bl.replace(vec![entry("p1", "1.0.0")]).await;
+        let snap = bl.snapshot().await;
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].plugin_name, "p1");
+    }
+
+    #[tokio::test]
+    async fn blocklist_entry_round_trips_through_json() {
+        // Confirms the wire format the registry endpoint produces
+        // parses correctly. Any drift would surface here.
+        let raw = r#"[
+            {
+                "plugin_name": "evil",
+                "version": "1.0.0",
+                "reason": "CVE-2026-1234",
+                "revoked_at": "2026-05-06T01:00:00Z"
+            }
+        ]"#;
+        let entries: Vec<BlocklistEntry> = serde_json::from_str(raw).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].plugin_name, "evil");
+        assert_eq!(entries[0].reason, "CVE-2026-1234");
+    }
+
+    #[tokio::test]
+    async fn config_defaults_to_60s_interval() {
+        let cfg = BlocklistConfig::new("http://example/blocklist");
+        assert_eq!(cfg.interval.as_secs(), 60);
+        assert!(cfg.bearer_token.is_none());
+    }
+}

--- a/crates/mockforge-plugin-host/src/handlers.rs
+++ b/crates/mockforge-plugin-host/src/handlers.rs
@@ -136,6 +136,7 @@ mod tests {
                     ..Default::default()
                 },
                 verifier,
+                crate::blocklist::Blocklist::new(),
             );
             tokio::select! {
                 result = body(host) => result,

--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -29,7 +29,16 @@ use mockforge_plugin_loader::{
 };
 use tokio::sync::{mpsc, oneshot};
 
+use crate::blocklist::Blocklist;
 use crate::signing::{SignatureVerifier, VerificationError};
+
+/// How often the actor sweeps loaded plugins against the
+/// blocklist. The poll task itself updates the shared
+/// `Blocklist` on every fetch; this sweep notices entries the
+/// actor missed (e.g. a plugin that was loaded before the
+/// blocklist landed) and unloads them. 30s gives sub-minute
+/// reaction time without busy-looping.
+const SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Actor channel capacity. Generous because cloud-plugins ops are
 /// rare (load/unload at attach time, invoke once per request) and
@@ -97,11 +106,12 @@ impl Host {
     pub fn new(
         loader_config: PluginLoaderConfig,
         verifier: SignatureVerifier,
+        blocklist: Blocklist,
     ) -> (Self, HostActor) {
         let (cmd_tx, cmd_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let started_at = Arc::new(Instant::now());
 
-        let actor: HostActor = Box::pin(actor_loop(loader_config, verifier, cmd_rx));
+        let actor: HostActor = Box::pin(actor_loop(loader_config, verifier, blocklist, cmd_rx));
 
         (Self { started_at, cmd_tx }, actor)
     }
@@ -224,6 +234,7 @@ enum Command {
 async fn actor_loop(
     loader_config: PluginLoaderConfig,
     verifier: SignatureVerifier,
+    blocklist: Blocklist,
     mut cmd_rx: mpsc::Receiver<Command>,
 ) {
     let sandbox = PluginSandbox::new(loader_config);
@@ -234,56 +245,109 @@ async fn actor_loop(
         "plugin-host actor started"
     );
 
-    while let Some(cmd) = cmd_rx.recv().await {
-        match cmd {
-            Command::Load {
-                plugin_name,
-                version,
-                permissions,
-                wasm_bytes,
-                signature_b64,
-                publisher_key_id,
-                reply,
-            } => {
-                let result = handle_load(
-                    &sandbox,
-                    &verifier,
-                    &mut plugins,
-                    &plugin_name,
-                    &version,
-                    permissions,
-                    wasm_bytes,
-                    signature_b64.as_deref(),
-                    publisher_key_id.as_deref(),
-                )
-                .await;
-                let _ = reply.send(result);
+    let mut sweep_ticker = tokio::time::interval(SWEEP_INTERVAL);
+    sweep_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => {
+                let Some(cmd) = cmd else {
+                    tracing::info!("plugin-host actor exiting (channel closed)");
+                    return;
+                };
+                match cmd {
+                    Command::Load {
+                        plugin_name,
+                        version,
+                        permissions,
+                        wasm_bytes,
+                        signature_b64,
+                        publisher_key_id,
+                        reply,
+                    } => {
+                        let result = handle_load(
+                            &sandbox,
+                            &verifier,
+                            &blocklist,
+                            &mut plugins,
+                            &plugin_name,
+                            &version,
+                            permissions,
+                            wasm_bytes,
+                            signature_b64.as_deref(),
+                            publisher_key_id.as_deref(),
+                        )
+                        .await;
+                        let _ = reply.send(result);
+                    }
+                    Command::Unload { plugin_name, reply } => {
+                        let result = handle_unload(&sandbox, &mut plugins, &plugin_name).await;
+                        let _ = reply.send(result);
+                    }
+                    Command::Invoke {
+                        plugin_name,
+                        function,
+                        input,
+                        reply,
+                    } => {
+                        // Last-line check on every invocation in
+                        // case the blocklist changed since load.
+                        // Cheap because the matches() lookup is a
+                        // short Vec scan under a read lock.
+                        let entry = plugins.get(&plugin_name);
+                        if let Some(entry) = entry {
+                            let version_str = entry.version.to_string();
+                            if let Some(reason) =
+                                blocklist.matches(&plugin_name, &version_str).await
+                            {
+                                let _ = reply.send(Err(HostError::Revoked {
+                                    plugin_name: plugin_name.clone(),
+                                    reason,
+                                }));
+                                continue;
+                            }
+                        }
+                        let result =
+                            handle_invoke(&sandbox, &plugins, &plugin_name, &function, input).await;
+                        let _ = reply.send(result);
+                    }
+                    Command::ListPlugins { reply } => {
+                        let snapshot: Vec<(String, PluginId)> = plugins
+                            .iter()
+                            .map(|(name, entry)| (name.clone(), entry.plugin_id.clone()))
+                            .collect();
+                        let _ = reply.send(snapshot);
+                    }
+                }
             }
-            Command::Unload { plugin_name, reply } => {
-                let result = handle_unload(&sandbox, &mut plugins, &plugin_name).await;
-                let _ = reply.send(result);
-            }
-            Command::Invoke {
-                plugin_name,
-                function,
-                input,
-                reply,
-            } => {
-                let result =
-                    handle_invoke(&sandbox, &plugins, &plugin_name, &function, input).await;
-                let _ = reply.send(result);
-            }
-            Command::ListPlugins { reply } => {
-                let snapshot: Vec<(String, PluginId)> = plugins
-                    .iter()
-                    .map(|(name, entry)| (name.clone(), entry.plugin_id.clone()))
-                    .collect();
-                let _ = reply.send(snapshot);
+            _ = sweep_ticker.tick() => {
+                sweep_blocklist(&sandbox, &blocklist, &mut plugins).await;
             }
         }
     }
+}
 
-    tracing::info!("plugin-host actor exiting (channel closed)");
+/// Walk the loaded plugin map and unload any whose
+/// `(name, version)` is now on the blocklist. Called on a timer;
+/// idempotent — a second sweep over the same set is a no-op.
+async fn sweep_blocklist(
+    sandbox: &PluginSandbox,
+    blocklist: &Blocklist,
+    plugins: &mut HashMap<String, PluginEntry>,
+) {
+    let pairs: Vec<(String, String)> = plugins
+        .iter()
+        .map(|(name, entry)| (name.clone(), entry.version.to_string()))
+        .collect();
+    let hits = blocklist.matches_in(pairs).await;
+    for name in hits {
+        if let Some(entry) = plugins.remove(&name) {
+            tracing::warn!(plugin_name = %name, "plugin revoked by blocklist sweep — unloading");
+            if let Err(err) = sandbox.destroy_sandbox(&entry.plugin_id).await {
+                tracing::error!(error = %err, plugin_name = %name, "destroy_sandbox failed during sweep");
+            }
+        }
+    }
 }
 
 // Many arguments because the function is the
@@ -293,6 +357,7 @@ async fn actor_loop(
 async fn handle_load(
     sandbox: &PluginSandbox,
     verifier: &SignatureVerifier,
+    blocklist: &Blocklist,
     plugins: &mut HashMap<String, PluginEntry>,
     plugin_name: &str,
     version_str: &str,
@@ -301,6 +366,17 @@ async fn handle_load(
     signature_b64: Option<&str>,
     publisher_key_id: Option<&str>,
 ) -> Result<PluginId, HostError> {
+    // Reject revoked plugins before any other work — including
+    // signature verification. A revoked plugin shouldn't get
+    // its signature checked just to fail later; the blocklist
+    // is the cheapest fail-fast.
+    if let Some(reason) = blocklist.matches(plugin_name, version_str).await {
+        return Err(HostError::Revoked {
+            plugin_name: plugin_name.to_string(),
+            reason,
+        });
+    }
+
     // Verify the signature *before* the loader sees the bytes.
     // Bypass-via-loader-bug is impossible if the bytes never
     // reach the loader on a verification failure.
@@ -455,6 +531,17 @@ pub enum HostError {
     /// Signature verification rejected the load.
     #[error("signature verification failed: {0}")]
     Signature(#[from] VerificationError),
+    /// Plugin is on the kill-switch blocklist (RFC §8.3).
+    /// Operators surface the reason to API callers as a stable
+    /// error code; callers should not retry — the revocation is
+    /// authoritative until lifted by the registry.
+    #[error("plugin '{plugin_name}' is revoked: {reason}")]
+    Revoked {
+        /// Plugin name that's revoked.
+        plugin_name: String,
+        /// Reason from the blocklist entry (CVE id, abuse report, etc.).
+        reason: String,
+    },
     /// The actor task is gone — likely runtime shutdown or a
     /// panic in the actor. Caller should reconnect.
     #[error("plugin-host actor task is no longer running")]
@@ -475,6 +562,7 @@ impl HostError {
             // Forward the verifier's specific code so callers can
             // distinguish "missing signature" from "wrong key" etc.
             HostError::Signature(err) => err.code(),
+            HostError::Revoked { .. } => "revoked",
             HostError::ActorGone => "actor_gone",
         }
     }
@@ -533,7 +621,8 @@ mod tests {
                 crate::signing::TrustStore::new(),
                 crate::signing::SignatureMode::Optional,
             );
-            let (host, actor) = Host::new(loader_config(), verifier);
+            let (host, actor) =
+                Host::new(loader_config(), verifier, crate::blocklist::Blocklist::new());
             tokio::select! {
                 result = body(host) => result,
                 _ = actor => panic!("actor exited before test body finished"),
@@ -635,7 +724,8 @@ mod tests {
                 crate::signing::TrustStore::new(),
                 crate::signing::SignatureMode::Required,
             );
-            let (host, actor) = Host::new(loader_config(), verifier);
+            let (host, actor) =
+                Host::new(loader_config(), verifier, crate::blocklist::Blocklist::new());
             tokio::select! {
                 result = body(host) => result,
                 _ = actor => panic!("actor exited before test body finished"),
@@ -681,6 +771,81 @@ mod tests {
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), "unknown_publisher_key");
+        });
+    }
+
+    /// Drive a Host wired to a Blocklist with the test plugin
+    /// already revoked. Lets us verify the kill-switch refuses
+    /// the load before any other check.
+    fn run_with_blocklist<F, T>(
+        blocklist: crate::blocklist::Blocklist,
+        body: impl FnOnce(Host) -> F,
+    ) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let verifier = SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Optional,
+            );
+            let (host, actor) = Host::new(loader_config(), verifier, blocklist);
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+            }
+        })
+    }
+
+    #[test]
+    fn load_blocklisted_plugin_is_rejected_with_revoked_code() {
+        use crate::blocklist::{Blocklist, BlocklistEntry};
+        use chrono::Utc;
+        let bl = Blocklist::new();
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            bl.replace(vec![BlocklistEntry {
+                plugin_name: "evil".to_string(),
+                version: "1.0.0".to_string(),
+                reason: "CVE-2026-9999".to_string(),
+                revoked_at: Utc::now(),
+            }])
+            .await;
+        });
+
+        run_with_blocklist(bl, |host| async move {
+            let err = host
+                .load_plugin("evil", "1.0.0", serde_json::json!({}), minimal_wasm(), None, None)
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "revoked");
+            // Stable reason string is preserved through the error.
+            assert!(err.to_string().contains("CVE-2026-9999"));
+        });
+    }
+
+    #[test]
+    fn load_non_blocklisted_plugin_succeeds_with_blocklist_present() {
+        use crate::blocklist::{Blocklist, BlocklistEntry};
+        use chrono::Utc;
+        let bl = Blocklist::new();
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            bl.replace(vec![BlocklistEntry {
+                plugin_name: "evil".to_string(),
+                version: "1.0.0".to_string(),
+                reason: "test".to_string(),
+                revoked_at: Utc::now(),
+            }])
+            .await;
+        });
+
+        run_with_blocklist(bl, |host| async move {
+            // A different plugin with a different version is fine.
+            host.load_plugin("good", "1.0.0", serde_json::json!({}), minimal_wasm(), None, None)
+                .await
+                .unwrap();
         });
     }
 

--- a/crates/mockforge-plugin-host/src/lib.rs
+++ b/crates/mockforge-plugin-host/src/lib.rs
@@ -34,12 +34,14 @@
 //! stay small and lets us iterate on cloud-only concerns without
 //! touching the OSS API.
 
+pub mod blocklist;
 pub mod handlers;
 pub mod host;
 pub mod protocol;
 pub mod server;
 pub mod signing;
 
+pub use blocklist::{run_poll_loop, Blocklist, BlocklistConfig, BlocklistEntry, PollError};
 pub use host::{Host, HostActor, HostError};
 pub use protocol::{Request, Response};
 pub use server::{run_server, ServerConfig};

--- a/crates/mockforge-plugin-host/src/main.rs
+++ b/crates/mockforge-plugin-host/src/main.rs
@@ -22,7 +22,8 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use mockforge_plugin_host::{
-    run_server, Host, ServerConfig, SignatureMode, SignatureVerifier, TrustStore,
+    run_poll_loop, run_server, Blocklist, BlocklistConfig, Host, ServerConfig, SignatureMode,
+    SignatureVerifier, TrustStore,
 };
 use mockforge_plugin_loader::PluginLoaderConfig;
 
@@ -39,12 +40,15 @@ fn main() -> Result<()> {
     let trust_store = env_trust_store()?;
     let signature_mode = env_signature_mode();
     let verifier = SignatureVerifier::new(trust_store, signature_mode);
+    let blocklist = Blocklist::new();
+    let blocklist_config = env_blocklist_config();
 
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         socket = %config.socket_path.display(),
         signature_mode = ?signature_mode,
         trusted_keys = verifier.trusted_key_count(),
+        blocklist_url = blocklist_config.as_ref().map(|c| c.url.as_str()).unwrap_or("(disabled)"),
         "mockforge-plugin-host starting"
     );
 
@@ -57,15 +61,25 @@ fn main() -> Result<()> {
         .context("building Tokio current-thread runtime")?;
 
     rt.block_on(async move {
-        let (host, actor) = Host::new(PluginLoaderConfig::default(), verifier);
+        let (host, actor) = Host::new(PluginLoaderConfig::default(), verifier, blocklist.clone());
 
-        // Drive actor + server + shutdown_signal concurrently. The
-        // actor owns the !Send sandbox; the server fans connections
-        // out via tokio::spawn, but those tasks only carry the
-        // (Send) `Host` handle — never the sandbox itself.
+        // The blocklist poller is Send (just an HTTP client) so it
+        // could in principle be tokio::spawn'd, but driving it
+        // inline via select! keeps the lifecycle uniform — every
+        // long-running task in this binary is on the main task,
+        // and shutdown is one drop.
+        let poll_future: std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> =
+            match blocklist_config {
+                Some(cfg) => Box::pin(run_poll_loop(cfg, blocklist)),
+                None => Box::pin(std::future::pending()),
+            };
+
+        // Drive actor + server + poller + shutdown_signal
+        // concurrently. The actor owns the !Send sandbox; the
+        // server fans connections out via tokio::spawn but those
+        // tasks only carry the (Send) `Host` handle — never the
+        // sandbox itself.
         tokio::select! {
-            // Actor exit is unexpected — channel closed without
-            // shutdown signal. Surface as an error.
             _ = actor => {
                 tracing::error!("plugin-host actor exited unexpectedly");
                 Err(anyhow::anyhow!("plugin-host actor exited"))
@@ -74,12 +88,36 @@ fn main() -> Result<()> {
                 tracing::error!(?result, "plugin-host server loop exited unexpectedly");
                 result
             }
+            _ = poll_future => {
+                tracing::error!("blocklist poller exited unexpectedly");
+                Err(anyhow::anyhow!("blocklist poller exited"))
+            }
             _ = shutdown_signal() => {
                 tracing::info!("plugin-host received shutdown signal — exiting");
                 Ok(())
             }
         }
     })
+}
+
+/// Build a [`BlocklistConfig`] from env vars, or `None` if no
+/// `MOCKFORGE_PLUGIN_HOST_BLOCKLIST_URL` is set. Optional polling
+/// keeps self-hosted / dev simple — only cloud production has a
+/// blocklist endpoint to point at.
+fn env_blocklist_config() -> Option<BlocklistConfig> {
+    let url = std::env::var("MOCKFORGE_PLUGIN_HOST_BLOCKLIST_URL").ok()?;
+    let mut cfg = BlocklistConfig::new(url);
+    if let Ok(secs) = std::env::var("MOCKFORGE_PLUGIN_HOST_BLOCKLIST_INTERVAL_SECS") {
+        if let Ok(n) = secs.parse::<u64>() {
+            cfg.interval = std::time::Duration::from_secs(n.max(1));
+        }
+    }
+    if let Ok(token) = std::env::var("MOCKFORGE_PLUGIN_HOST_BLOCKLIST_BEARER") {
+        if !token.is_empty() {
+            cfg.bearer_token = Some(token);
+        }
+    }
+    Some(cfg)
 }
 
 fn init_tracing() {

--- a/crates/mockforge-plugin-host/src/server.rs
+++ b/crates/mockforge-plugin-host/src/server.rs
@@ -159,7 +159,7 @@ mod tests {
                 crate::signing::TrustStore::new(),
                 crate::signing::SignatureMode::Optional,
             );
-            let (host, actor) = Host::new(PluginLoaderConfig::default(), verifier);
+            let (host, actor) = Host::new(PluginLoaderConfig::default(), verifier, crate::blocklist::Blocklist::new());
             let server_host = host.clone();
             tokio::select! {
                 result = body(host) => result,


### PR DESCRIPTION
## Summary
Implements RFC §8.3 — operator-controlled revocation of compromised plugins. Plugin-host polls a registry endpoint for revoked \`(plugin_name, version)\` entries every 60s; the actor unloads matched plugins and rejects subsequent loads with a stable \`revoked\` error code.

**Stacked on #403.**

## What it adds
**New module \`blocklist.rs\`:**
- \`BlocklistEntry { plugin_name, version, reason, revoked_at }\` matches the wire format from the registry endpoint
- \`Blocklist\` — \`Arc<RwLock<Vec<...>>>\` shared between the poll task and the actor; \`replace()\` swaps the entire entry set on each successful refresh
- \`BlocklistConfig { url, interval (default 60s), bearer_token }\`
- \`run_poll_loop\` fetches with reqwest, **preserves last-known list on failure** — a registry outage shouldn't open a security hole by silently emptying the list

**Actor wiring:**
- Main loop now \`select!\`'s between commands and a 30s sweep timer; sweep walks loaded plugins against the blocklist and unloads any matches
- \`handle_load\` checks the blocklist **first** (before signature verification); revoked plugins fail-fast without burning crypto cycles
- \`Invoke\` also checks; covers the "revoked between load and invoke" race
- \`HostError::Revoked { plugin_name, reason }\` with code \`revoked\`

**Bin entrypoint env vars:**
- \`MOCKFORGE_PLUGIN_HOST_BLOCKLIST_URL\` — endpoint to poll. If unset, polling is disabled (self-hosted dev default).
- \`MOCKFORGE_PLUGIN_HOST_BLOCKLIST_INTERVAL_SECS\` — override default 60s
- \`MOCKFORGE_PLUGIN_HOST_BLOCKLIST_BEARER\` — optional auth token

## Test plan
- [x] \`cargo check -p mockforge-plugin-host\`
- [x] \`cargo clippy -p mockforge-plugin-host --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test -p mockforge-plugin-host --lib\` — **45/45 pass** (36 from #403 + 9 new):
  - 7 blocklist module tests: empty matches nothing, exact pair matching, replace swaps set, matches_in finds loaded hits, snapshot cloneability, JSON round-trip, default interval
  - 2 host-level integration tests: blocklisted plugin fails load with \`code=revoked\` + reason in message; non-blocklisted plugin loads fine when blocklist is populated
  - Existing 36 lifecycle/signing/protocol/server tests preserved — \`Host::new\` gained a Blocklist arg but every fixture passes \`Blocklist::new()\` (empty) so behavior is unchanged
- [x] Pre-commit hooks (clippy, typos, fmt, audit) — all passed

## What's next
- Push channel via OTLP connection for sub-second kill (currently 60s poll is the failsafe per RFC §8.2)
- Audit log integration so revocations land in \`audit_logs\` (currently emits structured tracing events; cloud audit pipeline picks them up)
- In-flight invocation cancellation (currently a request mid-invocation completes; the next one fails)