### PR TITLE
feat(test-runner+registry): contract_stability fitness evaluator (#355 item 2 PR 3/4)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
+++ b/crates/mockforge-registry-server/src/handlers/internal_test_runs.rs
@@ -738,6 +738,101 @@ struct DeploymentLatencyStatsRow {
     avg_ms: Option<f64>,
 }
 
+/// Aggregate of contract-diff findings for a monitored service, used
+/// by `kind='contract_stability'` fitness checks. Counts findings by
+/// severity over the configured window.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize)]
+pub struct MonitoredServiceContractStability {
+    pub breaking_count: i64,
+    pub non_breaking_count: i64,
+    pub cosmetic_count: i64,
+    pub run_count: i64,
+    /// Most recent diff-run start timestamp inside the window. `None`
+    /// when no runs have happened — distinguishes "no data" from
+    /// "lots of data but no findings". ISO-8601 string for wire
+    /// stability across runner builds.
+    pub latest_run_at: Option<String>,
+}
+
+/// Query params for the contract-stability endpoint.
+#[derive(Debug, Deserialize)]
+pub struct ContractStabilityQuery {
+    /// Look-back window. Default 24h since contract diffs run far
+    /// less frequently than smoke / latency probes (typically once
+    /// per deploy or once per day on a schedule). Clamped to
+    /// `[1, 10080]` (1 minute to one week).
+    #[serde(default)]
+    pub window_minutes: Option<i64>,
+}
+
+/// `GET /api/v1/internal/monitored-services/{id}/contract-stability`
+///
+/// Internal-only — the FitnessExecutor calls this when evaluating
+/// `kind='contract_stability'` checks. Aggregates `contract_diff_findings`
+/// joined to `contract_diff_runs.monitored_service_id` over the
+/// requested window.
+pub async fn get_monitored_service_contract_stability(
+    State(state): State<AppState>,
+    Path(monitored_service_id): Path<Uuid>,
+    Query(params): Query<ContractStabilityQuery>,
+    headers: HeaderMap,
+) -> ApiResult<Json<MonitoredServiceContractStability>> {
+    require_internal_auth(&headers)?;
+    // 1 week ceiling — contract diffs are expensive and a longer
+    // window gives misleading "stable" signals when an old breaking
+    // finding has already been fixed.
+    let window = params.window_minutes.unwrap_or(1_440).clamp(1, 10_080);
+
+    let row = sqlx::query_as::<_, ContractStabilityRow>(
+        r#"
+        SELECT
+            COUNT(*) FILTER (WHERE f.severity = 'breaking')::bigint     AS breaking_count,
+            COUNT(*) FILTER (WHERE f.severity = 'non_breaking')::bigint AS non_breaking_count,
+            COUNT(*) FILTER (WHERE f.severity = 'cosmetic')::bigint     AS cosmetic_count,
+            (SELECT COUNT(*) FROM contract_diff_runs
+                WHERE monitored_service_id = $1
+                  AND started_at >= NOW() - ($2::bigint * INTERVAL '1 minute'))::bigint
+                                                                         AS run_count,
+            (SELECT MAX(started_at) FROM contract_diff_runs
+                WHERE monitored_service_id = $1
+                  AND started_at >= NOW() - ($2::bigint * INTERVAL '1 minute'))
+                                                                         AS latest_run_at
+        FROM contract_diff_findings f
+        JOIN contract_diff_runs r ON f.run_id = r.id
+        WHERE r.monitored_service_id = $1
+          AND r.started_at >= NOW() - ($2::bigint * INTERVAL '1 minute')
+        "#,
+    )
+    .bind(monitored_service_id)
+    .bind(window)
+    .fetch_one(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(MonitoredServiceContractStability {
+        breaking_count: row.breaking_count,
+        non_breaking_count: row.non_breaking_count,
+        cosmetic_count: row.cosmetic_count,
+        run_count: row.run_count,
+        latest_run_at: row.latest_run_at.map(|t| t.to_rfc3339()),
+    }))
+}
+
+/// SQL row shape for contract-stability. Severity counts come from
+/// the FILTERed COUNTs on `contract_diff_findings`; run_count + latest
+/// timestamp come from a correlated subquery so we get sensible
+/// values even when there are zero findings (i.e. count rows from
+/// `contract_diff_runs` directly rather than relying on the JOIN).
+#[derive(Debug, sqlx::FromRow)]
+struct ContractStabilityRow {
+    breaking_count: i64,
+    non_breaking_count: i64,
+    cosmetic_count: i64,
+    run_count: i64,
+    latest_run_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -109,6 +109,13 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             get(handlers::internal_test_runs::get_deployment_latency_stats),
         )
         .route(
+            // Contract-finding aggregate for kind='contract_stability'
+            // fitness checks. Counts contract_diff_findings by severity
+            // over the configured window for one monitored service.
+            "/api/v1/internal/monitored-services/{id}/contract-stability",
+            get(handlers::internal_test_runs::get_monitored_service_contract_stability),
+        )
+        .route(
             "/api/v1/internal/hosted-mocks/{id}/chaos",
             post(handlers::internal_test_runs::proxy_chaos_toggle),
         )

--- a/crates/mockforge-test-runner/src/callbacks.rs
+++ b/crates/mockforge-test-runner/src/callbacks.rs
@@ -181,6 +181,32 @@ impl RegistryCallbacks {
         Ok(stats)
     }
 
+    /// Pull contract-stability aggregates for a monitored service over
+    /// a window. Used by `kind='contract_stability'` fitness checks.
+    /// Returns severity counts (breaking / non_breaking / cosmetic)
+    /// plus run count + latest run timestamp; the executor asserts
+    /// thresholds against the breaking count.
+    pub async fn fetch_monitored_service_contract_stability(
+        &self,
+        monitored_service_id: Uuid,
+        window_minutes: i64,
+    ) -> Result<MonitoredServiceContractStability> {
+        let url = format!(
+            "{}/api/v1/internal/monitored-services/{monitored_service_id}/contract-stability",
+            self.base_url.trim_end_matches('/'),
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .query(&[("window_minutes", window_minutes.to_string())])
+            .send()
+            .await?;
+        let resp = resp.error_for_status()?;
+        let stats: MonitoredServiceContractStability = resp.json().await?;
+        Ok(stats)
+    }
+
     /// Toggle chaos on a hosted-mock deployment via the registry's
     /// internal proxy. Used by the chaos executor for
     /// target_kind=hosted_mock — the registry resolves the
@@ -238,6 +264,23 @@ pub struct DeploymentLatencyStats {
     pub p99_ms: Option<f64>,
     pub max_ms: Option<f64>,
     pub avg_ms: Option<f64>,
+}
+
+/// Aggregate of contract-diff findings for a monitored service over
+/// a window. Mirrors the registry handler's
+/// `MonitoredServiceContractStability` shape; used by
+/// `kind='contract_stability'` fitness checks.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct MonitoredServiceContractStability {
+    pub breaking_count: i64,
+    pub non_breaking_count: i64,
+    pub cosmetic_count: i64,
+    pub run_count: i64,
+    /// Most recent diff-run timestamp inside the window. `None` when
+    /// no runs happened — distinguishes "no data" (e.g. nothing
+    /// scheduled) from "lots of data but no findings".
+    pub latest_run_at: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/mockforge-test-runner/src/executors/fitness.rs
+++ b/crates/mockforge-test-runner/src/executors/fitness.rs
@@ -11,10 +11,12 @@
 //!     for a deployment and asserts a percentile latency < threshold.
 //!   - `error_rate` — same aggregate endpoint, asserts
 //!     `error_count / count <= threshold_rate`.
+//!   - `contract_stability` — aggregates `contract_diff_findings`
+//!     for a monitored service over a window, asserts
+//!     `breaking_count <= max_breaking` (default 0).
 //!
 //! Stubbed (returns `errored` with a clear "not yet implemented in
-//! cloud" message; tracking PRs follow this one):
-//!   - `contract_stability`
+//! cloud" message; tracking PR follows this one):
 //!   - `custom_query` — likely permanent stub since we don't run
 //!     arbitrary user code on cloud workers; will surface in the UI as
 //!     "self-hosted only".
@@ -34,7 +36,10 @@ use std::time::Instant;
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use crate::callbacks::{DeploymentLatencyStats, FitnessFunctionDefinition, RegistryCallbacks};
+use crate::callbacks::{
+    DeploymentLatencyStats, FitnessFunctionDefinition, MonitoredServiceContractStability,
+    RegistryCallbacks,
+};
 use crate::error::Result;
 use crate::executors::{Executor, JobOutcome, JobStatus, RunJob};
 
@@ -102,7 +107,10 @@ impl Executor for FitnessExecutor {
                 evaluate_latency_threshold(&function, callbacks, &job, started).await
             }
             "error_rate" => evaluate_error_rate(&function, callbacks, &job, started).await,
-            "contract_stability" | "custom_query" => {
+            "contract_stability" => {
+                evaluate_contract_stability(&function, callbacks, &job, started).await
+            }
+            "custom_query" => {
                 errored_run(
                     callbacks,
                     &job,
@@ -614,6 +622,241 @@ async fn evaluate_error_rate(
     })
 }
 
+// ─── contract_stability evaluator ────────────────────────────────────
+
+/// Resolved `contract_stability` config. Different shape from the
+/// latency-based evaluators because it queries a different data
+/// source (contract_diff_findings) keyed off `monitored_service_id`,
+/// not `deployment_id`.
+///
+/// `max_breaking` defaults to 0 — the strictest reading of "stable".
+/// `max_non_breaking` is opt-in: when omitted, non-breaking findings
+/// don't fail the assertion, matching the typical "I only care about
+/// breaking drift" check users want by default.
+#[derive(Debug)]
+struct ContractStabilityConfig {
+    monitored_service_id: Uuid,
+    max_breaking: i64,
+    max_non_breaking: Option<i64>,
+    window_minutes: i64,
+}
+
+/// 24h is the default window — contract diffs run on cron schedules
+/// (typically per-deploy or daily), so a 1h window often misses signal.
+const CONTRACT_STABILITY_DEFAULT_WINDOW: i64 = 1_440;
+/// 1 week ceiling. Matches the registry handler's clamp.
+const CONTRACT_STABILITY_MAX_WINDOW: i64 = 10_080;
+
+fn parse_contract_stability_config(
+    config: &serde_json::Value,
+) -> std::result::Result<ContractStabilityConfig, String> {
+    let monitored_service_id = config
+        .get("monitored_service_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "config.monitored_service_id missing".to_string())
+        .and_then(|s| {
+            Uuid::parse_str(s).map_err(|e| format!("config.monitored_service_id invalid: {e}"))
+        })?;
+    let max_breaking = config.get("max_breaking").and_then(|v| v.as_i64()).unwrap_or(0);
+    if max_breaking < 0 {
+        return Err(format!(
+            "config.max_breaking must be a non-negative integer (got {max_breaking})"
+        ));
+    }
+    let max_non_breaking = match config.get("max_non_breaking") {
+        Some(v) if v.is_null() => None,
+        Some(v) => {
+            let n = v
+                .as_i64()
+                .ok_or_else(|| "config.max_non_breaking must be an integer or null".to_string())?;
+            if n < 0 {
+                return Err(format!(
+                    "config.max_non_breaking must be a non-negative integer (got {n})"
+                ));
+            }
+            Some(n)
+        }
+        None => None,
+    };
+    let window_minutes = config
+        .get("window_minutes")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(CONTRACT_STABILITY_DEFAULT_WINDOW)
+        .clamp(1, CONTRACT_STABILITY_MAX_WINDOW);
+    Ok(ContractStabilityConfig {
+        monitored_service_id,
+        max_breaking,
+        max_non_breaking,
+        window_minutes,
+    })
+}
+
+async fn evaluate_contract_stability(
+    function: &FitnessFunctionDefinition,
+    callbacks: &RegistryCallbacks,
+    job: &RunJob,
+    started: Instant,
+) -> Result<JobOutcome> {
+    let config = match parse_contract_stability_config(&function.config) {
+        Ok(c) => c,
+        Err(reason) => {
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!("invalid contract_stability config: {reason}"),
+            )
+            .await;
+        }
+    };
+
+    let stats: MonitoredServiceContractStability = match callbacks
+        .fetch_monitored_service_contract_stability(
+            config.monitored_service_id,
+            config.window_minutes,
+        )
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            return errored_run(
+                callbacks,
+                job,
+                started,
+                2,
+                format!("failed to fetch contract stability stats: {e}"),
+            )
+            .await;
+        }
+    };
+
+    // No diff runs in the window: report `unknown` rather than passing
+    // by silence. A monitored service with no recent diffs probably
+    // means the schedule is misconfigured — operator should know.
+    if stats.run_count == 0 {
+        callbacks
+            .run_event(
+                job.run_id,
+                2,
+                "log",
+                serde_json::json!({
+                    "level": "warn",
+                    "message": format!(
+                        "No contract diff runs for monitored service {} in the last {} minutes — \
+                         cannot evaluate stability",
+                        config.monitored_service_id, config.window_minutes,
+                    ),
+                    "function_name": function.name,
+                }),
+            )
+            .await?;
+        let elapsed = started.elapsed();
+        return Ok(JobOutcome {
+            status: JobStatus::Errored,
+            runner_seconds: (elapsed.as_secs_f64().ceil() as i32).max(1),
+            summary: Some(serde_json::json!({
+                "executor_phase": "real_contract_stability",
+                "tracking_task": 8,
+                "function_id": function.id,
+                "function_name": function.name,
+                "kind": "contract_stability",
+                "monitored_service_id": config.monitored_service_id,
+                "window_minutes": config.window_minutes,
+                "max_breaking": config.max_breaking,
+                "measured_value": serde_json::Value::Null,
+                "threshold_value": config.max_breaking,
+                "run_count": 0,
+                "reason": "no_diff_runs",
+            })),
+        });
+    }
+
+    let breaking_pass = stats.breaking_count <= config.max_breaking;
+    let non_breaking_pass = match config.max_non_breaking {
+        Some(cap) => stats.non_breaking_count <= cap,
+        None => true,
+    };
+    let pass = breaking_pass && non_breaking_pass;
+    let event_type = if pass { "fitness_pass" } else { "fitness_fail" };
+    let reason = if pass {
+        String::new()
+    } else if !breaking_pass {
+        format!(
+            "{} breaking finding(s) > max_breaking {}",
+            stats.breaking_count, config.max_breaking,
+        )
+    } else {
+        // Only non-breaking ceiling exceeded.
+        format!(
+            "{} non-breaking finding(s) > max_non_breaking {}",
+            stats.non_breaking_count,
+            config.max_non_breaking.unwrap_or(0),
+        )
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            2,
+            event_type,
+            serde_json::json!({
+                "function_id": function.id,
+                "function_name": function.name,
+                "kind": "contract_stability",
+                "monitored_service_id": config.monitored_service_id,
+                // Primary axis the assertion fires on. The non-breaking
+                // count is reported alongside but the threshold for it
+                // is opt-in.
+                "measured_value": stats.breaking_count,
+                "threshold_value": config.max_breaking,
+                "breaking_count": stats.breaking_count,
+                "non_breaking_count": stats.non_breaking_count,
+                "cosmetic_count": stats.cosmetic_count,
+                "max_non_breaking": config.max_non_breaking,
+                "run_count": stats.run_count,
+                "latest_run_at": stats.latest_run_at,
+                "window_minutes": config.window_minutes,
+                "reason": reason,
+            }),
+        )
+        .await?;
+
+    let elapsed = started.elapsed();
+    let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
+    Ok(JobOutcome {
+        status: if pass {
+            JobStatus::Passed
+        } else {
+            JobStatus::Failed
+        },
+        runner_seconds: secs,
+        summary: Some(serde_json::json!({
+            "executor_phase": "real_contract_stability",
+            "tracking_task": 8,
+            "function_id": function.id,
+            "function_name": function.name,
+            "kind": "contract_stability",
+            "monitored_service_id": config.monitored_service_id,
+            "window_minutes": config.window_minutes,
+            // Same `measured_value` / `threshold_value` contract used
+            // by the other evaluators so mirror_kind_status can
+            // populate `fitness_evaluations` without per-kind logic.
+            // Cast to f64 because the column is DOUBLE PRECISION.
+            "measured_value": stats.breaking_count as f64,
+            "threshold_value": config.max_breaking as f64,
+            "breaking_count": stats.breaking_count,
+            "non_breaking_count": stats.non_breaking_count,
+            "cosmetic_count": stats.cosmetic_count,
+            "max_breaking": config.max_breaking,
+            "max_non_breaking": config.max_non_breaking,
+            "run_count": stats.run_count,
+            "latest_run_at": stats.latest_run_at,
+            "wall_ms": elapsed.as_millis() as u64,
+        })),
+    })
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────
 
 /// Emit a single error log + return an `Errored` outcome. Used for
@@ -907,5 +1150,109 @@ mod tests {
         }))
         .unwrap_err();
         assert!(err.contains("deployment_id"), "got: {err}");
+    }
+
+    fn cs_cfg(json: serde_json::Value) -> std::result::Result<ContractStabilityConfig, String> {
+        parse_contract_stability_config(&json)
+    }
+
+    #[test]
+    fn parse_contract_stability_config_minimal() {
+        let svc = Uuid::new_v4();
+        let c = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+        }))
+        .unwrap();
+        assert_eq!(c.monitored_service_id, svc);
+        assert_eq!(c.max_breaking, 0);
+        assert_eq!(c.max_non_breaking, None);
+        assert_eq!(c.window_minutes, CONTRACT_STABILITY_DEFAULT_WINDOW);
+    }
+
+    #[test]
+    fn parse_contract_stability_config_full() {
+        let svc = Uuid::new_v4();
+        let c = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_breaking": 2,
+            "max_non_breaking": 10,
+            "window_minutes": 60,
+        }))
+        .unwrap();
+        assert_eq!(c.max_breaking, 2);
+        assert_eq!(c.max_non_breaking, Some(10));
+        assert_eq!(c.window_minutes, 60);
+    }
+
+    #[test]
+    fn parse_contract_stability_config_explicit_null_non_breaking() {
+        let svc = Uuid::new_v4();
+        // Explicit null is the same as omitting the key — no ceiling
+        // on non-breaking findings.
+        let c = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_non_breaking": serde_json::Value::Null,
+        }))
+        .unwrap();
+        assert_eq!(c.max_non_breaking, None);
+    }
+
+    #[test]
+    fn parse_contract_stability_config_clamps_window() {
+        let svc = Uuid::new_v4();
+        let c = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "window_minutes": 99_999,
+        }))
+        .unwrap();
+        assert_eq!(c.window_minutes, CONTRACT_STABILITY_MAX_WINDOW);
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_missing_service() {
+        let err = cs_cfg(serde_json::json!({})).unwrap_err();
+        assert!(err.contains("monitored_service_id"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_invalid_uuid() {
+        let err = cs_cfg(serde_json::json!({
+            "monitored_service_id": "not-a-uuid",
+        }))
+        .unwrap_err();
+        assert!(err.contains("monitored_service_id"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_negative_max_breaking() {
+        let svc = Uuid::new_v4();
+        let err = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_breaking": -1,
+        }))
+        .unwrap_err();
+        assert!(err.contains("max_breaking"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_negative_max_non_breaking() {
+        let svc = Uuid::new_v4();
+        let err = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_non_breaking": -5,
+        }))
+        .unwrap_err();
+        assert!(err.contains("max_non_breaking"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_contract_stability_config_rejects_non_integer_max_non_breaking() {
+        let svc = Uuid::new_v4();
+        let err = cs_cfg(serde_json::json!({
+            "monitored_service_id": svc.to_string(),
+            "max_non_breaking": "many",
+        }))
+        .unwrap_err();
+        assert!(err.contains("max_non_breaking"), "got: {err}");
     }
 }


### PR DESCRIPTION
## Summary

PR 3/4 of #355 item 2. Adds the `contract_stability` evaluator. **Stacks on #432** (which itself stacks on #431).

Aggregates `contract_diff_findings` for a monitored service over a window and asserts `breaking_count <= max_breaking` (default 0). Different data source from latency / error_rate evaluators — this one queries the contract-diff side, not runtime_request_logs.

## What's wired

### Backend

- `GET /api/v1/internal/monitored-services/{id}/contract-stability` — aggregate endpoint. Counts findings by severity (`breaking` / `non_breaking` / `cosmetic`) joined with `contract_diff_runs`, plus `run_count` + `latest_run_at` so the executor can distinguish "no diffs scheduled" from "lots of diffs but no findings".
- Window default 24h (contract diffs run far less frequently than smoke/latency), clamped 1 minute to 1 week.

### Runner

- `fetch_monitored_service_contract_stability` callback method.
- `evaluate_contract_stability` function in `fitness.rs`:
  - **No-diff-runs case** → `Errored` with reason `no_diff_runs`. Passing on silence is misleading — likely indicates a misconfigured schedule.
  - **Pass** = `breaking_count ≤ max_breaking` AND (`max_non_breaking` is None OR `non_breaking_count ≤ max_non_breaking`).
  - Summary uses `measured_value=breaking_count` + `threshold_value=max_breaking` (cast to f64), matching the contract that `mirror_kind_status` reads to populate `fitness_evaluations` — no per-kind logic needed.

## Config payload

```json
{
  "monitored_service_id": "uuid",   // required
  "max_breaking":         0,        // optional, default 0; non-negative i64
  "max_non_breaking":     null,     // optional; null/omit = no ceiling
  "window_minutes":       1440      // optional, default 1440 (24h), clamped 1..=10080
}
```

`max_breaking = 0` is the strictest reading of "stable" and matches the typical user expectation. `max_non_breaking` is opt-in because most users don't care about non-breaking drift.

## Stub list reduced

Only `custom_query` remains stubbed. `contract_stability` moved from "stubbed (tracking PR follows)" to "currently implemented" in the module docstring.

## What's left on #355 item 2

- **PR 4** — `custom_query` decision. Recommendation: permanent "self-hosted only" stub since running arbitrary user code on cloud workers is a security risk we shouldn't take. Quick PR (~50 lines + an updated UI banner).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-{core,server} -p mockforge-test-runner --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-test-runner --lib executors::fitness` — **27 pass** (11 latency + 7 error_rate + 9 contract_stability)
- [ ] Post-merge: create a fitness function with `kind='contract_stability'`, point at a monitored service, trigger a contract diff that produces a breaking finding, verify the next fitness run returns `Failed` and an incident fires.
