### PR TITLE
feat(registry): raise incident on smoke-run failure (#392, incidents)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
+++ b/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
@@ -205,7 +205,8 @@ async fn mirror_kind_status(
     summary: Option<&serde_json::Value>,
 ) -> sqlx::Result<()> {
     use mockforge_registry_core::models::chaos::CreateChaosCampaignReport;
-    use mockforge_registry_core::models::{ChaosCampaignReport, CloneModel, Snapshot};
+    use mockforge_registry_core::models::incident::RaiseIncidentInput;
+    use mockforge_registry_core::models::{ChaosCampaignReport, CloneModel, Incident, Snapshot};
 
     let pool = state.db.pool();
     match run.kind.as_str() {
@@ -277,6 +278,81 @@ async fn mirror_kind_status(
                 },
             )
             .await?;
+        }
+        "smoke" => {
+            // Smoke runs against a hosted-mock deployment (issue #392).
+            // Failed routes (status not 2xx, or latency over budget)
+            // surface here as a non-passed run; the executor pre-flight
+            // path (bad URL / missing spec / build failure) surfaces as
+            // 'errored'. Either way we raise an incident so the on-call
+            // notification channels fire — matches the per-route audit
+            // surface the UI streams live, but durably.
+            //
+            // Dedupe on `(org_id, source, deployment_id)` so repeated
+            // smoke failures on the same deployment collapse onto one
+            // open incident until acknowledged. A re-fire after resolve
+            // creates a new incident (the partial-unique index only
+            // covers `status != 'resolved'`).
+            //
+            // `failed` (clean negative) → severity high; `errored`
+            // (executor pre-flight) → severity medium since it's an
+            // operational signal, not necessarily a deployment regression.
+            if !matches!(run.status.as_str(), "passed" | "cancelled") {
+                let failed_count =
+                    summary.and_then(|s| s.get("failed")).and_then(|v| v.as_i64()).unwrap_or(0);
+                let total_routes = summary
+                    .and_then(|s| s.get("total_routes"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let base_url =
+                    summary.and_then(|s| s.get("base_url")).and_then(|v| v.as_str()).unwrap_or("");
+
+                let severity = if run.status == "errored" {
+                    "medium"
+                } else {
+                    "high"
+                };
+                let title = if run.status == "errored" {
+                    "Smoke test errored before probing routes".to_string()
+                } else if total_routes > 0 {
+                    format!("{}/{} routes failed smoke test", failed_count.max(1), total_routes)
+                } else {
+                    "Smoke test failed".to_string()
+                };
+                let dedupe_key = run.suite_id.to_string();
+                let source_ref = run.id.to_string();
+                let description = serde_json::json!({
+                    "deployment_id": run.suite_id,
+                    "run_id": run.id,
+                    "run_status": run.status,
+                    "base_url": base_url,
+                    "total_routes": total_routes,
+                    "failed": failed_count,
+                })
+                .to_string();
+
+                Incident::raise(
+                    pool,
+                    RaiseIncidentInput {
+                        org_id: run.org_id,
+                        // Smoke runs are tied to a hosted-mock deployment,
+                        // not a workspace — workspaces hold templates +
+                        // scenarios, hosted mocks live one level up at
+                        // the org. Leaving this None keeps the routing
+                        // rules' workspace filter untouched (handler
+                        // matches on `workspace_id IS NULL` for
+                        // org-wide rules anyway).
+                        workspace_id: None,
+                        source: "hosted_mock_smoke",
+                        source_ref: Some(&source_ref),
+                        dedupe_key: &dedupe_key,
+                        severity,
+                        title: &title,
+                        description: Some(&description),
+                    },
+                )
+                .await?;
+            }
         }
         // Other kinds (unit/contract_diff/replay/flow.*) don't have a
         // separate per-resource status — the test_runs row is the


### PR DESCRIPTION
## Summary

Closes the operational-quality piece of #392: when a `kind='smoke'` test_run finishes failed or errored, raise an incident through the existing `Incident::raise()` API so on-call channels (Slack / webhook / etc.) fire. Stacks on #423 (executor) + #425 (handler) + #427 (UI).

## Wiring

| Field | Value | Why |
|---|---|---|
| **source** | `"hosted_mock_smoke"` | New string; the `incidents.source` column is plain TEXT, no schema change. |
| **source_ref** | the test_run id | Lets the incident detail panel deep-link back to the run. |
| **dedupe_key** | the deployment_id (`run.suite_id`) | Collapses repeated smoke failures on the same deployment onto one open incident; relies on the existing `idx_incidents_open_dedupe` partial unique. |
| **severity** | `high` for `failed`, `medium` for `errored` | Pre-flight errors (bad URL, missing spec, build) aren't deployment regressions. Severity-filtered routing rules let teams choose what pages them. |
| **workspace_id** | `None` | Hosted mocks are org-scoped, not workspace-scoped. The dispatch worker's existing routing rules match `workspace_id IS NULL` against org-wide rules, so this Just Works. |
| **status** check | `!matches!(passed | cancelled)` | User-initiated cancels shouldn't auto-page. |

## Where the hook lives

`mirror_kind_status()` in `internal_test_runs.rs` is called on `POST /api/v1/internal/test-runs/{id}/finish` after the runner reports terminal status. Adding a `"smoke"` arm there means smoke incidents flow through the same `record_run_finished → mirror_kind_status` path as every other test_run kind, with no new endpoints / workers / config.

## Pattern this establishes

This is the first kind to call `Incident::raise()` from `mirror_kind_status()`. The same shape will apply to:
- **#355 fitness-function failures** — currently filed but partial; the comment in the issue specifically says "same wiring as fitness functions in #355" and now there's something to mirror against.
- **#391 conformance** / **#390 verification** when those land — both will fit naturally as additional arms in this match.

## Out of scope

- A test for the wiring — `mirror_kind_status()` reads from the live DB and the existing test setup is integration-only. Covered indirectly by the existing `internal_test_runs` integration tests once smoke runs flow end-to-end (which they will once the rest of the #392 stack merges).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-server --lib` (335 pass)
- [ ] After merge: trigger a smoke run against a deployment with a deliberately broken route, confirm an incident appears in the cloud incidents page and the configured notification channel fires.

## Closes

Closes #392 in full once this and the prior three stack-mates merge.
