### PR TITLE
fix(mockforge-http): clear Warning Ratchet Preview on main

### DIFF
--- a/crates/mockforge-http/src/handlers/scenario_studio.rs
+++ b/crates/mockforge-http/src/handlers/scenario_studio.rs
@@ -222,7 +222,6 @@ pub async fn delete_flow(
 /// Execute a flow
 ///
 /// POST /api/v1/scenario-studio/flows/:id/execute
-#[axum::debug_handler]
 pub async fn execute_flow(
     Path(id): Path<String>,
     State(state): State<ScenarioStudioState>,

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -1430,7 +1430,7 @@ pub async fn serve_router_with_tls_notify_chaos(
     app: Router,
     tls_config: Option<mockforge_core::config::HttpTlsConfig>,
     bound_port_tx: Option<tokio::sync::oneshot::Sender<u16>>,
-    chaos_config: Option<std::sync::Arc<tokio::sync::RwLock<mockforge_chaos::ChaosConfig>>>,
+    chaos_config: Option<Arc<RwLock<mockforge_chaos::ChaosConfig>>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use std::net::SocketAddr;
 
@@ -1496,7 +1496,7 @@ pub async fn serve_router_with_tls_notify_chaos(
 /// `ConnectInfo<SocketAddr>` so handlers extracting `ConnectInfo<SocketAddr>`
 /// keep working when chaos TCP wrapping is enabled.
 async fn copy_chaos_addr_to_socketaddr(
-    mut req: axum::http::Request<axum::body::Body>,
+    mut req: Request<Body>,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
     use axum::extract::ConnectInfo;


### PR DESCRIPTION
## Summary
Two distinct issues in \`mockforge-http\`, both surfaced as Warning Ratchet Preview failures on main, blocking PR auto-merges.

### 1. Unnecessary qualifications (4 errors in \`lib.rs\`)
- Line 1433: \`std::sync::Arc<tokio::sync::RwLock<...>>\` → \`Arc<RwLock<...>>\` (both already imported above).
- Line 1499: \`axum::http::Request<axum::body::Body>\` → \`Request<Body>\` (both already imported).

### 2. \`unused_variables\` false-positives on \`execute_flow\`
After the axum 0.8.8 → 0.8.9 bump (#339), the warning ratchet started flagging \`Path(id)\`, \`State(state)\`, \`Json(request)\` as unused on \`execute_flow\` even though they're used several times in the body. Sibling handlers in the same file with identical patterns aren't flagged — the only difference is \`#[axum::debug_handler]\` on \`execute_flow\`, which generates wrapper code that confuses \`unused_variables\` in axum 0.8.9. The macro is diagnostic-only; removing it has no runtime effect.

## Test plan
- [x] \`scripts/lint-warning-ratchet-preview.sh\` passes locally.
- [x] \`cargo check -p mockforge-http --all-targets\` clean.

This unblocks Warning Ratchet Preview on main and on every active branch.