### PR TITLE
ci(jcs-fuzz): split build/run so link errors don't file fake fuzz issues (#332)

### DIFF
--- a/.github/workflows/jcs-fuzz.yml
+++ b/.github/workflows/jcs-fuzz.yml
@@ -62,6 +62,24 @@ jobs:
         with:
           key: jcs-fuzz
 
+      # Compile separately so that infrastructure failures (linker
+      # SIGBUS from runner-side disk pressure, OOM during compile,
+      # toolchain mismatch, etc.) don't masquerade as a JCS soundness
+      # bug. Issue #332 was filed by the workflow when the test step
+      # failed at *link* time — not because a counter-example was
+      # found. The downstream "Create issue on failure" step now
+      # only fires when `steps.fuzz.outcome == 'failure'`, so a
+      # build-only failure leaves the workflow red without filing a
+      # misleading "JCS canonicalization fuzz failed" issue.
+      - name: Build JCS fuzz tests
+        id: build
+        run: |
+          cargo test \
+            -p mockforge-registry-core \
+            --lib \
+            --no-run \
+            models::attestation::jcs_fuzz::
+
       - name: Run JCS fuzz proptests
         id: fuzz
         run: |
@@ -74,7 +92,7 @@ jobs:
             --test-threads=1
 
       - name: Upload proptest regression seeds on failure
-        if: failure()
+        if: failure() && steps.fuzz.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: jcs-fuzz-proptest-regressions
@@ -96,7 +114,7 @@ jobs:
       # maintainer sees why no PR was opened.
       - name: Detect new regression seeds
         id: seeds
-        if: failure()
+        if: failure() && steps.fuzz.outcome == 'failure'
         run: |
           set -euo pipefail
           shopt -s globstar nullglob
@@ -115,7 +133,7 @@ jobs:
 
       - name: Open PR with new regression seeds
         id: open_pr
-        if: failure() && steps.seeds.outputs.has_seeds == 'true'
+        if: failure() && steps.fuzz.outcome == 'failure' && steps.seeds.outputs.has_seeds == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           # `GITHUB_TOKEN` is the default; listed explicitly so it is
@@ -167,7 +185,7 @@ jobs:
           draft: true
 
       - name: Create issue on failure
-        if: failure()
+        if: failure() && steps.fuzz.outcome == 'failure'
         uses: actions/github-script@v9
         env:
           # `PR_URL` is the output of peter-evans/create-pull-request.


### PR DESCRIPTION
## Summary

Closes #332. The auto-filed issue was a **false positive** — the workflow's `Run JCS fuzz proptests` step failed at *link* time (the GHA log shows \`collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped\`), not because proptest discovered a counter-example. The downstream \`Create issue on failure\` step fires on any non-zero exit from the fuzz step, conflating compile/link failures (infrastructure: runner-side disk pressure, OOM, toolchain regressions) with actual JCS canonicalization soundness bugs.

The proptest code itself is fine — \`cargo test -p mockforge-registry-core --lib models::attestation::jcs_fuzz::\` passes locally.

## Fix

1. **Split** the test step into two — a \`--no-run\` build step (\`id: build\`) followed by the actual proptest run (\`id: fuzz\`). A linker SIGBUS now fails the build step, leaving the run step skipped.
2. **Tighten** every \`if: failure()\` condition on the issue-creation / artifact-upload / regression-PR steps to also require \`steps.fuzz.outcome == 'failure'\`. Build failures now leave the workflow red without firing the alert pipeline.

## What this preserves

- Genuine fuzz failures still fire the full alert pipeline (artifact upload + regression-seed detection + auto-PR + issue).
- The proptest test code itself is unchanged.

## What this doesn't address

- The underlying runner-side SIGBUS during linking. That's a separate infra concern tracked via the runner cleanup script. This PR just stops a transient infra failure from looking like a security incident.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/jcs-fuzz.yml'))"\` — workflow YAML parses
- [x] \`cargo test -p mockforge-registry-core --lib models::attestation::jcs_fuzz::\` — fuzz tests pass at default proptest cases (already verified during the #416/#417 work this session)
- [ ] After merge: kick a manual \`workflow_dispatch\` run and confirm a green run completes without spurious side-effects. The next nightly tick (or any future link-time SIGBUS) should leave the workflow red without filing an issue.

I'll close #332 once this PR merges, with a link back here.