### PR TITLE
fix(ci): install Rust toolchain in load-testing jobs

### DIFF
--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install k6
         run: |
           sudo gpg -k
@@ -97,6 +100,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install k6
         run: |


### PR DESCRIPTION
## Summary
\`Standard Load Test\` and \`Extended Load Test\` were failing on every PR with \`cargo: command not found\` (exit 127). The two jobs run \`cargo build --release --bin mockforge\` but never install Rust — the \`[self-hosted, linux, x64, rust]\` label is a runner tag, not a system Rust install.

## Fix
Add \`dtolnay/rust-toolchain@stable\` to both \`standard-load-test\` and \`extended-load-test\` jobs, matching the pattern already used by the sibling \`performance-benchmarks\` job in the same workflow file.

## Test plan
- [x] Diff review — six lines added, two identical step insertions.
- [ ] CI run on this branch — \`Standard Load Test\` should now reach \`Build MockForge\` instead of dying at the cargo invocation. (Will verify post-merge.)

Removes a recurring red check across all PRs against \`main\`.