### PR TITLE
feat(plugin-egress): live reload of allowlist via SIGHUP

### DIFF
--- a/crates/mockforge-plugin-egress/src/handle.rs
+++ b/crates/mockforge-plugin-egress/src/handle.rs
@@ -1,0 +1,189 @@
+//! Cheaply-cloneable, hot-swappable handle around a [`HostPolicy`].
+//!
+//! Built on `Arc<std::sync::RwLock<Arc<HostPolicy>>>`. The double
+//! `Arc` lets per-connection tasks `read()` the inner `Arc<Policy>`
+//! under a brief read lock and then drop the lock — checks against
+//! the policy don't hold the lock across await points. A reload
+//! takes the write lock just long enough to replace the inner
+//! `Arc`. Readers using the old version finish naturally as their
+//! `Arc<HostPolicy>` clones drop.
+//!
+//! Why `std::sync::RwLock` rather than `tokio::sync::RwLock`: the
+//! lock is held for nanoseconds (clone an Arc, drop the guard).
+//! Holding it across an `await` would be wrong; the API
+//! deliberately doesn't expose that. Tokio's RwLock would force
+//! every check to be `.await` for no benefit.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use crate::policy::{HostPolicy, PolicyDecision, PolicyError};
+
+/// Hot-swappable policy handle. Cloning is `Arc::clone` —
+/// per-connection tasks each hold one.
+#[derive(Clone)]
+pub struct PolicyHandle {
+    inner: Arc<RwLock<Arc<HostPolicy>>>,
+}
+
+impl PolicyHandle {
+    /// Wrap an existing `HostPolicy`.
+    pub fn new(policy: HostPolicy) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Arc::new(policy))),
+        }
+    }
+
+    /// Take a cheap snapshot of the current policy. The returned
+    /// `Arc<HostPolicy>` survives a concurrent `replace`; the
+    /// caller's view of the policy is consistent for the rest of
+    /// the request.
+    pub fn snapshot(&self) -> Arc<HostPolicy> {
+        // `expect` rather than `unwrap` so a poisoned lock surfaces
+        // a clear message — poisoning would mean a previous holder
+        // panicked while writing, which is a bug worth seeing.
+        Arc::clone(
+            &self
+                .inner
+                .read()
+                .expect("PolicyHandle read lock poisoned — earlier write panicked"),
+        )
+    }
+
+    /// One-shot check that combines `snapshot` and
+    /// `HostPolicy::check`. Convenient for the proxy hot path.
+    pub fn check(&self, host: &str) -> PolicyDecision {
+        self.snapshot().check(host)
+    }
+
+    /// Atomically replace the inner policy.
+    pub fn replace(&self, policy: HostPolicy) {
+        let mut guard = self
+            .inner
+            .write()
+            .expect("PolicyHandle write lock poisoned — previous holder panicked");
+        *guard = Arc::new(policy);
+    }
+}
+
+/// Read an allowlist file (one pattern per line, `#` comments) and
+/// build a fresh [`HostPolicy`]. Used by the SIGHUP handler in
+/// `main.rs`.
+pub fn load_policy_from_file(path: &Path) -> Result<HostPolicy, ReloadError> {
+    let contents = std::fs::read_to_string(path).map_err(|err| ReloadError::Io {
+        path: path.to_path_buf(),
+        err: err.to_string(),
+    })?;
+    let patterns: Vec<String> = contents
+        .lines()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && !s.starts_with('#'))
+        .map(|s| s.to_string())
+        .collect();
+    HostPolicy::from_patterns(&patterns).map_err(ReloadError::Compile)
+}
+
+/// Errors building a fresh policy from disk during reload.
+#[derive(Debug, thiserror::Error)]
+pub enum ReloadError {
+    /// Couldn't read the allowlist file.
+    #[error("io error reading {}: {err}", path.display())]
+    Io {
+        /// Path that failed to open.
+        path: PathBuf,
+        /// Underlying io::Error message.
+        err: String,
+    },
+    /// Patterns didn't compile (e.g. mid-string wildcard).
+    #[error("policy compile error: {0}")]
+    Compile(#[from] PolicyError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn handle_snapshot_returns_current_policy() {
+        let policy = HostPolicy::from_patterns(&["api.stripe.com".to_string()]).unwrap();
+        let handle = PolicyHandle::new(policy);
+        let snap = handle.snapshot();
+        assert_eq!(snap.check("api.stripe.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn handle_replace_swaps_policy() {
+        let initial = HostPolicy::from_patterns(&["a.example.com".to_string()]).unwrap();
+        let handle = PolicyHandle::new(initial);
+
+        // Old policy allows a.example.com but not b.example.com.
+        assert_eq!(handle.check("a.example.com"), PolicyDecision::Allowed);
+        assert!(matches!(handle.check("b.example.com"), PolicyDecision::Denied(_)));
+
+        // Hot-swap.
+        let updated = HostPolicy::from_patterns(&["b.example.com".to_string()]).unwrap();
+        handle.replace(updated);
+
+        assert!(matches!(handle.check("a.example.com"), PolicyDecision::Denied(_)));
+        assert_eq!(handle.check("b.example.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn handle_clone_shares_state() {
+        let policy = HostPolicy::from_patterns(&["api.example.com".to_string()]).unwrap();
+        let handle = PolicyHandle::new(policy);
+        let cloned = handle.clone();
+
+        // Replace via the clone — original sees the change.
+        cloned.replace(HostPolicy::from_patterns(&["new.example.com".to_string()]).unwrap());
+        assert_eq!(handle.check("new.example.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn pre_reload_snapshot_survives_concurrent_replace() {
+        let initial = HostPolicy::from_patterns(&["before.example.com".to_string()]).unwrap();
+        let handle = PolicyHandle::new(initial);
+
+        // Take a snapshot, then replace, then keep using the old
+        // snapshot. This simulates a long-lived request that
+        // started under an old policy — its decisions stay stable
+        // for the request's lifetime.
+        let snap = handle.snapshot();
+        handle.replace(HostPolicy::from_patterns(&["after.example.com".to_string()]).unwrap());
+
+        // Old snapshot still allows the old hostname.
+        assert_eq!(snap.check("before.example.com"), PolicyDecision::Allowed);
+        // New handle reads see the swap.
+        assert_eq!(handle.check("after.example.com"), PolicyDecision::Allowed);
+        assert!(matches!(handle.check("before.example.com"), PolicyDecision::Denied(_)));
+    }
+
+    #[test]
+    fn load_policy_from_file_strips_comments_and_blank_lines() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "# header comment").unwrap();
+        writeln!(file).unwrap();
+        writeln!(file, "api.stripe.com").unwrap();
+        writeln!(file, "  *.stripe.com  ").unwrap();
+        writeln!(file, "# another comment").unwrap();
+
+        let policy = load_policy_from_file(file.path()).unwrap();
+        assert_eq!(policy.check("api.stripe.com"), PolicyDecision::Allowed);
+        assert_eq!(policy.check("events.stripe.com"), PolicyDecision::Allowed);
+    }
+
+    #[test]
+    fn load_policy_from_file_surfaces_compile_errors() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "foo.*.com").unwrap(); // mid-string wildcard
+        let result = load_policy_from_file(file.path());
+        assert!(matches!(result, Err(ReloadError::Compile(_))));
+    }
+
+    #[test]
+    fn load_policy_from_file_surfaces_missing_file_errors() {
+        let result = load_policy_from_file(Path::new("/nonexistent/path/that/does/not/exist"));
+        assert!(matches!(result, Err(ReloadError::Io { .. })));
+    }
+}

--- a/crates/mockforge-plugin-egress/src/lib.rs
+++ b/crates/mockforge-plugin-egress/src/lib.rs
@@ -37,9 +37,11 @@
 //!   same allowlist. No "this rewrite-rule may call X, that one Y."
 
 pub mod denylist;
+pub mod handle;
 pub mod policy;
 pub mod proxy;
 
 pub use denylist::is_denied_target;
+pub use handle::{load_policy_from_file, PolicyHandle, ReloadError};
 pub use policy::{HostPolicy, PolicyDecision};
 pub use proxy::{run_proxy, ProxyConfig};

--- a/crates/mockforge-plugin-egress/src/main.rs
+++ b/crates/mockforge-plugin-egress/src/main.rs
@@ -6,17 +6,23 @@
 //! Bind address comes from `MOCKFORGE_PLUGIN_EGRESS_LISTEN`,
 //! defaulting to `127.0.0.1:8125`.
 //!
-//! In a Phase 2 production deployment, the plugin-host (PR #399/#400)
-//! is responsible for keeping this proxy's allowlist in sync with the
-//! per-plugin grants. v1 reads a static config; a future PR will
-//! add live reload via SIGHUP or an admin socket.
+//! ## Live reload
+//!
+//! When `MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE` is set, sending
+//! `SIGHUP` to the process re-reads the file and atomically swaps
+//! the active policy. In-flight connections finish under their
+//! pre-reload snapshot; new connections see the updated policy
+//! immediately. A failed reload (file missing, invalid pattern)
+//! is logged and the previous policy stays in place — a typo'd
+//! file shouldn't open the gates.
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use mockforge_plugin_egress::{run_proxy, HostPolicy, ProxyConfig};
+use mockforge_plugin_egress::{
+    load_policy_from_file, run_proxy, HostPolicy, PolicyHandle, ProxyConfig,
+};
 
 const DEFAULT_LISTEN: &str = "127.0.0.1:8125";
 
@@ -29,14 +35,19 @@ async fn main() -> Result<()> {
         .parse()
         .context("parsing MOCKFORGE_PLUGIN_EGRESS_LISTEN")?;
 
-    let patterns = load_allowlist()?;
+    let allowlist_file =
+        std::env::var("MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE").ok().map(PathBuf::from);
+
+    let patterns = load_initial_allowlist(allowlist_file.as_deref())?;
     let policy = HostPolicy::from_patterns(&patterns).context("compiling egress allowlist")?;
-    let config = ProxyConfig::new(listen, Arc::new(policy));
+    let handle = PolicyHandle::new(policy);
+    let config = ProxyConfig::new(listen, handle.clone());
 
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         listen = %listen,
         patterns = patterns.len(),
+        reload_path = allowlist_file.as_ref().map(|p| p.display().to_string()).unwrap_or_else(|| "(disabled)".into()),
         "mockforge-plugin-egress starting"
     );
 
@@ -45,6 +56,9 @@ async fn main() -> Result<()> {
             tracing::error!(?result, "proxy exited unexpectedly");
             result
         }
+        _ = sighup_loop(handle, allowlist_file) => {
+            unreachable!("sighup_loop runs forever until shutdown_signal cancels it")
+        }
         _ = shutdown_signal() => {
             tracing::info!("egress proxy received shutdown signal — exiting");
             Ok(())
@@ -52,9 +66,63 @@ async fn main() -> Result<()> {
     }
 }
 
-fn load_allowlist() -> Result<Vec<String>> {
-    if let Ok(path) = std::env::var("MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE") {
-        return load_allowlist_file(PathBuf::from(path));
+/// SIGHUP reload loop. Returns only on cancellation by the
+/// outer `select!`. If no allowlist file is configured (so a
+/// reload would have nothing to read), `pending()` blocks
+/// forever — the `select!` arm is effectively disabled but the
+/// shape of the binary stays simple.
+#[cfg(unix)]
+async fn sighup_loop(handle: PolicyHandle, allowlist_file: Option<PathBuf>) {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let Some(path) = allowlist_file else {
+        std::future::pending::<()>().await;
+        return;
+    };
+
+    let mut sighup = match signal(SignalKind::hangup()) {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to install SIGHUP handler; live reload disabled");
+            std::future::pending::<()>().await;
+            return;
+        }
+    };
+
+    while sighup.recv().await.is_some() {
+        match load_policy_from_file(&path) {
+            Ok(new_policy) => {
+                handle.replace(new_policy);
+                tracing::info!(path = %path.display(), "egress allowlist reloaded on SIGHUP");
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    path = %path.display(),
+                    "SIGHUP reload failed; previous policy retained"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn sighup_loop(_handle: PolicyHandle, _allowlist_file: Option<PathBuf>) {
+    // SIGHUP is Unix-only. Non-Unix builds (developer machines)
+    // get no live reload.
+    std::future::pending::<()>().await;
+}
+
+fn load_initial_allowlist(allowlist_file: Option<&std::path::Path>) -> Result<Vec<String>> {
+    if let Some(path) = allowlist_file {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("reading allowlist file {}", path.display()))?;
+        return Ok(contents
+            .lines()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty() && !s.starts_with('#'))
+            .map(|s| s.to_string())
+            .collect());
     }
     if let Ok(inline) = std::env::var("MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST") {
         return Ok(inline
@@ -70,17 +138,6 @@ fn load_allowlist() -> Result<Vec<String>> {
         "no allowlist configured (set MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST or _FILE) — deny-all"
     );
     Ok(Vec::new())
-}
-
-fn load_allowlist_file(path: PathBuf) -> Result<Vec<String>> {
-    let contents = std::fs::read_to_string(&path)
-        .with_context(|| format!("reading allowlist file {}", path.display()))?;
-    Ok(contents
-        .lines()
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty() && !s.starts_with('#'))
-        .map(|s| s.to_string())
-        .collect())
 }
 
 fn init_tracing() {

--- a/crates/mockforge-plugin-egress/src/proxy.rs
+++ b/crates/mockforge-plugin-egress/src/proxy.rs
@@ -5,14 +5,14 @@
 //! which is `Send + Sync`.
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::denylist::denied_ip;
-use crate::policy::{HostPolicy, PolicyDecision};
+use crate::handle::PolicyHandle;
+use crate::policy::PolicyDecision;
 
 /// Configuration for the proxy server.
 #[derive(Clone)]
@@ -20,9 +20,13 @@ pub struct ProxyConfig {
     /// TCP address to bind. Plugins set `HTTP_PROXY` /
     /// `HTTPS_PROXY` env vars at this address.
     pub listen: SocketAddr,
-    /// Per-plugin allowlist policy. Wrapped in `Arc` so the
-    /// per-connection tasks can clone the handle cheaply.
-    pub policy: Arc<HostPolicy>,
+    /// Hot-swappable allowlist handle. Per-connection tasks clone
+    /// the handle (cheap), snapshot it for each request, and drop
+    /// the snapshot when the request ends. The SIGHUP signal
+    /// handler in `main.rs` swaps the inner policy without
+    /// affecting in-flight connections — those finish under
+    /// their own snapshot.
+    pub policy: PolicyHandle,
     /// Hard cap on the number of bytes we'll buffer while reading
     /// the request line + headers. 64 KiB is generous for realistic
     /// HTTP traffic; protects against malicious clients sending
@@ -33,7 +37,7 @@ pub struct ProxyConfig {
 impl ProxyConfig {
     /// Convenience constructor with sensible defaults for header
     /// limits.
-    pub fn new(listen: SocketAddr, policy: Arc<HostPolicy>) -> Self {
+    pub fn new(listen: SocketAddr, policy: PolicyHandle) -> Self {
         Self {
             listen,
             policy,
@@ -72,7 +76,7 @@ pub async fn run_proxy(config: ProxyConfig) -> Result<()> {
 async fn handle_connection(
     mut stream: TcpStream,
     _peer: SocketAddr,
-    policy: Arc<HostPolicy>,
+    policy: PolicyHandle,
     max_header_bytes: usize,
 ) -> Result<()> {
     let request_line = read_request_line(&mut stream, max_header_bytes).await?;
@@ -191,7 +195,7 @@ async fn handle_connect(
     mut client: TcpStream,
     host: String,
     port: u16,
-    policy: Arc<HostPolicy>,
+    policy: PolicyHandle,
 ) -> Result<()> {
     // Drain remaining client headers before deciding — RFC 7231
     // requires consuming through the empty line. Use a fresh


### PR DESCRIPTION
## Summary
Plugin-host (#400) needs to push grant updates as plugins attach/detach without restarting the proxy and dropping in-flight connections. SIGHUP-based file reload is the simplest fit.

**Stacked on #401.**

## Smoke test (real curl + SIGHUP)
\`\`\`
$ printf "example.com\n" > allowlist.txt
$ MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE=allowlist.txt \\
  target/debug/mockforge-plugin-egress &
$ curl --proxy http://127.0.0.1:8125 https://github.com/
-> 403 (denied: host not in allowlist)

$ printf "example.com\ngithub.com\n" > allowlist.txt
$ kill -HUP $(pgrep mockforge-plugin-egress)
$ curl --proxy http://127.0.0.1:8125 https://github.com/
-> 200
\`\`\`

## What it adds
**New module \`handle.rs\`:**
- \`PolicyHandle\` wraps \`Arc<RwLock<Arc<HostPolicy>>>\`. \`snapshot()\` takes a brief read lock, clones the inner Arc, drops the lock — the returned snapshot survives a concurrent \`replace\` so in-flight requests see a stable policy. \`replace()\` takes the write lock just long enough to swap the inner Arc.
- \`load_policy_from_file()\` rebuilds policy from disk, handling \`#\` comments and blank lines.
- \`ReloadError\` surfaces both I/O and compile errors.

**Why \`std::sync::RwLock\` not \`tokio::sync::RwLock\`:** Lock held for nanoseconds (Arc::clone), never across an await. Tokio's RwLock would force every check to be \`.await\` for no benefit.

**main.rs \`sighup_loop\`:**
- Installs SIGHUP, re-reads the file on each signal, atomically replaces via \`PolicyHandle\`
- Failed reload (file missing, invalid pattern) is logged; previous policy stays active. **A typo'd file shouldn't open the gates.**
- If \`MOCKFORGE_PLUGIN_EGRESS_ALLOWLIST_FILE\` isn't set, \`sighup_loop\` blocks on \`pending()\`; inline allowlists can't reload.

## Test plan
- [x] \`cargo check -p mockforge-plugin-egress\`
- [x] \`cargo clippy -p mockforge-plugin-egress --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test -p mockforge-plugin-egress --lib\` — **34/34 pass** (27 from #401 + 7 new):
  - PolicyHandle: snapshot, replace, clone-shares-state, **pre-reload-snapshot survives concurrent replace** (the key correctness property)
  - load_policy_from_file: comment/blank-line stripping, compile-error surface, missing-file-error surface
- [x] **Live smoke test**: SIGHUP swaps allowlist between two real curl invocations through the proxy; log line confirms the reload
- [x] Pre-commit hooks all passed