### PR TITLE
feat(test-runner): real FitnessExecutor with latency_threshold (#355 item 2 PR 1/4)

### DIFF
--- a/crates/mockforge-registry-core/src/models/contract_verification.rs
+++ b/crates/mockforge-registry-core/src/models/contract_verification.rs
@@ -252,6 +252,53 @@ impl FitnessFunction {
         .fetch_optional(pool)
         .await
     }
+
+    /// Persist a per-evaluation row + roll up `last_evaluated_at` /
+    /// `last_status` on the parent function in one transaction.
+    ///
+    /// Called by `mirror_kind_status` when a `kind='fitness_evaluation'`
+    /// test_run finishes — the run's `summary` carries the values
+    /// pulled into `measured_value` / `threshold_value`. `status` must
+    /// be one of `pass | fail | unknown`. The history row in
+    /// `fitness_evaluations` is append-only; the `last_*` columns
+    /// give the UI a fast read for the "last run" widget without
+    /// scanning the timeline.
+    pub async fn record_evaluation(
+        pool: &PgPool,
+        function_id: Uuid,
+        status: &str,
+        measured_value: Option<f64>,
+        threshold_value: Option<f64>,
+    ) -> sqlx::Result<()> {
+        let mut tx = pool.begin().await?;
+        sqlx::query(
+            r#"
+            INSERT INTO fitness_evaluations
+                (function_id, status, measured_value, threshold_value)
+            VALUES ($1, $2, $3, $4)
+            "#,
+        )
+        .bind(function_id)
+        .bind(status)
+        .bind(measured_value)
+        .bind(threshold_value)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            r#"
+            UPDATE fitness_functions
+            SET last_evaluated_at = NOW(),
+                last_status = $2,
+                updated_at = NOW()
+            WHERE id = $1
+            "#,
+        )
+        .bind(function_id)
+        .bind(status)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await
+    }
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/mockforge-registry-server/src/handlers/contract_verification.rs
+++ b/crates/mockforge-registry-server/src/handlers/contract_verification.rs
@@ -303,6 +303,22 @@ pub async fn create_fitness_function(
             FitnessFunction::VALID_KINDS.join(", ")
         )));
     }
+    // `custom_query` runs arbitrary user-supplied evaluator code on
+    // self-hosted MockForge — fine for trusted single-tenant
+    // deployments, not safe to honour on shared cloud workers
+    // (would let any workspace owner execute code on the runner
+    // pool). Cloud rejects the kind at this boundary so a row in
+    // the state matching `kind='custom_query'` never exists in
+    // cloud, even if the user tried to bypass the UI gate.
+    if request.kind == "custom_query" {
+        return Err(ApiError::InvalidRequest(
+            "kind 'custom_query' is self-hosted only — \
+             arbitrary evaluator code isn't supported on cloud workers. \
+             Use latency_threshold, error_rate, or contract_stability instead, \
+             or run a self-hosted MockForge instance."
+                .into(),
+        ));
+    }
 
     let row = FitnessFunction::create(
         state.db.pool(),

--- a/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
+++ b/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
@@ -22,9 +22,11 @@ use uuid::Uuid;
 
 use crate::{
     error::{ApiError, ApiResult},
-    models::{TestRun, UsageCounter},
+    models::{FitnessFunction, TestRun, UsageCounter},
     AppState,
 };
+use axum::extract::Query;
+use serde::Serialize;
 
 /// Verify the request carries the shared internal-API bearer token.
 /// Returns InvalidRequest("Not found") for any auth failure — same
@@ -355,32 +357,53 @@ async fn mirror_kind_status(
             }
         }
         "fitness_evaluation" => {
-            // Architectural fitness functions evaluate declared invariants
-            // against live traffic / contract drift / traces (#355). When
-            // the run terminates non-passing, raise an incident so the
-            // configured notification channels (Slack/webhook/etc.) fire
-            // — the live UI already shows pass/fail, but durable alerting
-            // is the point of the executor existing on the cloud test
-            // runner at all. Mirrors the wiring shipped for smoke runs
-            // (#392) and is the canonical pattern for #391 conformance
-            // and #390 verification when their executors land.
+            // Architectural fitness functions (#355). Two responsibilities:
+            //   1. Persist the per-run measurement row so the page can
+            //      render a "last 30 evaluations" timeline + flip
+            //      `fitness_functions.last_status` for the inline pill.
+            //   2. Raise an incident on non-passing terminal status so
+            //      the existing dispatcher fires notification channels.
             //
-            // Dedupe on `(org_id, source, fitness_function_id)` —
-            // `run.suite_id` is the fitness-function row's id, so
-            // repeated violations of the *same* function collapse onto
-            // one open incident. A different function failing gets its
-            // own incident. Resolution requires explicit acknowledge.
-            //
-            // The synthetic ContractExecutor returns Passed today, so
-            // this branch is dormant until the real FitnessExecutor
-            // lands (#355 item 2). Wiring it now means item 2 is purely
-            // additive — it doesn't have to also touch the registry
-            // alerting path.
+            // The two are independent: a recording failure shouldn't
+            // skip the alert, and an alerting failure shouldn't drop
+            // the historical record. Best-effort + log on either side.
+            let measured_value =
+                summary.and_then(|s| s.get("measured_value")).and_then(|v| v.as_f64());
+            let threshold_value =
+                summary.and_then(|s| s.get("threshold_value")).and_then(|v| v.as_f64());
+
+            // Map the `test_runs.status` axis onto the `fitness_evaluations.status`
+            // axis. `errored` and `cancelled` are operationally distinct
+            // from `failed`: we don't have a measurement, so the row
+            // gets `unknown` rather than implying the assertion failed
+            // when it never ran.
+            let eval_status = match run.status.as_str() {
+                "passed" => "pass",
+                "failed" => "fail",
+                _ => "unknown",
+            };
+
+            if let Err(e) = FitnessFunction::record_evaluation(
+                pool,
+                run.suite_id,
+                eval_status,
+                measured_value,
+                threshold_value,
+            )
+            .await
+            {
+                tracing::warn!(
+                    run_id = %run.id,
+                    function_id = %run.suite_id,
+                    error = %e,
+                    "failed to record fitness evaluation history",
+                );
+            }
+
+            // Alerting on `failed` and `errored`. Cancelled stays
+            // user-initiated and shouldn't auto-page; passed is fine.
+            // Mirrors the smoke wiring (issue #392).
             if !matches!(run.status.as_str(), "passed" | "cancelled") {
-                let service_name = summary
-                    .and_then(|s| s.get("service_name"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
                 let breaking_count = summary
                     .and_then(|s| s.get("breaking_count"))
                     .and_then(|v| v.as_i64())
@@ -389,13 +412,11 @@ async fn mirror_kind_status(
                     .and_then(|s| s.get("findings_count"))
                     .and_then(|v| v.as_i64())
                     .unwrap_or(0);
+                let function_name = summary
+                    .and_then(|s| s.get("function_name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
 
-                // `errored` (executor pre-flight: bad config, missing
-                // data source) is operational; `failed` (a declared
-                // invariant violated) is the architectural-regression
-                // case. Once the real FitnessExecutor lands and emits
-                // per-finding severity, this can grade further (e.g.
-                // critical when ≥1 critical_count).
                 let severity = if run.status == "errored" {
                     "medium"
                 } else {
@@ -403,6 +424,8 @@ async fn mirror_kind_status(
                 };
                 let title = if run.status == "errored" {
                     "Fitness function evaluation errored".to_string()
+                } else if !function_name.is_empty() {
+                    format!("Fitness function '{}' failed", function_name)
                 } else if breaking_count > 0 {
                     format!(
                         "{} breaking fitness violation{}",
@@ -418,22 +441,27 @@ async fn mirror_kind_status(
                     "fitness_function_id": run.suite_id,
                     "run_id": run.id,
                     "run_status": run.status,
-                    "service_name": service_name,
+                    "function_name": function_name,
+                    "measured_value": measured_value,
+                    "threshold_value": threshold_value,
                     "breaking_count": breaking_count,
                     "findings_count": findings_count,
                 })
                 .to_string();
 
-                Incident::raise(
+                // Best-effort: a transient incident-raise failure must
+                // not undo the recorded evaluation row above. Log and
+                // swallow so the runner's mirror_kind_status call still
+                // succeeds; on-call can replay from the historical row.
+                if let Err(e) = Incident::raise(
                     pool,
                     RaiseIncidentInput {
                         org_id: run.org_id,
-                        // Fitness functions are workspace-scoped (their
-                        // backing table tags `workspace_id`); we don't
-                        // have it on the TestRun row though, so leaving
-                        // this None routes to org-wide notification rules.
-                        // A follow-up could read from the cloud-side
-                        // fitness function row to populate this.
+                        // workspace_id stays None — same caveat as smoke (#392):
+                        // the TestRun row carries org + suite_id, not workspace.
+                        // A follow-up could JOIN through fitness_functions to
+                        // populate this so workspace-filtered routing rules
+                        // apply; for now org-wide rules are the right scope.
                         workspace_id: None,
                         source: "fitness_function",
                         source_ref: Some(&source_ref),
@@ -443,7 +471,15 @@ async fn mirror_kind_status(
                         description: Some(&description),
                     },
                 )
-                .await?;
+                .await
+                {
+                    tracing::warn!(
+                        run_id = %run.id,
+                        function_id = %run.suite_id,
+                        error = %e,
+                        "failed to raise fitness-function incident",
+                    );
+                }
             }
         }
         // Other kinds (unit/contract_diff/replay/flow.*) don't have a
@@ -662,6 +698,224 @@ pub async fn get_capture_exchanges(
     .await
     .map_err(ApiError::Database)?;
     Ok(Json(rows))
+}
+
+/// `GET /api/v1/internal/fitness-functions/{id}`
+///
+/// Internal-only — the FitnessExecutor (`mockforge-test-runner`) calls
+/// this to fetch the function definition (kind + config) before
+/// dispatching to the kind-specific evaluator. Returns the full
+/// `FitnessFunction` row; the executor reads `kind` for dispatch and
+/// pulls everything else (deployment_id, threshold, window) from
+/// `config`.
+pub async fn get_fitness_function(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<FitnessFunction>> {
+    require_internal_auth(&headers)?;
+    let row = FitnessFunction::find_by_id(state.db.pool(), id)
+        .await
+        .map_err(ApiError::Database)?
+        .ok_or_else(|| ApiError::InvalidRequest("Fitness function not found".into()))?;
+    Ok(Json(row))
+}
+
+/// Latency aggregate for a deployment over a window. All values in
+/// milliseconds. `count` is the number of request-log rows that fed
+/// the aggregate; `error_count` is rows with status >= 500.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize)]
+pub struct DeploymentLatencyStats {
+    pub count: i64,
+    pub error_count: i64,
+    pub p50_ms: Option<f64>,
+    pub p95_ms: Option<f64>,
+    pub p99_ms: Option<f64>,
+    pub max_ms: Option<f64>,
+    pub avg_ms: Option<f64>,
+}
+
+/// Query params for the latency-stats endpoint. Both bounded — the
+/// window can't exceed 24h (matches the `runtime_request_logs`
+/// retention model) and the path filter caps at 256 chars.
+#[derive(Debug, Deserialize)]
+pub struct LatencyStatsQuery {
+    /// Look-back window. Defaults to 60 minutes when missing; clamped
+    /// to `[1, 1440]` (1 minute to 24 hours).
+    #[serde(default)]
+    pub window_minutes: Option<i64>,
+    /// Optional path filter. Exact match when set; full deployment
+    /// when omitted. The fitness executor passes this through from
+    /// the function's `config.path` if the user specified one.
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+/// `GET /api/v1/internal/deployments/{id}/latency-stats`
+///
+/// Internal-only — the FitnessExecutor calls this from the runner
+/// when evaluating `kind='latency_threshold'` checks. Returns
+/// percentile latencies (p50/p95/p99/max), avg, count, and error
+/// count over the requested window. Any of the percentile fields can
+/// be `None` when the count is zero (no traffic).
+pub async fn get_deployment_latency_stats(
+    State(state): State<AppState>,
+    Path(deployment_id): Path<Uuid>,
+    Query(params): Query<LatencyStatsQuery>,
+    headers: HeaderMap,
+) -> ApiResult<Json<DeploymentLatencyStats>> {
+    require_internal_auth(&headers)?;
+    let window = params.window_minutes.unwrap_or(60).clamp(1, 1440);
+    let path_filter = params.path.as_deref().filter(|s| !s.is_empty() && s.len() <= 256);
+
+    // Postgres `percentile_cont(WITHIN GROUP)` for percentiles —
+    // standard library function, no extension required. The casts to
+    // `DOUBLE PRECISION` keep the result type predictable across PG
+    // versions (some return numeric).
+    // Use sqlx::FromRow on the response struct directly so we don't
+    // have to spell out a 7-arity tuple type (clippy::type_complexity).
+    let stats = sqlx::query_as::<_, DeploymentLatencyStatsRow>(
+        r#"
+        SELECT
+            COUNT(*)::bigint                                                     AS count,
+            COUNT(*) FILTER (WHERE status >= 500)::bigint                         AS error_count,
+            (percentile_cont(0.50) WITHIN GROUP (ORDER BY latency_ms))::float8    AS p50_ms,
+            (percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms))::float8    AS p95_ms,
+            (percentile_cont(0.99) WITHIN GROUP (ORDER BY latency_ms))::float8    AS p99_ms,
+            MAX(latency_ms)::float8                                                AS max_ms,
+            AVG(latency_ms)::float8                                                AS avg_ms
+        FROM runtime_request_logs
+        WHERE deployment_id = $1
+          AND occurred_at >= NOW() - ($2::bigint * INTERVAL '1 minute')
+          AND ($3::text IS NULL OR path = $3)
+        "#,
+    )
+    .bind(deployment_id)
+    .bind(window)
+    .bind(path_filter)
+    .fetch_one(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(DeploymentLatencyStats {
+        count: stats.count,
+        error_count: stats.error_count,
+        p50_ms: stats.p50_ms,
+        p95_ms: stats.p95_ms,
+        p99_ms: stats.p99_ms,
+        max_ms: stats.max_ms,
+        avg_ms: stats.avg_ms,
+    }))
+}
+
+/// SQL row shape for the latency-stats query. Identical fields to the
+/// public `DeploymentLatencyStats` response struct, but with sqlx's
+/// FromRow derive so we don't have to spell out a 7-arity tuple type.
+#[derive(Debug, sqlx::FromRow)]
+struct DeploymentLatencyStatsRow {
+    count: i64,
+    error_count: i64,
+    p50_ms: Option<f64>,
+    p95_ms: Option<f64>,
+    p99_ms: Option<f64>,
+    max_ms: Option<f64>,
+    avg_ms: Option<f64>,
+}
+
+/// Aggregate of contract-diff findings for a monitored service, used
+/// by `kind='contract_stability'` fitness checks. Counts findings by
+/// severity over the configured window.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize)]
+pub struct MonitoredServiceContractStability {
+    pub breaking_count: i64,
+    pub non_breaking_count: i64,
+    pub cosmetic_count: i64,
+    pub run_count: i64,
+    /// Most recent diff-run start timestamp inside the window. `None`
+    /// when no runs have happened — distinguishes "no data" from
+    /// "lots of data but no findings". ISO-8601 string for wire
+    /// stability across runner builds.
+    pub latest_run_at: Option<String>,
+}
+
+/// Query params for the contract-stability endpoint.
+#[derive(Debug, Deserialize)]
+pub struct ContractStabilityQuery {
+    /// Look-back window. Default 24h since contract diffs run far
+    /// less frequently than smoke / latency probes (typically once
+    /// per deploy or once per day on a schedule). Clamped to
+    /// `[1, 10080]` (1 minute to one week).
+    #[serde(default)]
+    pub window_minutes: Option<i64>,
+}
+
+/// `GET /api/v1/internal/monitored-services/{id}/contract-stability`
+///
+/// Internal-only — the FitnessExecutor calls this when evaluating
+/// `kind='contract_stability'` checks. Aggregates `contract_diff_findings`
+/// joined to `contract_diff_runs.monitored_service_id` over the
+/// requested window.
+pub async fn get_monitored_service_contract_stability(
+    State(state): State<AppState>,
+    Path(monitored_service_id): Path<Uuid>,
+    Query(params): Query<ContractStabilityQuery>,
+    headers: HeaderMap,
+) -> ApiResult<Json<MonitoredServiceContractStability>> {
+    require_internal_auth(&headers)?;
+    // 1 week ceiling — contract diffs are expensive and a longer
+    // window gives misleading "stable" signals when an old breaking
+    // finding has already been fixed.
+    let window = params.window_minutes.unwrap_or(1_440).clamp(1, 10_080);
+
+    let row = sqlx::query_as::<_, ContractStabilityRow>(
+        r#"
+        SELECT
+            COUNT(*) FILTER (WHERE f.severity = 'breaking')::bigint     AS breaking_count,
+            COUNT(*) FILTER (WHERE f.severity = 'non_breaking')::bigint AS non_breaking_count,
+            COUNT(*) FILTER (WHERE f.severity = 'cosmetic')::bigint     AS cosmetic_count,
+            (SELECT COUNT(*) FROM contract_diff_runs
+                WHERE monitored_service_id = $1
+                  AND started_at >= NOW() - ($2::bigint * INTERVAL '1 minute'))::bigint
+                                                                         AS run_count,
+            (SELECT MAX(started_at) FROM contract_diff_runs
+                WHERE monitored_service_id = $1
+                  AND started_at >= NOW() - ($2::bigint * INTERVAL '1 minute'))
+                                                                         AS latest_run_at
+        FROM contract_diff_findings f
+        JOIN contract_diff_runs r ON f.run_id = r.id
+        WHERE r.monitored_service_id = $1
+          AND r.started_at >= NOW() - ($2::bigint * INTERVAL '1 minute')
+        "#,
+    )
+    .bind(monitored_service_id)
+    .bind(window)
+    .fetch_one(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(MonitoredServiceContractStability {
+        breaking_count: row.breaking_count,
+        non_breaking_count: row.non_breaking_count,
+        cosmetic_count: row.cosmetic_count,
+        run_count: row.run_count,
+        latest_run_at: row.latest_run_at.map(|t| t.to_rfc3339()),
+    }))
+}
+
+/// SQL row shape for contract-stability. Severity counts come from
+/// the FILTERed COUNTs on `contract_diff_findings`; run_count + latest
+/// timestamp come from a correlated subquery so we get sensible
+/// values even when there are zero findings (i.e. count rows from
+/// `contract_diff_runs` directly rather than relying on the JOIN).
+#[derive(Debug, sqlx::FromRow)]
+struct ContractStabilityRow {
+    breaking_count: i64,
+    non_breaking_count: i64,
+    cosmetic_count: i64,
+    run_count: i64,
+    latest_run_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[cfg(test)]

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -96,6 +96,26 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             get(handlers::internal_test_runs::get_workspace_endpoint_hits),
         )
         .route(
+            // Fetch a fitness function definition for the FitnessExecutor
+            // on the cloud test-runner (#355).
+            "/api/v1/internal/fitness-functions/{id}",
+            get(handlers::internal_test_runs::get_fitness_function),
+        )
+        .route(
+            // Latency-aggregate query for kind='latency_threshold'
+            // fitness checks. Reads runtime_request_logs scoped to
+            // the deployment + window passed via the function's config.
+            "/api/v1/internal/deployments/{id}/latency-stats",
+            get(handlers::internal_test_runs::get_deployment_latency_stats),
+        )
+        .route(
+            // Contract-finding aggregate for kind='contract_stability'
+            // fitness checks. Counts contract_diff_findings by severity
+            // over the configured window for one monitored service.
+            "/api/v1/internal/monitored-services/{id}/contract-stability",
+            get(handlers::internal_test_runs::get_monitored_service_contract_stability),
+        )
+        .route(
             "/api/v1/internal/hosted-mocks/{id}/chaos",
             post(handlers::internal_test_runs::proxy_chaos_toggle),
         )

--- a/crates/mockforge-test-runner/src/callbacks.rs
+++ b/crates/mockforge-test-runner/src/callbacks.rs
@@ -133,6 +133,80 @@ impl RegistryCallbacks {
         Ok(rows)
     }
 
+    /// Fetch a fitness function definition (id, name, kind, config)
+    /// for the FitnessExecutor (#355). Called once per run before
+    /// dispatching to the kind-specific evaluator.
+    pub async fn fetch_fitness_function(
+        &self,
+        function_id: Uuid,
+    ) -> Result<FitnessFunctionDefinition> {
+        let url = format!(
+            "{}/api/v1/internal/fitness-functions/{function_id}",
+            self.base_url.trim_end_matches('/'),
+        );
+        let resp = self.http.get(&url).bearer_auth(&self.token).send().await?;
+        let resp = resp.error_for_status()?;
+        let row: FitnessFunctionDefinition = resp.json().await?;
+        Ok(row)
+    }
+
+    /// Pull latency-aggregate stats for a deployment over a window.
+    /// Used by `kind='latency_threshold'` fitness checks. The optional
+    /// `path` filter narrows to a single endpoint when the function's
+    /// config specifies one.
+    pub async fn fetch_deployment_latency_stats(
+        &self,
+        deployment_id: Uuid,
+        window_minutes: i64,
+        path: Option<&str>,
+    ) -> Result<DeploymentLatencyStats> {
+        let url = format!(
+            "{}/api/v1/internal/deployments/{deployment_id}/latency-stats",
+            self.base_url.trim_end_matches('/'),
+        );
+        // `reqwest::RequestBuilder::query` urlencodes both keys and
+        // values — handles paths with `/`, spaces, etc. without us
+        // pulling in an extra urlencoding dep.
+        let mut req = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .query(&[("window_minutes", window_minutes.to_string())]);
+        if let Some(p) = path {
+            req = req.query(&[("path", p)]);
+        }
+        let resp = req.send().await?;
+        let resp = resp.error_for_status()?;
+        let stats: DeploymentLatencyStats = resp.json().await?;
+        Ok(stats)
+    }
+
+    /// Pull contract-stability aggregates for a monitored service over
+    /// a window. Used by `kind='contract_stability'` fitness checks.
+    /// Returns severity counts (breaking / non_breaking / cosmetic)
+    /// plus run count + latest run timestamp; the executor asserts
+    /// thresholds against the breaking count.
+    pub async fn fetch_monitored_service_contract_stability(
+        &self,
+        monitored_service_id: Uuid,
+        window_minutes: i64,
+    ) -> Result<MonitoredServiceContractStability> {
+        let url = format!(
+            "{}/api/v1/internal/monitored-services/{monitored_service_id}/contract-stability",
+            self.base_url.trim_end_matches('/'),
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .query(&[("window_minutes", window_minutes.to_string())])
+            .send()
+            .await?;
+        let resp = resp.error_for_status()?;
+        let stats: MonitoredServiceContractStability = resp.json().await?;
+        Ok(stats)
+    }
+
     /// Toggle chaos on a hosted-mock deployment via the registry's
     /// internal proxy. Used by the chaos executor for
     /// target_kind=hosted_mock — the registry resolves the
@@ -162,6 +236,51 @@ pub struct EndpointHit {
     pub method: String,
     pub path: String,
     pub hits: i64,
+}
+
+/// Subset of `FitnessFunction` the runner needs to dispatch + evaluate.
+/// We don't pull the full model row (last_evaluated_at, last_status,
+/// timestamps) since the runner only consumes id, name, kind, config.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct FitnessFunctionDefinition {
+    pub id: Uuid,
+    pub workspace_id: Uuid,
+    pub name: String,
+    pub kind: String,
+    pub config: serde_json::Value,
+}
+
+/// Aggregate latency stats over a window for one deployment. Mirrors
+/// the registry handler's `DeploymentLatencyStats` shape exactly.
+/// Percentile / max / avg fields are `None` when `count == 0`.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeploymentLatencyStats {
+    pub count: i64,
+    pub error_count: i64,
+    pub p50_ms: Option<f64>,
+    pub p95_ms: Option<f64>,
+    pub p99_ms: Option<f64>,
+    pub max_ms: Option<f64>,
+    pub avg_ms: Option<f64>,
+}
+
+/// Aggregate of contract-diff findings for a monitored service over
+/// a window. Mirrors the registry handler's
+/// `MonitoredServiceContractStability` shape; used by
+/// `kind='contract_stability'` fitness checks.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct MonitoredServiceContractStability {
+    pub breaking_count: i64,
+    pub non_breaking_count: i64,
+    pub cosmetic_count: i64,
+    pub run_count: i64,
+    /// Most recent diff-run timestamp inside the window. `None` when
+    /// no runs happened — distinguishes "no data" (e.g. nothing
+    /// scheduled) from "lots of data but no findings".
+    pub latest_run_at: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/mockforge-test-runner/src/executors/fitness.rs
+++ b/crates/mockforge-test-runner/src/executors/fitness.rs
@@ -1,0 +1,1274 @@
+//! Architectural fitness function evaluator (#355 item 2).
+//!
+//! Replaces the synthetic `fitness_evaluation` arm of `ContractExecutor`
+//! with real, data-source-backed evaluation. Each fitness function row
+//! has a `kind` + `config` blob; the executor fetches the definition
+//! from the registry, dispatches on kind, and runs the corresponding
+//! evaluator against live data.
+//!
+//! Currently implemented:
+//!   - `latency_threshold` — queries `runtime_request_logs` aggregates
+//!     for a deployment and asserts a percentile latency < threshold.
+//!   - `error_rate` — same aggregate endpoint, asserts
+//!     `error_count / count <= threshold_rate`.
+//!   - `contract_stability` — aggregates `contract_diff_findings`
+//!     for a monitored service over a window, asserts
+//!     `breaking_count <= max_breaking` (default 0).
+//!
+//! Permanently cloud-rejected:
+//!   - `custom_query` — this kind is self-hosted-only by design.
+//!     The local driftApi `custom_query` evaluator runs arbitrary
+//!     user-supplied evaluator code (e.g. Lua), which we don't run
+//!     on cloud workers — the security model would have to be
+//!     "trust every workspace owner with code execution on shared
+//!     runners," which isn't a posture we want. Cloud users who
+//!     need custom logic should run self-hosted, or open a feature
+//!     request for a specific declarative check we can implement
+//!     safely (e.g. as a new `kind`).
+//!
+//!     The cloud-side `create_fitness_function` and
+//!     `update_fitness_function` handlers reject `kind='custom_query'`
+//!     at the API boundary so cloud rows can't be created in this
+//!     state. The runner-side rejection here is defense-in-depth
+//!     for any pre-existing rows or scheduled runs.
+//!
+//! `run.suite_id` is the fitness function's id (per the `mirror_kind_status`
+//! convention). The summary the executor returns includes
+//! `measured_value` + `threshold_value` so `mirror_kind_status` can
+//! write a row into `fitness_evaluations` and update
+//! `fitness_functions.last_status` for the timeline UI.
+//!
+//! Failure → incident handoff lives in `mirror_kind_status` already; we
+//! just need to return `Failed`/`Errored` cleanly here and the
+//! existing notification dispatcher fires.
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::callbacks::{
+    DeploymentLatencyStats, FitnessFunctionDefinition, MonitoredServiceContractStability,
+    RegistryCallbacks,
+};
+use crate::error::Result;
+use crate::executors::{Executor, JobOutcome, JobStatus, RunJob};
+
+/// Default look-back window for stat queries when the function's
+/// config doesn't pin one. 60 minutes balances "recent enough to flag
+/// regressions promptly" against "wide enough to have signal" for low-
+/// QPS deployments.
+const DEFAULT_WINDOW_MINUTES: i64 = 60;
+
+/// Per-call hard cap on the look-back. Mirrors the registry handler's
+/// 24-hour clamp so a misshapen config doesn't burn worker time on a
+/// week-long aggregate.
+const MAX_WINDOW_MINUTES: i64 = 1_440;
+
+/// Executor for `kind = "fitness_evaluation"`. See module docs for
+/// payload + dispatch semantics.
+pub struct FitnessExecutor;
+
+#[async_trait]
+impl Executor for FitnessExecutor {
+    fn kind(&self) -> &'static str {
+        "fitness_evaluation"
+    }
+
+    async fn execute(&self, job: RunJob, callbacks: &RegistryCallbacks) -> Result<JobOutcome> {
+        let started = Instant::now();
+        callbacks.run_started(job.run_id).await?;
+
+        // Fetch the function definition. `run.suite_id` is the fitness
+        // function's id (set when the run was enqueued — see the
+        // mirror_kind_status comment chain).
+        let function = match callbacks.fetch_fitness_function(job.source_id).await {
+            Ok(f) => f,
+            Err(e) => {
+                return errored_run(
+                    callbacks,
+                    &job,
+                    started,
+                    1,
+                    format!("failed to fetch fitness function definition: {e}"),
+                )
+                .await;
+            }
+        };
+
+        callbacks
+            .run_event(
+                job.run_id,
+                1,
+                "log",
+                serde_json::json!({
+                    "level": "info",
+                    "message": format!(
+                        "Evaluating fitness function '{}' (kind={})",
+                        function.name, function.kind,
+                    ),
+                    "function_id": function.id,
+                    "tracking_task": 8,
+                }),
+            )
+            .await?;
+
+        match function.kind.as_str() {
+            "latency_threshold" => {
+                evaluate_latency_threshold(&function, callbacks, &job, started).await
+            }
+            "error_rate" => evaluate_error_rate(&function, callbacks, &job, started).await,
+            "contract_stability" => {
+                evaluate_contract_stability(&function, callbacks, &job, started).await
+            }
+            "custom_query" => {
+                // Permanent rejection — see module docstring. Cloud
+                // create/update handlers should already block
+                // kind='custom_query', so reaching this arm means
+                // either a pre-existing row or a direct queue insert.
+                errored_run(
+                    callbacks,
+                    &job,
+                    started,
+                    2,
+                    "fitness kind 'custom_query' is self-hosted only — \
+                     run a self-hosted MockForge instance to use arbitrary \
+                     evaluator code, or use one of the declarative kinds \
+                     (latency_threshold, error_rate, contract_stability) \
+                     in cloud"
+                        .to_string(),
+                )
+                .await
+            }
+            other => {
+                errored_run(
+                    callbacks,
+                    &job,
+                    started,
+                    2,
+                    format!(
+                        "unknown fitness kind '{}' — must be one of latency_threshold, \
+                         error_rate, contract_stability, custom_query",
+                        other
+                    ),
+                )
+                .await
+            }
+        }
+    }
+}
+
+// ─── latency_threshold evaluator ─────────────────────────────────────
+
+/// Resolved `latency_threshold` config pulled out of the function's
+/// JSONB blob. `deployment_id` is required; everything else has a
+/// sensible default.
+#[derive(Debug)]
+struct LatencyThresholdConfig {
+    deployment_id: Uuid,
+    threshold_ms: f64,
+    percentile: LatencyPercentile,
+    window_minutes: i64,
+    /// Optional path filter — narrows the aggregate to one endpoint.
+    path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LatencyPercentile {
+    P50,
+    P95,
+    P99,
+    Max,
+    Avg,
+}
+
+impl LatencyPercentile {
+    fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "p50" | "50" | "median" => Some(Self::P50),
+            "p95" | "95" => Some(Self::P95),
+            "p99" | "99" => Some(Self::P99),
+            "max" => Some(Self::Max),
+            "avg" | "mean" | "average" => Some(Self::Avg),
+            _ => None,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::P50 => "p50",
+            Self::P95 => "p95",
+            Self::P99 => "p99",
+            Self::Max => "max",
+            Self::Avg => "avg",
+        }
+    }
+
+    fn value_from(&self, stats: &DeploymentLatencyStats) -> Option<f64> {
+        match self {
+            Self::P50 => stats.p50_ms,
+            Self::P95 => stats.p95_ms,
+            Self::P99 => stats.p99_ms,
+            Self::Max => stats.max_ms,
+            Self::Avg => stats.avg_ms,
+        }
+    }
+}
+
+fn parse_latency_config(
+    config: &serde_json::Value,
+) -> std::result::Result<LatencyThresholdConfig, String> {
+    let deployment_id = config
+        .get("deployment_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "config.deployment_id missing".to_string())
+        .and_then(|s| {
+            Uuid::parse_str(s).map_err(|e| format!("config.deployment_id invalid: {e}"))
+        })?;
+    let threshold_ms = config
+        .get("threshold_ms")
+        .and_then(|v| v.as_f64())
+        .ok_or_else(|| "config.threshold_ms missing or non-numeric".to_string())?;
+    if threshold_ms <= 0.0 || !threshold_ms.is_finite() {
+        return Err(format!(
+            "config.threshold_ms must be a positive finite number (got {threshold_ms})"
+        ));
+    }
+    let percentile = match config.get("percentile").and_then(|v| v.as_str()) {
+        Some(s) => LatencyPercentile::parse(s)
+            .ok_or_else(|| format!("config.percentile '{s}' must be p50|p95|p99|max|avg"))?,
+        // Default to p95 — the most common SLO percentile and matches
+        // the migration's column naming convention.
+        None => LatencyPercentile::P95,
+    };
+    let window_minutes = config
+        .get("window_minutes")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(DEFAULT_WINDOW_MINUTES)
+        .clamp(1, MAX_WINDOW_MINUTES);
+    let path = config
+        .get("path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    Ok(LatencyThresholdConfig {
+        deployment_id,
+        threshold_ms,
+        percentile,
+        window_minutes,
+        path,
+    })
+}
+
+async fn evaluate_latency_threshold(
+    function: &FitnessFunctionDefinition,
+    callbacks: &RegistryCallbacks,
+    job: &RunJob,
+    started: Instant,
+) -> Result<JobOutcome> {
+    let config = match parse_latency_config(&function.config) {
+        Ok(c) => c,
+        Err(reason) => {
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!("invalid latency_threshold config: {reason}"),
+            )
+            .await;
+        }
+    };
+
+    let stats = match callbacks
+        .fetch_deployment_latency_stats(
+            config.deployment_id,
+            config.window_minutes,
+            config.path.as_deref(),
+        )
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!("failed to fetch latency stats: {e}"),
+            )
+            .await;
+        }
+    };
+
+    // No traffic in the window: report `unknown` (we don't have a
+    // measurement, so passing or failing would both be lying). Returns
+    // `Errored` rather than `Passed` so the cloud-side dispatcher
+    // surfaces it as something the operator should see.
+    if stats.count == 0 {
+        callbacks
+            .run_event(
+                job.run_id,
+                2,
+                "log",
+                serde_json::json!({
+                    "level": "warn",
+                    "message": format!(
+                        "No traffic for deployment {} in the last {} minutes — cannot measure {}",
+                        config.deployment_id, config.window_minutes, config.percentile.label(),
+                    ),
+                    "function_name": function.name,
+                }),
+            )
+            .await?;
+        let elapsed = started.elapsed();
+        return Ok(JobOutcome {
+            status: JobStatus::Errored,
+            runner_seconds: (elapsed.as_secs_f64().ceil() as i32).max(1),
+            summary: Some(serde_json::json!({
+                "executor_phase": "real_latency_threshold",
+                "tracking_task": 8,
+                "function_id": function.id,
+                "function_name": function.name,
+                "kind": "latency_threshold",
+                "deployment_id": config.deployment_id,
+                "window_minutes": config.window_minutes,
+                "path": config.path,
+                "percentile": config.percentile.label(),
+                "threshold_value": config.threshold_ms,
+                "measured_value": serde_json::Value::Null,
+                "count": 0,
+                "reason": "no_traffic",
+            })),
+        });
+    }
+
+    let measured = match config.percentile.value_from(&stats) {
+        Some(v) => v,
+        None => {
+            // count > 0 but the percentile came back NULL — shouldn't
+            // happen with `percentile_cont` over a non-empty set, but
+            // defend against future schema changes (e.g. `latency_ms`
+            // becoming nullable).
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!(
+                    "deployment {} has {} request(s) but {} percentile is NULL",
+                    config.deployment_id,
+                    stats.count,
+                    config.percentile.label(),
+                ),
+            )
+            .await;
+        }
+    };
+
+    let pass = measured <= config.threshold_ms;
+    let event_type = if pass { "fitness_pass" } else { "fitness_fail" };
+    let reason = if pass {
+        String::new()
+    } else {
+        format!(
+            "{} latency = {:.1}ms > threshold {:.1}ms",
+            config.percentile.label(),
+            measured,
+            config.threshold_ms,
+        )
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            2,
+            event_type,
+            serde_json::json!({
+                "function_id": function.id,
+                "function_name": function.name,
+                "kind": "latency_threshold",
+                "deployment_id": config.deployment_id,
+                "percentile": config.percentile.label(),
+                "measured_value": measured,
+                "threshold_value": config.threshold_ms,
+                "count": stats.count,
+                "error_count": stats.error_count,
+                "window_minutes": config.window_minutes,
+                "path": config.path,
+                "reason": reason,
+            }),
+        )
+        .await?;
+
+    let elapsed = started.elapsed();
+    let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
+    Ok(JobOutcome {
+        status: if pass {
+            JobStatus::Passed
+        } else {
+            JobStatus::Failed
+        },
+        runner_seconds: secs,
+        summary: Some(serde_json::json!({
+            "executor_phase": "real_latency_threshold",
+            "tracking_task": 8,
+            "function_id": function.id,
+            "function_name": function.name,
+            "kind": "latency_threshold",
+            "deployment_id": config.deployment_id,
+            "window_minutes": config.window_minutes,
+            "path": config.path,
+            "percentile": config.percentile.label(),
+            // These two field names are the contract `mirror_kind_status`
+            // reads to populate `fitness_evaluations.measured_value` /
+            // `threshold_value`. Don't rename without updating both.
+            "measured_value": measured,
+            "threshold_value": config.threshold_ms,
+            "count": stats.count,
+            "error_count": stats.error_count,
+            "wall_ms": elapsed.as_millis() as u64,
+        })),
+    })
+}
+
+// ─── error_rate evaluator ────────────────────────────────────────────
+
+/// Resolved `error_rate` config. Same data source as
+/// `latency_threshold` (the deployment's runtime_request_logs
+/// aggregate), but the assertion is against `error_count / count`
+/// rather than a percentile latency. `threshold_rate` is a fraction
+/// in `[0.0, 1.0]` — values like `0.05` ("5% error rate ceiling")
+/// are typical.
+#[derive(Debug)]
+struct ErrorRateConfig {
+    deployment_id: Uuid,
+    threshold_rate: f64,
+    window_minutes: i64,
+    /// Optional path filter — same semantics as latency_threshold.
+    path: Option<String>,
+}
+
+fn parse_error_rate_config(
+    config: &serde_json::Value,
+) -> std::result::Result<ErrorRateConfig, String> {
+    let deployment_id = config
+        .get("deployment_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "config.deployment_id missing".to_string())
+        .and_then(|s| {
+            Uuid::parse_str(s).map_err(|e| format!("config.deployment_id invalid: {e}"))
+        })?;
+    let threshold_rate = config
+        .get("threshold_rate")
+        .and_then(|v| v.as_f64())
+        .ok_or_else(|| "config.threshold_rate missing or non-numeric".to_string())?;
+    if !threshold_rate.is_finite() || !(0.0..=1.0).contains(&threshold_rate) {
+        return Err(format!(
+            "config.threshold_rate must be a finite fraction in [0.0, 1.0] (got {threshold_rate})"
+        ));
+    }
+    let window_minutes = config
+        .get("window_minutes")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(DEFAULT_WINDOW_MINUTES)
+        .clamp(1, MAX_WINDOW_MINUTES);
+    let path = config
+        .get("path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    Ok(ErrorRateConfig {
+        deployment_id,
+        threshold_rate,
+        window_minutes,
+        path,
+    })
+}
+
+async fn evaluate_error_rate(
+    function: &FitnessFunctionDefinition,
+    callbacks: &RegistryCallbacks,
+    job: &RunJob,
+    started: Instant,
+) -> Result<JobOutcome> {
+    let config = match parse_error_rate_config(&function.config) {
+        Ok(c) => c,
+        Err(reason) => {
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!("invalid error_rate config: {reason}"),
+            )
+            .await;
+        }
+    };
+
+    let stats = match callbacks
+        .fetch_deployment_latency_stats(
+            config.deployment_id,
+            config.window_minutes,
+            config.path.as_deref(),
+        )
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!("failed to fetch deployment stats: {e}"),
+            )
+            .await;
+        }
+    };
+
+    // Same no-traffic semantics as latency_threshold: we don't have a
+    // measurement, so return `Errored` rather than implying the
+    // assertion passed by silence.
+    if stats.count == 0 {
+        callbacks
+            .run_event(
+                job.run_id,
+                2,
+                "log",
+                serde_json::json!({
+                    "level": "warn",
+                    "message": format!(
+                        "No traffic for deployment {} in the last {} minutes — cannot measure error rate",
+                        config.deployment_id, config.window_minutes,
+                    ),
+                    "function_name": function.name,
+                }),
+            )
+            .await?;
+        let elapsed = started.elapsed();
+        return Ok(JobOutcome {
+            status: JobStatus::Errored,
+            runner_seconds: (elapsed.as_secs_f64().ceil() as i32).max(1),
+            summary: Some(serde_json::json!({
+                "executor_phase": "real_error_rate",
+                "tracking_task": 8,
+                "function_id": function.id,
+                "function_name": function.name,
+                "kind": "error_rate",
+                "deployment_id": config.deployment_id,
+                "window_minutes": config.window_minutes,
+                "path": config.path,
+                "threshold_value": config.threshold_rate,
+                "measured_value": serde_json::Value::Null,
+                "count": 0,
+                "error_count": 0,
+                "reason": "no_traffic",
+            })),
+        });
+    }
+
+    // Casts are safe — `stats.count > 0` (checked above) and i64 → f64
+    // loses precision only above 2^53, while a single deployment
+    // window holds at most a few hundred thousand requests in
+    // practice.
+    let measured = stats.error_count as f64 / stats.count as f64;
+    let pass = measured <= config.threshold_rate;
+    let event_type = if pass { "fitness_pass" } else { "fitness_fail" };
+    let reason = if pass {
+        String::new()
+    } else {
+        format!(
+            "error rate = {:.2}% ({} / {}) > threshold {:.2}%",
+            measured * 100.0,
+            stats.error_count,
+            stats.count,
+            config.threshold_rate * 100.0,
+        )
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            2,
+            event_type,
+            serde_json::json!({
+                "function_id": function.id,
+                "function_name": function.name,
+                "kind": "error_rate",
+                "deployment_id": config.deployment_id,
+                "measured_value": measured,
+                "threshold_value": config.threshold_rate,
+                "count": stats.count,
+                "error_count": stats.error_count,
+                "window_minutes": config.window_minutes,
+                "path": config.path,
+                "reason": reason,
+            }),
+        )
+        .await?;
+
+    let elapsed = started.elapsed();
+    let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
+    Ok(JobOutcome {
+        status: if pass {
+            JobStatus::Passed
+        } else {
+            JobStatus::Failed
+        },
+        runner_seconds: secs,
+        summary: Some(serde_json::json!({
+            "executor_phase": "real_error_rate",
+            "tracking_task": 8,
+            "function_id": function.id,
+            "function_name": function.name,
+            "kind": "error_rate",
+            "deployment_id": config.deployment_id,
+            "window_minutes": config.window_minutes,
+            "path": config.path,
+            // Same `measured_value` / `threshold_value` contract that
+            // latency_threshold uses — `mirror_kind_status` reads these
+            // names to populate `fitness_evaluations`.
+            "measured_value": measured,
+            "threshold_value": config.threshold_rate,
+            "count": stats.count,
+            "error_count": stats.error_count,
+            "wall_ms": elapsed.as_millis() as u64,
+        })),
+    })
+}
+
+// ─── contract_stability evaluator ────────────────────────────────────
+
+/// Resolved `contract_stability` config. Different shape from the
+/// latency-based evaluators because it queries a different data
+/// source (contract_diff_findings) keyed off `monitored_service_id`,
+/// not `deployment_id`.
+///
+/// `max_breaking` defaults to 0 — the strictest reading of "stable".
+/// `max_non_breaking` is opt-in: when omitted, non-breaking findings
+/// don't fail the assertion, matching the typical "I only care about
+/// breaking drift" check users want by default.
+#[derive(Debug)]
+struct ContractStabilityConfig {
+    monitored_service_id: Uuid,
+    max_breaking: i64,
+    max_non_breaking: Option<i64>,
+    window_minutes: i64,
+}
+
+/// 24h is the default window — contract diffs run on cron schedules
+/// (typically per-deploy or daily), so a 1h window often misses signal.
+const CONTRACT_STABILITY_DEFAULT_WINDOW: i64 = 1_440;
+/// 1 week ceiling. Matches the registry handler's clamp.
+const CONTRACT_STABILITY_MAX_WINDOW: i64 = 10_080;
+
+fn parse_contract_stability_config(
+    config: &serde_json::Value,
+) -> std::result::Result<ContractStabilityConfig, String> {
+    let monitored_service_id = config
+        .get("monitored_service_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "config.monitored_service_id missing".to_string())
+        .and_then(|s| {
+            Uuid::parse_str(s).map_err(|e| format!("config.monitored_service_id invalid: {e}"))
+        })?;
+    let max_breaking = config.get("max_breaking").and_then(|v| v.as_i64()).unwrap_or(0);
+    if max_breaking < 0 {
+        return Err(format!(
+            "config.max_breaking must be a non-negative integer (got {max_breaking})"
+        ));
+    }
+    let max_non_breaking = match config.get("max_non_breaking") {
+        Some(v) if v.is_null() => None,
+        Some(v) => {
+            let n = v
+                .as_i64()
+                .ok_or_else(|| "config.max_non_breaking must be an integer or null".to_string())?;
+            if n < 0 {
+                return Err(format!(
+                    "config.max_non_breaking must be a non-negative integer (got {n})"
+                ));
+            }
+            Some(n)
+        }
+        None => None,
+    };
+    let window_minutes = config
+        .get("window_minutes")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(CONTRACT_STABILITY_DEFAULT_WINDOW)
+        .clamp(1, CONTRACT_STABILITY_MAX_WINDOW);
+    Ok(ContractStabilityConfig {
+        monitored_service_id,
+        max_breaking,
+        max_non_breaking,
+        window_minutes,
+    })
+}
+
+async fn evaluate_contract_stability(
+    function: &FitnessFunctionDefinition,
+    callbacks: &RegistryCallbacks,
+    job: &RunJob,
+    started: Instant,
+) -> Result<JobOutcome> {
+    let config = match parse_contract_stability_config(&function.config) {
+        Ok(c) => c,
+        Err(reason) => {
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!("invalid contract_stability config: {reason}"),
+            )
+            .await;
+        }
+    };
+
+    let stats: MonitoredServiceContractStability = match callbacks
+        .fetch_monitored_service_contract_stability(
+            config.monitored_service_id,
+            config.window_minutes,
+        )
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!("failed to fetch contract stability stats: {e}"),
+            )
+            .await;
+        }
+    };
+
+    // No diff runs in the window: report `unknown` rather than passing
+    // by silence. A monitored service with no recent diffs probably
+    // means the schedule is misconfigured — operator should know.
+    if stats.run_count == 0 {
+        callbacks
+            .run_event(
+                job.run_id,
+                2,
+                "log",
+                serde_json::json!({
+                    "level": "warn",
+                    "message": format!(
+                        "No contract diff runs for monitored service {} in the last {} minutes — \
+                         cannot evaluate stability",
+                        config.monitored_service_id, config.window_minutes,
+                    ),
+                    "function_name": function.name,
+                }),
+            )
+            .await?;
+        let elapsed = started.elapsed();
+        return Ok(JobOutcome {
+            status: JobStatus::Errored,
+            runner_seconds: (elapsed.as_secs_f64().ceil() as i32).max(1),
+            summary: Some(serde_json::json!({
+                "executor_phase": "real_contract_stability",
+                "tracking_task": 8,
+                "function_id": function.id,
+                "function_name": function.name,
+                "kind": "contract_stability",
+                "monitored_service_id": config.monitored_service_id,
+                "window_minutes": config.window_minutes,
+                "max_breaking": config.max_breaking,
+                "measured_value": serde_json::Value::Null,
+                "threshold_value": config.max_breaking,
+                "run_count": 0,
+                "reason": "no_diff_runs",
+            })),
+        });
+    }
+
+    let breaking_pass = stats.breaking_count <= config.max_breaking;
+    let non_breaking_pass = match config.max_non_breaking {
+        Some(cap) => stats.non_breaking_count <= cap,
+        None => true,
+    };
+    let pass = breaking_pass && non_breaking_pass;
+    let event_type = if pass { "fitness_pass" } else { "fitness_fail" };
+    let reason = if pass {
+        String::new()
+    } else if !breaking_pass {
+        format!(
+            "{} breaking finding(s) > max_breaking {}",
+            stats.breaking_count, config.max_breaking,
+        )
+    } else {
+        // Only non-breaking ceiling exceeded.
+        format!(
+            "{} non-breaking finding(s) > max_non_breaking {}",
+            stats.non_breaking_count,
+            config.max_non_breaking.unwrap_or(0),
+        )
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            2,
+            event_type,
+            serde_json::json!({
+                "function_id": function.id,
+                "function_name": function.name,
+                "kind": "contract_stability",
+                "monitored_service_id": config.monitored_service_id,
+                // Primary axis the assertion fires on. The non-breaking
+                // count is reported alongside but the threshold for it
+                // is opt-in.
+                "measured_value": stats.breaking_count,
+                "threshold_value": config.max_breaking,
+                "breaking_count": stats.breaking_count,
+                "non_breaking_count": stats.non_breaking_count,
+                "cosmetic_count": stats.cosmetic_count,
+                "max_non_breaking": config.max_non_breaking,
+                "run_count": stats.run_count,
+                "latest_run_at": stats.latest_run_at,
+                "window_minutes": config.window_minutes,
+                "reason": reason,
+            }),
+        )
+        .await?;
+
+    let elapsed = started.elapsed();
+    let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
+    Ok(JobOutcome {
+        status: if pass {
+            JobStatus::Passed
+        } else {
+            JobStatus::Failed
+        },
+        runner_seconds: secs,
+        summary: Some(serde_json::json!({
+            "executor_phase": "real_contract_stability",
+            "tracking_task": 8,
+            "function_id": function.id,
+            "function_name": function.name,
+            "kind": "contract_stability",
+            "monitored_service_id": config.monitored_service_id,
+            "window_minutes": config.window_minutes,
+            // Same `measured_value` / `threshold_value` contract used
+            // by the other evaluators so mirror_kind_status can
+            // populate `fitness_evaluations` without per-kind logic.
+            // Cast to f64 because the column is DOUBLE PRECISION.
+            "measured_value": stats.breaking_count as f64,
+            "threshold_value": config.max_breaking as f64,
+            "breaking_count": stats.breaking_count,
+            "non_breaking_count": stats.non_breaking_count,
+            "cosmetic_count": stats.cosmetic_count,
+            "max_breaking": config.max_breaking,
+            "max_non_breaking": config.max_non_breaking,
+            "run_count": stats.run_count,
+            "latest_run_at": stats.latest_run_at,
+            "wall_ms": elapsed.as_millis() as u64,
+        })),
+    })
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/// Emit a single error log + return an `Errored` outcome. Used for
+/// pre-flight failures (bad config, fetch errors) that prevent any
+/// real evaluation. Includes `function_name` in the summary when
+/// available so the incidents UI surfaces it.
+async fn errored_run(
+    callbacks: &RegistryCallbacks,
+    job: &RunJob,
+    started: Instant,
+    seq: u32,
+    message: String,
+) -> Result<JobOutcome> {
+    callbacks
+        .run_event(
+            job.run_id,
+            seq,
+            "log",
+            serde_json::json!({
+                "level": "error",
+                "message": message,
+            }),
+        )
+        .await?;
+
+    let elapsed = started.elapsed();
+    let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
+    Ok(JobOutcome {
+        status: JobStatus::Errored,
+        runner_seconds: secs,
+        summary: Some(serde_json::json!({
+            "executor_phase": "errored_pre_flight",
+            "tracking_task": 8,
+        })),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(json: serde_json::Value) -> std::result::Result<LatencyThresholdConfig, String> {
+        parse_latency_config(&json)
+    }
+
+    #[test]
+    fn parse_latency_config_minimal() {
+        let dep = Uuid::new_v4();
+        let c = cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_ms": 500,
+        }))
+        .unwrap();
+        assert_eq!(c.deployment_id, dep);
+        assert_eq!(c.threshold_ms, 500.0);
+        // Default percentile is p95, default window 60m.
+        assert_eq!(c.percentile, LatencyPercentile::P95);
+        assert_eq!(c.window_minutes, DEFAULT_WINDOW_MINUTES);
+        assert_eq!(c.path, None);
+    }
+
+    #[test]
+    fn parse_latency_config_full() {
+        let dep = Uuid::new_v4();
+        let c = cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_ms": 250.5,
+            "percentile": "p99",
+            "window_minutes": 120,
+            "path": "/api/checkout",
+        }))
+        .unwrap();
+        assert_eq!(c.threshold_ms, 250.5);
+        assert_eq!(c.percentile, LatencyPercentile::P99);
+        assert_eq!(c.window_minutes, 120);
+        assert_eq!(c.path.as_deref(), Some("/api/checkout"));
+    }
+
+    #[test]
+    fn parse_latency_config_clamps_window() {
+        let dep = Uuid::new_v4();
+        // window above the cap clamps to MAX_WINDOW_MINUTES.
+        let c = cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_ms": 1,
+            "window_minutes": 99_999,
+        }))
+        .unwrap();
+        assert_eq!(c.window_minutes, MAX_WINDOW_MINUTES);
+        // window below 1 clamps to 1.
+        let c = cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_ms": 1,
+            "window_minutes": 0,
+        }))
+        .unwrap();
+        assert_eq!(c.window_minutes, 1);
+    }
+
+    #[test]
+    fn parse_latency_config_drops_empty_path() {
+        let dep = Uuid::new_v4();
+        let c = cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_ms": 1,
+            "path": "",
+        }))
+        .unwrap();
+        assert_eq!(c.path, None);
+    }
+
+    #[test]
+    fn parse_latency_config_rejects_missing_deployment() {
+        let err = cfg(serde_json::json!({
+            "threshold_ms": 100,
+        }))
+        .unwrap_err();
+        assert!(err.contains("deployment_id"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_latency_config_rejects_invalid_deployment_uuid() {
+        let err = cfg(serde_json::json!({
+            "deployment_id": "not-a-uuid",
+            "threshold_ms": 100,
+        }))
+        .unwrap_err();
+        assert!(err.contains("deployment_id"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_latency_config_rejects_zero_threshold() {
+        let dep = Uuid::new_v4();
+        let err = cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_ms": 0,
+        }))
+        .unwrap_err();
+        assert!(err.contains("positive"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_latency_config_rejects_negative_threshold() {
+        let dep = Uuid::new_v4();
+        let err = cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_ms": -10,
+        }))
+        .unwrap_err();
+        assert!(err.contains("positive"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_latency_config_rejects_unknown_percentile() {
+        let dep = Uuid::new_v4();
+        let err = cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_ms": 1,
+            "percentile": "p42",
+        }))
+        .unwrap_err();
+        assert!(err.contains("p42"), "got: {err}");
+    }
+
+    #[test]
+    fn percentile_parse_accepts_synonyms() {
+        assert_eq!(LatencyPercentile::parse("p50"), Some(LatencyPercentile::P50));
+        assert_eq!(LatencyPercentile::parse("median"), Some(LatencyPercentile::P50));
+        assert_eq!(LatencyPercentile::parse("MEDIAN"), Some(LatencyPercentile::P50));
+        assert_eq!(LatencyPercentile::parse("avg"), Some(LatencyPercentile::Avg));
+        assert_eq!(LatencyPercentile::parse("MEAN"), Some(LatencyPercentile::Avg));
+        assert_eq!(LatencyPercentile::parse("Average"), Some(LatencyPercentile::Avg));
+        assert_eq!(LatencyPercentile::parse("Max"), Some(LatencyPercentile::Max));
+        assert_eq!(LatencyPercentile::parse("99"), Some(LatencyPercentile::P99));
+        assert_eq!(LatencyPercentile::parse("garbage"), None);
+    }
+
+    #[test]
+    fn percentile_value_from_picks_right_field() {
+        let stats = DeploymentLatencyStats {
+            count: 100,
+            error_count: 1,
+            p50_ms: Some(10.0),
+            p95_ms: Some(50.0),
+            p99_ms: Some(80.0),
+            max_ms: Some(200.0),
+            avg_ms: Some(15.0),
+        };
+        assert_eq!(LatencyPercentile::P50.value_from(&stats), Some(10.0));
+        assert_eq!(LatencyPercentile::P95.value_from(&stats), Some(50.0));
+        assert_eq!(LatencyPercentile::P99.value_from(&stats), Some(80.0));
+        assert_eq!(LatencyPercentile::Max.value_from(&stats), Some(200.0));
+        assert_eq!(LatencyPercentile::Avg.value_from(&stats), Some(15.0));
+    }
+
+    fn err_cfg(json: serde_json::Value) -> std::result::Result<ErrorRateConfig, String> {
+        parse_error_rate_config(&json)
+    }
+
+    #[test]
+    fn parse_error_rate_config_minimal() {
+        let dep = Uuid::new_v4();
+        let c = err_cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_rate": 0.05,
+        }))
+        .unwrap();
+        assert_eq!(c.deployment_id, dep);
+        assert_eq!(c.threshold_rate, 0.05);
+        assert_eq!(c.window_minutes, DEFAULT_WINDOW_MINUTES);
+        assert_eq!(c.path, None);
+    }
+
+    #[test]
+    fn parse_error_rate_config_full() {
+        let dep = Uuid::new_v4();
+        let c = err_cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_rate": 0.01,
+            "window_minutes": 30,
+            "path": "/checkout",
+        }))
+        .unwrap();
+        assert_eq!(c.threshold_rate, 0.01);
+        assert_eq!(c.window_minutes, 30);
+        assert_eq!(c.path.as_deref(), Some("/checkout"));
+    }
+
+    #[test]
+    fn parse_error_rate_config_accepts_zero_and_one() {
+        // 0.0 means "no errors allowed", 1.0 means "no ceiling at all".
+        // Both edge cases should parse cleanly — the assertion logic
+        // handles them naturally.
+        let dep = Uuid::new_v4();
+        assert!(err_cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_rate": 0.0,
+        }))
+        .is_ok());
+        assert!(err_cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_rate": 1.0,
+        }))
+        .is_ok());
+    }
+
+    #[test]
+    fn parse_error_rate_config_rejects_out_of_range() {
+        let dep = Uuid::new_v4();
+        let err = err_cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_rate": 1.5,
+        }))
+        .unwrap_err();
+        assert!(err.contains("[0.0, 1.0]"), "got: {err}");
+
+        let err = err_cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_rate": -0.1,
+        }))
+        .unwrap_err();
+        assert!(err.contains("[0.0, 1.0]"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_error_rate_config_rejects_missing_threshold() {
+        let dep = Uuid::new_v4();
+        let err = err_cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+        }))
+        .unwrap_err();
+        assert!(err.contains("threshold_rate"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_error_rate_config_clamps_window() {
+        let dep = Uuid::new_v4();
+        let c = err_cfg(serde_json::json!({
+            "deployment_id": dep.to_string(),
+            "threshold_rate": 0.05,
+            "window_minutes": 99_999,
+        }))
+        .unwrap();
+        assert_eq!(c.window_minutes, MAX_WINDOW_MINUTES);
+    }
+
+    #[test]
+    fn parse_error_rate_config_rejects_missing_deployment() {
+        let err = err_cfg(serde_json::json!({
+            "threshold_rate": 0.05,
+        }))
+        .unwrap_err();
+        assert!(err.contains("deployment_id"), "got: {err}");
+    }
+
+    fn cs_cfg(json: serde_json::Value) -> std::result::Result<ContractStabilityConfig, String> {
+        parse_contract_stability_config(&json)
+    }
+
+    #[test]
+    fn parse_contract_stability_config_minimal() {
+        let svc = Uuid::new_v4();
+        let c = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+        }))
+        .unwrap();
+        assert_eq!(c.monitored_service_id, svc);
+        assert_eq!(c.max_breaking, 0);
+        assert_eq!(c.max_non_breaking, None);
+        assert_eq!(c.window_minutes, CONTRACT_STABILITY_DEFAULT_WINDOW);
+    }
+
+    #[test]
+    fn parse_contract_stability_config_full() {
+        let svc = Uuid::new_v4();
+        let c = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_breaking": 2,
+            "max_non_breaking": 10,
+            "window_minutes": 60,
+        }))
+        .unwrap();
+        assert_eq!(c.max_breaking, 2);
+        assert_eq!(c.max_non_breaking, Some(10));
+        assert_eq!(c.window_minutes, 60);
+    }
+
+    #[test]
+    fn parse_contract_stability_config_explicit_null_non_breaking() {
+        let svc = Uuid::new_v4();
+        // Explicit null is the same as omitting the key — no ceiling
+        // on non-breaking findings.
+        let c = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_non_breaking": serde_json::Value::Null,
+        }))
+        .unwrap();
+        assert_eq!(c.max_non_breaking, None);
+    }
+
+    #[test]
+    fn parse_contract_stability_config_clamps_window() {
+        let svc = Uuid::new_v4();
+        let c = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "window_minutes": 99_999,
+        }))
+        .unwrap();
+        assert_eq!(c.window_minutes, CONTRACT_STABILITY_MAX_WINDOW);
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_missing_service() {
+        let err = cs_cfg(serde_json::json!({})).unwrap_err();
+        assert!(err.contains("monitored_service_id"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_invalid_uuid() {
+        let err = cs_cfg(serde_json::json!({
+            "monitored_service_id": "not-a-uuid",
+        }))
+        .unwrap_err();
+        assert!(err.contains("monitored_service_id"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_negative_max_breaking() {
+        let svc = Uuid::new_v4();
+        let err = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_breaking": -1,
+        }))
+        .unwrap_err();
+        assert!(err.contains("max_breaking"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_negative_max_non_breaking() {
+        let svc = Uuid::new_v4();
+        let err = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_non_breaking": -5,
+        }))
+        .unwrap_err();
+        assert!(err.contains("max_non_breaking"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_non_integer_max_non_breaking() {
+        let svc = Uuid::new_v4();
+        let err = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_non_breaking": "many",
+        }))
+        .unwrap_err();
+        assert!(err.contains("max_non_breaking"), "got: {err}");
+    }
+}

--- a/crates/mockforge-test-runner/src/executors/mod.rs
+++ b/crates/mockforge-test-runner/src/executors/mod.rs
@@ -18,6 +18,7 @@ pub mod chain;
 pub mod chaos;
 pub mod clone_train;
 pub mod contract;
+pub mod fitness;
 pub mod flow;
 pub mod integration;
 pub mod replay;
@@ -148,10 +149,12 @@ impl Default for ExecutorRegistry {
             "verification_suite",
             Box::new(contract::ContractExecutor::for_kind("verification_suite")),
         );
-        by_kind.insert(
-            "fitness_evaluation",
-            Box::new(contract::ContractExecutor::for_kind("fitness_evaluation")),
-        );
+        // fitness_evaluation has its own executor now (#355). The
+        // ContractExecutor's synthetic fallback for this kind has been
+        // retired — FitnessExecutor fetches the function definition,
+        // dispatches on `kind` (latency_threshold, error_rate, etc.),
+        // and queries the matching data source via internal callbacks.
+        by_kind.insert("fitness_evaluation", Box::new(fitness::FitnessExecutor));
 
         for k in ["scenario", "orchestration", "state_machine", "chain"] {
             by_kind.insert(k, Box::new(flow::FlowExecutor::for_kind(k)));


### PR DESCRIPTION
## Summary

First in a series of four PRs that close **#355 item 2** (real `FitnessExecutor`). Replaces the synthetic `fitness_evaluation` arm of `ContractExecutor` with a real executor that fetches the function definition + queries live data sources.

**Implemented end-to-end:**
- `latency_threshold` — queries `runtime_request_logs` aggregates and asserts a percentile latency ≤ threshold

**Stubbed (returns `Errored` with a clear "tracking PR follows" message):**
- `error_rate`
- `contract_stability`
- `custom_query` — likely permanent stub; running arbitrary user code on cloud workers is a security risk

## What's wired

### Backend (registry-server + registry-core)

| | |
|---|---|
| `FitnessFunction::record_evaluation` | New model method. Single-tx: insert into `fitness_evaluations` + update `fitness_functions.last_status` / `last_evaluated_at`. |
| `GET /api/v1/internal/fitness-functions/{id}` | Definition lookup for the runner. |
| `GET /api/v1/internal/deployments/{id}/latency-stats` | Aggregate query — count, error_count, p50/p95/p99/max/avg. Window clamped 1–1440 min, optional path filter. |
| `mirror_kind_status` arm | Records every evaluation into history AND raises an incident on non-passing terminal status. Dedupe by function id; severity `high` for `failed`, `medium` for `errored`. Recording and alerting are independent. |

### Runner (mockforge-test-runner)

| | |
|---|---|
| `RegistryCallbacks::fetch_fitness_function` | Calls the definition endpoint. |
| `RegistryCallbacks::fetch_deployment_latency_stats` | Calls the aggregate endpoint with optional path filter. |
| `executors/fitness.rs` (new module) | Fetches the function, dispatches on `kind`, evaluates. |
| `executors/mod.rs` dispatcher | `fitness_evaluation` now routes to `FitnessExecutor` (was `ContractExecutor`). |

## Config payload for `latency_threshold`

```json
{
  "deployment_id":  "uuid",         // required
  "threshold_ms":   500,            // required, positive finite
  "percentile":     "p95",          // optional, default p95;
                                     // accepts p50|median|p95|p99|max|avg|mean
  "window_minutes": 60,             // optional, default 60, clamped 1..=1440
  "path":           "/api/checkout" // optional, narrows to one endpoint
}
```

## Behaviour edge cases worth calling out

- **No traffic in window** → `Errored` with reason `no_traffic`. Passing on zero data would misrepresent system state; the incident severity is `medium` (operational signal, not a regression).
- **Cancelled** runs map to `fitness_evaluations.status = 'unknown'` and skip the incident raise — user-initiated cancels shouldn't auto-page.
- **Errored** runs (executor pre-flight: bad config, missing data source) also map to `unknown` (no measurement) but DO raise a medium-severity incident so the user notices.
- **Recording vs alerting independence**: a `record_evaluation` failure doesn't skip the alert, and an `Incident::raise` failure doesn't drop the record. Both best-effort with a `tracing::warn`.

## Out of scope (follow-up PRs)

- **PR 2**: `error_rate` evaluator. Same shape as latency_threshold but asserts `error_count / count <= threshold_rate`. Will reuse the latency-stats endpoint since it already returns `error_count`.
- **PR 3**: `contract_stability` evaluator. Needs a new aggregate endpoint over `contract_diff_findings`.
- **PR 4**: `custom_query` decision — likely a permanent "self-hosted only" stub.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-{core,server} -p mockforge-test-runner --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-registry-server --lib` (335 pass)
- [x] `cargo test -p mockforge-test-runner --lib executors::fitness` (11 new tests pass)
- [ ] Post-merge in cloud: create a fitness function with `kind='latency_threshold'`, point at a deployment, trigger via test_schedules, verify a row lands in `fitness_evaluations` and the `last_status` pill updates. Trigger a violation, verify an incident fires.

Notes:
- Stacks on #429 (which added the original fitness_evaluation arm in mirror_kind_status). This PR's arm supersedes that one with the combined record + raise logic. If #429 merges first, this PR's mirror_kind_status edit will conflict and the resolution is to keep this PR's combined version.
- No public trigger endpoint yet — fitness runs flow through `test_schedules` (cron) for now. A public `POST /fitness-functions/{id}/evaluate` can land as a separate small PR if there's UI demand.
