### PR TITLE
chore(release): bump workspace to 0.3.127 (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [0.3.127] - 2026-05-08
+
+### Fixed
+
+- **[Reality]** TPS / RPS200 dashboard counters stuck at 0 under load (#351, #79)
+  - Root cause: `record_response()` lives inside `collect_http_metrics`, but the middleware was exported from `mockforge-http` and never `.layer()`d onto the production router built in `serve.rs`. CPS kept ticking because `CountingMakeService` wraps the make-service at a different layer.
+  - Layer `collect_http_metrics` as the outermost wrapper on `http_app` so every response — including chaos-mutated ones — bumps the rate counters the dashboard sampler reads.
+  - Regression test pins the actual counter delta on a 2xx response, not just the response status.
+
+### Added
+
+- **[DevX]** `bench-chunked` accepts `--base-path`, humantime `--duration`, `--validate-requests`, `--export-requests` (#352, #79)
+  - `--base-path <PATH>` prepends to every spec-derived operation path before URL construction. CLI > spec.servers > none, matching `mockforge bench`. No-op without `--spec`.
+  - `-d 600s` / `--duration <DURATION>` switched from bare seconds (u64) to humantime parsing — `30s`, `5m`, `1h`, or bare seconds all parse.
+  - `--validate-requests` (OpenAPI request validation) and `--export-requests` (per-request JSON export) now mirror the same flags on `mockforge bench`.
+  - The full Microsoft Graph invocation reported in #79 now parses end-to-end:
+    ```
+    mockforge bench-chunked --chunk-size-bytes 4096 --total-size-bytes 10485760 \
+      --chunk-interval-ms 50 --spec microsoft-graph.yaml \
+      --target https://192.168.2.86 --base-path /v1.0 \
+      --validate-requests --export-requests --insecure -d 600s
+    ```
+- **[DevX]** Supervisor wrappers for unattended runs under heavy traffic (#350, #79)
+  - `deploy/systemd/mockforge.service` — systemd unit with `Restart=always`, resource limits, and hardening directives. Documents the install dance and the two knobs (`MemoryMax`, `LimitNOFILE`) most likely to matter at high concurrency.
+  - `deploy/scripts/run-forever.sh` — bash supervisor that restarts the binary after any non-clean exit. Forwards SIGINT/SIGTERM so Ctrl-C stops cleanly. Useful on macOS / non-systemd hosts and ad-hoc bench rigs.
+  - `deploy/systemd/README.md` picks between them.
+
 ## [0.3.126] - 2026-05-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7668,7 +7668,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7691,7 +7691,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7749,7 +7749,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7789,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7868,7 +7868,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7912,7 +7912,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7922,7 +7922,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7943,7 +7943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8080,7 +8080,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8103,7 +8103,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8124,7 +8124,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8150,7 +8150,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8231,7 +8231,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8310,7 +8310,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8357,7 +8357,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8372,7 +8372,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8421,7 +8421,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8467,7 +8467,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8493,7 +8493,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8509,7 +8509,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8568,7 +8568,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8597,7 +8597,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8633,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8673,7 +8673,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8691,7 +8691,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8710,7 +8710,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8735,7 +8735,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8782,7 +8782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8820,7 +8820,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8889,7 +8889,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8909,7 +8909,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8922,7 +8922,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8981,7 +8981,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9009,7 +9009,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9039,7 +9039,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9066,7 +9066,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9090,14 +9090,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9124,7 +9124,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9156,7 +9156,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9174,7 +9174,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9197,7 +9197,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9228,7 +9228,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9280,7 +9280,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9315,7 +9315,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9326,7 +9326,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9343,7 +9343,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15059,7 +15059,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.126"
+version = "0.3.127"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.126"
+version = "0.3.127"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,23 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.127] - 2026-05-08
+
+### Fixed
+
+- **[Reality]** TPS / RPS200 dashboard counters stuck at 0 under load (#351, #79)
+  - Metrics middleware (`collect_http_metrics`) was never `.layer()`d on the production router built in `serve.rs`. CPS still advanced because `CountingMakeService` wraps the make-service at a different layer.
+  - Layer `collect_http_metrics` as the outermost wrapper on `http_app` so every response — including chaos-mutated ones — bumps the rate counters the dashboard sampler reads.
+
+### Added
+
+- **[DevX]** `bench-chunked` accepts `--base-path`, humantime `--duration`, `--validate-requests`, `--export-requests` (#352, #79)
+  - `--base-path <PATH>` prepends to every spec-derived operation path before URL construction. CLI > spec.servers > none.
+  - `-d 600s` / `--duration <DURATION>` switched from bare seconds (u64) to humantime parsing.
+  - `--validate-requests` and `--export-requests` mirror the flags already on `mockforge bench`.
+- **[DevX]** Supervisor wrappers for unattended runs under heavy traffic (#350, #79)
+  - `deploy/systemd/mockforge.service` — systemd unit with `Restart=always`.
+  - `deploy/scripts/run-forever.sh` — bash supervisor that restarts the binary after any non-clean exit.
+
 ## [0.3.73] - 2026-03-05
 
 ### Fixed

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -50,8 +50,12 @@ check_pillar_tags() {
   fi
 
   # Extract the first version section (most recent release)
-  # Skip the [Unreleased] section and get the first actual version
-  local version_section=$(awk '/^## \[[0-9]/{p=1} p{print} /^## \[[0-9]/ && NR>1{exit}' "$changelog_file" 2>/dev/null || true)
+  # Skip the [Unreleased] section and get the first actual version.
+  # The previous awk used `NR>1` to detect "this is the second version heading",
+  # but that exits immediately when the first version heading is itself past
+  # line 1 (e.g. book/src/reference/changelog.md has a preamble blockquote).
+  # Track whether we already opened a section instead.
+  local version_section=$(awk '/^## \[[0-9]/{ if (in_section) exit; in_section=1 } in_section{print}' "$changelog_file" 2>/dev/null || true)
 
   if [ -z "$version_section" ]; then
     # If no version section found, might be a new file or only Unreleased section


### PR DESCRIPTION
## Summary

Issue #79 follow-up release. Picks up four merged-but-unreleased PRs that address @srikr's 2026-05-04 feedback:

- **#351** — TPS / RPS200 dashboard counters were stuck at 0 under load. Root cause: `collect_http_metrics` middleware was never `.layer()`d on the production router built in `serve.rs` (CPS kept ticking because it's wired one layer up). Regression test pins the counter delta on a 2xx response.
- **#352** — `bench-chunked` accepts `--base-path`, humantime `--duration` (so `-d 600s` works), `--validate-requests`, `--export-requests`. The full Microsoft Graph invocation in @srikr's report now parses end-to-end.
- **#350** — `deploy/systemd/mockforge.service` (Restart=always) + `deploy/scripts/run-forever.sh` bash supervisor for hosts without systemd. Addresses the "server gets killed under heavy traffic" feedback.

CHANGELOG entry covers all three under `[0.3.127]`.

## Test plan

- [x] `cargo test -p mockforge-http middleware_advances_rate_counters_on_2xx` — passes locally (regression test from #351)
- [x] `mockforge bench-chunked --help` shows `--base-path`, `--duration` (humantime), `--validate-requests`, `--export-requests`
- [x] `deploy/scripts/run-forever.sh` and `deploy/systemd/mockforge.service` are present and executable
- [x] `cargo check -p mockforge-cli` clean at 0.3.127
- [ ] CI green on this PR
- [ ] After merge: `scripts/publish-crates.sh` to crates.io, then tag `v0.3.127`