### PR TITLE
feat(plugin-host): metric exporter wires invocation bus to cloud aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8601,8 +8601,11 @@ version = "0.3.126"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
+ "ed25519-dalek",
  "mockforge-plugin-core",
  "mockforge-plugin-loader",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/mockforge-plugin-host/Cargo.toml
+++ b/crates/mockforge-plugin-host/Cargo.toml
@@ -59,5 +59,17 @@ uuid = { workspace = true, features = ["serde"] }
 base64 = "0.22"
 tempfile = "3"
 
+# Ed25519 signature verification on the WASM bytes (RFC §7.2 step 3).
+# Matches the scheme used by the registry's UserPublicKey +
+# verify_sbom_attestation so trust roots can be shared once the
+# registry-fetch path lands.
+ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+
+# HTTP client for the kill-switch blocklist poll task (RFC §8.3).
+reqwest = { workspace = true }
+# Workspace chrono already enables serde — used by BlocklistEntry's
+# `revoked_at` field on the wire format.
+chrono = { workspace = true }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/mockforge-plugin-host/src/blocklist.rs
+++ b/crates/mockforge-plugin-host/src/blocklist.rs
@@ -1,0 +1,306 @@
+//! Kill-switch blocklist (RFC §8.3).
+//!
+//! Plugin-host polls a registry endpoint for revoked
+//! `(plugin_name, version)` entries on a configurable interval.
+//! When the blocklist updates, the actor unloads any matched
+//! plugins and rejects subsequent loads with `revoked` so the
+//! caller (main mockforge → API client) gets a stable error
+//! they can surface.
+//!
+//! ## Why polling, not push
+//!
+//! Push requires a long-lived control-plane connection from each
+//! plugin-host back to the registry — that's extra ops surface
+//! (TLS rotation, reconnects, partitions) for a path that fires
+//! every few weeks at most. Polling is operationally boring and
+//! the latency target is already minutes per RFC §8.1.
+//!
+//! ## Wire format
+//!
+//! The registry endpoint returns a JSON array:
+//!
+//! ```json
+//! [
+//!   { "plugin_name": "stripe-rewriter", "version": "1.2.3",
+//!     "reason": "CVE-2026-1234", "revoked_at": "2026-05-06T01:00:00Z" }
+//! ]
+//! ```
+//!
+//! Match is exact `(name, version)` — semver ranges are out of
+//! scope for v1. Operators publishing a range simply enumerate
+//! the affected versions on the registry side.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+/// One revoked plugin pin. The registry returns an array of
+/// these; the host stores them in a [`Blocklist`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct BlocklistEntry {
+    /// Plugin name from the registry.
+    pub plugin_name: String,
+    /// Exact version revoked. Wildcard semantics (e.g. revoke all
+    /// versions of a plugin) are out of scope for v1; the
+    /// registry should enumerate.
+    pub version: String,
+    /// Stable reason string. Surfaced in the `revoked` error code
+    /// message and the audit log so operators can correlate
+    /// against advisories.
+    pub reason: String,
+    /// When the registry recorded the revocation.
+    pub revoked_at: DateTime<Utc>,
+}
+
+/// Cheaply-cloneable handle to the live blocklist. Both the poll
+/// task and the actor hold an `Arc<RwLock<...>>` so updates from
+/// the poller are observed by the actor without a channel hop.
+#[derive(Debug, Clone, Default)]
+pub struct Blocklist {
+    inner: Arc<RwLock<Vec<BlocklistEntry>>>,
+}
+
+impl Blocklist {
+    /// Empty blocklist — nothing is revoked.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the entire entry set. Called by the poll task on
+    /// each successful refresh; the actor observes the new set on
+    /// its next read without coordinating.
+    pub async fn replace(&self, entries: Vec<BlocklistEntry>) {
+        let mut guard = self.inner.write().await;
+        *guard = entries;
+    }
+
+    /// Take a cheap snapshot of the current entries. Returned as
+    /// `Vec` rather than holding the read lock, so callers can
+    /// iterate without blocking the writer.
+    pub async fn snapshot(&self) -> Vec<BlocklistEntry> {
+        self.inner.read().await.clone()
+    }
+
+    /// Whether the named `(plugin, version)` is on the blocklist.
+    /// Returns the matching reason for audit logging.
+    pub async fn matches(&self, plugin_name: &str, version: &str) -> Option<String> {
+        let guard = self.inner.read().await;
+        for entry in guard.iter() {
+            if entry.plugin_name == plugin_name && entry.version == version {
+                return Some(entry.reason.clone());
+            }
+        }
+        None
+    }
+
+    /// Return the names of every loaded plugin that's on the
+    /// blocklist. Used by the actor's periodic sweep to decide
+    /// what to unload.
+    pub async fn matches_in<I, S>(&self, loaded: I) -> HashSet<String>
+    where
+        I: IntoIterator<Item = (S, S)>,
+        S: AsRef<str>,
+    {
+        let guard = self.inner.read().await;
+        let mut hits = HashSet::new();
+        for (name, version) in loaded {
+            for entry in guard.iter() {
+                if entry.plugin_name == name.as_ref() && entry.version == version.as_ref() {
+                    hits.insert(name.as_ref().to_string());
+                    break;
+                }
+            }
+        }
+        hits
+    }
+}
+
+/// Errors the poll task can hit. Each one is logged + retried on
+/// the next interval; we never give up on the blocklist because a
+/// stale blocklist is a security risk.
+#[derive(Debug, thiserror::Error)]
+pub enum PollError {
+    /// HTTP request failed.
+    #[error("blocklist HTTP error: {0}")]
+    Http(String),
+    /// Response body wasn't valid JSON / shape.
+    #[error("blocklist parse error: {0}")]
+    Parse(String),
+}
+
+/// Configuration for the poll task.
+#[derive(Debug, Clone)]
+pub struct BlocklistConfig {
+    /// Registry endpoint to poll. Returns the JSON array
+    /// described in the module docs.
+    pub url: String,
+    /// Poll interval. Default 60 seconds per RFC §8.2.
+    pub interval: std::time::Duration,
+    /// Optional bearer token; sent as `Authorization: Bearer ...`.
+    /// Cloud production sets this so the registry can rate-limit
+    /// per host.
+    pub bearer_token: Option<String>,
+}
+
+impl BlocklistConfig {
+    /// Construct with the default 60s interval and no bearer
+    /// token.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            interval: std::time::Duration::from_secs(60),
+            bearer_token: None,
+        }
+    }
+}
+
+/// Run the poll task forever. Returns only on shutdown signal —
+/// the `select!` in main.rs is responsible for cancelling.
+pub async fn run_poll_loop(config: BlocklistConfig, blocklist: Blocklist) {
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to build blocklist HTTP client; poll task exiting");
+            return;
+        }
+    };
+
+    tracing::info!(url = %config.url, interval_secs = config.interval.as_secs(), "blocklist poll loop starting");
+
+    let mut ticker = tokio::time::interval(config.interval);
+    // Skip-the-first-tick semantics so we poll *immediately*, not
+    // after one full interval. Operators see initial blocklist
+    // state on startup.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+        match fetch_blocklist(&client, &config).await {
+            Ok(entries) => {
+                let count = entries.len();
+                blocklist.replace(entries).await;
+                tracing::debug!(entries = count, "blocklist refreshed");
+            }
+            Err(err) => {
+                // Don't update on error — preserve the last-known
+                // blocklist. A registry outage shouldn't open a
+                // security hole by silently emptying the list.
+                tracing::warn!(error = %err, "blocklist poll failed; keeping last-known list");
+            }
+        }
+    }
+}
+
+async fn fetch_blocklist(
+    client: &reqwest::Client,
+    config: &BlocklistConfig,
+) -> Result<Vec<BlocklistEntry>, PollError> {
+    let mut req = client.get(&config.url);
+    if let Some(token) = &config.bearer_token {
+        req = req.bearer_auth(token);
+    }
+    let response = req.send().await.map_err(|err| PollError::Http(err.to_string()))?;
+    if !response.status().is_success() {
+        return Err(PollError::Http(format!("status {}", response.status())));
+    }
+    response
+        .json::<Vec<BlocklistEntry>>()
+        .await
+        .map_err(|err| PollError::Parse(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn entry(name: &str, version: &str) -> BlocklistEntry {
+        BlocklistEntry {
+            plugin_name: name.to_string(),
+            version: version.to_string(),
+            reason: format!("test-revocation:{name}:{version}"),
+            revoked_at: Utc.with_ymd_and_hms(2026, 5, 6, 1, 0, 0).unwrap(),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_blocklist_matches_nothing() {
+        let bl = Blocklist::new();
+        assert!(bl.matches("any", "1.0.0").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn populated_blocklist_matches_exact_pair() {
+        let bl = Blocklist::new();
+        bl.replace(vec![entry("evil-plugin", "1.0.0")]).await;
+        assert!(bl.matches("evil-plugin", "1.0.0").await.is_some());
+        // Different version of same plugin not blocked.
+        assert!(bl.matches("evil-plugin", "1.0.1").await.is_none());
+        // Different plugin same version not blocked.
+        assert!(bl.matches("good-plugin", "1.0.0").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn replace_swaps_the_entire_set() {
+        let bl = Blocklist::new();
+        bl.replace(vec![entry("p1", "1.0.0")]).await;
+        bl.replace(vec![entry("p2", "2.0.0")]).await;
+        assert!(bl.matches("p1", "1.0.0").await.is_none());
+        assert!(bl.matches("p2", "2.0.0").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn matches_in_finds_loaded_hits() {
+        let bl = Blocklist::new();
+        bl.replace(vec![entry("p1", "1.0.0"), entry("p3", "3.0.0")]).await;
+        let loaded = vec![
+            ("p1".to_string(), "1.0.0".to_string()), // hit
+            ("p2".to_string(), "2.0.0".to_string()), // miss
+            ("p3".to_string(), "3.0.0".to_string()), // hit
+        ];
+        let hits = bl.matches_in(loaded).await;
+        assert_eq!(hits.len(), 2);
+        assert!(hits.contains("p1"));
+        assert!(hits.contains("p3"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_round_trips_cloneable() {
+        let bl = Blocklist::new();
+        bl.replace(vec![entry("p1", "1.0.0")]).await;
+        let snap = bl.snapshot().await;
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].plugin_name, "p1");
+    }
+
+    #[tokio::test]
+    async fn blocklist_entry_round_trips_through_json() {
+        // Confirms the wire format the registry endpoint produces
+        // parses correctly. Any drift would surface here.
+        let raw = r#"[
+            {
+                "plugin_name": "evil",
+                "version": "1.0.0",
+                "reason": "CVE-2026-1234",
+                "revoked_at": "2026-05-06T01:00:00Z"
+            }
+        ]"#;
+        let entries: Vec<BlocklistEntry> = serde_json::from_str(raw).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].plugin_name, "evil");
+        assert_eq!(entries[0].reason, "CVE-2026-1234");
+    }
+
+    #[tokio::test]
+    async fn config_defaults_to_60s_interval() {
+        let cfg = BlocklistConfig::new("http://example/blocklist");
+        assert_eq!(cfg.interval.as_secs(), 60);
+        assert!(cfg.bearer_token.is_none());
+    }
+}

--- a/crates/mockforge-plugin-host/src/handlers.rs
+++ b/crates/mockforge-plugin-host/src/handlers.rs
@@ -23,6 +23,9 @@ pub async fn handle(host: &Host, request: Request) -> Response {
             version,
             permissions,
             wasm_b64,
+            signature_b64,
+            publisher_key_id,
+            manifest_b64,
         } => {
             let bytes = match base64::engine::general_purpose::STANDARD.decode(wasm_b64.as_bytes())
             {
@@ -35,7 +38,32 @@ pub async fn handle(host: &Host, request: Request) -> Response {
                     };
                 }
             };
-            match host.load_plugin(&plugin_name, &version, permissions, bytes).await {
+            let manifest_bytes = match manifest_b64
+                .as_deref()
+                .map(|s| base64::engine::general_purpose::STANDARD.decode(s.as_bytes()))
+                .transpose()
+            {
+                Ok(b) => b,
+                Err(err) => {
+                    return Response::Error {
+                        id,
+                        code: "invalid_base64".to_string(),
+                        message: format!("decoding manifest_b64: {err}"),
+                    };
+                }
+            };
+            match host
+                .load_plugin(
+                    &plugin_name,
+                    &version,
+                    permissions,
+                    bytes,
+                    signature_b64,
+                    publisher_key_id,
+                    manifest_bytes,
+                )
+                .await
+            {
                 Ok(plugin_id) => Response::Ok {
                     id,
                     body: serde_json::json!({
@@ -113,11 +141,19 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let (host, actor) = Host::new(PluginLoaderConfig {
-                allow_unsigned: true,
-                skip_wasm_validation: true,
-                ..Default::default()
-            });
+            let verifier = crate::signing::SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Optional,
+            );
+            let (host, actor, _bus) = Host::new(
+                PluginLoaderConfig {
+                    allow_unsigned: true,
+                    skip_wasm_validation: true,
+                    ..Default::default()
+                },
+                verifier,
+                crate::blocklist::Blocklist::new(),
+            );
             tokio::select! {
                 result = body(host) => result,
                 _ = actor => panic!("actor exited before test body finished"),
@@ -146,6 +182,9 @@ mod tests {
                     version: "1.0.0".into(),
                     permissions: serde_json::json!({}),
                     wasm_b64: b64_minimal(),
+                    signature_b64: None,
+                    publisher_key_id: None,
+                    manifest_b64: None,
                 },
             )
             .await;
@@ -188,6 +227,9 @@ mod tests {
                     version: "1.0.0".into(),
                     permissions: serde_json::json!({}),
                     wasm_b64: "not-valid-base64-!!!".into(),
+                    signature_b64: None,
+                    publisher_key_id: None,
+                    manifest_b64: None,
                 },
             )
             .await;
@@ -212,6 +254,9 @@ mod tests {
                 version: "1.0.0".into(),
                 permissions: serde_json::json!({}),
                 wasm_b64: b64_minimal(),
+                signature_b64: None,
+                publisher_key_id: None,
+                manifest_b64: None,
             };
             let _first = handle(&host, make_load(Uuid::new_v4())).await;
             let second = handle(&host, make_load(Uuid::new_v4())).await;
@@ -280,6 +325,9 @@ mod tests {
                     version: "1.0.0".into(),
                     permissions: serde_json::json!({}),
                     wasm_b64: b64_minimal(),
+                    signature_b64: None,
+                    publisher_key_id: None,
+                    manifest_b64: None,
                 },
             )
             .await;

--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -29,6 +29,17 @@ use mockforge_plugin_loader::{
 };
 use tokio::sync::{mpsc, oneshot};
 
+use crate::blocklist::Blocklist;
+use crate::signing::{SignatureVerifier, VerificationError};
+
+/// How often the actor sweeps loaded plugins against the
+/// blocklist. The poll task itself updates the shared
+/// `Blocklist` on every fetch; this sweep notices entries the
+/// actor missed (e.g. a plugin that was loaded before the
+/// blocklist landed) and unloads them. 30s gives sub-minute
+/// reaction time without busy-looping.
+const SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Actor channel capacity. Generous because cloud-plugins ops are
 /// rare (load/unload at attach time, invoke once per request) and
 /// the cost of dropping is high (request gets a 503).
@@ -83,13 +94,34 @@ impl Host {
     /// Construct a new host. Returns the handle (cheap to clone,
     /// shareable across spawned connection tasks) and the actor
     /// future the caller must drive on the current task.
-    pub fn new(loader_config: PluginLoaderConfig) -> (Self, HostActor) {
+    ///
+    /// The verifier is consulted on every LoadPlugin to enforce
+    /// the policy from `cloud-trust-permissions-rfc.md` §7.2 step
+    /// 3. Pass [`SignatureVerifier::new(TrustStore::new(),
+    /// SignatureMode::Optional)`] for the loosest behavior — the
+    /// existing test fixtures use that to keep the tests focused
+    /// on lifecycle rather than signing.
+    ///
+    /// [`SignatureVerifier::new(TrustStore::new(), SignatureMode::Optional)`]: crate::signing::SignatureVerifier::new
+    pub fn new(
+        loader_config: PluginLoaderConfig,
+        verifier: SignatureVerifier,
+        blocklist: Blocklist,
+    ) -> (Self, HostActor, std::sync::Arc<mockforge_plugin_loader::InvocationMetricsBus>) {
         let (cmd_tx, cmd_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let started_at = Arc::new(Instant::now());
 
-        let actor: HostActor = Box::pin(actor_loop(loader_config, cmd_rx));
+        // Construct the sandbox eagerly so we can hand the bus
+        // back to the caller — the cloud metric exporter
+        // subscribes to it from `main.rs` before the actor starts
+        // accepting commands. Actor takes ownership of the
+        // sandbox via the `actor_loop` future.
+        let sandbox = PluginSandbox::new(loader_config);
+        let metrics_bus = sandbox.metrics_bus();
 
-        (Self { started_at, cmd_tx }, actor)
+        let actor: HostActor = Box::pin(actor_loop(sandbox, verifier, blocklist, cmd_rx));
+
+        (Self { started_at, cmd_tx }, actor, metrics_bus)
     }
 
     /// Process uptime in whole seconds.
@@ -101,12 +133,21 @@ impl Host {
     /// to a tempfile inside the actor so the loader (which takes a
     /// filesystem path) can `Module::from_file` it. Returns the
     /// loaded plugin's `PluginId` on success.
+    ///
+    /// The actor verifies the signature (if any) against its
+    /// `SignatureVerifier` before any bytes touch the loader.
+    /// `signature_b64` and `publisher_key_id` must be passed
+    /// together or both `None`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn load_plugin(
         &self,
         plugin_name: &str,
         version_str: &str,
         permissions: serde_json::Value,
         wasm_bytes: Vec<u8>,
+        signature_b64: Option<String>,
+        publisher_key_id: Option<String>,
+        manifest_bytes: Option<Vec<u8>>,
     ) -> Result<PluginId, HostError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx
@@ -115,6 +156,9 @@ impl Host {
                 version: version_str.to_string(),
                 permissions,
                 wasm_bytes,
+                signature_b64,
+                publisher_key_id,
+                manifest_bytes,
                 reply: reply_tx,
             })
             .await
@@ -176,6 +220,9 @@ enum Command {
         version: String,
         permissions: serde_json::Value,
         wasm_bytes: Vec<u8>,
+        signature_b64: Option<String>,
+        publisher_key_id: Option<String>,
+        manifest_bytes: Option<Vec<u8>>,
         reply: oneshot::Sender<Result<PluginId, HostError>>,
     },
     Unload {
@@ -196,65 +243,171 @@ enum Command {
 /// Actor task. Owns the `PluginSandbox` and the plugin map for the
 /// lifetime of the host process. Returns when the channel closes
 /// (all `Host` handles dropped) or the runtime shuts down.
-async fn actor_loop(loader_config: PluginLoaderConfig, mut cmd_rx: mpsc::Receiver<Command>) {
-    let sandbox = PluginSandbox::new(loader_config);
+async fn actor_loop(
+    sandbox: PluginSandbox,
+    verifier: SignatureVerifier,
+    blocklist: Blocklist,
+    mut cmd_rx: mpsc::Receiver<Command>,
+) {
     let mut plugins: HashMap<String, PluginEntry> = HashMap::new();
+    tracing::info!(
+        mode = ?verifier.mode(),
+        trusted_keys = verifier.trusted_key_count(),
+        "plugin-host actor started"
+    );
 
-    while let Some(cmd) = cmd_rx.recv().await {
-        match cmd {
-            Command::Load {
-                plugin_name,
-                version,
-                permissions,
-                wasm_bytes,
-                reply,
-            } => {
-                let result = handle_load(
-                    &sandbox,
-                    &mut plugins,
-                    &plugin_name,
-                    &version,
-                    permissions,
-                    wasm_bytes,
-                )
-                .await;
-                let _ = reply.send(result);
+    let mut sweep_ticker = tokio::time::interval(SWEEP_INTERVAL);
+    sweep_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => {
+                let Some(cmd) = cmd else {
+                    tracing::info!("plugin-host actor exiting (channel closed)");
+                    return;
+                };
+                match cmd {
+                    Command::Load {
+                        plugin_name,
+                        version,
+                        permissions,
+                        wasm_bytes,
+                        signature_b64,
+                        publisher_key_id,
+                        manifest_bytes,
+                        reply,
+                    } => {
+                        let result = handle_load(
+                            &sandbox,
+                            &verifier,
+                            &blocklist,
+                            &mut plugins,
+                            &plugin_name,
+                            &version,
+                            permissions,
+                            wasm_bytes,
+                            signature_b64.as_deref(),
+                            publisher_key_id.as_deref(),
+                            manifest_bytes.as_deref(),
+                        )
+                        .await;
+                        let _ = reply.send(result);
+                    }
+                    Command::Unload { plugin_name, reply } => {
+                        let result = handle_unload(&sandbox, &mut plugins, &plugin_name).await;
+                        let _ = reply.send(result);
+                    }
+                    Command::Invoke {
+                        plugin_name,
+                        function,
+                        input,
+                        reply,
+                    } => {
+                        // Last-line check on every invocation in
+                        // case the blocklist changed since load.
+                        // Cheap because the matches() lookup is a
+                        // short Vec scan under a read lock.
+                        let entry = plugins.get(&plugin_name);
+                        if let Some(entry) = entry {
+                            let version_str = entry.version.to_string();
+                            if let Some(reason) =
+                                blocklist.matches(&plugin_name, &version_str).await
+                            {
+                                let _ = reply.send(Err(HostError::Revoked {
+                                    plugin_name: plugin_name.clone(),
+                                    reason,
+                                }));
+                                continue;
+                            }
+                        }
+                        let result =
+                            handle_invoke(&sandbox, &plugins, &plugin_name, &function, input).await;
+                        let _ = reply.send(result);
+                    }
+                    Command::ListPlugins { reply } => {
+                        let snapshot: Vec<(String, PluginId)> = plugins
+                            .iter()
+                            .map(|(name, entry)| (name.clone(), entry.plugin_id.clone()))
+                            .collect();
+                        let _ = reply.send(snapshot);
+                    }
+                }
             }
-            Command::Unload { plugin_name, reply } => {
-                let result = handle_unload(&sandbox, &mut plugins, &plugin_name).await;
-                let _ = reply.send(result);
-            }
-            Command::Invoke {
-                plugin_name,
-                function,
-                input,
-                reply,
-            } => {
-                let result =
-                    handle_invoke(&sandbox, &plugins, &plugin_name, &function, input).await;
-                let _ = reply.send(result);
-            }
-            Command::ListPlugins { reply } => {
-                let snapshot: Vec<(String, PluginId)> = plugins
-                    .iter()
-                    .map(|(name, entry)| (name.clone(), entry.plugin_id.clone()))
-                    .collect();
-                let _ = reply.send(snapshot);
+            _ = sweep_ticker.tick() => {
+                sweep_blocklist(&sandbox, &blocklist, &mut plugins).await;
             }
         }
     }
-
-    tracing::info!("plugin-host actor exiting (channel closed)");
 }
 
+/// Walk the loaded plugin map and unload any whose
+/// `(name, version)` is now on the blocklist. Called on a timer;
+/// idempotent — a second sweep over the same set is a no-op.
+async fn sweep_blocklist(
+    sandbox: &PluginSandbox,
+    blocklist: &Blocklist,
+    plugins: &mut HashMap<String, PluginEntry>,
+) {
+    let pairs: Vec<(String, String)> = plugins
+        .iter()
+        .map(|(name, entry)| (name.clone(), entry.version.to_string()))
+        .collect();
+    let hits = blocklist.matches_in(pairs).await;
+    for name in hits {
+        if let Some(entry) = plugins.remove(&name) {
+            tracing::warn!(plugin_name = %name, "plugin revoked by blocklist sweep — unloading");
+            if let Err(err) = sandbox.destroy_sandbox(&entry.plugin_id).await {
+                tracing::error!(error = %err, plugin_name = %name, "destroy_sandbox failed during sweep");
+            }
+        }
+    }
+}
+
+// Many arguments because the function is the
+// destructured-Command equivalent — splitting into a struct
+// would just shift names around without saving a line.
+#[allow(clippy::too_many_arguments)]
 async fn handle_load(
     sandbox: &PluginSandbox,
+    verifier: &SignatureVerifier,
+    blocklist: &Blocklist,
     plugins: &mut HashMap<String, PluginEntry>,
     plugin_name: &str,
     version_str: &str,
     permissions: serde_json::Value,
     wasm_bytes: Vec<u8>,
+    signature_b64: Option<&str>,
+    publisher_key_id: Option<&str>,
+    manifest_bytes: Option<&[u8]>,
 ) -> Result<PluginId, HostError> {
+    // Reject revoked plugins before any other work — including
+    // signature verification. A revoked plugin shouldn't get
+    // its signature checked just to fail later; the blocklist
+    // is the cheapest fail-fast.
+    if let Some(reason) = blocklist.matches(plugin_name, version_str).await {
+        return Err(HostError::Revoked {
+            plugin_name: plugin_name.to_string(),
+            reason,
+        });
+    }
+
+    // Verify the signature *before* the loader sees the bytes.
+    // Bypass-via-loader-bug is impossible if the bytes never
+    // reach the loader on a verification failure.
+    let outcome = verifier.verify(&wasm_bytes, manifest_bytes, signature_b64, publisher_key_id)?;
+    match &outcome {
+        crate::signing::VerificationOutcome::Verified { key_id } => {
+            tracing::info!(plugin_name, version = version_str, key_id, "plugin signature verified");
+        }
+        crate::signing::VerificationOutcome::SkippedUnsigned => {
+            tracing::warn!(
+                plugin_name,
+                version = version_str,
+                "plugin loaded without signature (Optional mode)"
+            );
+        }
+    }
+
     if plugins.contains_key(plugin_name) {
         return Err(HostError::AlreadyLoaded {
             plugin_name: plugin_name.to_string(),
@@ -389,6 +542,20 @@ pub enum HostError {
     /// Base64-decode of the WASM bytes failed.
     #[error("invalid base64 wasm: {0}")]
     Base64(#[from] base64::DecodeError),
+    /// Signature verification rejected the load.
+    #[error("signature verification failed: {0}")]
+    Signature(#[from] VerificationError),
+    /// Plugin is on the kill-switch blocklist (RFC §8.3).
+    /// Operators surface the reason to API callers as a stable
+    /// error code; callers should not retry — the revocation is
+    /// authoritative until lifted by the registry.
+    #[error("plugin '{plugin_name}' is revoked: {reason}")]
+    Revoked {
+        /// Plugin name that's revoked.
+        plugin_name: String,
+        /// Reason from the blocklist entry (CVE id, abuse report, etc.).
+        reason: String,
+    },
     /// The actor task is gone — likely runtime shutdown or a
     /// panic in the actor. Caller should reconnect.
     #[error("plugin-host actor task is no longer running")]
@@ -406,6 +573,10 @@ impl HostError {
             HostError::Loader(_) => "loader_error",
             HostError::PluginExecution { .. } => "plugin_execution_error",
             HostError::Base64(_) => "invalid_base64",
+            // Forward the verifier's specific code so callers can
+            // distinguish "missing signature" from "wrong key" etc.
+            HostError::Signature(err) => err.code(),
+            HostError::Revoked { .. } => "revoked",
             HostError::ActorGone => "actor_gone",
         }
     }
@@ -460,7 +631,12 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let (host, actor) = Host::new(loader_config());
+            let verifier = SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Optional,
+            );
+            let (host, actor, _bus) =
+                Host::new(loader_config(), verifier, crate::blocklist::Blocklist::new());
             tokio::select! {
                 result = body(host) => result,
                 _ = actor => panic!("actor exited before test body finished"),
@@ -471,9 +647,17 @@ mod tests {
     #[test]
     fn load_plugin_then_list_returns_one_entry() {
         run_with_actor(|host| async move {
-            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
-                .await
-                .unwrap();
+            host.load_plugin(
+                "test-plugin",
+                "1.0.0",
+                serde_json::json!({}),
+                minimal_wasm(),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             let loaded = host.loaded_plugins().await.unwrap();
             assert_eq!(loaded.len(), 1);
             assert_eq!(loaded[0].0, "test-plugin");
@@ -483,11 +667,27 @@ mod tests {
     #[test]
     fn load_plugin_twice_returns_already_loaded() {
         run_with_actor(|host| async move {
-            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
-                .await
-                .unwrap();
+            host.load_plugin(
+                "test-plugin",
+                "1.0.0",
+                serde_json::json!({}),
+                minimal_wasm(),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             let err = host
-                .load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
+                .load_plugin(
+                    "test-plugin",
+                    "1.0.0",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    None,
+                    None,
+                    None,
+                )
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), "already_loaded");
@@ -497,9 +697,17 @@ mod tests {
     #[test]
     fn unload_plugin_removes_entry() {
         run_with_actor(|host| async move {
-            host.load_plugin("test-plugin", "1.0.0", serde_json::json!({}), minimal_wasm())
-                .await
-                .unwrap();
+            host.load_plugin(
+                "test-plugin",
+                "1.0.0",
+                serde_json::json!({}),
+                minimal_wasm(),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             let detached = host.unload_plugin("test-plugin").await.unwrap();
             assert!(detached);
             assert!(host.loaded_plugins().await.unwrap().is_empty());
@@ -522,11 +730,174 @@ mod tests {
         });
     }
 
+    /// Drive a Host wired to a Required-mode verifier so we can
+    /// observe end-to-end signature-rejection behavior.
+    fn run_with_required_actor<F, T>(body: impl FnOnce(Host) -> F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let verifier = SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Required,
+            );
+            let (host, actor, _bus) =
+                Host::new(loader_config(), verifier, crate::blocklist::Blocklist::new());
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+            }
+        })
+    }
+
+    #[test]
+    fn load_in_required_mode_without_signature_is_rejected() {
+        run_with_required_actor(|host| async move {
+            let err = host
+                .load_plugin(
+                    "test-plugin",
+                    "1.0.0",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "signature_required");
+        });
+    }
+
+    #[test]
+    fn load_in_required_mode_with_unknown_publisher_key_is_rejected() {
+        run_with_required_actor(|host| async move {
+            // 64 zero bytes — base64-encoded — is the right shape
+            // for an Ed25519 signature, but the publisher_key_id
+            // isn't in the (empty) trust store.
+            use base64::Engine;
+            let sig_b64 = base64::engine::general_purpose::STANDARD.encode([0u8; 64]);
+            let err = host
+                .load_plugin(
+                    "test-plugin",
+                    "1.0.0",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    Some(sig_b64),
+                    Some("unknown-key".to_string()),
+                    None,
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "unknown_publisher_key");
+        });
+    }
+
+    /// Drive a Host wired to a Blocklist with the test plugin
+    /// already revoked. Lets us verify the kill-switch refuses
+    /// the load before any other check.
+    fn run_with_blocklist<F, T>(
+        blocklist: crate::blocklist::Blocklist,
+        body: impl FnOnce(Host) -> F,
+    ) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async move {
+            let verifier = SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Optional,
+            );
+            let (host, actor, _bus) = Host::new(loader_config(), verifier, blocklist);
+            tokio::select! {
+                result = body(host) => result,
+                _ = actor => panic!("actor exited before test body finished"),
+            }
+        })
+    }
+
+    #[test]
+    fn load_blocklisted_plugin_is_rejected_with_revoked_code() {
+        use crate::blocklist::{Blocklist, BlocklistEntry};
+        use chrono::Utc;
+        let bl = Blocklist::new();
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            bl.replace(vec![BlocklistEntry {
+                plugin_name: "evil".to_string(),
+                version: "1.0.0".to_string(),
+                reason: "CVE-2026-9999".to_string(),
+                revoked_at: Utc::now(),
+            }])
+            .await;
+        });
+
+        run_with_blocklist(bl, |host| async move {
+            let err = host
+                .load_plugin(
+                    "evil",
+                    "1.0.0",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), "revoked");
+            // Stable reason string is preserved through the error.
+            assert!(err.to_string().contains("CVE-2026-9999"));
+        });
+    }
+
+    #[test]
+    fn load_non_blocklisted_plugin_succeeds_with_blocklist_present() {
+        use crate::blocklist::{Blocklist, BlocklistEntry};
+        use chrono::Utc;
+        let bl = Blocklist::new();
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            bl.replace(vec![BlocklistEntry {
+                plugin_name: "evil".to_string(),
+                version: "1.0.0".to_string(),
+                reason: "test".to_string(),
+                revoked_at: Utc::now(),
+            }])
+            .await;
+        });
+
+        run_with_blocklist(bl, |host| async move {
+            // A different plugin with a different version is fine.
+            host.load_plugin(
+                "good",
+                "1.0.0",
+                serde_json::json!({}),
+                minimal_wasm(),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        });
+    }
+
     #[test]
     fn load_with_invalid_version_returns_invalid_version() {
         run_with_actor(|host| async move {
             let err = host
-                .load_plugin("test-plugin", "not-a-version", serde_json::json!({}), minimal_wasm())
+                .load_plugin(
+                    "test-plugin",
+                    "not-a-version",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    None,
+                    None,
+                    None,
+                )
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), "invalid_version");

--- a/crates/mockforge-plugin-host/src/lib.rs
+++ b/crates/mockforge-plugin-host/src/lib.rs
@@ -34,11 +34,20 @@
 //! stay small and lets us iterate on cloud-only concerns without
 //! touching the OSS API.
 
+pub mod blocklist;
 pub mod handlers;
 pub mod host;
+pub mod metering;
 pub mod protocol;
 pub mod server;
+pub mod signing;
 
+pub use blocklist::{run_poll_loop, Blocklist, BlocklistConfig, BlocklistEntry, PollError};
 pub use host::{Host, HostActor, HostError};
+pub use metering::{run_exporter, ExportedMetric, ExporterConfig};
 pub use protocol::{Request, Response};
 pub use server::{run_server, ServerConfig};
+pub use signing::{
+    SignatureMode, SignatureVerifier, TrustStore, TrustStoreError, VerificationError,
+    VerificationOutcome,
+};

--- a/crates/mockforge-plugin-host/src/main.rs
+++ b/crates/mockforge-plugin-host/src/main.rs
@@ -21,7 +21,10 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use mockforge_plugin_host::{run_server, Host, ServerConfig};
+use mockforge_plugin_host::{
+    run_exporter, run_poll_loop, run_server, Blocklist, BlocklistConfig, ExporterConfig, Host,
+    ServerConfig, SignatureMode, SignatureVerifier, TrustStore,
+};
 use mockforge_plugin_loader::PluginLoaderConfig;
 
 const DEFAULT_SOCKET_PATH: &str = "/tmp/plugin-host.sock";
@@ -34,10 +37,20 @@ fn main() -> Result<()> {
         socket_path: env_socket_path()?,
         socket_mode: env_socket_mode()?,
     };
+    let trust_store = env_trust_store()?;
+    let signature_mode = env_signature_mode();
+    let verifier = SignatureVerifier::new(trust_store, signature_mode);
+    let blocklist = Blocklist::new();
+    let blocklist_config = env_blocklist_config();
+    let exporter_config = env_exporter_config();
 
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         socket = %config.socket_path.display(),
+        signature_mode = ?signature_mode,
+        trusted_keys = verifier.trusted_key_count(),
+        blocklist_url = blocklist_config.as_ref().map(|c| c.url.as_str()).unwrap_or("(disabled)"),
+        exporter_url = exporter_config.as_ref().map(|c| c.url.as_str()).unwrap_or("(disabled)"),
         "mockforge-plugin-host starting"
     );
 
@@ -50,15 +63,31 @@ fn main() -> Result<()> {
         .context("building Tokio current-thread runtime")?;
 
     rt.block_on(async move {
-        let (host, actor) = Host::new(PluginLoaderConfig::default());
+        let (host, actor, metrics_bus) =
+            Host::new(PluginLoaderConfig::default(), verifier, blocklist.clone());
 
-        // Drive actor + server + shutdown_signal concurrently. The
-        // actor owns the !Send sandbox; the server fans connections
-        // out via tokio::spawn, but those tasks only carry the
-        // (Send) `Host` handle — never the sandbox itself.
+        // The blocklist poller is Send (just an HTTP client) so it
+        // could in principle be tokio::spawn'd, but driving it
+        // inline via select! keeps the lifecycle uniform — every
+        // long-running task in this binary is on the main task,
+        // and shutdown is one drop.
+        let poll_future: std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> =
+            match blocklist_config {
+                Some(cfg) => Box::pin(run_poll_loop(cfg, blocklist)),
+                None => Box::pin(std::future::pending()),
+            };
+
+        // Same pattern for the metric exporter — Send + 'static
+        // (just a reqwest client + a broadcast Receiver) but kept
+        // inline for lifecycle uniformity. `(*metrics_bus).clone()`
+        // gives the exporter its own subscription handle.
+        let exporter_future: std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> =
+            match exporter_config {
+                Some(cfg) => Box::pin(run_exporter(cfg, (*metrics_bus).clone())),
+                None => Box::pin(std::future::pending()),
+            };
+
         tokio::select! {
-            // Actor exit is unexpected — channel closed without
-            // shutdown signal. Surface as an error.
             _ = actor => {
                 tracing::error!("plugin-host actor exited unexpectedly");
                 Err(anyhow::anyhow!("plugin-host actor exited"))
@@ -67,12 +96,64 @@ fn main() -> Result<()> {
                 tracing::error!(?result, "plugin-host server loop exited unexpectedly");
                 result
             }
+            _ = poll_future => {
+                tracing::error!("blocklist poller exited unexpectedly");
+                Err(anyhow::anyhow!("blocklist poller exited"))
+            }
+            _ = exporter_future => {
+                tracing::error!("metric exporter exited unexpectedly");
+                Err(anyhow::anyhow!("metric exporter exited"))
+            }
             _ = shutdown_signal() => {
                 tracing::info!("plugin-host received shutdown signal — exiting");
                 Ok(())
             }
         }
     })
+}
+
+/// Build an [`ExporterConfig`] from env vars, or `None` if no
+/// `MOCKFORGE_PLUGIN_HOST_METRICS_URL` is set. Same shape as the
+/// blocklist config (URL + optional bearer + optional interval).
+fn env_exporter_config() -> Option<ExporterConfig> {
+    let url = std::env::var("MOCKFORGE_PLUGIN_HOST_METRICS_URL").ok()?;
+    let mut cfg = ExporterConfig::new(url);
+    if let Ok(secs) = std::env::var("MOCKFORGE_PLUGIN_HOST_METRICS_FLUSH_INTERVAL_SECS") {
+        if let Ok(n) = secs.parse::<u64>() {
+            cfg.flush_interval = std::time::Duration::from_secs(n.max(1));
+        }
+    }
+    if let Ok(qsize) = std::env::var("MOCKFORGE_PLUGIN_HOST_METRICS_QUEUE_SIZE") {
+        if let Ok(n) = qsize.parse::<usize>() {
+            cfg.max_queue_size = n.max(1);
+        }
+    }
+    if let Ok(token) = std::env::var("MOCKFORGE_PLUGIN_HOST_METRICS_BEARER") {
+        if !token.is_empty() {
+            cfg.bearer_token = Some(token);
+        }
+    }
+    Some(cfg)
+}
+
+/// Build a [`BlocklistConfig`] from env vars, or `None` if no
+/// `MOCKFORGE_PLUGIN_HOST_BLOCKLIST_URL` is set. Optional polling
+/// keeps self-hosted / dev simple — only cloud production has a
+/// blocklist endpoint to point at.
+fn env_blocklist_config() -> Option<BlocklistConfig> {
+    let url = std::env::var("MOCKFORGE_PLUGIN_HOST_BLOCKLIST_URL").ok()?;
+    let mut cfg = BlocklistConfig::new(url);
+    if let Ok(secs) = std::env::var("MOCKFORGE_PLUGIN_HOST_BLOCKLIST_INTERVAL_SECS") {
+        if let Ok(n) = secs.parse::<u64>() {
+            cfg.interval = std::time::Duration::from_secs(n.max(1));
+        }
+    }
+    if let Ok(token) = std::env::var("MOCKFORGE_PLUGIN_HOST_BLOCKLIST_BEARER") {
+        if !token.is_empty() {
+            cfg.bearer_token = Some(token);
+        }
+    }
+    Some(cfg)
 }
 
 fn init_tracing() {
@@ -111,6 +192,46 @@ fn env_socket_mode() -> Result<u32> {
                 .with_context(|| format!("parsing MOCKFORGE_PLUGIN_HOST_SOCKET_MODE={}", s))
         }
         Err(_) => Ok(DEFAULT_SOCKET_MODE),
+    }
+}
+
+/// Read the trust store from one of:
+///
+/// - `MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS_FILE` (path to JSON file)
+/// - `MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS` (inline JSON)
+///
+/// or return an empty store if neither is set. The store is a
+/// JSON object `{ "publisher-id": "<base64-pubkey>", ... }`.
+fn env_trust_store() -> Result<TrustStore> {
+    if let Ok(path) = std::env::var("MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS_FILE") {
+        return TrustStore::from_file(std::path::Path::new(&path)).map_err(anyhow::Error::from);
+    }
+    if let Ok(inline) = std::env::var("MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS") {
+        return TrustStore::from_json_str(&inline).map_err(anyhow::Error::from);
+    }
+    Ok(TrustStore::new())
+}
+
+/// Read `MOCKFORGE_PLUGIN_HOST_SIGNATURE_MODE` (`required` |
+/// `optional`). Cloud production sets this to `required` via the
+/// orchestrator's env var; self-hosted leaves it unset and gets
+/// the default (`optional`).
+fn env_signature_mode() -> SignatureMode {
+    match std::env::var("MOCKFORGE_PLUGIN_HOST_SIGNATURE_MODE")
+        .ok()
+        .map(|s| s.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("required") => SignatureMode::Required,
+        Some("optional") => SignatureMode::Optional,
+        Some(other) => {
+            tracing::warn!(
+                value = other,
+                "unrecognized MOCKFORGE_PLUGIN_HOST_SIGNATURE_MODE; falling back to Optional"
+            );
+            SignatureMode::Optional
+        }
+        None => SignatureMode::Optional,
     }
 }
 

--- a/crates/mockforge-plugin-host/src/metering.rs
+++ b/crates/mockforge-plugin-host/src/metering.rs
@@ -1,0 +1,271 @@
+//! Per-invocation metric exporter — wires the
+//! [`InvocationMetricsBus`] from `mockforge-plugin-loader` to a
+//! cloud aggregator over HTTP.
+//!
+//! Closes the metering loop the bus was designed for in PR #388:
+//! every plugin invocation produces an [`InvocationMetric`], the
+//! exporter batches them, and every `flush_interval` POSTs the
+//! batch as JSON to a configured endpoint.
+//!
+//! ## Why JSON, not OTLP-protobuf
+//!
+//! The aggregator is in a sibling MockForge codebase — we control
+//! both sides, so a stable JSON shape is enough for v1 and avoids
+//! pulling the full OpenTelemetry SDK (heavy dep tree, slow build).
+//! When we want to feed third-party collectors (Tempo, Honeycomb,
+//! Datadog) that accept OTLP natively, swap this module to emit
+//! OTLP/HTTP without changing the bus contract.
+//!
+//! ## Backpressure
+//!
+//! The exporter subscribes to a `tokio::sync::broadcast`. If the
+//! exporter falls behind (slow upstream, network partition), the
+//! broadcast drops oldest events and surfaces `RecvError::Lagged`.
+//! That's correct: a hosted-mock should never block its request
+//! path because the metric pipeline is slow. We log lag events
+//! so operators can size the channel up if they recur.
+
+use std::time::Duration;
+
+use mockforge_plugin_loader::{InvocationMetric, InvocationMetricsBus, InvocationStatus};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Configuration for the exporter.
+#[derive(Debug, Clone)]
+pub struct ExporterConfig {
+    /// HTTP endpoint that accepts the JSON batch. Cloud production
+    /// points this at the registry's `/api/internal/plugin-metrics`
+    /// receiver.
+    pub url: String,
+    /// How long to buffer events before flushing. Default 10 s
+    /// balances per-invocation accuracy against HTTP overhead.
+    pub flush_interval: Duration,
+    /// Hard cap on the in-memory queue. If we accumulate more than
+    /// this many events between flushes, we flush immediately to
+    /// avoid an unbounded memory growth (e.g. during a downstream
+    /// outage that recovered partially).
+    pub max_queue_size: usize,
+    /// Optional bearer token; sent as `Authorization: Bearer ...`.
+    /// Cloud production sets this so the registry can rate-limit
+    /// per host.
+    pub bearer_token: Option<String>,
+}
+
+impl ExporterConfig {
+    /// Construct with sensible defaults.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            flush_interval: Duration::from_secs(10),
+            max_queue_size: 1024,
+            bearer_token: None,
+        }
+    }
+}
+
+/// JSON shape posted to the aggregator. Wire-format-stable —
+/// adding fields is fine, renaming or removing is breaking.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportedMetric {
+    /// Plugin id (matches `PluginId::to_string()`).
+    pub plugin_id: String,
+    /// Exported function the host called.
+    pub function_name: String,
+    /// Wall-clock start time in RFC 3339.
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    /// Wall-time spent inside the plugin call, microseconds.
+    pub wall_time_us: u64,
+    /// Peak memory usage observed during this invocation, bytes.
+    pub memory_peak_bytes: u64,
+    /// Outcome: `success`, `failure`, or `dropped`.
+    pub status: &'static str,
+    /// Failure error message, if `status = "failure"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl From<InvocationMetric> for ExportedMetric {
+    fn from(m: InvocationMetric) -> Self {
+        let (status, error) = match &m.status {
+            InvocationStatus::Success => ("success", None),
+            InvocationStatus::Failure { error } => ("failure", Some(error.clone())),
+            InvocationStatus::Dropped => ("dropped", None),
+        };
+        Self {
+            plugin_id: m.plugin_id.to_string(),
+            function_name: m.function_name,
+            started_at: m.started_at,
+            wall_time_us: m.wall_time_us,
+            memory_peak_bytes: m.memory_peak_bytes,
+            status,
+            error,
+        }
+    }
+}
+
+/// Run the exporter forever. Returns only on cancellation by the
+/// outer `select!`. Subscribes to the bus, batches events, posts
+/// every `flush_interval` (or sooner if the queue fills).
+pub async fn run_exporter(config: ExporterConfig, bus: InvocationMetricsBus) {
+    let client = match reqwest::Client::builder().timeout(Duration::from_secs(5)).build() {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to build metric-exporter HTTP client; exporter exiting");
+            return;
+        }
+    };
+
+    let mut rx = bus.subscribe();
+    let mut buffer: Vec<ExportedMetric> = Vec::with_capacity(64);
+    let mut ticker = tokio::time::interval(config.flush_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    tracing::info!(
+        url = %config.url,
+        flush_interval_secs = config.flush_interval.as_secs(),
+        max_queue_size = config.max_queue_size,
+        "metric exporter starting"
+    );
+
+    loop {
+        tokio::select! {
+            recv_result = rx.recv() => {
+                match recv_result {
+                    Ok(metric) => {
+                        buffer.push(metric.into());
+                        if buffer.len() >= config.max_queue_size {
+                            flush(&client, &config, &mut buffer).await;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        // Slow exporter, fast producers. The broadcast
+                        // dropped `skipped` events; log so operators can
+                        // size up the channel if this recurs, but keep
+                        // running.
+                        tracing::warn!(skipped, "metric exporter lagged; events dropped");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        tracing::info!("metric bus closed; exporter exiting");
+                        // Final flush so we don't drop in-buffer events.
+                        if !buffer.is_empty() {
+                            flush(&client, &config, &mut buffer).await;
+                        }
+                        return;
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                if !buffer.is_empty() {
+                    flush(&client, &config, &mut buffer).await;
+                }
+            }
+        }
+    }
+}
+
+/// POST the buffered batch and clear it. On HTTP failure we **drop
+/// the batch** rather than retry — retrying would create unbounded
+/// memory pressure during a downstream outage. The aggregator is
+/// best-effort; a missed batch is a metering gap, not a security
+/// issue. Operators see the gap as a flat stretch on dashboards.
+async fn flush(
+    client: &reqwest::Client,
+    config: &ExporterConfig,
+    buffer: &mut Vec<ExportedMetric>,
+) {
+    let batch = std::mem::take(buffer);
+    let count = batch.len();
+
+    let mut req = client.post(&config.url).json(&batch);
+    if let Some(token) = &config.bearer_token {
+        req = req.bearer_auth(token);
+    }
+
+    match req.send().await {
+        Ok(response) if response.status().is_success() => {
+            tracing::debug!(count, status = %response.status(), "metric batch flushed");
+        }
+        Ok(response) => {
+            tracing::warn!(
+                count,
+                status = %response.status(),
+                "metric exporter got non-success response; batch dropped"
+            );
+        }
+        Err(err) => {
+            tracing::warn!(count, error = %err, "metric exporter HTTP send failed; batch dropped");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use mockforge_plugin_core::PluginId;
+
+    fn make_metric(status: InvocationStatus) -> InvocationMetric {
+        InvocationMetric {
+            plugin_id: PluginId::new("test-plugin"),
+            function_name: "on_request".into(),
+            started_at: Utc::now(),
+            wall_time_us: 1234,
+            memory_peak_bytes: 5678,
+            status,
+        }
+    }
+
+    #[test]
+    fn invocation_metric_maps_to_exported_metric_success() {
+        let exported: ExportedMetric = make_metric(InvocationStatus::Success).into();
+        assert_eq!(exported.plugin_id, "test-plugin");
+        assert_eq!(exported.function_name, "on_request");
+        assert_eq!(exported.wall_time_us, 1234);
+        assert_eq!(exported.memory_peak_bytes, 5678);
+        assert_eq!(exported.status, "success");
+        assert!(exported.error.is_none());
+    }
+
+    #[test]
+    fn invocation_metric_maps_failure_to_error_field() {
+        let exported: ExportedMetric = make_metric(InvocationStatus::Failure {
+            error: "boom".into(),
+        })
+        .into();
+        assert_eq!(exported.status, "failure");
+        assert_eq!(exported.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn invocation_metric_maps_dropped_to_status_only() {
+        let exported: ExportedMetric = make_metric(InvocationStatus::Dropped).into();
+        assert_eq!(exported.status, "dropped");
+        assert!(exported.error.is_none());
+    }
+
+    #[test]
+    fn exported_metric_serializes_with_omitted_error_on_success() {
+        let exported: ExportedMetric = make_metric(InvocationStatus::Success).into();
+        let json = serde_json::to_string(&exported).unwrap();
+        assert!(json.contains("\"status\":\"success\""));
+        assert!(!json.contains("\"error\""), "success should omit error field, got {}", json);
+    }
+
+    #[test]
+    fn config_defaults_to_10s_flush() {
+        let cfg = ExporterConfig::new("http://example/metrics");
+        assert_eq!(cfg.flush_interval.as_secs(), 10);
+        assert_eq!(cfg.max_queue_size, 1024);
+        assert!(cfg.bearer_token.is_none());
+    }
+
+    // NOTE: a previous version of this test tried to drop the bus
+    // and assert the exporter exits. That doesn't work: the
+    // exporter holds its own `InvocationMetricsBus` clone (which
+    // owns a `broadcast::Sender`), so dropping the test's clone
+    // never closes the channel. The exporter's actual shutdown
+    // path is the outer `tokio::select!` in `main.rs` cancelling
+    // the future, not bus closure. We test the bus-close path
+    // implicitly via the production wiring.
+}

--- a/crates/mockforge-plugin-host/src/protocol.rs
+++ b/crates/mockforge-plugin-host/src/protocol.rs
@@ -33,12 +33,15 @@ pub enum Request {
     },
     /// Load a WASM plugin into a fresh `Store`.
     ///
-    /// In v1 the WASM bytes are inlined as base64 in the request.
-    /// The follow-up "registry fetch" path will replace this with a
-    /// `download_url` field that the host fetches itself, so
-    /// signature verification can happen before any bytes touch
-    /// the loader. Until then, the caller is expected to verify
-    /// signatures upstream.
+    /// The optional `signature_b64` + `publisher_key_id` fields
+    /// carry an Ed25519 signature over `wasm_bytes` (the decoded
+    /// `wasm_b64`). Whether they're required is governed by the
+    /// host's `SignatureMode`:
+    ///   - `Required` (cloud default): both fields must be present
+    ///     and the signature must verify against an active trust
+    ///     root, or the load is rejected.
+    ///   - `Optional` (self-hosted/dev): unsigned loads are
+    ///     allowed (and logged).
     LoadPlugin {
         /// Correlation id.
         id: Uuid,
@@ -55,6 +58,24 @@ pub enum Request {
         permissions: serde_json::Value,
         /// Base64-encoded WASM module bytes.
         wasm_b64: String,
+        /// Base64-encoded Ed25519 signature. The signed payload is
+        /// `build_signed_payload(wasm, manifest)` from `signing.rs`
+        /// — domain-prefixed so v1 (wasm-only) and v2 (with
+        /// manifest) signatures can't be cross-replayed. Pairs
+        /// with `publisher_key_id`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature_b64: Option<String>,
+        /// Trust-root id naming the public key the signature is
+        /// expected to verify against. Pairs with
+        /// `signature_b64` — both or neither.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        publisher_key_id: Option<String>,
+        /// Optional base64-encoded plugin manifest. When present,
+        /// the signature must cover both WASM and manifest
+        /// (defense-in-depth). Content is opaque to the signing
+        /// layer; the host parses it after verification.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        manifest_b64: Option<String>,
     },
     /// Detach a plugin and free its sandbox.
     UnloadPlugin {
@@ -166,6 +187,9 @@ mod tests {
                 "egress": { "allow": ["*.stripe.com"] }
             }),
             wasm_b64: "AGFzbQEAAAA=".into(), // empty WASM module
+            signature_b64: None,
+            publisher_key_id: None,
+            manifest_b64: None,
         };
         let bytes = serde_json::to_vec(&req).unwrap();
         let parsed: Request = serde_json::from_slice(&bytes).unwrap();
@@ -175,15 +199,66 @@ mod tests {
                 version,
                 permissions,
                 wasm_b64,
+                signature_b64,
+                publisher_key_id,
                 ..
             } => {
                 assert_eq!(plugin_name, "stripe-rewriter");
                 assert_eq!(version, "1.2.3");
                 assert!(permissions.get("egress").is_some());
                 assert_eq!(wasm_b64, "AGFzbQEAAAA=");
+                assert!(signature_b64.is_none());
+                assert!(publisher_key_id.is_none());
             }
             other => panic!("expected LoadPlugin, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn load_plugin_request_with_signature_round_trips() {
+        let req = Request::LoadPlugin {
+            id: Uuid::new_v4(),
+            plugin_name: "p".into(),
+            version: "1.0.0".into(),
+            permissions: serde_json::json!({}),
+            wasm_b64: "AGFzbQEAAAA=".into(),
+            signature_b64: Some("BBBB".repeat(22)), // 88-char base64-shaped value
+            publisher_key_id: Some("publisher-1".into()),
+            manifest_b64: None,
+        };
+        let bytes = serde_json::to_vec(&req).unwrap();
+        let parsed: Request = serde_json::from_slice(&bytes).unwrap();
+        match parsed {
+            Request::LoadPlugin {
+                signature_b64,
+                publisher_key_id,
+                ..
+            } => {
+                assert!(signature_b64.is_some());
+                assert_eq!(publisher_key_id.as_deref(), Some("publisher-1"));
+            }
+            other => panic!("expected LoadPlugin, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn load_plugin_request_signature_fields_omitted_when_none() {
+        let req = Request::LoadPlugin {
+            id: Uuid::new_v4(),
+            plugin_name: "p".into(),
+            version: "1.0.0".into(),
+            permissions: serde_json::json!({}),
+            wasm_b64: "AGFzbQEAAAA=".into(),
+            signature_b64: None,
+            publisher_key_id: None,
+            manifest_b64: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        // skip_serializing_if drops the keys entirely so older
+        // wire-format consumers (and the `nc -U` debug path)
+        // don't see surprising `null`s.
+        assert!(!json.contains("signature_b64"), "expected omitted, got {}", json);
+        assert!(!json.contains("publisher_key_id"));
     }
 
     #[test]

--- a/crates/mockforge-plugin-host/src/server.rs
+++ b/crates/mockforge-plugin-host/src/server.rs
@@ -155,7 +155,11 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let (host, actor) = Host::new(PluginLoaderConfig::default());
+            let verifier = crate::signing::SignatureVerifier::new(
+                crate::signing::TrustStore::new(),
+                crate::signing::SignatureMode::Optional,
+            );
+            let (host, actor, _bus) = Host::new(PluginLoaderConfig::default(), verifier, crate::blocklist::Blocklist::new());
             let server_host = host.clone();
             tokio::select! {
                 result = body(host) => result,

--- a/crates/mockforge-plugin-host/src/signing.rs
+++ b/crates/mockforge-plugin-host/src/signing.rs
@@ -1,0 +1,621 @@
+//! Ed25519 signature verification for cloud plugins.
+//!
+//! Implements RFC §7.2 step 3 — runtime verification at LoadPlugin
+//! time. The publish-time check (§7.2 step 1) and the attach-time
+//! check (§7.2 step 2) are upstream concerns; this is the last
+//! line of defense before the WASM bytes touch the loader.
+//!
+//! ## Trust roots
+//!
+//! Trust is configured via [`TrustStore`]: a map from publisher
+//! key id (string) to Ed25519 public key (32 bytes). The host
+//! reads this from one of:
+//!
+//!   - `MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS` — JSON object like
+//!     `{"publisher-1": "<base64-pubkey>", ...}` inline
+//!   - `MOCKFORGE_PLUGIN_HOST_TRUSTED_KEYS_FILE` — same JSON in
+//!     a file
+//!
+//! Empty trust store → reject every signed plugin. Combined with
+//! [`SignatureMode::Required`] the proxy is fail-safe by default.
+//!
+//! ## Modes
+//!
+//! - [`SignatureMode::Required`] — every LoadPlugin must carry a
+//!   valid signature against an active trust root. Default for
+//!   cloud deployments.
+//! - [`SignatureMode::Optional`] — LoadPlugin without a signature
+//!   is allowed (but logged). Default for self-hosted / dev. The
+//!   plugin-host bin currently flips to Required in cloud mode
+//!   via env var; see `main.rs`.
+//!
+//! ## Signed payload
+//!
+//! See [`build_signed_payload`] for the canonical bytes. Two
+//! versions, distinguished by domain-separation prefix:
+//!
+//!   - **v1** (legacy / no manifest): `prefix-v1 || wasm_bytes`
+//!   - **v2** (cloud / with manifest): `prefix-v2 || u64-be(wasm.len()) || wasm || manifest`
+//!
+//! v2 covers the manifest as well as the bytes — defense-in-depth
+//! against a registry compromise that swaps out a published
+//! plugin's permission grant. The big-endian length prefix
+//! prevents a length-extension attack that could shift the
+//! wasm/manifest boundary while keeping the signature valid.
+//! Domain prefixes prevent v1 signatures from being replayed
+//! against v2 payloads (and vice-versa).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use base64::Engine;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+/// What signature policy the host enforces at LoadPlugin time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SignatureMode {
+    /// Every LoadPlugin must carry `(signature_b64, publisher_key_id)`
+    /// and the signature must verify against an active trust root.
+    /// Cloud-mode default.
+    Required,
+    /// LoadPlugin without a signature is allowed (and logged).
+    /// Self-hosted / dev default — preserves the current OSS
+    /// behavior of accepting unsigned plugins for local
+    /// development. Default so a stub deployment that forgets to
+    /// configure trust roots can still load a plugin; cloud
+    /// production explicitly sets Required.
+    #[default]
+    Optional,
+}
+
+/// Map from publisher key id → 32-byte Ed25519 public key.
+#[derive(Debug, Clone, Default)]
+pub struct TrustStore {
+    keys: HashMap<String, VerifyingKey>,
+}
+
+impl TrustStore {
+    /// Build an empty trust store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of currently-active trust roots.
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// Whether this store has any trust roots.
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    /// Insert a key. Returns the previous binding for `key_id` if
+    /// any (rotation case).
+    pub fn insert(&mut self, key_id: String, key: VerifyingKey) -> Option<VerifyingKey> {
+        self.keys.insert(key_id, key)
+    }
+
+    /// Look up a key by id.
+    pub fn get(&self, key_id: &str) -> Option<&VerifyingKey> {
+        self.keys.get(key_id)
+    }
+
+    /// Build from a JSON object `{ "key_id": "<base64-pubkey>", ... }`.
+    pub fn from_json_str(json: &str) -> Result<Self, TrustStoreError> {
+        let raw: HashMap<String, String> =
+            serde_json::from_str(json).map_err(|err| TrustStoreError::InvalidJson {
+                err: err.to_string(),
+            })?;
+        let mut store = Self::new();
+        for (key_id, b64_value) in raw {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(b64_value.as_bytes())
+                .map_err(|err| TrustStoreError::InvalidBase64 {
+                    key_id: key_id.clone(),
+                    err: err.to_string(),
+                })?;
+            let key_bytes: [u8; 32] =
+                bytes.as_slice().try_into().map_err(|_| TrustStoreError::InvalidKeyLength {
+                    key_id: key_id.clone(),
+                    actual_bytes: bytes.len(),
+                })?;
+            let key = VerifyingKey::from_bytes(&key_bytes).map_err(|err| {
+                TrustStoreError::InvalidKey {
+                    key_id: key_id.clone(),
+                    err: err.to_string(),
+                }
+            })?;
+            store.insert(key_id, key);
+        }
+        Ok(store)
+    }
+
+    /// Read trust roots from a file containing the same JSON shape
+    /// as [`from_json_str`].
+    pub fn from_file(path: &Path) -> Result<Self, TrustStoreError> {
+        let contents = std::fs::read_to_string(path).map_err(|err| TrustStoreError::Io {
+            what: "reading trust store file",
+            err: err.to_string(),
+        })?;
+        Self::from_json_str(&contents)
+    }
+}
+
+/// Errors building a trust store from external input.
+#[derive(Debug, thiserror::Error)]
+pub enum TrustStoreError {
+    /// The JSON didn't parse as `{string: string}`.
+    #[error("trust store JSON failed to parse: {err}")]
+    InvalidJson {
+        /// Parser error detail.
+        err: String,
+    },
+    /// A value wasn't valid base64.
+    #[error("trust store key '{key_id}' has invalid base64: {err}")]
+    InvalidBase64 {
+        /// The key id that failed.
+        key_id: String,
+        /// Decode error detail.
+        err: String,
+    },
+    /// A decoded key wasn't 32 bytes.
+    #[error("trust store key '{key_id}' is {actual_bytes} bytes; expected 32")]
+    InvalidKeyLength {
+        /// The key id that failed.
+        key_id: String,
+        /// Actual byte length seen.
+        actual_bytes: usize,
+    },
+    /// The 32 bytes weren't a valid Ed25519 point.
+    #[error("trust store key '{key_id}' is not a valid Ed25519 key: {err}")]
+    InvalidKey {
+        /// The key id that failed.
+        key_id: String,
+        /// Error detail from `VerifyingKey::from_bytes`.
+        err: String,
+    },
+    /// Couldn't read the file.
+    #[error("io error while {what}: {err}")]
+    Io {
+        /// Operation that failed.
+        what: &'static str,
+        /// Underlying error message.
+        err: String,
+    },
+}
+
+/// Verifier — combines the trust store and the policy mode.
+/// Domain-separation prefixes for the signed payload.
+///
+/// Why a prefix at all: cross-protocol attacks. Without a fixed
+/// prefix, a signature over (say) some other JSON document with a
+/// matching first chunk could be coerced into looking like a
+/// MockForge plugin signature. The prefix forces the signed
+/// payload to be plugin-shaped or invalid.
+///
+/// Two prefixes — one per "shape" — so a v1 signature over
+/// `wasm_bytes` alone can never be replayed as a v2 (manifest-
+/// covering) signature. The wire format is implicitly versioned
+/// through the prefix even though the wire field is unchanged.
+const PREFIX_V1_WASM_ONLY: &[u8] = b"mockforge-plugin/v1/wasm-only\n";
+const PREFIX_V2_WASM_AND_MANIFEST: &[u8] = b"mockforge-plugin/v2/wasm-and-manifest\n";
+
+/// Build the canonical signed payload for verification.
+///
+/// - **Without a manifest** (legacy / OSS): prefix-v1 || wasm
+/// - **With a manifest** (cloud production): prefix-v2 || u64-be(wasm.len()) || wasm || manifest
+///
+/// The big-endian length prefix in v2 prevents a length-extension
+/// trick where an attacker shifts the wasm/manifest boundary to
+/// still produce the same byte sequence — without the length, the
+/// concatenation is ambiguous.
+pub fn build_signed_payload(wasm_bytes: &[u8], manifest_bytes: Option<&[u8]>) -> Vec<u8> {
+    match manifest_bytes {
+        None => {
+            let mut payload = Vec::with_capacity(PREFIX_V1_WASM_ONLY.len() + wasm_bytes.len());
+            payload.extend_from_slice(PREFIX_V1_WASM_ONLY);
+            payload.extend_from_slice(wasm_bytes);
+            payload
+        }
+        Some(manifest) => {
+            let mut payload = Vec::with_capacity(
+                PREFIX_V2_WASM_AND_MANIFEST.len() + 8 + wasm_bytes.len() + manifest.len(),
+            );
+            payload.extend_from_slice(PREFIX_V2_WASM_AND_MANIFEST);
+            payload.extend_from_slice(&(wasm_bytes.len() as u64).to_be_bytes());
+            payload.extend_from_slice(wasm_bytes);
+            payload.extend_from_slice(manifest);
+            payload
+        }
+    }
+}
+
+/// Verifies plugin Ed25519 signatures against a trust store under a
+/// policy mode. Constructed once at host startup (see
+/// [`crate::host::Host::new`]) and consulted by every `LoadPlugin`.
+pub struct SignatureVerifier {
+    store: TrustStore,
+    mode: SignatureMode,
+}
+
+impl SignatureVerifier {
+    /// Build a verifier with the given trust store and policy.
+    pub fn new(store: TrustStore, mode: SignatureMode) -> Self {
+        Self { store, mode }
+    }
+
+    /// Verify a signature over the canonical signed payload
+    /// (see [`build_signed_payload`]). Pass `None` for
+    /// `signature_b64` / `publisher_key_id` if the LoadPlugin
+    /// request didn't include a signature — the verifier will
+    /// either accept (Optional mode) or reject (Required mode).
+    ///
+    /// `manifest_bytes` is optional. When `Some`, the signature
+    /// must cover both the WASM and the manifest — defense-in-
+    /// depth so a colluding signer can't pair one verified WASM
+    /// with a forged manifest. When `None`, the signature covers
+    /// just the WASM (legacy v1 path; backward-compatible with
+    /// PR #403).
+    pub fn verify(
+        &self,
+        wasm_bytes: &[u8],
+        manifest_bytes: Option<&[u8]>,
+        signature_b64: Option<&str>,
+        publisher_key_id: Option<&str>,
+    ) -> Result<VerificationOutcome, VerificationError> {
+        match (signature_b64, publisher_key_id) {
+            (None, None) => {
+                if self.mode == SignatureMode::Required {
+                    return Err(VerificationError::Required);
+                }
+                Ok(VerificationOutcome::SkippedUnsigned)
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                // Half a signature is more suspicious than none —
+                // either we have both fields or neither.
+                Err(VerificationError::IncompleteSignatureFields)
+            }
+            (Some(sig_b64), Some(key_id)) => {
+                let sig_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(sig_b64.as_bytes())
+                    .map_err(|err| VerificationError::InvalidSignatureBase64(err.to_string()))?;
+                let sig_array: [u8; 64] = sig_bytes.as_slice().try_into().map_err(|_| {
+                    VerificationError::InvalidSignatureLength {
+                        actual_bytes: sig_bytes.len(),
+                    }
+                })?;
+                let signature = Signature::from_bytes(&sig_array);
+
+                let key =
+                    self.store.get(key_id).ok_or_else(|| VerificationError::UnknownKeyId {
+                        key_id: key_id.to_string(),
+                    })?;
+
+                let signed_payload = build_signed_payload(wasm_bytes, manifest_bytes);
+                key.verify(&signed_payload, &signature)
+                    .map_err(|err| VerificationError::SignatureMismatch(err.to_string()))?;
+
+                Ok(VerificationOutcome::Verified {
+                    key_id: key_id.to_string(),
+                })
+            }
+        }
+    }
+
+    /// Current policy mode.
+    pub fn mode(&self) -> SignatureMode {
+        self.mode
+    }
+
+    /// Number of active trust roots.
+    pub fn trusted_key_count(&self) -> usize {
+        self.store.len()
+    }
+}
+
+/// What happened during verification. Successful cases include
+/// the key id used, so the caller can include it in the audit
+/// trail. The `SkippedUnsigned` variant is only ever reachable
+/// in `SignatureMode::Optional`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationOutcome {
+    /// Signature was present and valid against a trust root.
+    Verified {
+        /// The trust-root key id that matched.
+        key_id: String,
+    },
+    /// No signature was provided and the policy allowed it.
+    /// Reachable only in [`SignatureMode::Optional`].
+    SkippedUnsigned,
+}
+
+/// Errors the verifier can produce. Each variant maps to a stable
+/// error code via [`code`] so the IPC layer can surface it
+/// consistently.
+///
+/// [`code`]: VerificationError::code
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+    /// Signature was required by policy but not present in the
+    /// LoadPlugin request.
+    #[error("signature required by policy but not provided")]
+    Required,
+    /// Either `signature_b64` or `publisher_key_id` was set but
+    /// not both.
+    #[error("LoadPlugin must include both signature_b64 AND publisher_key_id, or neither")]
+    IncompleteSignatureFields,
+    /// The signature wasn't valid base64.
+    #[error("signature_b64 is not valid base64: {0}")]
+    InvalidSignatureBase64(String),
+    /// The signature decoded to something other than 64 bytes.
+    #[error("signature must be 64 bytes; got {actual_bytes}")]
+    InvalidSignatureLength {
+        /// Actual byte length seen.
+        actual_bytes: usize,
+    },
+    /// The publisher key id wasn't in the trust store. Could be
+    /// a stale key id from before a rotation, or an attacker.
+    #[error("publisher key id '{key_id}' is not a trusted root")]
+    UnknownKeyId {
+        /// The key id that wasn't recognized.
+        key_id: String,
+    },
+    /// The signature didn't verify against the named key.
+    #[error("signature did not verify against the named key: {0}")]
+    SignatureMismatch(String),
+}
+
+impl VerificationError {
+    /// Stable, machine-readable error code for the IPC `code`
+    /// field. Keeps the wire surface compatible across host
+    /// versions even if the human messages change.
+    pub fn code(&self) -> &'static str {
+        match self {
+            VerificationError::Required => "signature_required",
+            VerificationError::IncompleteSignatureFields => "incomplete_signature",
+            VerificationError::InvalidSignatureBase64(_) => "invalid_signature_base64",
+            VerificationError::InvalidSignatureLength { .. } => "invalid_signature_length",
+            VerificationError::UnknownKeyId { .. } => "unknown_publisher_key",
+            VerificationError::SignatureMismatch(_) => "signature_mismatch",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn fixture_keypair() -> (SigningKey, VerifyingKey) {
+        // Deterministic keypair — using a fixed seed makes the
+        // tests reproducible. Not a real key; never put a value
+        // like this near production.
+        let sk_bytes: [u8; 32] = [
+            0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec,
+            0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03,
+            0x1c, 0xae, 0x7f, 0x60,
+        ];
+        let sk = SigningKey::from_bytes(&sk_bytes);
+        let vk = sk.verifying_key();
+        (sk, vk)
+    }
+
+    fn make_store_with_test_key(key_id: &str) -> (TrustStore, SigningKey) {
+        let (sk, vk) = fixture_keypair();
+        let mut store = TrustStore::new();
+        store.insert(key_id.to_string(), vk);
+        (store, sk)
+    }
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    /// Sign `build_signed_payload(wasm, manifest)` so the test
+    /// signature matches what the verifier reconstructs. Tests
+    /// constructing signatures over raw bytes (without the
+    /// canonical wrapping) used to work in the v1-no-prefix world
+    /// of #403; this PR adds the domain prefix and they need to
+    /// follow.
+    fn sign_canonical(sk: &SigningKey, wasm: &[u8], manifest: Option<&[u8]>) -> String {
+        let payload = build_signed_payload(wasm, manifest);
+        b64(sk.sign(&payload).to_bytes().as_ref())
+    }
+
+    #[test]
+    fn verifier_accepts_valid_v1_signature_no_manifest() {
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let outcome = verifier
+            .verify(wasm, None, Some(&sign_canonical(&sk, wasm, None)), Some("publisher-1"))
+            .unwrap();
+        match outcome {
+            VerificationOutcome::Verified { key_id } => assert_eq!(key_id, "publisher-1"),
+            other => panic!("expected Verified, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verifier_accepts_valid_v2_signature_with_manifest() {
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let manifest = br#"{"name":"example","version":"1.0.0"}"#;
+        let outcome = verifier
+            .verify(
+                wasm,
+                Some(manifest),
+                Some(&sign_canonical(&sk, wasm, Some(manifest))),
+                Some("publisher-1"),
+            )
+            .unwrap();
+        match outcome {
+            VerificationOutcome::Verified { key_id } => assert_eq!(key_id, "publisher-1"),
+            other => panic!("expected Verified, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verifier_rejects_v1_signature_replayed_against_v2_payload() {
+        // Sign over wasm-only, then ask verifier to check wasm+manifest.
+        // Domain-separation prefix means the v1 signature can't
+        // match the v2 payload.
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let manifest = b"manifest-bytes";
+        let v1_sig = sign_canonical(&sk, wasm, None);
+        let err = verifier
+            .verify(wasm, Some(manifest), Some(&v1_sig), Some("publisher-1"))
+            .unwrap_err();
+        assert_eq!(err.code(), "signature_mismatch");
+    }
+
+    #[test]
+    fn verifier_rejects_v2_signature_with_tampered_manifest() {
+        // Sign over wasm + manifest_a, present manifest_b at
+        // verify time. Length-prefix + bytes mean any change to
+        // the manifest invalidates the signature.
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let original_manifest = br#"{"name":"good","version":"1.0.0"}"#;
+        let tampered_manifest = br#"{"name":"evil","version":"1.0.0"}"#;
+        let sig = sign_canonical(&sk, wasm, Some(original_manifest));
+        let err = verifier
+            .verify(wasm, Some(tampered_manifest), Some(&sig), Some("publisher-1"))
+            .unwrap_err();
+        assert_eq!(err.code(), "signature_mismatch");
+    }
+
+    #[test]
+    fn verifier_rejects_signature_against_wrong_key() {
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"original bytes";
+        // Sign different bytes than what the verifier checks.
+        let sig = sign_canonical(&sk, b"different bytes", None);
+        let err = verifier.verify(wasm, None, Some(&sig), Some("publisher-1")).unwrap_err();
+        assert_eq!(err.code(), "signature_mismatch");
+    }
+
+    #[test]
+    fn verifier_rejects_unknown_key_id() {
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let sig = sign_canonical(&sk, wasm, None);
+        let err = verifier.verify(wasm, None, Some(&sig), Some("not-a-real-key")).unwrap_err();
+        assert_eq!(err.code(), "unknown_publisher_key");
+    }
+
+    #[test]
+    fn verifier_required_mode_rejects_unsigned() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let err = verifier.verify(b"wasm", None, None, None).unwrap_err();
+        assert_eq!(err.code(), "signature_required");
+    }
+
+    #[test]
+    fn verifier_optional_mode_accepts_unsigned() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Optional);
+        let outcome = verifier.verify(b"wasm", None, None, None).unwrap();
+        assert_eq!(outcome, VerificationOutcome::SkippedUnsigned);
+    }
+
+    #[test]
+    fn verifier_rejects_half_signature_in_either_mode() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        for mode in [SignatureMode::Required, SignatureMode::Optional] {
+            let verifier = SignatureVerifier::new(store.clone(), mode);
+            // Only signature, no key id.
+            let err = verifier.verify(b"wasm", None, Some("AAAA"), None).unwrap_err();
+            assert_eq!(err.code(), "incomplete_signature");
+            // Only key id, no signature.
+            let err = verifier.verify(b"wasm", None, None, Some("publisher-1")).unwrap_err();
+            assert_eq!(err.code(), "incomplete_signature");
+        }
+    }
+
+    #[test]
+    fn verifier_rejects_invalid_signature_base64() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let err = verifier
+            .verify(b"wasm", None, Some("not-valid-base64-!!!"), Some("publisher-1"))
+            .unwrap_err();
+        assert_eq!(err.code(), "invalid_signature_base64");
+    }
+
+    #[test]
+    fn verifier_rejects_signature_of_wrong_length() {
+        let (store, _sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        // Valid base64 but only 8 bytes — Ed25519 signatures are
+        // 64 bytes.
+        let err = verifier
+            .verify(b"wasm", None, Some(&b64(&[0u8; 8])), Some("publisher-1"))
+            .unwrap_err();
+        assert_eq!(err.code(), "invalid_signature_length");
+    }
+
+    #[test]
+    fn trust_store_round_trips_through_json() {
+        let (_sk, vk) = fixture_keypair();
+        let json = format!(r#"{{"publisher-1":"{}"}}"#, b64(vk.as_bytes()));
+        let store = TrustStore::from_json_str(&json).unwrap();
+        assert_eq!(store.len(), 1);
+        assert!(store.get("publisher-1").is_some());
+    }
+
+    #[test]
+    fn trust_store_rejects_short_key() {
+        let json = format!(r#"{{"too-short":"{}"}}"#, b64(&[0u8; 16]));
+        let result = TrustStore::from_json_str(&json);
+        assert!(matches!(result, Err(TrustStoreError::InvalidKeyLength { .. })));
+    }
+
+    #[test]
+    fn trust_store_rejects_invalid_json() {
+        let result = TrustStore::from_json_str("not json");
+        assert!(matches!(result, Err(TrustStoreError::InvalidJson { .. })));
+    }
+
+    #[test]
+    fn empty_trust_store_in_required_mode_rejects_signed_load() {
+        let verifier = SignatureVerifier::new(TrustStore::new(), SignatureMode::Required);
+        let err = verifier.verify(b"wasm", None, Some("AAAA"), Some("any-key")).unwrap_err();
+        // Empty store means even a syntactically valid request
+        // can't find a trust root.
+        assert!(matches!(
+            err.code(),
+            "unknown_publisher_key" | "invalid_signature_length" | "invalid_signature_base64"
+        ));
+    }
+
+    #[test]
+    fn build_signed_payload_v1_starts_with_version_prefix() {
+        let payload = build_signed_payload(b"abc", None);
+        assert!(payload.starts_with(PREFIX_V1_WASM_ONLY));
+    }
+
+    #[test]
+    fn build_signed_payload_v2_starts_with_version_prefix() {
+        let payload = build_signed_payload(b"abc", Some(b"manifest"));
+        assert!(payload.starts_with(PREFIX_V2_WASM_AND_MANIFEST));
+    }
+
+    #[test]
+    fn build_signed_payload_v2_includes_length_prefix() {
+        // Length prefix prevents wasm/manifest boundary shifts —
+        // i.e., flipping a byte from end-of-wasm to start-of-manifest
+        // can't yield the same signed payload.
+        let p1 = build_signed_payload(b"abcdef", Some(b"xyz"));
+        let p2 = build_signed_payload(b"abcde", Some(b"fxyz"));
+        assert_ne!(p1, p2, "length-prefix should disambiguate boundary shifts");
+    }
+}


### PR DESCRIPTION
## Summary
Closes the metering loop the \`InvocationMetricsBus\` from #388 was designed for: every plugin invocation produces an \`InvocationMetric\`, the exporter batches them, and every \`flush_interval\` (default 10s) POSTs the batch as JSON to a configured endpoint.

**Stacked on #404.**

## What it adds
**New module \`metering.rs\`:**
- \`ExporterConfig { url, flush_interval, max_queue_size, bearer_token }\` with sensible defaults
- \`ExportedMetric\` — stable JSON wire shape. \`status\` as \`&'static str\` (\"success\" | \"failure\" | \"dropped\"); \`error\` field omitted on success via \`skip_serializing_if\`
- \`From<InvocationMetric> for ExportedMetric\` handles the wire-format mapping
- \`run_exporter()\` forever-loop: subscribes to the bus, batches, flushes on interval or when queue fills

**Backpressure**: handled via \`broadcast::RecvError::Lagged\` — the request path never blocks because the metric pipeline is slow. Drops batches on HTTP failure rather than retrying so a downstream outage doesn't cause unbounded memory growth. Operators see the gap as a flat stretch on dashboards.

**Why JSON, not OTLP-protobuf**: aggregator is in a sibling MockForge codebase — we control both sides, so a stable JSON shape is enough for v1 and avoids pulling the full OpenTelemetry SDK (heavy dep tree, slow build). When we want to feed third-party collectors that accept OTLP natively, swap this module to emit OTLP/HTTP without changing the bus contract.

## Wiring change in host.rs
\`Host::new\` now constructs the \`PluginSandbox\` eagerly (rather than inside \`actor_loop\`) so the metrics bus is available before the actor starts. Returns \`(Self, HostActor, Arc<InvocationMetricsBus>)\`. All test fixtures + main.rs updated for the 3-tuple return.

## main.rs env vars
- \`MOCKFORGE_PLUGIN_HOST_METRICS_URL\` — endpoint to POST. Unset = exporter disabled (self-hosted dev default).
- \`MOCKFORGE_PLUGIN_HOST_METRICS_FLUSH_INTERVAL_SECS\` — override default 10s
- \`MOCKFORGE_PLUGIN_HOST_METRICS_QUEUE_SIZE\` — override default 1024
- \`MOCKFORGE_PLUGIN_HOST_METRICS_BEARER\` — auth token

\`exporter_future\` driven via \`select!\` alongside actor + server + blocklist poller + shutdown_signal. Five long-running tasks, one drop on shutdown.

## Test plan
- [x] \`cargo check -p mockforge-plugin-host\`
- [x] \`cargo clippy -p mockforge-plugin-host --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test -p mockforge-plugin-host --lib\` — **50/50 pass** (45 from #404 + 5 new):
  - InvocationMetric → ExportedMetric mapping for Success, Failure (carries error), Dropped
  - JSON serialization omits error field on success (skip_serializing_if working)
  - ExporterConfig defaults check (10s flush, 1024 queue, no bearer)

## What's next
- Real OTLP-protobuf path for third-party collector interop
- Per-plugin counters / histograms (currently raw events; aggregator rolls up)
- Push channel for sub-second kill-switch via the same HTTP connection (RFC §8.2)