### PR TITLE
fix(bench): cap k6 metric names + wire chaos fault counters (#79)

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -1326,7 +1326,10 @@ impl BenchCommand {
         let mut all_placeholders: HashSet<DynamicPlaceholder> = HashSet::new();
 
         let flows_data: Vec<serde_json::Value> = flows.iter().map(|f| {
-            let sanitized_name = K6ScriptGenerator::sanitize_js_identifier(&f.name);
+            // Use the metric-name sanitizer (caps at 112 chars + hash suffix)
+            // so deeply nested flow names don't blow past k6's 128-char limit
+            // when concatenated with `_step{i}_latency`. See issue #79.
+            let sanitized_name = K6ScriptGenerator::sanitize_k6_metric_name(&f.name);
             serde_json::json!({
                 "name": sanitized_name.clone(),
                 "display_name": f.name,
@@ -1688,8 +1691,11 @@ impl BenchCommand {
         let mut all_placeholders: HashSet<DynamicPlaceholder> = HashSet::new();
 
         let flows_data: Vec<serde_json::Value> = flows.iter().map(|f| {
-            // Sanitize flow name for use as JavaScript variable and k6 metric names
-            let sanitized_name = K6ScriptGenerator::sanitize_js_identifier(&f.name);
+            // Sanitize flow name for use as JavaScript variable and k6 metric names.
+            // Use the metric-name sanitizer (caps at 112 chars + hash suffix) so
+            // deeply nested flow names don't blow past k6's 128-char limit when
+            // concatenated with `_step{i}_latency`. See issue #79.
+            let sanitized_name = K6ScriptGenerator::sanitize_k6_metric_name(&f.name);
             serde_json::json!({
                 "name": sanitized_name.clone(),  // Use sanitized name for variable names
                 "display_name": f.name,          // Keep original for comments/display

--- a/crates/mockforge-bench/src/k6_gen.rs
+++ b/crates/mockforge-bench/src/k6_gen.rs
@@ -141,6 +141,48 @@ impl K6ScriptGenerator {
             .map_err(|e| BenchError::ScriptGenerationFailed(e.to_string()))
     }
 
+    /// Maximum length for a k6 metric name *base* (the part before any
+    /// `_latency` / `_errors` / `_step{N}_*` suffix). k6 enforces a
+    /// 128-char limit on the full metric name; the longest suffix used by
+    /// our templates is `_step99_errors` (15 chars), so we cap the base at
+    /// 128 - 16 = 112 to be safe.
+    const K6_METRIC_NAME_BASE_MAX_LEN: usize = 112;
+
+    /// Sanitize a name into a valid k6 metric-name base, capped at
+    /// `K6_METRIC_NAME_BASE_MAX_LEN` characters.
+    ///
+    /// k6 rejects metric names longer than 128 chars, and our templates
+    /// append suffixes like `_latency`, `_errors`, `_stepN_latency` —
+    /// reserve room for the longest suffix and truncate the base name
+    /// when needed. Truncation appends an 8-hex-char hash of the original
+    /// name so distinct long names produce distinct metric names.
+    ///
+    /// Examples:
+    /// - "short_name" -> "short_name"
+    /// - 200-char OperationId -> "<first-103-chars>_<8-hex-hash>"
+    pub fn sanitize_k6_metric_name(name: &str) -> String {
+        let sanitized = Self::sanitize_js_identifier(name);
+        if sanitized.len() <= Self::K6_METRIC_NAME_BASE_MAX_LEN {
+            return sanitized;
+        }
+
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        // Hash the original name (not the sanitized one) so two distinct
+        // sources that sanitize to the same string still get different
+        // hashes when they exceed the limit.
+        name.hash(&mut hasher);
+        let hash_suffix = format!("{:08x}", hasher.finish() as u32);
+
+        // Reserve `_<8-hex>` = 9 chars at the end.
+        let prefix_len = Self::K6_METRIC_NAME_BASE_MAX_LEN - 9;
+        let prefix = &sanitized[..prefix_len];
+        // Strip a trailing underscore on the prefix so we don't end up with `__hash`.
+        let prefix = prefix.trim_end_matches('_');
+        format!("{}_{}", prefix, hash_suffix)
+    }
+
     /// Sanitize a name to be a valid JavaScript identifier
     ///
     /// Replaces invalid characters (dots, spaces, special chars) with underscores.
@@ -204,9 +246,12 @@ impl K6ScriptGenerator {
             .map(|(idx, template)| {
                 let display_name = template.operation.display_name();
                 let sanitized_name = Self::sanitize_js_identifier(&display_name);
-                // metric_name must also be sanitized for k6 metric name validation
-                // k6 metric names must only contain ASCII letters, numbers, or underscores
-                let metric_name = sanitized_name.clone();
+                // metric_name must satisfy k6's 128-char limit AND leave room
+                // for suffixes like `_latency` / `_errors` / `_stepN_*`.
+                // Long deeply-nested operationIds (e.g. Microsoft Graph) exceed
+                // this; sanitize_k6_metric_name truncates with a hash suffix
+                // for uniqueness. (See issue #79 — Srikanth's microsoft-graph.yaml run.)
+                let metric_name = Self::sanitize_k6_metric_name(&display_name);
                 // k6 uses 'del' instead of 'delete' for HTTP DELETE method
                 let k6_method = match template.operation.method.to_lowercase().as_str() {
                     "delete" => "del".to_string(),
@@ -519,6 +564,109 @@ mod tests {
             "plans_update_pricing_schemes"
         );
         assert_eq!(K6ScriptGenerator::sanitize_js_identifier("users CRUD"), "users_CRUD");
+    }
+
+    #[test]
+    fn test_sanitize_k6_metric_name_short_passthrough() {
+        // Names within the limit should pass through unchanged.
+        let short = "billing_subscriptions_list";
+        let out = K6ScriptGenerator::sanitize_k6_metric_name(short);
+        assert_eq!(out, short);
+        assert!(K6ScriptGenerator::is_valid_k6_metric_name(&format!("{out}_latency")));
+    }
+
+    #[test]
+    fn test_sanitize_k6_metric_name_truncates_long_microsoft_graph_id() {
+        // Real example from issue #79 (Srikanth's microsoft-graph.yaml run):
+        // operationId nested deep enough that the sanitized name + `_latency`
+        // exceeds k6's 128-char limit and gets rejected by validate_script.
+        let long = "drives.drive.items.driveItem.workbook.worksheets.workbookWorksheet.\
+                    charts.workbookChart.axes.categoryAxis.format.line.clear";
+        let metric = K6ScriptGenerator::sanitize_k6_metric_name(long);
+
+        // Base must fit within MAX_LEN, leaving room for `_latency` / `_errors`.
+        assert!(
+            metric.len() <= K6ScriptGenerator::K6_METRIC_NAME_BASE_MAX_LEN,
+            "metric base len {} exceeded cap {}",
+            metric.len(),
+            K6ScriptGenerator::K6_METRIC_NAME_BASE_MAX_LEN
+        );
+
+        // Both the bare metric and the suffixed forms must pass k6's validator.
+        assert!(K6ScriptGenerator::is_valid_k6_metric_name(&metric));
+        assert!(K6ScriptGenerator::is_valid_k6_metric_name(&format!("{metric}_latency")));
+        assert!(K6ScriptGenerator::is_valid_k6_metric_name(&format!("{metric}_errors")));
+        // Worst-case suffix used by `k6_crud_flow.hbs`.
+        assert!(K6ScriptGenerator::is_valid_k6_metric_name(&format!("{metric}_step99_latency")));
+    }
+
+    #[test]
+    fn test_sanitize_k6_metric_name_distinct_long_names_get_distinct_metrics() {
+        // Two long names that share a long common prefix must NOT collide
+        // after truncation — the trailing hash makes them distinct.
+        let prefix = "a".repeat(150);
+        let a = format!("{prefix}.foo");
+        let b = format!("{prefix}.bar");
+        let ma = K6ScriptGenerator::sanitize_k6_metric_name(&a);
+        let mb = K6ScriptGenerator::sanitize_k6_metric_name(&b);
+        assert_ne!(ma, mb, "distinct long names produced the same metric name");
+    }
+
+    #[test]
+    fn test_sanitize_k6_metric_name_truncated_starts_with_letter() {
+        // Truncation must preserve the "starts with letter or _" k6 rule.
+        let long = format!("{}123end", "x".repeat(120));
+        let metric = K6ScriptGenerator::sanitize_k6_metric_name(&long);
+        assert!(K6ScriptGenerator::is_valid_k6_metric_name(&metric));
+    }
+
+    #[test]
+    fn test_microsoft_graph_long_operation_id_passes_validation() {
+        // End-to-end: an ApiOperation with a microsoft-graph-style long
+        // operationId must produce a script that passes validate_script.
+        use crate::spec_parser::ApiOperation;
+        use openapiv3::Operation;
+
+        let long_op_id = "drives.drive.items.driveItem.workbook.worksheets.\
+            workbookWorksheet.charts.workbookChart.axes.categoryAxis.format.\
+            line.clear";
+
+        let operation = ApiOperation {
+            method: "post".to_string(),
+            path: "/drives/{drive-id}/items/{item-id}/workbook/worksheets/{worksheet-id}/charts/{chart-id}/axes/categoryAxis/format/line/clear".to_string(),
+            operation: Operation::default(),
+            operation_id: Some(long_op_id.to_string()),
+        };
+        let template = RequestTemplate {
+            operation,
+            path_params: HashMap::new(),
+            query_params: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        let config = K6Config {
+            target_url: "https://api.example.com".to_string(),
+            base_path: Some("/v1.0".to_string()),
+            scenario: LoadScenario::Constant,
+            duration_secs: 30,
+            max_vus: 5,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            auth_header: None,
+            custom_headers: HashMap::new(),
+            skip_tls_verify: false,
+            security_testing_enabled: false,
+            chunked_request_bodies: false,
+        };
+        let generator = K6ScriptGenerator::new(config, vec![template]);
+        let script = generator.generate().expect("script generates");
+
+        let errors = K6ScriptGenerator::validate_script(&script);
+        assert!(
+            errors.is_empty(),
+            "validate_script returned errors for long operationId: {errors:#?}"
+        );
     }
 
     #[test]

--- a/crates/mockforge-chaos/src/chaos_listener.rs
+++ b/crates/mockforge-chaos/src/chaos_listener.rs
@@ -118,11 +118,13 @@ impl axum::serve::Listener for ChaosTcpListener {
                     }
                     drop(stream);
                     warn!("[chaos] injected TCP RST on connection from {}", addr);
+                    crate::metrics::CHAOS_METRICS.record_fault("tcp_reset", "_listener");
                     continue;
                 }
                 Some(ConnectionErrorKind::TcpClose) => {
                     drop(stream);
                     warn!("[chaos] injected TCP FIN on connection from {}", addr);
+                    crate::metrics::CHAOS_METRICS.record_fault("tcp_close", "_listener");
                     continue;
                 }
                 // `Http503` (or no fault hit) lets the connection through; the

--- a/crates/mockforge-chaos/src/middleware.rs
+++ b/crates/mockforge-chaos/src/middleware.rs
@@ -269,6 +269,8 @@ async fn chaos_middleware_core(
     if let Err(_e) = rate_limiter.check(Some(&ip), Some(&path)) {
         drop(rate_limiter);
         warn!("Rate limit exceeded: {} - {}", ip, path);
+        crate::metrics::CHAOS_METRICS.record_rate_limit_violation(&path);
+        crate::metrics::CHAOS_METRICS.record_fault("rate_limit", &path);
         return (StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded").into_response();
     }
     drop(rate_limiter);
@@ -278,6 +280,7 @@ async fn chaos_middleware_core(
     if !traffic_shaper.check_connection_limit() {
         drop(traffic_shaper);
         warn!("Connection limit exceeded");
+        crate::metrics::CHAOS_METRICS.record_fault("connection_limit", &path);
         return (StatusCode::SERVICE_UNAVAILABLE, "Connection limit exceeded").into_response();
     }
 
@@ -288,6 +291,7 @@ async fn chaos_middleware_core(
     if traffic_shaper.should_drop_packet() {
         drop(traffic_shaper);
         warn!("Simulating packet loss for: {}", path);
+        crate::metrics::CHAOS_METRICS.record_fault("packet_loss", &path);
         return (StatusCode::REQUEST_TIMEOUT, "Connection dropped").into_response();
     }
     drop(traffic_shaper);
@@ -298,6 +302,7 @@ async fn chaos_middleware_core(
     drop(latency_injector);
     if delay_ms > 0 {
         chaos.latency_tracker.record_latency(delay_ms);
+        crate::metrics::CHAOS_METRICS.record_latency(&path, delay_ms as f64);
     }
 
     // Detect chunked transfer encoding *before* we collect the body, since
@@ -374,6 +379,7 @@ async fn chaos_middleware_core(
 
     if let Some(status_code) = http_error_status {
         warn!("Injecting HTTP error: {}", status_code);
+        crate::metrics::CHAOS_METRICS.record_fault("http_error", &path);
         return (
             StatusCode::from_u16(status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
             format!("Injected error: {}", status_code),
@@ -383,6 +389,7 @@ async fn chaos_middleware_core(
 
     if let Some(timeout_ms) = timeout_fault {
         warn!("Injecting timeout: sleeping {}ms then returning 504", timeout_ms);
+        crate::metrics::CHAOS_METRICS.record_fault("timeout", &path);
         tokio::time::sleep(std::time::Duration::from_millis(timeout_ms)).await;
         return (StatusCode::GATEWAY_TIMEOUT, "Injected timeout (Gateway Timeout)").into_response();
     }
@@ -464,6 +471,7 @@ async fn chaos_middleware_core(
             "Injecting partial response (chunked={}, original_size={})",
             response_was_chunked, response_size
         );
+        crate::metrics::CHAOS_METRICS.record_fault("partial_response", &path);
         let mut rng = rand::rng();
         let truncate_at = if response_size > 0 {
             rng.random_range(0..response_size)
@@ -485,6 +493,7 @@ async fn chaos_middleware_core(
     // Apply payload corruption if enabled
     if should_corrupt && corruption_type != CorruptionType::None {
         warn!("Injecting payload corruption: {:?}", corruption_type);
+        crate::metrics::CHAOS_METRICS.record_fault("payload_corruption", &path);
         final_body_bytes = corrupt_payload(&final_body_bytes, corruption_type);
     }
 

--- a/crates/mockforge-chaos/src/middleware.rs
+++ b/crates/mockforge-chaos/src/middleware.rs
@@ -645,4 +645,24 @@ mod tests {
         assert!(!samples.is_empty(), "Should have recorded at least one latency sample");
         assert_eq!(samples[0].latency_ms, 50, "Recorded latency should match injected delay");
     }
+
+    /// Issue #79 item 6: pre-fix the prometheus counter sat at zero forever
+    /// because nothing called `record_fault`. This is a coarse smoke check
+    /// that the counter mechanism itself works — the actual call sites are
+    /// covered by the wiring in `chaos_middleware_core` and `ChaosTcpListener`.
+    #[test]
+    fn fault_counter_bumps_when_record_fault_is_called() {
+        use crate::metrics::CHAOS_METRICS;
+        let endpoint = "/test_chaos_fault_wiring_smoke";
+        let before = CHAOS_METRICS
+            .faults_injected_total
+            .with_label_values(&["http_error", endpoint])
+            .get();
+        CHAOS_METRICS.record_fault("http_error", endpoint);
+        let after = CHAOS_METRICS
+            .faults_injected_total
+            .with_label_values(&["http_error", endpoint])
+            .get();
+        assert_eq!((after - before) as u64, 1);
+    }
 }


### PR DESCRIPTION
## Summary

Two related fixes for Srikanth's #79 follow-up:

**1. k6 metric-name 128-char cap** (`mockforge-bench`)
Microsoft Graph and other deeply nested OpenAPI specs produce `operationId`s that, after dot-to-underscore sanitization plus the `_latency` / `_errors` suffix, exceed k6's 128-char metric-name cap. `validate_script` was correctly catching it, but the generator was producing names that couldn't pass — Srikanth's microsoft-graph.yaml run hit it on op `drives.drive.items.driveItem.workbook.worksheets.workbookWorksheet.charts.workbookChart.axes.categoryAxis.format.line.clear`. New `K6ScriptGenerator::sanitize_k6_metric_name` caps the base at 112 chars (128 − 16 for `_step99_latency`) and appends an 8-hex-char hash of the original name when truncating. Wired into both render paths: `k6_script.hbs` and `k6_crud_flow.hbs`.

**2. Chaos prometheus counters** (`mockforge-chaos`)
`CHAOS_METRICS.faults_total{fault_type, endpoint}` was registered but never incremented — Srikanth's #79 item 6 ("currently in mockforge-tui I only see what configuration is enabled for chaos but not able to figure out how the configuration is taking effect") was masked by zero counters. Wired `record_fault(...)` at every fault decision point in the HTTP middleware (http_error, timeout, rate_limit, connection_limit, packet_loss, partial_response, payload_corruption, latency) and in the TCP chaos listener (tcp_reset, tcp_close). The counters now show up in `/metrics` with non-zero values when rules fire.

## Test plan

- [x] `cargo test -p mockforge-bench` — 28 k6_gen tests pass (5 new)
- [x] `cargo test -p mockforge-chaos --lib` — all 351 tests pass
- [x] `cargo clippy -p mockforge-bench -p mockforge-chaos --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] End-to-end: synthetic spec with the long Microsoft-Graph-style operationId → `mockforge bench --use-k6` → `Validating k6 script ✓ Script validation passed`. Two long sister operationIds (sharing 100-char prefix) get distinct metric names via the hash suffix. Generated metric strings observed at 120 chars (under k6's 128-char cap).

Refs #79