### PR TITLE
feat(registry): raise incident on fitness-evaluation failure (#355 item 3)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
+++ b/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
@@ -354,6 +354,98 @@ async fn mirror_kind_status(
                 .await?;
             }
         }
+        "fitness_evaluation" => {
+            // Architectural fitness functions evaluate declared invariants
+            // against live traffic / contract drift / traces (#355). When
+            // the run terminates non-passing, raise an incident so the
+            // configured notification channels (Slack/webhook/etc.) fire
+            // — the live UI already shows pass/fail, but durable alerting
+            // is the point of the executor existing on the cloud test
+            // runner at all. Mirrors the wiring shipped for smoke runs
+            // (#392) and is the canonical pattern for #391 conformance
+            // and #390 verification when their executors land.
+            //
+            // Dedupe on `(org_id, source, fitness_function_id)` —
+            // `run.suite_id` is the fitness-function row's id, so
+            // repeated violations of the *same* function collapse onto
+            // one open incident. A different function failing gets its
+            // own incident. Resolution requires explicit acknowledge.
+            //
+            // The synthetic ContractExecutor returns Passed today, so
+            // this branch is dormant until the real FitnessExecutor
+            // lands (#355 item 2). Wiring it now means item 2 is purely
+            // additive — it doesn't have to also touch the registry
+            // alerting path.
+            if !matches!(run.status.as_str(), "passed" | "cancelled") {
+                let service_name = summary
+                    .and_then(|s| s.get("service_name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let breaking_count = summary
+                    .and_then(|s| s.get("breaking_count"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let findings_count = summary
+                    .and_then(|s| s.get("findings_count"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+
+                // `errored` (executor pre-flight: bad config, missing
+                // data source) is operational; `failed` (a declared
+                // invariant violated) is the architectural-regression
+                // case. Once the real FitnessExecutor lands and emits
+                // per-finding severity, this can grade further (e.g.
+                // critical when ≥1 critical_count).
+                let severity = if run.status == "errored" {
+                    "medium"
+                } else {
+                    "high"
+                };
+                let title = if run.status == "errored" {
+                    "Fitness function evaluation errored".to_string()
+                } else if breaking_count > 0 {
+                    format!(
+                        "{} breaking fitness violation{}",
+                        breaking_count,
+                        if breaking_count == 1 { "" } else { "s" },
+                    )
+                } else {
+                    "Fitness function failed".to_string()
+                };
+                let dedupe_key = run.suite_id.to_string();
+                let source_ref = run.id.to_string();
+                let description = serde_json::json!({
+                    "fitness_function_id": run.suite_id,
+                    "run_id": run.id,
+                    "run_status": run.status,
+                    "service_name": service_name,
+                    "breaking_count": breaking_count,
+                    "findings_count": findings_count,
+                })
+                .to_string();
+
+                Incident::raise(
+                    pool,
+                    RaiseIncidentInput {
+                        org_id: run.org_id,
+                        // Fitness functions are workspace-scoped (their
+                        // backing table tags `workspace_id`); we don't
+                        // have it on the TestRun row though, so leaving
+                        // this None routes to org-wide notification rules.
+                        // A follow-up could read from the cloud-side
+                        // fitness function row to populate this.
+                        workspace_id: None,
+                        source: "fitness_function",
+                        source_ref: Some(&source_ref),
+                        dedupe_key: &dedupe_key,
+                        severity,
+                        title: &title,
+                        description: Some(&description),
+                    },
+                )
+                .await?;
+            }
+        }
         // Other kinds (unit/contract_diff/replay/flow.*) don't have a
         // separate per-resource status — the test_runs row is the
         // source of truth.


### PR DESCRIPTION
## Summary

Closes **item 3** of #355 (PR #384 already shipped items 4 + 5: read-only UI dispatch + nav allowlist). When a `kind='fitness_evaluation'` test_run finishes `failed` or `errored`, raise an incident through `Incident::raise()` so the configured notification channels fire.

Mirrors the smoke-incident wiring landed in #428 — same `mirror_kind_status() → Incident::raise()` pattern, just a different match arm.

## Wiring

| Field | Value | Why |
|---|---|---|
| **source** | `"fitness_function"` | Distinct source string lets routing rules filter "page me on fitness violations only" separately from smoke or other kinds. |
| **source_ref** | the test_run id | Deep-links the incident back to the run that produced the violation. |
| **dedupe_key** | `run.suite_id` (fitness function's id) | Repeated violations of the *same* function collapse onto one open incident; different functions get their own. |
| **severity** | `high` for `failed`, `medium` for `errored` | Pre-flight errors aren't architectural regressions. Future grading can use `breaking_count` / `critical_count` once the real executor populates them. |
| **workspace_id** | `None` | Same caveat as smoke: the TestRun row carries org_id + suite_id but not workspace_id. JOIN-to-populate is a separate follow-up. |
| **status** check | `!matches!(passed | cancelled)` | User-initiated cancels shouldn't auto-page. |

## Why this lands now (before items 1 + 2)

The synthetic `ContractExecutor` for `fitness_evaluation` always returns `Passed` today — so this branch is **dormant** until the real `FitnessExecutor` (item 2) lands. That's intentional:

- Wiring now keeps item 2 (the executor) a **pure additive change** to mockforge-test-runner. No need to also touch the registry alerting path.
- The `mirror_kind_status() → Incident::raise()` pattern is now used by **both** smoke (#392, #428) and fitness — establishes the precedent for #391 conformance and #390 verification too.

## Out of scope (separate follow-ups on #355)

- **Item 1**: write resource UI (create/update/delete fitness functions). Backend handlers already exist; just needs cloud-mode write paths in `FitnessFunctionsPage` via `cloudContractApi`.
- **Item 2**: the real `FitnessExecutor`. Evaluates declared invariants against `runtime_request_logs` / `contract_diff` results / traces. Substantial work — own design pass.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-server --lib` (335 pass)
- [ ] After item 2 lands: trigger a fitness function with a deliberately-violated invariant and confirm an incident appears in the cloud incidents page with `source='fitness_function'` and the configured channels fire.

## Closes

Closes #355's item 3. Issue stays open for items 1 and 2.
