### PR TITLE
feat(ui+registry): cloud-mode fitness-function write paths (#355 item 1)

### DIFF
--- a/crates/mockforge-registry-core/src/models/contract_verification.rs
+++ b/crates/mockforge-registry-core/src/models/contract_verification.rs
@@ -225,6 +225,33 @@ impl FitnessFunction {
             .rows_affected();
         Ok(rows > 0)
     }
+
+    /// Replace the mutable fields (name, kind, config) on an existing
+    /// fitness function. Returns `Ok(None)` if the row doesn't exist
+    /// rather than erroring — caller can map that to a 404. Bumps
+    /// `updated_at` (no DB trigger covers this column on the table).
+    pub async fn update(
+        pool: &PgPool,
+        id: Uuid,
+        name: &str,
+        kind: &str,
+        config: &serde_json::Value,
+    ) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            UPDATE fitness_functions
+            SET name = $2, kind = $3, config = $4, updated_at = NOW()
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(name)
+        .bind(kind)
+        .bind(config)
+        .fetch_optional(pool)
+        .await
+    }
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/mockforge-registry-server/src/handlers/contract_verification.rs
+++ b/crates/mockforge-registry-server/src/handlers/contract_verification.rs
@@ -316,6 +316,56 @@ pub async fn create_fitness_function(
     Ok(Json(row))
 }
 
+/// `PATCH /api/v1/fitness-functions/{id}`
+///
+/// Replace name + kind + config on an existing fitness function. The
+/// surface mirrors `create_fitness_function` so the cloud UI can reuse
+/// the same form payload for both create and edit.
+///
+/// 404 InvalidRequest when the row doesn't exist or the caller's org
+/// doesn't own its workspace (cross-org access surfaces as not-found
+/// to avoid leaking existence — matches `delete_fitness_function`).
+pub async fn update_fitness_function(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(request): Json<CreateFitnessFunctionRequest>,
+) -> ApiResult<Json<FitnessFunction>> {
+    // Existence + auth check via the existing row's workspace_id, mirroring
+    // delete_fitness_function. The body's workspace_id is implicit (we don't
+    // allow re-homing fitness functions across workspaces in the same call).
+    let existing = FitnessFunction::find_by_id(state.db.pool(), id)
+        .await
+        .map_err(ApiError::Database)?
+        .ok_or_else(|| ApiError::InvalidRequest("Fitness function not found".into()))?;
+    authorize_workspace(&state, user_id, &headers, existing.workspace_id).await?;
+
+    if request.name.trim().is_empty() {
+        return Err(ApiError::InvalidRequest("name must not be empty".into()));
+    }
+    if !FitnessFunction::is_valid_kind(&request.kind) {
+        return Err(ApiError::InvalidRequest(format!(
+            "kind must be one of: {}",
+            FitnessFunction::VALID_KINDS.join(", ")
+        )));
+    }
+
+    let row = FitnessFunction::update(
+        state.db.pool(),
+        id,
+        request.name.trim(),
+        &request.kind,
+        &request.config,
+    )
+    .await
+    .map_err(ApiError::Database)?
+    // Lost a race with a concurrent delete — surface as not-found, same
+    // as the cross-org check above.
+    .ok_or_else(|| ApiError::InvalidRequest("Fitness function not found".into()))?;
+    Ok(Json(row))
+}
+
 /// `DELETE /api/v1/fitness-functions/{id}`
 pub async fn delete_fitness_function(
     State(state): State<AppState>,

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -579,7 +579,8 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         )
         .route(
             "/api/v1/fitness-functions/{id}",
-            axum::routing::delete(handlers::contract_verification::delete_fitness_function),
+            patch(handlers::contract_verification::update_fitness_function)
+                .delete(handlers::contract_verification::delete_fitness_function),
         )
         .route(
             "/api/v1/workspaces/{workspace_id}/verification-suites",

--- a/crates/mockforge-ui/ui/src/pages/FitnessFunctionsPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/FitnessFunctionsPage.tsx
@@ -19,7 +19,11 @@ import {
 } from 'lucide-react';
 import { driftApi, type FitnessFunction, type FitnessFunctionType, type FitnessScope, type CreateFitnessFunctionRequest, type FitnessTestResult, type DriftIncident } from '../services/driftApi';
 import { useDriftIncidents } from '../hooks/useApi';
-import { cloudContractApi, type FitnessFunction as CloudFitnessFunction } from '../services/api/cloudContract';
+import {
+  cloudContractApi,
+  type FitnessFunction as CloudFitnessFunction,
+  type CreateFitnessFunctionRequest as CloudCreateFitnessFunctionRequest,
+} from '../services/api/cloudContract';
 import { isCloudMode } from '../utils/cloudMode';
 import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 import {
@@ -96,12 +100,17 @@ function FitnessFunctionRow({
   onDelete,
   onTest,
   readOnly = false,
+  hideTest = false,
 }: {
   function: FitnessFunction;
   onEdit: (func: FitnessFunction) => void;
   onDelete: (id: string) => void;
   onTest: (id: string) => void;
+  /** Hide the entire action group. Reserved for genuinely read-only views. */
   readOnly?: boolean;
+  /** Hide only the Test button — used in cloud mode where the test-now
+   *  endpoint isn't wired yet, while edit/delete still work. */
+  hideTest?: boolean;
 }) {
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleString();
@@ -137,14 +146,16 @@ function FitnessFunctionRow({
 
           {!readOnly && (
             <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => onTest(func.id)}
-              >
-                <Play className="w-4 h-4 mr-1" />
-                Test
-              </Button>
+              {!hideTest && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onTest(func.id)}
+                >
+                  <Play className="w-4 h-4 mr-1" />
+                  Test
+                </Button>
+              )}
               <Button
                 variant="outline"
                 size="sm"
@@ -677,10 +688,43 @@ function GlobalFitnessSummary({ incidents }: { incidents: DriftIncident[] }) {
   );
 }
 
+// Fold the local typed shape (`function_type` + `scope`) back into the
+// cloud's flat `{name, kind, config}` payload. Goes the opposite
+// direction from `adaptCloudFitnessFunction`. Symmetry matters for
+// edit: a cloud row read → adapted to local → user edits → folded back
+// for the PATCH must round-trip without dropping config keys, so
+// `function_type` and `scope` ride inside `config` alongside whatever
+// kind-specific fields the form added.
+function localToCloudFitnessFunction(
+  request: CreateFitnessFunctionRequest,
+): CloudCreateFitnessFunctionRequest {
+  return {
+    name: request.name,
+    kind: request.function_type.type,
+    config: {
+      ...(request.config ?? {}),
+      // Persist the rich typing alongside the raw config so a future
+      // round-trip back to the local shape can reconstruct exactly
+      // what the user picked, instead of having `adaptCloudFitnessFunction`
+      // guess from `kind`.
+      function_type: request.function_type,
+      scope: request.scope,
+      // `description` and `enabled` aren't part of the backend schema
+      // (no columns), but the local form collects them. Stashing inside
+      // config keeps them visible to a future edit without losing data;
+      // the cloud-side `FitnessFunction` interface already exposes
+      // `description` + `enabled` as optional fields, so the read-side
+      // adapter can pull these back out when they were set.
+      description: request.description,
+      enabled: request.enabled ?? true,
+    },
+  };
+}
+
 // Adapt the generic cloud FitnessFunction (kind + config blob) into the
-// richer typed shape the local UI expects. Cloud rows are read-only —
-// the registry exposes a list endpoint only — so the mapping is
-// best-effort and only needs to keep the table viewable.
+// richer typed shape the local UI expects. Mapping is best-effort —
+// extra fields the local UI added when writing (function_type, scope,
+// description, enabled) are pulled back out of `config` if present.
 function adaptCloudFitnessFunction(cf: CloudFitnessFunction): FitnessFunction {
   const cfg = (cf.config ?? {}) as Record<string, unknown>;
   const fnType = cfg.function_type as FitnessFunctionType | undefined;
@@ -740,11 +784,32 @@ export function FitnessFunctionsPage() {
   const { data: incidentsData } = useDriftIncidents({}, { refetchInterval: 10000 });
   const incidents = incidentsData?.incidents || [];
 
-  // Create mutation
+  // Invalidation key — must match the queryKey used above so create/
+  // update/delete refresh the right cache slot regardless of mode.
+  const fitnessFunctionsQueryKey: (string | undefined)[] = cloudMode
+    ? ['fitness-functions', 'cloud', activeWorkspace?.id ?? '']
+    : ['fitness-functions'];
+
+  // Create mutation. In cloud mode, the workspace id is required by the
+  // backend route; without it we surface a clear error before queueing
+  // a request that would fail on the server.
   const createMutation = useMutation({
-    mutationFn: (request: CreateFitnessFunctionRequest) => driftApi.createFitnessFunction(request),
+    mutationFn: (request: CreateFitnessFunctionRequest) => {
+      if (cloudMode) {
+        if (!activeWorkspace?.id) {
+          return Promise.reject(
+            new Error('Pick a workspace before creating a fitness function.'),
+          );
+        }
+        return cloudContractApi.createFitnessFunction(
+          activeWorkspace.id,
+          localToCloudFitnessFunction(request),
+        );
+      }
+      return driftApi.createFitnessFunction(request);
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['fitness-functions'] });
+      queryClient.invalidateQueries({ queryKey: fitnessFunctionsQueryKey });
       setShowForm(false);
       setEditingFunction(null);
     },
@@ -756,10 +821,17 @@ export function FitnessFunctionsPage() {
 
   // Update mutation
   const updateMutation = useMutation({
-    mutationFn: ({ id, request }: { id: string; request: CreateFitnessFunctionRequest }) =>
-      driftApi.updateFitnessFunction(id, request),
+    mutationFn: ({ id, request }: { id: string; request: CreateFitnessFunctionRequest }) => {
+      if (cloudMode) {
+        return cloudContractApi.updateFitnessFunction(
+          id,
+          localToCloudFitnessFunction(request),
+        );
+      }
+      return driftApi.updateFitnessFunction(id, request);
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['fitness-functions'] });
+      queryClient.invalidateQueries({ queryKey: fitnessFunctionsQueryKey });
       setShowForm(false);
       setEditingFunction(null);
     },
@@ -771,9 +843,14 @@ export function FitnessFunctionsPage() {
 
   // Delete mutation
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => driftApi.deleteFitnessFunction(id),
+    mutationFn: (id: string) => {
+      if (cloudMode) {
+        return cloudContractApi.deleteFitnessFunction(id);
+      }
+      return driftApi.deleteFitnessFunction(id);
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['fitness-functions'] });
+      queryClient.invalidateQueries({ queryKey: fitnessFunctionsQueryKey });
     },
     onError: (error: Error) => {
       logger.error('Failed to delete fitness function', error);
@@ -835,9 +912,10 @@ export function FitnessFunctionsPage() {
 
       {cloudMode && (
         <Alert variant="info">
-          Cloud workspaces expose fitness functions read-only — create and
-          edit aren&apos;t wired to the registry yet. Use the local CLI or
-          contract verification config to author new functions.
+          Cloud fitness functions support create, edit, and delete via the
+          registry. The <strong>Test</strong> button is currently
+          local-only — until the cloud-side evaluator lands, evaluation
+          happens on a schedule via the test-runner.
         </Alert>
       )}
 
@@ -854,8 +932,12 @@ export function FitnessFunctionsPage() {
               setEditingFunction(null);
               setShowForm(true);
             }}
-            disabled={cloudMode}
-            title={cloudMode ? 'Create not supported in cloud mode' : undefined}
+            disabled={cloudMode && !activeWorkspace?.id}
+            title={
+              cloudMode && !activeWorkspace?.id
+                ? 'Pick a workspace before creating a fitness function.'
+                : undefined
+            }
           >
             <Plus className="w-4 h-4 mr-2" />
             Create Fitness Function
@@ -889,7 +971,7 @@ export function FitnessFunctionsPage() {
                 onEdit={handleEdit}
                 onDelete={handleDelete}
                 onTest={handleTest}
-                readOnly={cloudMode}
+                hideTest={cloudMode}
               />
             ))}
           </div>

--- a/crates/mockforge-ui/ui/src/services/api/cloudContract.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudContract.ts
@@ -57,6 +57,18 @@ export interface FitnessFunction {
   updated_at: string;
 }
 
+/**
+ * Wire shape for create + update — matches `CreateFitnessFunctionRequest`
+ * on the registry handler. The richer `function_type` / `scope` typing
+ * the local `driftApi` uses gets folded into the opaque `config` blob
+ * via the page-side adapter so the cloud surface stays minimal.
+ */
+export interface CreateFitnessFunctionRequest {
+  name: string;
+  kind: string;
+  config: Record<string, unknown>;
+}
+
 class CloudContractApi {
   private guard(method: string): void {
     if (!isCloudMode()) {
@@ -126,6 +138,40 @@ class CloudContractApi {
     return fetchJsonWithErrorBody(
       `/api/v1/workspaces/${workspaceId}/fitness-functions`,
     ) as Promise<FitnessFunction[]>;
+  }
+
+  async createFitnessFunction(
+    workspaceId: string,
+    body: CreateFitnessFunctionRequest,
+  ): Promise<FitnessFunction> {
+    this.guard('createFitnessFunction');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/fitness-functions`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    ) as Promise<FitnessFunction>;
+  }
+
+  async updateFitnessFunction(
+    id: string,
+    body: CreateFitnessFunctionRequest,
+  ): Promise<FitnessFunction> {
+    this.guard('updateFitnessFunction');
+    return fetchJsonWithErrorBody(`/api/v1/fitness-functions/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as Promise<FitnessFunction>;
+  }
+
+  async deleteFitnessFunction(id: string): Promise<{ deleted: boolean }> {
+    this.guard('deleteFitnessFunction');
+    return fetchJsonWithErrorBody(`/api/v1/fitness-functions/${id}`, {
+      method: 'DELETE',
+    }) as Promise<{ deleted: boolean }>;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes **item 1** of #355. With this PR cloud users can create, edit, and delete fitness functions directly from `FitnessFunctionsPage`. Previously the page was read-only in cloud mode (PR #384 wired the read path; the write path stayed local-only because the registry only had create/delete handlers and the UI mutations all went through `driftApi`).

Stacks naturally on **#429** (incident wiring) — fitness functions you create in cloud mode now flow into the same notification dispatch when their evaluations fail (once #355 item 2 lands the real evaluator).

## What's in the box

### Backend

- `FitnessFunction::update(pool, id, name, kind, config) → Option<Self>` model method — returns `None` on miss so handler can 404 cleanly.
- `PATCH /api/v1/fitness-functions/{id}` handler. Mirrors `create_fitness_function`'s auth pattern: existence check + `authorize_workspace` on the existing row's workspace, validation of name + kind, lost-race-with-delete = 404.
- Reuses the existing `CreateFitnessFunctionRequest` body shape so the cloud UI sends the same payload for both create and edit.

### UI

- `cloudContractApi.{createFitnessFunction, updateFitnessFunction, deleteFitnessFunction}` — three new methods on the existing client, all guarded with `isCloudMode()`.
- `localToCloudFitnessFunction` adapter — the reverse of the existing `adaptCloudFitnessFunction`. Folds the rich local typing (`function_type`, `scope`, `description`, `enabled`) into the flat cloud payload's `config` blob so a write-then-read round-trips losslessly.
- `FitnessFunctionsPage` mutations branch on `isCloudMode()`. Query keys match between fetch + invalidate so writes refresh the right cache slot in both modes.
- `FitnessFunctionRow` row: `readOnly={cloudMode}` → `hideTest={cloudMode}`. Edit + Delete buttons now appear in cloud mode; only the Test button stays hidden because the cloud-side test-now endpoint isn't wired yet (deferred to item 2).

## Behaviour by mode

| Action | Local | Cloud (this PR) |
|---|---|---|
| List | ✅ via `driftApi` | ✅ via `cloudContractApi.listFitnessFunctions` |
| Create | ✅ | ✅ (needs active workspace) |
| Edit | ✅ | ✅ |
| Delete | ✅ | ✅ |
| Test (now) | ✅ via `driftApi.testFitnessFunction` | ❌ button hidden — needs item 2's executor |

## What's still open on #355

- **Item 2**: real `FitnessExecutor` in `mockforge-test-runner`. Until it lands, fitness functions you create here are inert — they don't get evaluated against live traffic. The incident wiring from #429 starts firing real alerts the moment item 2 ships.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-{core,server} --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-server --lib` (335 pass)
- [x] `pnpm type-check` (clean)
- [x] `pnpm exec eslint` on touched files (clean — only pre-existing warnings on unrelated lines)
- [ ] Post-merge: in cloud, create a fitness function, edit it, delete it. Verify the rows refresh without a manual reload.
- [ ] Post-merge: confirm in self-hosted that the local `driftApi`-backed flow still works end-to-end.

## Closes

Closes #355's item 1. Issue stays open for item 2 (real executor).
