### PR TITLE
fix(ui): position request-traffic analytics as self-hosted in cloud (#394)

### DIFF
--- a/book/src/user-guide/cloud/analytics-dashboard.md
+++ b/book/src/user-guide/cloud/analytics-dashboard.md
@@ -4,6 +4,8 @@
 
 The Analytics Dashboard provides leadership insight into coverage, risk, and usage. It shows which scenarios are used most, what personas are hit by CI, which endpoints are under-tested, which mocks have stale reality levels, and what percentage of mocks are drifting from real data.
 
+> **Scope.** This dashboard surfaces *pillar-level usage* (Reality / Chaos / Contracts / etc.) at workspace and org scope. **Request-traffic analytics** — per-server request volume, p95/p99 latency, error rate, and endpoint heatmaps — is a self-hosted feature exposed through the local `/analytics` page. In cloud mode use this dashboard plus the in-app **Cloud Traces** view for individual-request inspection.
+
 > Deployment note: the analytics routes documented here exist in the codebase, but they depend on the analytics database and the UI/router layer being enabled in your environment. Treat this as a real API surface with deployment prerequisites, not a guaranteed default on every MockForge install.
 
 ## Overview

--- a/book/src/user-guide/observability.md
+++ b/book/src/user-guide/observability.md
@@ -14,11 +14,14 @@ MockForge ships all three. Pick whichever fits your workflow.
 | Surface | Source of truth | When to use |
 |---|---|---|
 | TUI dashboard | In-process | Local dev, quick eyeballing |
+| Admin UI **Analytics** page | In-process | Browser-based per-server traffic charts (request volume, p95/p99 latency, error rate, endpoint heatmap) — self-hosted only |
 | Prometheus `/metrics` | In-process Prometheus registry | You already run Prometheus / Grafana |
 | OpenTelemetry / OTLP | OTLP exporter → collector | You already run Jaeger / Tempo / Honeycomb |
 | CSV metrics log | `MOCKFORGE_METRICS_LOG_FILE` env var | Multi-day soak tests; want a flat file |
 
 These aren't mutually exclusive — turn on whichever combination fits.
+
+> **Cloud users:** the Admin UI Analytics page reads in-process counters from the local mock server and is hidden in cloud mode. For hosted-mock analytics see the [Analytics Dashboard](./cloud/analytics-dashboard.md) (pillar-level usage) and the in-app Cloud Traces view (individual requests).
 
 ## TUI dashboard
 

--- a/crates/mockforge-ui/ui/e2e-cloud/03-phase2-remaining.js
+++ b/crates/mockforge-ui/ui/e2e-cloud/03-phase2-remaining.js
@@ -119,14 +119,15 @@ module.exports = async (page) => {
   m = await mainText();
   results['behavioral_cloning_renders'] = !m.includes('Something went wrong');
 
-  // ===== Additional: World State, Performance, Incidents, Traces, Analytics, Pillar Analytics =====
+  // ===== Additional: World State, Performance, Incidents, Traces, Analytics =====
+  // Note: in cloud mode the local Analytics tab is hidden and pillar-analytics
+  // surfaces under the plain "Analytics" label (#394).
   for (const pageName of [
     'World State',
     'Performance',
     'Incidents',
     'Traces',
     'Analytics',
-    'Pillar Analytics',
     'Integration Tests',
     'Test Execution',
     'MockAI Rules',

--- a/crates/mockforge-ui/ui/e2e/analytics-deployed.spec.ts
+++ b/crates/mockforge-ui/ui/e2e/analytics-deployed.spec.ts
@@ -1,10 +1,15 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Analytics Page E2E Tests for Deployed Site (https://app.mockforge.dev/)
+ * /analytics route — cloud-mode notice (issue #394).
  *
- * Covers the /analytics route, which renders AnalyticsDashboardV2.
- * (PillarAnalyticsPage at /pillar-analytics is covered separately.)
+ * The local AnalyticsPage (request-traffic dashboard) is a self-hosted feature.
+ * In cloud mode the route renders a banner pointing users to PillarAnalyticsPage
+ * and CloudTracesPage. This spec verifies that notice on the deployed cloud
+ * site (https://app.mockforge.dev/).
+ *
+ * The full request-traffic dashboard tests live in component-level vitest
+ * specs and are exercised against a self-hosted runtime.
  */
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'https://app.mockforge.dev';
@@ -13,7 +18,7 @@ function mainContent(page: import('@playwright/test').Page) {
   return page.getByRole('main');
 }
 
-test.describe('Analytics Dashboard — Deployed Site', () => {
+test.describe('/analytics — Cloud Mode Notice', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`${BASE_URL}/analytics`, {
       waitUntil: 'domcontentloaded',
@@ -23,78 +28,37 @@ test.describe('Analytics Dashboard — Deployed Site', () => {
       state: 'visible',
       timeout: 15000,
     });
-    await expect(
-      mainContent(page).getByRole('heading', { name: 'Analytics Dashboard', level: 1 })
-    ).toBeVisible({ timeout: 10000 });
   });
 
-  test.describe('Page Load & Layout', () => {
-    test('should load the analytics page', async ({ page }) => {
-      await expect(page).toHaveURL(/\/analytics/);
-      await expect(page).toHaveTitle(/MockForge/);
-    });
-
-    test('should display the page heading', async ({ page }) => {
-      await expect(
-        mainContent(page).getByRole('heading', { name: 'Analytics Dashboard', level: 1 })
-      ).toBeVisible();
-    });
-
-    test('should display the subtitle', async ({ page }) => {
-      await expect(
-        mainContent(page).getByText('Comprehensive traffic analytics and metrics visualization')
-      ).toBeVisible();
-    });
-  });
-
-  test.describe('Header Controls', () => {
-    test('should display the Live Updates toggle', async ({ page }) => {
-      await expect(mainContent(page).getByText('Live Updates')).toBeVisible();
-    });
-
-    test('should allow toggling Live Updates', async ({ page }) => {
+  test.describe('Cloud Notice', () => {
+    test('renders the self-hosted feature notice', async ({ page }) => {
       const main = mainContent(page);
-      const toggle = main.getByText('Live Updates').locator('..').getByRole('button').first();
-      if (await toggle.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await toggle.click();
-        await page.waitForTimeout(300);
-        await toggle.click();
-      }
-    });
-
-    test('should display an Export control', async ({ page }) => {
-      const main = mainContent(page);
-      const hasExport = await main
-        .getByRole('button', { name: /Export/i })
-        .first()
-        .isVisible({ timeout: 3000 })
-        .catch(() => false);
-      expect(hasExport).toBeTruthy();
-    });
-  });
-
-  test.describe('Filters & Content', () => {
-    test('should render the filter panel toggle', async ({ page }) => {
-      // FilterPanel is collapsed behind a "Filters" button on the deployed site.
       await expect(
-        mainContent(page).getByRole('button', { name: 'Filters' })
-      ).toBeVisible({ timeout: 5000 });
+        main.getByText('Request-traffic analytics is a self-hosted feature')
+      ).toBeVisible({ timeout: 10000 });
     });
 
-    test('should render overview content (cards or error state)', async ({ page }) => {
+    test('links to Pillar Analytics', async ({ page }) => {
       const main = mainContent(page);
-      // Either overview metric cards render, or an inline error/empty state appears.
-      const hasContent = await main
-        .getByText(/requests|errors|latency|throughput|Error loading analytics/i)
-        .first()
-        .isVisible({ timeout: 5000 })
-        .catch(() => false);
-      expect(hasContent).toBeTruthy();
+      const link = main.getByRole('button', { name: 'Analytics', exact: true });
+      await expect(link).toBeVisible();
+      await link.click();
+      await page.waitForTimeout(1500);
+      await expect(page).toHaveURL(/\/pillar-analytics/);
+    });
+
+    test('links to Cloud Traces', async ({ page }) => {
+      const main = mainContent(page);
+      const link = main.getByRole('button', { name: 'Cloud Traces', exact: true });
+      await expect(link).toBeVisible();
+      await link.click();
+      await page.waitForTimeout(1500);
+      await expect(page).toHaveURL(/\/cloud-traces/);
     });
   });
 
   test.describe('Navigation', () => {
-    test('should navigate to Dashboard and back', async ({ page }) => {
+    test('navigates to Dashboard and back', async ({ page }) => {
       const nav = page.locator('nav[aria-label="Main navigation"]');
       await nav.getByRole('button', { name: 'Dashboard' }).click();
       await page.waitForTimeout(1500);
@@ -105,25 +69,20 @@ test.describe('Analytics Dashboard — Deployed Site', () => {
   });
 
   test.describe('Accessibility', () => {
-    test('should have a single H1', async ({ page }) => {
-      const h1 = mainContent(page).getByRole('heading', { level: 1 });
-      await expect(h1).toHaveCount(1);
-    });
-
-    test('should have landmarks', async ({ page }) => {
+    test('has landmarks', async ({ page }) => {
       await expect(page.getByRole('main')).toBeVisible();
       await expect(page.getByRole('navigation', { name: 'Main navigation' })).toBeVisible();
       await expect(page.getByRole('banner')).toBeVisible();
     });
 
-    test('should have skip links', async ({ page }) => {
+    test('has skip links', async ({ page }) => {
       await expect(page.getByRole('link', { name: 'Skip to navigation' })).toBeAttached();
       await expect(page.getByRole('link', { name: 'Skip to main content' })).toBeAttached();
     });
   });
 
   test.describe('Error-Free Operation', () => {
-    test('should load without critical console errors', async ({ page }) => {
+    test('loads without critical console errors', async ({ page }) => {
       const errors: string[] = [];
       page.on('console', (msg) => {
         if (msg.type() === 'error') errors.push(msg.text());
@@ -148,7 +107,7 @@ test.describe('Analytics Dashboard — Deployed Site', () => {
       expect(critical).toHaveLength(0);
     });
 
-    test('should not show error UI', async ({ page }) => {
+    test('does not show error UI', async ({ page }) => {
       const hasErr = await page
         .getByText(/Something went wrong|Unexpected error|Application error/i)
         .first()

--- a/crates/mockforge-ui/ui/e2e/pillar-analytics-deployed.spec.ts
+++ b/crates/mockforge-ui/ui/e2e/pillar-analytics-deployed.spec.ts
@@ -63,9 +63,11 @@ test.describe('Pillar Analytics — Deployed Site', () => {
     });
 
     test('should display breadcrumb navigation', async ({ page }) => {
+      // In cloud mode the local Analytics tab is hidden and pillar-analytics
+      // surfaces under the plain "Analytics" label (#394).
       const banner = page.getByRole('banner');
       await expect(banner.getByText('Home')).toBeVisible();
-      await expect(banner.getByText('Pillar Analytics')).toBeVisible();
+      await expect(banner.getByText('Analytics', { exact: true })).toBeVisible();
     });
   });
 
@@ -214,7 +216,9 @@ test.describe('Pillar Analytics — Deployed Site', () => {
         mainContent(page).getByRole('heading', { name: 'Dashboard', level: 1 })
       ).toBeVisible({ timeout: 5000 });
 
-      await nav.getByRole('button', { name: 'Pillar Analytics' }).click();
+      // In cloud mode the pillar-analytics nav button surfaces under the
+      // plain "Analytics" label (#394).
+      await nav.getByRole('button', { name: 'Analytics', exact: true }).click();
       await page.waitForTimeout(1500);
 
       await expect(

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -352,6 +352,13 @@ const cloudHiddenNavItemIds = new Set([
 // In cloud mode, items outside the allowlist are shown as disabled "Local only"
 // entries so users can discover the full product surface and understand what
 // requires a local MockForge instance. In self-hosted mode every item is active.
+//
+// Cloud-mode label overrides: when the local Analytics tab is hidden in cloud,
+// pillar-analytics becomes the de-facto analytics destination, so it surfaces
+// under the plain "Analytics" label instead of "Pillar Analytics" (#394).
+const cloudLabelOverrides: Record<string, string> = {
+  'pillar-analytics': 'tab.analytics',
+};
 const effectiveNavSections = navSections
   .map(section => ({
     ...section,
@@ -359,16 +366,22 @@ const effectiveNavSections = navSections
       .filter(item => !(isCloudMode && cloudHiddenNavItemIds.has(item.id)))
       .map(item => ({
         ...item,
+        labelKey: (isCloudMode && cloudLabelOverrides[item.id]) || item.labelKey,
         localOnly: isCloudMode && !cloudNavItemIds.has(item.id),
       })),
   }))
   .filter(section => section.items.length > 0);
 
-// Flattened items for title lookup (includes non-sidebar pages for breadcrumb resolution)
+// Flattened items for title lookup (includes non-sidebar pages for breadcrumb
+// resolution). Apply the same cloud-mode label overrides so the breadcrumb
+// matches the nav label users clicked on.
 const allNavItems = [
   ...navSections.flatMap(section => section.items),
   { id: 'api-explorer', labelKey: 'tab.apiExplorer', icon: Code2 },
-];
+].map(item => ({
+  ...item,
+  labelKey: (isCloudMode && cloudLabelOverrides[item.id]) || item.labelKey,
+}));
 
 export function AppShell({ children, onRefresh }: AppShellProps) {
   const { t, locale, supportedLocales, setLocale } = useI18n();

--- a/crates/mockforge-ui/ui/src/pages/AnalyticsPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/AnalyticsPage.tsx
@@ -1,13 +1,65 @@
 /**
  * Analytics Page - Uses the V2 Analytics Dashboard
- * This page provides comprehensive analytics visualization with real-time updates
+ * This page provides comprehensive analytics visualization with real-time updates.
+ *
+ * In cloud mode, the underlying /api/v2/analytics/* surface is local-only and
+ * stubbed empty (see LOCAL_ONLY_API_PREFIXES in apiClient.ts), so we render a
+ * banner pointing cloud users to PillarAnalyticsPage and CloudTracesPage —
+ * the closest equivalents at workspace / org scope. See issue #394.
  */
 
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AnalyticsDashboardV2 } from '@/components/analytics/AnalyticsDashboardV2';
+import { isCloudMode } from '../utils/cloudMode';
 
 export const AnalyticsPage: React.FC = () => {
+  if (isCloudMode()) {
+    return <CloudModeNotice />;
+  }
   return <AnalyticsDashboardV2 />;
+};
+
+const CloudModeNotice: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <div className="rounded-lg border border-blue-200 bg-blue-50 p-5 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-900/20 dark:text-blue-300">
+        <h2 className="text-base font-semibold mb-2">
+          Request-traffic analytics is a self-hosted feature
+        </h2>
+        <p className="mb-3">
+          The per-server request-volume, p95/p99 latency, error-rate, and endpoint
+          heatmap charts are part of the local MockForge runtime. They aren&apos;t
+          aggregated at workspace scope in cloud mode.
+        </p>
+        <p className="mb-2">For analytics on hosted mocks, use:</p>
+        <ul className="list-disc ml-5 space-y-1">
+          <li>
+            <button
+              type="button"
+              className="font-medium underline"
+              onClick={() => navigate('/pillar-analytics')}
+            >
+              Analytics
+            </button>{' '}
+            &mdash; pillar-level usage stats (Reality / Chaos / Contracts / etc.)
+            scoped to your org.
+          </li>
+          <li>
+            <button
+              type="button"
+              className="font-medium underline"
+              onClick={() => navigate('/cloud-traces')}
+            >
+              Cloud Traces
+            </button>{' '}
+            &mdash; cross-deployment OTLP trace search for individual requests.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
 };
 
 export default AnalyticsPage;


### PR DESCRIPTION
## Summary

Closes #394 with **Option A** (per the recommendation comment): keep the local `AnalyticsPage` hidden in cloud mode and ship three small mitigations so cloud users aren't left guessing where the analytics surface went. No new request-analytics API on the registry — that would duplicate the `cloud-traces` aggregation pipeline without cloud-specific differentiation.

- **Cloud nav rename** — in cloud mode, `pillar-analytics` surfaces under the plain "Analytics" label (and matching breadcrumb) since the local Analytics tab is already filtered out via `cloudHiddenNavItemIds`. Self-hosted continues to read "Pillar Analytics".
- **Cloud-mode notice on `/analytics`** — when a cloud user manually hits the route, render a banner explaining the request-traffic dashboard is a self-hosted feature, with explicit links to `/pillar-analytics` and `/cloud-traces`. Mirrors the inverse pattern used by 10+ Cloud* pages.
- **Docs positioning** — the cloud Analytics Dashboard page now states its scope (pillar-level usage, not request traffic), and `observability.md` calls out the Admin UI Analytics page as a self-hosted surface with a cloud-mode pointer.
- Updated affected playwright e2e (`analytics-deployed`, `pillar-analytics-deployed`, `e2e-cloud/03-phase2-remaining`) for the renamed cloud labels and new `/analytics` cloud notice.

When to revisit Option B: if ≥3 unrelated customer requests come in for workspace-scope request volume / latency charts, reopen and build the pre-aggregation tables properly. Until then, B is speculative.

## Test plan

- [x] `pnpm type-check` (clean)
- [x] `pnpm exec eslint` on touched files (clean)
- [x] Pre-commit clippy (workspace) passed
- [ ] Playwright `analytics-deployed.spec.ts` (run post-merge against deployed site)
- [ ] Playwright `pillar-analytics-deployed.spec.ts` (run post-merge against deployed site)
- [ ] Visual smoke in cloud mode after deploy: `/analytics` shows the notice and both buttons navigate correctly