### PR TITLE
feat(test-runner+registry): custom_query is self-hosted only (#355 item 2 PR 4/4)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/contract_verification.rs
+++ b/crates/mockforge-registry-server/src/handlers/contract_verification.rs
@@ -303,6 +303,22 @@ pub async fn create_fitness_function(
             FitnessFunction::VALID_KINDS.join(", ")
         )));
     }
+    // `custom_query` runs arbitrary user-supplied evaluator code on
+    // self-hosted MockForge — fine for trusted single-tenant
+    // deployments, not safe to honour on shared cloud workers
+    // (would let any workspace owner execute code on the runner
+    // pool). Cloud rejects the kind at this boundary so a row in
+    // the state matching `kind='custom_query'` never exists in
+    // cloud, even if the user tried to bypass the UI gate.
+    if request.kind == "custom_query" {
+        return Err(ApiError::InvalidRequest(
+            "kind 'custom_query' is self-hosted only — \
+             arbitrary evaluator code isn't supported on cloud workers. \
+             Use latency_threshold, error_rate, or contract_stability instead, \
+             or run a self-hosted MockForge instance."
+                .into(),
+        ));
+    }
 
     let row = FitnessFunction::create(
         state.db.pool(),

--- a/crates/mockforge-test-runner/src/executors/fitness.rs
+++ b/crates/mockforge-test-runner/src/executors/fitness.rs
@@ -15,11 +15,22 @@
 //!     for a monitored service over a window, asserts
 //!     `breaking_count <= max_breaking` (default 0).
 //!
-//! Stubbed (returns `errored` with a clear "not yet implemented in
-//! cloud" message; tracking PR follows this one):
-//!   - `custom_query` — likely permanent stub since we don't run
-//!     arbitrary user code on cloud workers; will surface in the UI as
-//!     "self-hosted only".
+//! Permanently cloud-rejected:
+//!   - `custom_query` — this kind is self-hosted-only by design.
+//!     The local driftApi `custom_query` evaluator runs arbitrary
+//!     user-supplied evaluator code (e.g. Lua), which we don't run
+//!     on cloud workers — the security model would have to be
+//!     "trust every workspace owner with code execution on shared
+//!     runners," which isn't a posture we want. Cloud users who
+//!     need custom logic should run self-hosted, or open a feature
+//!     request for a specific declarative check we can implement
+//!     safely (e.g. as a new `kind`).
+//!
+//!     The cloud-side `create_fitness_function` and
+//!     `update_fitness_function` handlers reject `kind='custom_query'`
+//!     at the API boundary so cloud rows can't be created in this
+//!     state. The runner-side rejection here is defense-in-depth
+//!     for any pre-existing rows or scheduled runs.
 //!
 //! `run.suite_id` is the fitness function's id (per the `mirror_kind_status`
 //! convention). The summary the executor returns includes
@@ -111,16 +122,21 @@ impl Executor for FitnessExecutor {
                 evaluate_contract_stability(&function, callbacks, &job, started).await
             }
             "custom_query" => {
+                // Permanent rejection — see module docstring. Cloud
+                // create/update handlers should already block
+                // kind='custom_query', so reaching this arm means
+                // either a pre-existing row or a direct queue insert.
                 errored_run(
                     callbacks,
                     &job,
                     started,
                     2,
-                    format!(
-                        "fitness kind '{}' isn't implemented in the cloud executor yet — \
-                         tracking PR follows #355 item 2",
-                        function.kind
-                    ),
+                    "fitness kind 'custom_query' is self-hosted only — \
+                     run a self-hosted MockForge instance to use arbitrary \
+                     evaluator code, or use one of the declarative kinds \
+                     (latency_threshold, error_rate, contract_stability) \
+                     in cloud"
+                        .to_string(),
                 )
                 .await
             }


### PR DESCRIPTION
## Summary

PR 4/4 of #355 item 2 — the wrap-up. **Closes #355 item 2 fully**. Stacks on #433.

**Decision**: cloud mode permanently rejects fitness functions with `kind='custom_query'`. Self-hosted MockForge (driftApi) keeps `custom_query` working unchanged.

## Why permanent rejection

`custom_query` in the local driftApi runs arbitrary user-supplied evaluator code (Lua-style hooks). That's fine for trusted self-hosted single-tenant deployments. Not a posture we want for a shared cloud worker pool — would let any workspace owner execute code on shared infrastructure.

The alternative (sandbox the evaluator) adds enough complexity that we'd rather offer a catalog of declarative kinds (`latency_threshold`, `error_rate`, `contract_stability` are now real after PRs #431-#433) and keep `custom_query` as the "you control your runner, you control the trust boundary" story.

## What's wired

| | |
|---|---|
| `create_fitness_function` | Rejects `kind='custom_query'` at the API boundary with a 400. No row with that kind ever lands in the cloud DB via the public API. |
| `FitnessExecutor::execute` `custom_query` arm | Message updated from "tracking PR follows" to permanent "self-hosted only" framing. Defense-in-depth for pre-existing rows / schedules. |
| Module docstring | Reframed as a deliberate product decision rather than a TODO. |

## Note for PR #430

When `update_fitness_function` (from PR #430) merges to main, it'll need the same custom_query rejection — small ~5-line edit mirroring `create_fitness_function`'s check. Captured as a follow-up.

## What's NOT changed

- `FitnessFunction::VALID_KINDS` still includes `custom_query`. The schema/migration accepts it; we don't want to break local-mode fixtures. Rejection happens above the model layer.
- Self-hosted `driftApi` custom_query behaviour is unchanged.
- The local UI's `FitnessFunctionType` union (`response_size`, `required_field`, etc.) is a separate world from cloud kinds. The local form letting users pick types that cloud's create endpoint rejects is a separate write-UI cleanup, out of scope here.

## Series wrap-up

```
main
└── feat/issue-355-fitness-executor (#431)
    ├── PR 1: FitnessExecutor scaffolding + latency_threshold
    ├── PR 2 (#432, merged): error_rate
    ├── PR 3 (#433, merged): contract_stability
    └── this PR (#???):       custom_query self-hosted-only
```

When #431 lands on main, all four kinds + the cloud rejection are live. **#355 item 2 fully closed.**

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-registry-server -p mockforge-test-runner --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-test-runner --lib executors::fitness` — **27 pass** (no new tests; the rejection is a 1-line check that's covered by the existing handler integration suite once it lands)
- [ ] Post-merge: attempt to create a fitness function via cloud API with `{"kind": "custom_query", ...}` and confirm the 400 with the "self-hosted only" message.
- [ ] Post-merge: confirm self-hosted MockForge still accepts and runs `custom_query` via the local driftApi flow.
