### PR TITLE
fix(ui): UI tests force local mode so cloud-mode dispatch doesn't break mocks

### DIFF
--- a/crates/mockforge-ui/ui/src/pages/__tests__/ChainsPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/ChainsPage.test.tsx
@@ -64,6 +64,11 @@ describe('ChainsPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Force local mode — global setup sets VITE_API_BASE_URL, which would
+    // route ChainsPage through cloud dispatchers instead of the mocked
+    // apiService.* methods.
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('VITE_MOCKFORGE_MODE', '');
     (apiService.listChains as any) = vi.fn().mockResolvedValue({ chains: mockChains });
   });
 

--- a/crates/mockforge-ui/ui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/DashboardPage.test.tsx
@@ -44,6 +44,14 @@ const createWrapper = () => {
   );
 };
 
+// DashboardPage captures `const isCloud = isCloudMode()` at module load,
+// so per-test env stubbing is too late. Mock the module to keep the page
+// in local mode for the existing tests.
+vi.mock('../../utils/cloudMode', () => ({
+  isCloudMode: () => false,
+  getCloudApiBase: () => '',
+}));
+
 describe('DashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/crates/mockforge-ui/ui/src/pages/__tests__/ImportPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/ImportPage.test.tsx
@@ -88,6 +88,11 @@ describe('ImportPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Force local mode — global setup sets VITE_API_BASE_URL, which would
+    // route ImportPage through cloudPreview/cloudImport instead of the
+    // mocked usePreviewImport/useImportPostman hooks.
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('VITE_MOCKFORGE_MODE', '');
   });
 
   it('renders import page header', () => {

--- a/crates/mockforge-ui/ui/src/pages/__tests__/ScenarioStateMachineEditor.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/ScenarioStateMachineEditor.test.tsx
@@ -62,6 +62,11 @@ vi.mock('@xyflow/react', async () => {
 describe('ScenarioStateMachineEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Force local mode — global setup sets VITE_API_BASE_URL, which would
+    // route the editor through cloud dispatchers instead of the mocked
+    // local API service.
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('VITE_MOCKFORGE_MODE', '');
   });
 
   it('should render editor page', () => {


### PR DESCRIPTION
## Summary
\`UI Tests\` has been failing on every PR with 28+ test failures across \`ChainsPage\`, \`DashboardPage\`, \`ImportPage\`, and \`ScenarioStateMachineEditor\`. Root cause: the global test setup (\`src/test/setup.ts\`) sets \`VITE_API_BASE_URL='http://localhost:3000/api'\`, which makes \`isCloudMode()\` return true everywhere. Pages with cloud-mode branching then route through cloud dispatchers (\`cloudPreview\`, \`cloudFetchScenarioStateMachine\`, etc.) instead of the local hooks the tests have mocked — so the spies are never called and the assertions fail.

## Fix
Two patterns depending on where the page calls \`isCloudMode()\`:

- **\`ChainsPage\`, \`ImportPage\`, \`ScenarioStateMachineEditor\`** call \`isCloudMode()\` per-render or per-handler. Adding \`vi.stubEnv('VITE_API_BASE_URL', '')\` to \`beforeEach\` is enough.
- **\`DashboardPage\`** captures \`const isCloud = isCloudMode()\` at module load, so per-test env stubbing fires too late. Uses \`vi.mock('../utils/cloudMode')\` to force \`isCloudMode\` to return \`false\` for the whole file.

## Test plan
- [x] \`pnpm exec vitest run\` for the four affected files → 4 files / 54 tests pass.
- [x] \`pnpm exec vitest run\` for the whole UI suite → 74 files / 872 tests pass.

## Why not flip the global default
\`setup.ts\`'s \`VITE_API_BASE_URL\` is load-bearing for cloud-mode tests (\`cloudCommunity.test.ts\`, \`useServiceStore.test.ts\`, \`CloudPluginsBetaCta.test.tsx\`). Flipping the default would break those. Per-file opt-out matches the existing pattern in \`useSSE.test.ts\`, \`useWebSocket.test.ts\`, and \`ConfigPage.test.tsx\`.