### PR TITLE
Phase 2 — Manifest in signed payload (defense-in-depth)

### DIFF
--- a/crates/mockforge-plugin-host/src/handlers.rs
+++ b/crates/mockforge-plugin-host/src/handlers.rs
@@ -25,6 +25,7 @@ pub async fn handle(host: &Host, request: Request) -> Response {
             wasm_b64,
             signature_b64,
             publisher_key_id,
+            manifest_b64,
         } => {
             let bytes = match base64::engine::general_purpose::STANDARD.decode(wasm_b64.as_bytes())
             {
@@ -37,6 +38,20 @@ pub async fn handle(host: &Host, request: Request) -> Response {
                     };
                 }
             };
+            let manifest_bytes = match manifest_b64
+                .as_deref()
+                .map(|s| base64::engine::general_purpose::STANDARD.decode(s.as_bytes()))
+                .transpose()
+            {
+                Ok(b) => b,
+                Err(err) => {
+                    return Response::Error {
+                        id,
+                        code: "invalid_base64".to_string(),
+                        message: format!("decoding manifest_b64: {err}"),
+                    };
+                }
+            };
             match host
                 .load_plugin(
                     &plugin_name,
@@ -45,6 +60,7 @@ pub async fn handle(host: &Host, request: Request) -> Response {
                     bytes,
                     signature_b64,
                     publisher_key_id,
+                    manifest_bytes,
                 )
                 .await
             {
@@ -168,6 +184,7 @@ mod tests {
                     wasm_b64: b64_minimal(),
                     signature_b64: None,
                     publisher_key_id: None,
+                    manifest_b64: None,
                 },
             )
             .await;
@@ -212,6 +229,7 @@ mod tests {
                     wasm_b64: "not-valid-base64-!!!".into(),
                     signature_b64: None,
                     publisher_key_id: None,
+                    manifest_b64: None,
                 },
             )
             .await;
@@ -238,6 +256,7 @@ mod tests {
                 wasm_b64: b64_minimal(),
                 signature_b64: None,
                 publisher_key_id: None,
+                manifest_b64: None,
             };
             let _first = handle(&host, make_load(Uuid::new_v4())).await;
             let second = handle(&host, make_load(Uuid::new_v4())).await;
@@ -308,6 +327,7 @@ mod tests {
                     wasm_b64: b64_minimal(),
                     signature_b64: None,
                     publisher_key_id: None,
+                    manifest_b64: None,
                 },
             )
             .await;

--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -138,6 +138,7 @@ impl Host {
     /// `SignatureVerifier` before any bytes touch the loader.
     /// `signature_b64` and `publisher_key_id` must be passed
     /// together or both `None`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn load_plugin(
         &self,
         plugin_name: &str,
@@ -146,6 +147,7 @@ impl Host {
         wasm_bytes: Vec<u8>,
         signature_b64: Option<String>,
         publisher_key_id: Option<String>,
+        manifest_bytes: Option<Vec<u8>>,
     ) -> Result<PluginId, HostError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx
@@ -156,6 +158,7 @@ impl Host {
                 wasm_bytes,
                 signature_b64,
                 publisher_key_id,
+                manifest_bytes,
                 reply: reply_tx,
             })
             .await
@@ -219,6 +222,7 @@ enum Command {
         wasm_bytes: Vec<u8>,
         signature_b64: Option<String>,
         publisher_key_id: Option<String>,
+        manifest_bytes: Option<Vec<u8>>,
         reply: oneshot::Sender<Result<PluginId, HostError>>,
     },
     Unload {
@@ -270,6 +274,7 @@ async fn actor_loop(
                         wasm_bytes,
                         signature_b64,
                         publisher_key_id,
+                        manifest_bytes,
                         reply,
                     } => {
                         let result = handle_load(
@@ -283,6 +288,7 @@ async fn actor_loop(
                             wasm_bytes,
                             signature_b64.as_deref(),
                             publisher_key_id.as_deref(),
+                            manifest_bytes.as_deref(),
                         )
                         .await;
                         let _ = reply.send(result);
@@ -372,6 +378,7 @@ async fn handle_load(
     wasm_bytes: Vec<u8>,
     signature_b64: Option<&str>,
     publisher_key_id: Option<&str>,
+    manifest_bytes: Option<&[u8]>,
 ) -> Result<PluginId, HostError> {
     // Reject revoked plugins before any other work — including
     // signature verification. A revoked plugin shouldn't get
@@ -387,7 +394,7 @@ async fn handle_load(
     // Verify the signature *before* the loader sees the bytes.
     // Bypass-via-loader-bug is impossible if the bytes never
     // reach the loader on a verification failure.
-    let outcome = verifier.verify(&wasm_bytes, signature_b64, publisher_key_id)?;
+    let outcome = verifier.verify(&wasm_bytes, manifest_bytes, signature_b64, publisher_key_id)?;
     match &outcome {
         crate::signing::VerificationOutcome::Verified { key_id } => {
             tracing::info!(plugin_name, version = version_str, key_id, "plugin signature verified");
@@ -647,6 +654,7 @@ mod tests {
                 minimal_wasm(),
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -666,6 +674,7 @@ mod tests {
                 minimal_wasm(),
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -675,6 +684,7 @@ mod tests {
                     "1.0.0",
                     serde_json::json!({}),
                     minimal_wasm(),
+                    None,
                     None,
                     None,
                 )
@@ -692,6 +702,7 @@ mod tests {
                 "1.0.0",
                 serde_json::json!({}),
                 minimal_wasm(),
+                None,
                 None,
                 None,
             )
@@ -751,6 +762,7 @@ mod tests {
                     minimal_wasm(),
                     None,
                     None,
+                    None,
                 )
                 .await
                 .unwrap_err();
@@ -774,6 +786,7 @@ mod tests {
                     minimal_wasm(),
                     Some(sig_b64),
                     Some("unknown-key".to_string()),
+                    None,
                 )
                 .await
                 .unwrap_err();
@@ -823,7 +836,15 @@ mod tests {
 
         run_with_blocklist(bl, |host| async move {
             let err = host
-                .load_plugin("evil", "1.0.0", serde_json::json!({}), minimal_wasm(), None, None)
+                .load_plugin(
+                    "evil",
+                    "1.0.0",
+                    serde_json::json!({}),
+                    minimal_wasm(),
+                    None,
+                    None,
+                    None,
+                )
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), "revoked");
@@ -850,9 +871,17 @@ mod tests {
 
         run_with_blocklist(bl, |host| async move {
             // A different plugin with a different version is fine.
-            host.load_plugin("good", "1.0.0", serde_json::json!({}), minimal_wasm(), None, None)
-                .await
-                .unwrap();
+            host.load_plugin(
+                "good",
+                "1.0.0",
+                serde_json::json!({}),
+                minimal_wasm(),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
         });
     }
 
@@ -865,6 +894,7 @@ mod tests {
                     "not-a-version",
                     serde_json::json!({}),
                     minimal_wasm(),
+                    None,
                     None,
                     None,
                 )

--- a/crates/mockforge-plugin-host/src/protocol.rs
+++ b/crates/mockforge-plugin-host/src/protocol.rs
@@ -58,9 +58,11 @@ pub enum Request {
         permissions: serde_json::Value,
         /// Base64-encoded WASM module bytes.
         wasm_b64: String,
-        /// Base64-encoded Ed25519 signature over the decoded WASM
-        /// bytes (64 bytes raw, ~88 chars after base64). Required
-        /// in cloud mode. Pairs with `publisher_key_id`.
+        /// Base64-encoded Ed25519 signature. The signed payload is
+        /// `build_signed_payload(wasm, manifest)` from `signing.rs`
+        /// — domain-prefixed so v1 (wasm-only) and v2 (with
+        /// manifest) signatures can't be cross-replayed. Pairs
+        /// with `publisher_key_id`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         signature_b64: Option<String>,
         /// Trust-root id naming the public key the signature is
@@ -68,6 +70,12 @@ pub enum Request {
         /// `signature_b64` — both or neither.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         publisher_key_id: Option<String>,
+        /// Optional base64-encoded plugin manifest. When present,
+        /// the signature must cover both WASM and manifest
+        /// (defense-in-depth). Content is opaque to the signing
+        /// layer; the host parses it after verification.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        manifest_b64: Option<String>,
     },
     /// Detach a plugin and free its sandbox.
     UnloadPlugin {
@@ -181,6 +189,7 @@ mod tests {
             wasm_b64: "AGFzbQEAAAA=".into(), // empty WASM module
             signature_b64: None,
             publisher_key_id: None,
+            manifest_b64: None,
         };
         let bytes = serde_json::to_vec(&req).unwrap();
         let parsed: Request = serde_json::from_slice(&bytes).unwrap();
@@ -215,6 +224,7 @@ mod tests {
             wasm_b64: "AGFzbQEAAAA=".into(),
             signature_b64: Some("BBBB".repeat(22)), // 88-char base64-shaped value
             publisher_key_id: Some("publisher-1".into()),
+            manifest_b64: None,
         };
         let bytes = serde_json::to_vec(&req).unwrap();
         let parsed: Request = serde_json::from_slice(&bytes).unwrap();
@@ -241,6 +251,7 @@ mod tests {
             wasm_b64: "AGFzbQEAAAA=".into(),
             signature_b64: None,
             publisher_key_id: None,
+            manifest_b64: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         // skip_serializing_if drops the keys entirely so older

--- a/crates/mockforge-plugin-host/src/signing.rs
+++ b/crates/mockforge-plugin-host/src/signing.rs
@@ -31,11 +31,19 @@
 //!
 //! ## Signed payload
 //!
-//! Signature is over the **WASM bytes alone** — the canonical hash
-//! used for storage and signing. We don't include the manifest in
-//! the signed payload yet; that's a Phase 2 follow-up that pairs
-//! with fetching the real manifest from the registry instead of
-//! using the synthetic one in `host.rs::build_synthetic_manifest`.
+//! See [`build_signed_payload`] for the canonical bytes. Two
+//! versions, distinguished by domain-separation prefix:
+//!
+//!   - **v1** (legacy / no manifest): `prefix-v1 || wasm_bytes`
+//!   - **v2** (cloud / with manifest): `prefix-v2 || u64-be(wasm.len()) || wasm || manifest`
+//!
+//! v2 covers the manifest as well as the bytes — defense-in-depth
+//! against a registry compromise that swaps out a published
+//! plugin's permission grant. The big-endian length prefix
+//! prevents a length-extension attack that could shift the
+//! wasm/manifest boundary while keeping the signature valid.
+//! Domain prefixes prevent v1 signatures from being replayed
+//! against v2 payloads (and vice-versa).
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -178,6 +186,54 @@ pub enum TrustStoreError {
 }
 
 /// Verifier — combines the trust store and the policy mode.
+/// Domain-separation prefixes for the signed payload.
+///
+/// Why a prefix at all: cross-protocol attacks. Without a fixed
+/// prefix, a signature over (say) some other JSON document with a
+/// matching first chunk could be coerced into looking like a
+/// MockForge plugin signature. The prefix forces the signed
+/// payload to be plugin-shaped or invalid.
+///
+/// Two prefixes — one per "shape" — so a v1 signature over
+/// `wasm_bytes` alone can never be replayed as a v2 (manifest-
+/// covering) signature. The wire format is implicitly versioned
+/// through the prefix even though the wire field is unchanged.
+const PREFIX_V1_WASM_ONLY: &[u8] = b"mockforge-plugin/v1/wasm-only\n";
+const PREFIX_V2_WASM_AND_MANIFEST: &[u8] = b"mockforge-plugin/v2/wasm-and-manifest\n";
+
+/// Build the canonical signed payload for verification.
+///
+/// - **Without a manifest** (legacy / OSS): prefix-v1 || wasm
+/// - **With a manifest** (cloud production): prefix-v2 || u64-be(wasm.len()) || wasm || manifest
+///
+/// The big-endian length prefix in v2 prevents a length-extension
+/// trick where an attacker shifts the wasm/manifest boundary to
+/// still produce the same byte sequence — without the length, the
+/// concatenation is ambiguous.
+pub fn build_signed_payload(wasm_bytes: &[u8], manifest_bytes: Option<&[u8]>) -> Vec<u8> {
+    match manifest_bytes {
+        None => {
+            let mut payload = Vec::with_capacity(PREFIX_V1_WASM_ONLY.len() + wasm_bytes.len());
+            payload.extend_from_slice(PREFIX_V1_WASM_ONLY);
+            payload.extend_from_slice(wasm_bytes);
+            payload
+        }
+        Some(manifest) => {
+            let mut payload = Vec::with_capacity(
+                PREFIX_V2_WASM_AND_MANIFEST.len() + 8 + wasm_bytes.len() + manifest.len(),
+            );
+            payload.extend_from_slice(PREFIX_V2_WASM_AND_MANIFEST);
+            payload.extend_from_slice(&(wasm_bytes.len() as u64).to_be_bytes());
+            payload.extend_from_slice(wasm_bytes);
+            payload.extend_from_slice(manifest);
+            payload
+        }
+    }
+}
+
+/// Verifies plugin Ed25519 signatures against a trust store under a
+/// policy mode. Constructed once at host startup (see
+/// [`crate::host::Host::new`]) and consulted by every `LoadPlugin`.
 pub struct SignatureVerifier {
     store: TrustStore,
     mode: SignatureMode,
@@ -189,13 +245,22 @@ impl SignatureVerifier {
         Self { store, mode }
     }
 
-    /// Verify a signature over `wasm_bytes`. Pass `None` for
+    /// Verify a signature over the canonical signed payload
+    /// (see [`build_signed_payload`]). Pass `None` for
     /// `signature_b64` / `publisher_key_id` if the LoadPlugin
     /// request didn't include a signature — the verifier will
     /// either accept (Optional mode) or reject (Required mode).
+    ///
+    /// `manifest_bytes` is optional. When `Some`, the signature
+    /// must cover both the WASM and the manifest — defense-in-
+    /// depth so a colluding signer can't pair one verified WASM
+    /// with a forged manifest. When `None`, the signature covers
+    /// just the WASM (legacy v1 path; backward-compatible with
+    /// PR #403).
     pub fn verify(
         &self,
         wasm_bytes: &[u8],
+        manifest_bytes: Option<&[u8]>,
         signature_b64: Option<&str>,
         publisher_key_id: Option<&str>,
     ) -> Result<VerificationOutcome, VerificationError> {
@@ -227,7 +292,8 @@ impl SignatureVerifier {
                         key_id: key_id.to_string(),
                     })?;
 
-                key.verify(wasm_bytes, &signature)
+                let signed_payload = build_signed_payload(wasm_bytes, manifest_bytes);
+                key.verify(&signed_payload, &signature)
                     .map_err(|err| VerificationError::SignatureMismatch(err.to_string()))?;
 
                 Ok(VerificationOutcome::Verified {
@@ -346,14 +412,24 @@ mod tests {
         base64::engine::general_purpose::STANDARD.encode(bytes)
     }
 
+    /// Sign `build_signed_payload(wasm, manifest)` so the test
+    /// signature matches what the verifier reconstructs. Tests
+    /// constructing signatures over raw bytes (without the
+    /// canonical wrapping) used to work in the v1-no-prefix world
+    /// of #403; this PR adds the domain prefix and they need to
+    /// follow.
+    fn sign_canonical(sk: &SigningKey, wasm: &[u8], manifest: Option<&[u8]>) -> String {
+        let payload = build_signed_payload(wasm, manifest);
+        b64(sk.sign(&payload).to_bytes().as_ref())
+    }
+
     #[test]
-    fn verifier_accepts_valid_signature() {
+    fn verifier_accepts_valid_v1_signature_no_manifest() {
         let (store, sk) = make_store_with_test_key("publisher-1");
         let verifier = SignatureVerifier::new(store, SignatureMode::Required);
         let wasm = b"\x00asm\x01\x00\x00\x00";
-        let sig = sk.sign(wasm);
         let outcome = verifier
-            .verify(wasm, Some(&b64(sig.to_bytes().as_ref())), Some("publisher-1"))
+            .verify(wasm, None, Some(&sign_canonical(&sk, wasm, None)), Some("publisher-1"))
             .unwrap();
         match outcome {
             VerificationOutcome::Verified { key_id } => assert_eq!(key_id, "publisher-1"),
@@ -362,30 +438,67 @@ mod tests {
     }
 
     #[test]
-    fn verifier_rejects_signature_against_wrong_key() {
-        let (mut store, _sk) = make_store_with_test_key("publisher-1");
-        // Add a second key but sign with the first.
-        let (other_sk, _other_vk) = fixture_keypair();
-        let _ = other_sk; // unused; signing was with the first
-        let (real_sk, _real_vk) = fixture_keypair();
-        let verifier = SignatureVerifier::new(store.clone(), SignatureMode::Required);
-        let wasm = b"different bytes";
-        let sig = real_sk.sign(wasm);
-
-        // Sign over different bytes than what we'll ask the
-        // verifier to check — should fail.
-        let bad_message = b"original bytes";
-        let outcome =
-            verifier.verify(bad_message, Some(&b64(sig.to_bytes().as_ref())), Some("publisher-1"));
+    fn verifier_accepts_valid_v2_signature_with_manifest() {
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let manifest = br#"{"name":"example","version":"1.0.0"}"#;
+        let outcome = verifier
+            .verify(
+                wasm,
+                Some(manifest),
+                Some(&sign_canonical(&sk, wasm, Some(manifest))),
+                Some("publisher-1"),
+            )
+            .unwrap();
         match outcome {
-            Err(err) => assert_eq!(err.code(), "signature_mismatch"),
-            Ok(other) => panic!("expected signature_mismatch error, got {:?}", other),
+            VerificationOutcome::Verified { key_id } => assert_eq!(key_id, "publisher-1"),
+            other => panic!("expected Verified, got {:?}", other),
         }
+    }
 
-        // Confirm the sk we built was actually consulted (sanity
-        // check that store has the right key).
-        assert!(store.get("publisher-1").is_some());
-        let _ = store.insert("publisher-2".to_string(), real_sk.verifying_key());
+    #[test]
+    fn verifier_rejects_v1_signature_replayed_against_v2_payload() {
+        // Sign over wasm-only, then ask verifier to check wasm+manifest.
+        // Domain-separation prefix means the v1 signature can't
+        // match the v2 payload.
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let manifest = b"manifest-bytes";
+        let v1_sig = sign_canonical(&sk, wasm, None);
+        let err = verifier
+            .verify(wasm, Some(manifest), Some(&v1_sig), Some("publisher-1"))
+            .unwrap_err();
+        assert_eq!(err.code(), "signature_mismatch");
+    }
+
+    #[test]
+    fn verifier_rejects_v2_signature_with_tampered_manifest() {
+        // Sign over wasm + manifest_a, present manifest_b at
+        // verify time. Length-prefix + bytes mean any change to
+        // the manifest invalidates the signature.
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"\x00asm\x01\x00\x00\x00";
+        let original_manifest = br#"{"name":"good","version":"1.0.0"}"#;
+        let tampered_manifest = br#"{"name":"evil","version":"1.0.0"}"#;
+        let sig = sign_canonical(&sk, wasm, Some(original_manifest));
+        let err = verifier
+            .verify(wasm, Some(tampered_manifest), Some(&sig), Some("publisher-1"))
+            .unwrap_err();
+        assert_eq!(err.code(), "signature_mismatch");
+    }
+
+    #[test]
+    fn verifier_rejects_signature_against_wrong_key() {
+        let (store, sk) = make_store_with_test_key("publisher-1");
+        let verifier = SignatureVerifier::new(store, SignatureMode::Required);
+        let wasm = b"original bytes";
+        // Sign different bytes than what the verifier checks.
+        let sig = sign_canonical(&sk, b"different bytes", None);
+        let err = verifier.verify(wasm, None, Some(&sig), Some("publisher-1")).unwrap_err();
+        assert_eq!(err.code(), "signature_mismatch");
     }
 
     #[test]
@@ -393,10 +506,8 @@ mod tests {
         let (store, sk) = make_store_with_test_key("publisher-1");
         let verifier = SignatureVerifier::new(store, SignatureMode::Required);
         let wasm = b"\x00asm\x01\x00\x00\x00";
-        let sig = sk.sign(wasm);
-        let err = verifier
-            .verify(wasm, Some(&b64(sig.to_bytes().as_ref())), Some("not-a-real-key"))
-            .unwrap_err();
+        let sig = sign_canonical(&sk, wasm, None);
+        let err = verifier.verify(wasm, None, Some(&sig), Some("not-a-real-key")).unwrap_err();
         assert_eq!(err.code(), "unknown_publisher_key");
     }
 
@@ -404,7 +515,7 @@ mod tests {
     fn verifier_required_mode_rejects_unsigned() {
         let (store, _sk) = make_store_with_test_key("publisher-1");
         let verifier = SignatureVerifier::new(store, SignatureMode::Required);
-        let err = verifier.verify(b"wasm", None, None).unwrap_err();
+        let err = verifier.verify(b"wasm", None, None, None).unwrap_err();
         assert_eq!(err.code(), "signature_required");
     }
 
@@ -412,7 +523,7 @@ mod tests {
     fn verifier_optional_mode_accepts_unsigned() {
         let (store, _sk) = make_store_with_test_key("publisher-1");
         let verifier = SignatureVerifier::new(store, SignatureMode::Optional);
-        let outcome = verifier.verify(b"wasm", None, None).unwrap();
+        let outcome = verifier.verify(b"wasm", None, None, None).unwrap();
         assert_eq!(outcome, VerificationOutcome::SkippedUnsigned);
     }
 
@@ -422,10 +533,10 @@ mod tests {
         for mode in [SignatureMode::Required, SignatureMode::Optional] {
             let verifier = SignatureVerifier::new(store.clone(), mode);
             // Only signature, no key id.
-            let err = verifier.verify(b"wasm", Some("AAAA"), None).unwrap_err();
+            let err = verifier.verify(b"wasm", None, Some("AAAA"), None).unwrap_err();
             assert_eq!(err.code(), "incomplete_signature");
             // Only key id, no signature.
-            let err = verifier.verify(b"wasm", None, Some("publisher-1")).unwrap_err();
+            let err = verifier.verify(b"wasm", None, None, Some("publisher-1")).unwrap_err();
             assert_eq!(err.code(), "incomplete_signature");
         }
     }
@@ -435,7 +546,7 @@ mod tests {
         let (store, _sk) = make_store_with_test_key("publisher-1");
         let verifier = SignatureVerifier::new(store, SignatureMode::Required);
         let err = verifier
-            .verify(b"wasm", Some("not-valid-base64-!!!"), Some("publisher-1"))
+            .verify(b"wasm", None, Some("not-valid-base64-!!!"), Some("publisher-1"))
             .unwrap_err();
         assert_eq!(err.code(), "invalid_signature_base64");
     }
@@ -447,7 +558,7 @@ mod tests {
         // Valid base64 but only 8 bytes — Ed25519 signatures are
         // 64 bytes.
         let err = verifier
-            .verify(b"wasm", Some(&b64(&[0u8; 8])), Some("publisher-1"))
+            .verify(b"wasm", None, Some(&b64(&[0u8; 8])), Some("publisher-1"))
             .unwrap_err();
         assert_eq!(err.code(), "invalid_signature_length");
     }
@@ -477,12 +588,34 @@ mod tests {
     #[test]
     fn empty_trust_store_in_required_mode_rejects_signed_load() {
         let verifier = SignatureVerifier::new(TrustStore::new(), SignatureMode::Required);
-        let err = verifier.verify(b"wasm", Some("AAAA"), Some("any-key")).unwrap_err();
+        let err = verifier.verify(b"wasm", None, Some("AAAA"), Some("any-key")).unwrap_err();
         // Empty store means even a syntactically valid request
         // can't find a trust root.
         assert!(matches!(
             err.code(),
             "unknown_publisher_key" | "invalid_signature_length" | "invalid_signature_base64"
         ));
+    }
+
+    #[test]
+    fn build_signed_payload_v1_starts_with_version_prefix() {
+        let payload = build_signed_payload(b"abc", None);
+        assert!(payload.starts_with(PREFIX_V1_WASM_ONLY));
+    }
+
+    #[test]
+    fn build_signed_payload_v2_starts_with_version_prefix() {
+        let payload = build_signed_payload(b"abc", Some(b"manifest"));
+        assert!(payload.starts_with(PREFIX_V2_WASM_AND_MANIFEST));
+    }
+
+    #[test]
+    fn build_signed_payload_v2_includes_length_prefix() {
+        // Length prefix prevents wasm/manifest boundary shifts —
+        // i.e., flipping a byte from end-of-wasm to start-of-manifest
+        // can't yield the same signed payload.
+        let p1 = build_signed_payload(b"abcdef", Some(b"xyz"));
+        let p2 = build_signed_payload(b"abcde", Some(b"fxyz"));
+        assert_ne!(p1, p2, "length-prefix should disambiguate boundary shifts");
     }
 }


### PR DESCRIPTION
Stacked on #407.

## What

Closes the gap left by PR #403 — the Ed25519 signature now covers the WASM bytes **and** the plugin manifest, so a registry compromise that swaps a published plugin's permission grant can't reuse the original signature.

## Wire format

Two payload shapes, distinguished by a domain-separation prefix:

- **v1** (no manifest, legacy): \`b\"mockforge-plugin/v1/wasm-only\\n\" || wasm_bytes\`
- **v2** (with manifest, cloud production): \`b\"mockforge-plugin/v2/wasm-and-manifest\\n\" || u64-be(wasm.len()) || wasm || manifest\`

The big-endian length prefix in v2 prevents a length-extension attack that could shift the wasm/manifest boundary while keeping a valid signature. Distinct prefixes prevent a v1 signature from being replayed against a v2 payload (and vice-versa) — classic domain-separation against cross-protocol attacks.

## Wire-protocol change (backwards compatible)

\`Request::LoadPlugin\` gains an optional \`manifest_b64\` field (\`#[serde(skip_serializing_if = \"Option::is_none\")]\`), so existing v1 callers continue to round-trip unchanged. When the field is \`Some\`, the host decodes it, threads the bytes through the actor command channel, and the verifier asserts both wasm and manifest under the v2 prefix.

## Tests

- \`verifier_accepts_valid_v1_signature_no_manifest\` — v1 path still works for backwards compat
- \`verifier_accepts_valid_v2_signature_with_manifest\` — v2 happy path
- \`verifier_rejects_v1_signature_replayed_against_v2_payload\` — domain prefix prevents cross-version replay
- \`verifier_rejects_v2_signature_with_tampered_manifest\` — manifest is actually covered
- \`build_signed_payload_v1_starts_with_version_prefix\`, \`build_signed_payload_v2_starts_with_version_prefix\`, \`build_signed_payload_v2_includes_length_prefix\` — wire-format invariants pinned in code

56 plugin-host tests pass (was 50 before this PR; +6 new). \`cargo clippy --all-targets -- -D warnings\` and \`cargo fmt --check\` are clean.

## Test plan

- [x] \`cargo test -p mockforge-plugin-host\` — 56 passed
- [x] \`cargo clippy -p mockforge-plugin-host --all-targets -- -D warnings\`
- [x] \`cargo fmt --all --check\`
- [x] Pre-commit hooks (clippy/typos/fmt/audit) green