### PR TITLE
feat(cloud-plugins): orchestrator picks cloud-plugins image when plugins attached

### DIFF
--- a/crates/mockforge-registry-server/src/deployment/orchestrator.rs
+++ b/crates/mockforge-registry-server/src/deployment/orchestrator.rs
@@ -13,7 +13,54 @@ use uuid::Uuid;
 use crate::deployment::flyio::{
     FlyioCheck, FlyioClient, FlyioMachineConfig, FlyioPort, FlyioRegistryAuth, FlyioService,
 };
-use crate::models::{DeploymentLog, DeploymentStatus, HostedMock};
+use crate::models::{DeploymentLog, DeploymentStatus, HostedMock, HostedMockPlugin};
+
+/// Default OCI image for plugin-disabled hosted-mocks. Same as the
+/// existing main mockforge image — preserves prior behavior.
+const DEFAULT_BASE_IMAGE: &str = "ghcr.io/saasy-solutions/mockforge:latest";
+
+/// Default OCI image for plugin-enabled hosted-mocks. Bundles
+/// main mockforge + mockforge-plugin-host + mockforge-plugin-egress
+/// per `Dockerfile.cloud-plugins`. Operators can override via
+/// `MOCKFORGE_CLOUD_PLUGINS_IMAGE` env var.
+const DEFAULT_CLOUD_PLUGINS_IMAGE: &str = "ghcr.io/saasy-solutions/mockforge-cloud-plugins:latest";
+
+/// Pick the right OCI image for a deployment based on whether
+/// any plugins are attached. Reads:
+///
+/// - `MOCKFORGE_CLOUD_PLUGINS_IMAGE` — overrides the default
+///   plugin-enabled image
+/// - `MOCKFORGE_DOCKER_IMAGE` — overrides the default base image
+///
+/// Pairs with [`crate::deployment::flyio::FlyioGuest::for_hosted_mock`]
+/// so the orchestrator picks both the right image AND the right
+/// machine size for the deployment's tier.
+async fn resolve_image_for_deployment(pool: &PgPool, deployment_id: Uuid) -> String {
+    let plugins_attached = match HostedMockPlugin::count_active_by_deployment(pool, deployment_id)
+        .await
+    {
+        Ok(count) => count > 0,
+        Err(err) => {
+            // A query failure shouldn't block deploy. Fall back to
+            // the base image — the deploy proceeds without plugin
+            // support, and the next attach call surfaces the
+            // failure on the control-plane API.
+            warn!(
+                error = %err,
+                deployment_id = %deployment_id,
+                "could not count attached plugins for image selection; falling back to base image"
+            );
+            false
+        }
+    };
+
+    if plugins_attached {
+        std::env::var("MOCKFORGE_CLOUD_PLUGINS_IMAGE")
+            .unwrap_or_else(|_| DEFAULT_CLOUD_PLUGINS_IMAGE.to_string())
+    } else {
+        std::env::var("MOCKFORGE_DOCKER_IMAGE").unwrap_or_else(|_| DEFAULT_BASE_IMAGE.to_string())
+    }
+}
 
 /// Deployment orchestrator that manages hosted mock deployments
 pub struct DeploymentOrchestrator {
@@ -304,8 +351,7 @@ impl DeploymentOrchestrator {
         }
 
         // Use MockForge Docker image
-        let image = std::env::var("MOCKFORGE_DOCKER_IMAGE")
-            .unwrap_or_else(|_| "ghcr.io/saasy-solutions/mockforge:latest".to_string());
+        let image = resolve_image_for_deployment(pool, deployment.id).await;
 
         // Always-on HTTP service (also serves WS upgrade and /graphql).
         let mut services = vec![FlyioService {
@@ -561,8 +607,7 @@ impl DeploymentOrchestrator {
             env.insert("MOCKFORGE_OPENAPI_SPEC_URL".to_string(), spec_url.clone());
         }
 
-        let image = std::env::var("MOCKFORGE_DOCKER_IMAGE")
-            .unwrap_or_else(|_| "ghcr.io/saasy-solutions/mockforge:latest".to_string());
+        let image = resolve_image_for_deployment(pool, deployment.id).await;
 
         let services = vec![FlyioService {
             protocol: "tcp".to_string(),


### PR DESCRIPTION
## Summary
Closes the gap between #389 (schema), #398 (\`FlyioGuest\` sizing), and #402 (Dockerfile). The orchestrator now picks the right OCI image *and* machine size based on whether a hosted-mock has plugins attached.

**Stacked on #398.**

## Behavior
| Attached plugins | Image |
|---|---|
| 0 | \`ghcr.io/saasy-solutions/mockforge:latest\` (overridable via \`MOCKFORGE_DOCKER_IMAGE\` — same as before). No behavior change for legacy deployments. |
| ≥1 | \`ghcr.io/saasy-solutions/mockforge-cloud-plugins:latest\` (overridable via \`MOCKFORGE_CLOUD_PLUGINS_IMAGE\`). Bundles main mockforge + plugin-host + egress-proxy per #402. |

## Implementation
Extracted \`resolve_image_for_deployment(pool, deployment_id)\` helper called by both the initial deploy (orchestrator.rs:356) and redeploy (orchestrator.rs:612) codepaths. Single source of truth for image selection so the two paths can't drift.

## Failure handling
A \`count_active_by_deployment\` query failure falls back to the base image rather than blocking deploy. The control-plane API in #395 surfaces attach failures separately; deploy proceeds without plugin support and the operator gets two distinct signals.

## Test plan
- [x] \`cargo check -p mockforge-registry-server\`
- [x] \`cargo clippy -p mockforge-registry-server --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] Pre-commit hooks all passed

## What's next
- Trigger redeploy from the attach/detach handler so the image changes pick up without operator intervention
- Surface "image was upgraded for plugin support" as a deploy-log event