### PR TITLE
feat(cloud-plugins): Phase 3.1 UI scaffold — read-only attachment listing

### DIFF
--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -198,6 +198,7 @@ const navSections = [
     titleKey: 'nav.plugins',
     items: [
       { id: 'plugins', labelKey: 'tab.plugins', icon: Puzzle },
+      { id: 'cloud-plugins', labelKey: 'tab.cloudPlugins', icon: Puzzle },
       { id: 'plugin-registry', labelKey: 'tab.pluginRegistry', icon: Package },
     ]
   },
@@ -309,6 +310,11 @@ const cloudNavItemIds = new Set([
   // Showcase admin authoring via cloudShowcaseApi.adminList / adminCreate /
   // adminUpdate / adminDelete.
   'cloud-showcase-admin',
+  // Cloud plugins (Phase 3) — read-only attachment listing today;
+  // attach/permission/detach controls land in subsequent sub-PRs once
+  // PR #395's control-plane API merges. Listed here so the sidebar
+  // shows it as active in cloud mode.
+  'cloud-plugins',
   // Public showcase + learning hub adapt /api/v1/showcase/* and
   // /api/v1/learning/* into the legacy ShowcaseProject / LearningResource
   // shapes via cloudCommunityApi (services/api/cloudCommunity.ts).

--- a/crates/mockforge-ui/ui/src/i18n/translations.ts
+++ b/crates/mockforge-ui/ui/src/i18n/translations.ts
@@ -95,6 +95,7 @@ const en: Dictionary = {
   'tab.showcase': 'Showcase',
   'tab.learningHub': 'Learning Hub',
   'tab.plugins': 'Plugins',
+  'tab.cloudPlugins': 'Cloud Plugins',
   'tab.pluginRegistry': 'Plugin Registry',
   'tab.config': 'Config',
   'tab.organization': 'Organization',
@@ -128,6 +129,10 @@ const en: Dictionary = {
   'page.plugins.browseMarketplace': 'Browse Marketplace',
   'page.plugins.installPlugin': 'Install Plugin',
   'page.plugins.reloadAll': 'Reload All',
+  'page.cloudPlugins.title': 'Cloud Plugins',
+  'page.cloudPlugins.subtitle':
+    'Manage plugins attached to your hosted-mock deployments. Each attachment has its own permission grants and runtime config.',
+  'page.cloudPlugins.browseRegistry': 'Browse Registry',
   'page.mockai.title': 'MockAI',
   'page.mockai.description':
     'AI-powered mock API intelligence for realistic, context-aware responses',

--- a/crates/mockforge-ui/ui/src/pages/CloudPluginsPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/CloudPluginsPage.tsx
@@ -1,0 +1,238 @@
+/**
+ * Cloud Plugins — manage plugins attached to hosted-mock deployments.
+ *
+ * Phase 3.1 scaffold (read-only). Lists each deployment in the org with
+ * its attached plugins. Attach / permission-edit / detach land in 3.2 –
+ * 3.4. The control-plane endpoints come from PR #395; until that merges
+ * `listAttachments` returns [] for every deployment and the page shows
+ * the empty state.
+ */
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { Puzzle, ExternalLink, AlertCircle } from 'lucide-react';
+import { isCloudMode } from '../utils/cloudMode';
+import { authenticatedFetch } from '../utils/apiClient';
+import {
+  cloudPluginsApi,
+  type PluginAttachment,
+} from '../services/api/cloudPlugins';
+import { useI18n } from '../i18n/I18nProvider';
+
+interface DeploymentSummary {
+  id: string;
+  name: string;
+  slug: string;
+  status: string;
+  region?: string;
+}
+
+async function fetchDeployments(): Promise<DeploymentSummary[]> {
+  const response = await authenticatedFetch('/api/v1/hosted-mocks');
+  if (!response.ok) {
+    throw new Error(`Failed to load deployments (HTTP ${response.status})`);
+  }
+  const data = await response.json();
+  const list = (data?.data ?? data) as unknown;
+  return Array.isArray(list) ? (list as DeploymentSummary[]) : [];
+}
+
+export const CloudPluginsPage: React.FC = () => {
+  if (!isCloudMode()) {
+    return <LocalModeNotice />;
+  }
+  return <CloudView />;
+};
+
+const LocalModeNotice: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-900/20 dark:text-blue-300">
+        Cloud plugin management only applies to cloud-hosted deployments. For
+        plugins on a local MockForge runtime, open the{' '}
+        <button
+          type="button"
+          className="font-medium underline"
+          onClick={() => navigate('/plugins')}
+        >
+          local Plugins page
+        </button>
+        .
+      </div>
+    </div>
+  );
+};
+
+const CloudView: React.FC = () => {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  const deploymentsQuery = useQuery({
+    queryKey: ['cloud', 'plugins', 'deployments'],
+    queryFn: fetchDeployments,
+  });
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto space-y-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold flex items-center gap-2">
+            <Puzzle className="w-6 h-6" />
+            {t('page.cloudPlugins.title')}
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1 max-w-3xl">
+            {t('page.cloudPlugins.subtitle')}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => navigate('/plugin-registry')}
+          className="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+        >
+          {t('page.cloudPlugins.browseRegistry')}
+          <ExternalLink className="w-4 h-4" />
+        </button>
+      </header>
+
+      <BetaBanner />
+
+      {deploymentsQuery.isLoading && (
+        <div className="text-sm text-muted-foreground">
+          {t('app.loading')}
+        </div>
+      )}
+
+      {deploymentsQuery.isError && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300">
+          <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+          <span>{(deploymentsQuery.error as Error).message}</span>
+        </div>
+      )}
+
+      {deploymentsQuery.data && deploymentsQuery.data.length === 0 && (
+        <EmptyState onCreate={() => navigate('/hosted-mocks')} />
+      )}
+
+      {deploymentsQuery.data && deploymentsQuery.data.length > 0 && (
+        <div className="space-y-4">
+          {deploymentsQuery.data.map((deployment) => (
+            <DeploymentRow key={deployment.id} deployment={deployment} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const BetaBanner: React.FC = () => (
+  <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
+    <p className="font-medium">Cloud plugin runtime — beta</p>
+    <p className="mt-1">
+      Cloud plugin management is rolling out alongside the cloud plugin
+      runtime. Attach, permission, and detach controls land in the next
+      sub-PRs of Phase 3. Today this page lists deployments and any plugins
+      already wired up.
+    </p>
+  </div>
+);
+
+const EmptyState: React.FC<{ onCreate: () => void }> = ({ onCreate }) => (
+  <div className="rounded-lg border border-dashed border-input p-8 text-center">
+    <Puzzle className="w-8 h-8 mx-auto text-muted-foreground" />
+    <h3 className="mt-3 font-medium">No hosted-mock deployments yet</h3>
+    <p className="mt-1 text-sm text-muted-foreground">
+      Create a hosted mock first — plugins attach per deployment.
+    </p>
+    <button
+      type="button"
+      onClick={onCreate}
+      className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground hover:bg-primary/90"
+    >
+      Go to Hosted Mocks
+    </button>
+  </div>
+);
+
+const DeploymentRow: React.FC<{ deployment: DeploymentSummary }> = ({
+  deployment,
+}) => {
+  const attachmentsQuery = useQuery({
+    queryKey: ['cloud', 'plugins', 'attachments', deployment.id],
+    queryFn: () => cloudPluginsApi.listAttachments(deployment.id),
+  });
+
+  return (
+    <section className="rounded-lg border border-input bg-card">
+      <header className="flex items-center justify-between border-b border-input px-4 py-3">
+        <div>
+          <h2 className="font-medium">{deployment.name}</h2>
+          <p className="text-xs text-muted-foreground">
+            {deployment.slug}
+            {deployment.region ? ` · ${deployment.region}` : ''} ·{' '}
+            <StatusBadge status={deployment.status} />
+          </p>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {attachmentsQuery.data?.length ?? 0} plugin
+          {(attachmentsQuery.data?.length ?? 0) === 1 ? '' : 's'}
+        </span>
+      </header>
+
+      {attachmentsQuery.isLoading && (
+        <p className="px-4 py-3 text-xs text-muted-foreground">Loading…</p>
+      )}
+      {attachmentsQuery.isError && (
+        <p className="px-4 py-3 text-xs text-red-700 dark:text-red-400">
+          {(attachmentsQuery.error as Error).message}
+        </p>
+      )}
+      {attachmentsQuery.data && attachmentsQuery.data.length === 0 && (
+        <p className="px-4 py-3 text-xs text-muted-foreground">
+          No plugins attached to this deployment.
+        </p>
+      )}
+      {attachmentsQuery.data && attachmentsQuery.data.length > 0 && (
+        <ul className="divide-y divide-input">
+          {attachmentsQuery.data.map((a) => (
+            <AttachmentRow key={a.id} attachment={a} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+const AttachmentRow: React.FC<{ attachment: PluginAttachment }> = ({
+  attachment,
+}) => (
+  <li className="flex items-center justify-between gap-4 px-4 py-3 text-sm">
+    <div className="min-w-0">
+      <p className="font-medium truncate">
+        {attachment.plugin_name ?? attachment.plugin_id}
+      </p>
+      <p className="text-xs text-muted-foreground truncate">
+        v{attachment.plugin_version ?? '—'} · attached{' '}
+        {new Date(attachment.attached_at).toLocaleString()}
+      </p>
+    </div>
+    <span
+      className={
+        attachment.enabled
+          ? 'inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300'
+          : 'inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'
+      }
+    >
+      {attachment.enabled ? 'Enabled' : 'Disabled'}
+    </span>
+  </li>
+);
+
+const StatusBadge: React.FC<{ status: string }> = ({ status }) => {
+  const tone =
+    status === 'active'
+      ? 'text-emerald-700 dark:text-emerald-400'
+      : status === 'failed'
+        ? 'text-red-700 dark:text-red-400'
+        : 'text-muted-foreground';
+  return <span className={tone}>{status}</span>;
+};

--- a/crates/mockforge-ui/ui/src/routes/index.tsx
+++ b/crates/mockforge-ui/ui/src/routes/index.tsx
@@ -105,6 +105,9 @@ const CloudRecorderPage = lazy(() => import('../pages/CloudRecorderPage').then(m
 // Cloud showcase admin (#12) — submit / publish / feature gallery entries
 const CloudShowcaseAdminPage = lazy(() => import('../pages/CloudShowcaseAdminPage').then(m => ({ default: m.CloudShowcaseAdminPage })));
 
+// Cloud plugins (Phase 3) — manage plugins attached to hosted-mock deployments
+const CloudPluginsPage = lazy(() => import('../pages/CloudPluginsPage').then(m => ({ default: m.CloudPluginsPage })));
+
 // Registry admin (cloud: Postgres via /api/v1/*, self-hosted: SQLite via /api/admin/registry/*)
 const RegistryLoginPage = lazy(() => import('../pages/RegistryLoginPage').then(m => ({ default: m.RegistryLoginPage })));
 const RegistryAdminPage = lazy(() => import('../pages/RegistryAdminPage').then(m => ({ default: m.RegistryAdminPage })));
@@ -224,6 +227,7 @@ export const routes: RouteConfig[] = [
 
   // Plugins
   { path: '/plugins', element: <PluginsPage /> },
+  { path: '/cloud-plugins', element: <CloudPluginsPage /> },
   { path: '/plugin-registry', element: <PluginRegistryPage /> },
   { path: '/plugin-registry/moderation', element: <PluginModerationPage /> },
 

--- a/crates/mockforge-ui/ui/src/services/api/cloudPlugins.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudPlugins.ts
@@ -1,12 +1,22 @@
 /**
- * Cloud Plugins beta interest API (Phase 0 demand validation).
+ * Cloud Plugins API client.
  *
- * Wraps `/api/v1/cloud-plugins/beta-interest{,/me}`. The endpoints are
- * per-user (not org-scoped) — registering interest is an individual
- * action, even if we snapshot the user's current org context server
- * side for analysis.
+ * Two surfaces:
+ *   1. Beta-interest CTA (Phase 0 — `/api/v1/cloud-plugins/beta-interest`).
+ *      Per-user, not org-scoped.
+ *   2. Per-deployment plugin attachments (Phase 1 control-plane —
+ *      `/api/v1/hosted-mocks/{deployment_id}/plugins`). Org from
+ *      `X-Organization-Id` is set on the request by `authenticatedFetch`
+ *      / the registry's auth middleware; no header needed here.
+ *
+ * The attachment endpoints land in PR #395; until that merges they
+ * return 404 and `listAttachments` swallows that into an empty list so
+ * the page renders cleanly during the gap.
  */
 import { fetchJsonWithErrorBody } from './client';
+import { authenticatedFetch } from '../../utils/apiClient';
+
+// ─── Beta interest (Phase 0) ───────────────────────────────────────────
 
 export interface BetaInterestStatus {
   signed_up: boolean;
@@ -24,7 +34,50 @@ export interface SubmitBetaInterestRequest {
   use_case?: string;
 }
 
+// ─── Plugin attachments (Phase 1, PR #395) ─────────────────────────────
+
+/**
+ * Permission grant payload — structured per RFC §4.2. The shape is
+ * intentionally open here; the editor in 3.3 will narrow each section
+ * to typed inputs. Today the UI just round-trips whatever the backend
+ * returns.
+ */
+export type PermissionsGrant = Record<string, unknown>;
+
+export type PluginConfig = Record<string, unknown>;
+
+export interface PluginAttachment {
+  id: string;
+  deployment_id: string;
+  plugin_id: string;
+  plugin_version_id: string;
+  /** Joined fields from `plugins` / `plugin_versions` for display. */
+  plugin_name?: string;
+  plugin_version?: string;
+  config_json: PluginConfig;
+  permissions_json: PermissionsGrant;
+  enabled: boolean;
+  attached_at: string;
+  updated_at: string;
+  attached_by?: string | null;
+}
+
+export interface AttachPluginRequest {
+  plugin_name: string;
+  plugin_version: string;
+  config_json?: PluginConfig;
+  /** Empty object = deny-all (RFC §4.2 default). */
+  permissions_json?: PermissionsGrant;
+}
+
+export interface UpdateAttachmentRequest {
+  enabled?: boolean;
+  config_json?: PluginConfig;
+  permissions_json?: PermissionsGrant;
+}
+
 export const cloudPluginsApi = {
+  // ── Beta interest ────────────────────────────────────────────────
   async getMyBetaInterest(): Promise<BetaInterestStatus> {
     return (await fetchJsonWithErrorBody(
       '/api/v1/cloud-plugins/beta-interest/me',
@@ -39,5 +92,72 @@ export const cloudPluginsApi = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     })) as BetaInterestSubmission;
+  },
+
+  // ── Per-deployment attachments ───────────────────────────────────
+  /**
+   * GET /api/v1/hosted-mocks/{deployment_id}/plugins
+   *
+   * Returns 404 when the control-plane API isn't deployed yet (pre PR
+   * #395 merge). We translate 404 into an empty list so the page can
+   * render without an error banner — the absence of attachments is
+   * indistinguishable from "feature not yet live" to the end user.
+   */
+  async listAttachments(deploymentId: string): Promise<PluginAttachment[]> {
+    const response = await authenticatedFetch(
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/plugins`,
+    );
+    if (response.status === 404) {
+      return [];
+    }
+    if (!response.ok) {
+      throw new Error(`Failed to list attachments (HTTP ${response.status})`);
+    }
+    const json = await response.json();
+    const data = json.data ?? json;
+    return Array.isArray(data) ? (data as PluginAttachment[]) : [];
+  },
+
+  async attachPlugin(
+    deploymentId: string,
+    body: AttachPluginRequest,
+  ): Promise<PluginAttachment> {
+    return (await fetchJsonWithErrorBody(
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/plugins`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    )) as PluginAttachment;
+  },
+
+  async updateAttachment(
+    deploymentId: string,
+    attachmentId: string,
+    body: UpdateAttachmentRequest,
+  ): Promise<PluginAttachment> {
+    return (await fetchJsonWithErrorBody(
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/plugins/${encodeURIComponent(attachmentId)}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    )) as PluginAttachment;
+  },
+
+  async detachPlugin(
+    deploymentId: string,
+    attachmentId: string,
+  ): Promise<void> {
+    const response = await authenticatedFetch(
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/plugins/${encodeURIComponent(attachmentId)}`,
+      { method: 'DELETE' },
+    );
+    // DELETE is idempotent in #395 — 404 on a stale row is fine.
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`Failed to detach plugin (HTTP ${response.status})`);
+    }
   },
 };


### PR DESCRIPTION
## Summary
Phase 3.1 of the cloud-plugins UI plan from PR #385. Restores a sidebar entry for cloud plugins — currently the `Plugins` section in cloud mode shows only `Plugin Registry` because PR #384 hid the local `/plugins` item without a cloud sibling existing yet.

This is the **thin vertical slice**: a `/cloud-plugins` page that lists each hosted-mock deployment with its attached plugins (read-only). Attach / permission-edit / detach flows land in subsequent sub-PRs.

## Why thin first
The control-plane API (`GET/POST/PATCH/DELETE /api/v1/hosted-mocks/{id}/plugins`) is in PR #395, currently open. This scaffold ships against that contract verbatim — `listAttachments` swallows 404 into an empty list, so the page renders cleanly **before, during, and after** #395 merges. No coordination needed; the page comes alive automatically once #395 lands.

## What's in the box
- **`pages/CloudPluginsPage.tsx`** — deployment list with per-deployment attachment rows; cloud-mode guard with a clear pointer back to `/plugins` for self-hosted users.
- **`services/api/cloudPlugins.ts`** — extended beyond beta-interest with the four endpoints from #395. 404 → `[]` for the list; DELETE is idempotent.
- **`routes/index.tsx`** — registers `/cloud-plugins` with lazy import.
- **`components/layout/AppShell.tsx`** — adds `cloud-plugins` to `cloudNavItemIds` and inserts it into the existing `nav.plugins` section. Local `'plugins'` stays in `cloudHiddenNavItemIds` per #384's intent (local-vs-cloud split is deliberate).
- **`i18n/translations.ts`** — adds `tab.cloudPlugins`, `page.cloudPlugins.title`, `page.cloudPlugins.subtitle`, `page.cloudPlugins.browseRegistry`.

## Phase 3 follow-ups
| | Sub-PR | Blocked by |
|---|---|---|
| 3.2 | attach modal + plugin picker | this PR + #395 merge |
| 3.3 | permission-grant editor (RFC §4.2 sections + manifest-vs-grant diff per RFC open question 6) | 3.2 |
| 3.4 | enable toggle + detach + plugin-config editor | 3.3 |
| 3.5 | org trust-roots tab on `OrganizationPage` | backend prereq #416 |
| 3.6 | metering / quota panel | backend prereq #417 |
| 3.7 | Playwright e2e | 3.4 |

## Test plan
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — no errors in changed files; only pre-existing warnings remain
- [x] Route registers and `/cloud-plugins` returns 200; lazy import resolves without console errors (AuthGuard intercepts before mount, as expected for a gated page)
- [ ] Visual verification in cloud mode against a live registry — needs an authenticated session; will validate post-merge in staging

## Refs
- Phase plan: PR #385 §"Phase plan"
- Schema: `crates/mockforge-registry-server/migrations/20250101000074_cloud_plugin_attachments.sql`
- Trust model: `docs/plugins/security/cloud-trust-permissions-rfc.md`
- Control-plane API contract: PR #395 (open, mergeable)
- Backend prereqs: #416 (trust-roots API), #417 (per-deployment usage endpoint)