### PR TITLE
chore(release): bump workspace to 0.3.128 (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.3.128] - 2026-05-09
+
+### Fixed
+
+- **[DevX]** k6 metric-name validation failure on deeply nested OpenAPI specs (Microsoft Graph etc.) (#436, #79)
+  - Root cause: `operationId`s like `drives.drive.items.driveItem.workbook.worksheets.workbookWorksheet.charts.workbookChart.axes.categoryAxis.format.line.clear`, after dot-to-underscore sanitization plus `_latency` / `_errors` suffix, exceeded k6's 128-char metric-name cap. `validate_script` correctly rejected the script before k6 ran.
+  - New `K6ScriptGenerator::sanitize_k6_metric_name` caps the base at 112 chars (128 − 16 for `_step99_latency`) and appends an 8-hex-char hash of the original name when truncating, so distinct long names produce distinct metric names. JS variable identifiers keep the full readable form; only the metric *string* is truncated.
+  - Wired into both render paths: `k6_script.hbs` (per-operation) and `k6_crud_flow.hbs`. Tests cover passthrough, truncation, prefix-collision uniqueness, the "starts with letter or _" rule after truncation, and end-to-end script validation on a microsoft-graph-style operationId.
+- **[Reality]** Chaos prometheus counters were registered but never incremented (#436, #79)
+  - `mockforge_chaos_faults_total{fault_type, endpoint}`, `mockforge_chaos_latency_ms`, and `mockforge_chaos_rate_limit_violations_total` all existed in the registry, but no caller invoked the corresponding `record_*` methods. `/metrics` reported zero faults regardless of how many were actually firing — masking the effect of configured chaos rules from operators.
+  - Wired `record_fault(...)` at every fault decision point in the HTTP middleware (`http_error`, `timeout`, `rate_limit`, `connection_limit`, `packet_loss`, `partial_response`, `payload_corruption`) and the TCP chaos listener (`tcp_reset`, `tcp_close`). Latency injection also now records to the histogram via `record_latency`.
+  - The TUI Chaos screen still renders config-only; surfacing these counters as a stats panel is tracked as a follow-up.
+
 ## [0.3.127] - 2026-05-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7652,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7862,7 +7862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7883,7 +7883,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7954,7 +7954,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7987,7 +7987,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8090,7 +8090,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8171,7 +8171,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8250,7 +8250,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8297,7 +8297,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8312,7 +8312,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8334,7 +8334,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8361,7 +8361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8386,7 +8386,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8552,7 +8552,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8573,7 +8573,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8650,7 +8650,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8675,7 +8675,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8689,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8722,7 +8722,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8862,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8884,7 +8884,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8949,7 +8949,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8979,7 +8979,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9006,7 +9006,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9030,14 +9030,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9064,7 +9064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9075,7 +9075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9096,7 +9096,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9137,7 +9137,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9168,7 +9168,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -14969,7 +14969,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.127"
+version = "0.3.128"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.127"
+version = "0.3.128"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,18 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.128] - 2026-05-09
+
+### Fixed
+
+- **[DevX]** k6 metric-name validation failure on deeply nested OpenAPI specs (Microsoft Graph etc.) (#436, #79)
+  - Root cause: `operationId`s like `drives.drive.items.driveItem.workbook.worksheets.workbookWorksheet.charts.workbookChart.axes.categoryAxis.format.line.clear`, after dot-to-underscore sanitization plus `_latency` / `_errors` suffix, exceeded k6's 128-char metric-name cap. `validate_script` correctly rejected the script before k6 ran.
+  - New `K6ScriptGenerator::sanitize_k6_metric_name` caps the base at 112 chars (128 − 16 for `_step99_latency`) and appends an 8-hex-char hash of the original name when truncating, so distinct long names produce distinct metric names. JS variable identifiers keep the full readable form; only the metric *string* is truncated.
+  - Wired into both render paths: `k6_script.hbs` (per-operation) and `k6_crud_flow.hbs`. Tests cover passthrough, truncation, prefix-collision uniqueness, the "starts with letter or _" rule after truncation, and end-to-end script validation on a microsoft-graph-style operationId.
+- **[Reality]** Chaos prometheus counters were registered but never incremented (#436, #79)
+  - `mockforge_chaos_faults_total{fault_type, endpoint}`, `mockforge_chaos_latency_ms`, and `mockforge_chaos_rate_limit_violations_total` all existed in the registry, but no caller invoked the corresponding `record_*` methods. `/metrics` reported zero faults regardless of how many were actually firing — masking the effect of configured chaos rules from operators.
+  - Wired `record_fault(...)` at every fault decision point in the HTTP middleware (`http_error`, `timeout`, `rate_limit`, `connection_limit`, `packet_loss`, `partial_response`, `payload_corruption`) and the TCP chaos listener (`tcp_reset`, `tcp_close`). Latency injection also now records to the histogram via `record_latency`.
+  - The TUI Chaos screen still renders config-only; surfacing these counters as a stats panel is tracked as a follow-up.
+
 ## [0.3.127] - 2026-05-08
 
 ### Fixed


### PR DESCRIPTION
## Summary

Issue #79 follow-up release. Picks up the two fixes from #436 that address @srikr's 2026-05-09 feedback:

- **k6 metric-name 128-char cap** (`mockforge-bench`) — Microsoft Graph and other deeply nested OpenAPI specs produced metric names that exceeded k6's 128-char limit, so `validate_script` rejected the generated script (Srikanth's `microsoft-graph.yaml` run hit it on `drives.drive.items.driveItem.workbook.worksheets.workbookWorksheet.charts.workbookChart.axes.categoryAxis.format.line.clear`). Fix: cap the metric base at 112 chars + 8-hex hash suffix for uniqueness when truncating.
- **Chaos prometheus counters were never incremented** (`mockforge-chaos`) — `mockforge_chaos_faults_total{fault_type, endpoint}` and the latency / rate-limit counters were registered but no caller invoked the `record_*` methods. `/metrics` reported zero faults regardless of how many were actually firing. Fix: wire `record_fault(...)` at every fault decision point in the HTTP middleware (http_error, timeout, rate_limit, connection_limit, packet_loss, partial_response, payload_corruption) and the TCP chaos listener (tcp_reset, tcp_close).

CHANGELOG entries cover both under `[0.3.128]` with `[DevX]` and `[Reality]` pillar tags.

## Test plan

- [x] `cargo check -p mockforge-cli` clean at 0.3.128
- [x] `cargo test -p mockforge-bench` (28 k6_gen tests, 5 new) and `cargo test -p mockforge-chaos --lib` (351 tests) pass at 0.3.128
- [ ] CI green on this PR
- [ ] After merge: `scripts/publish-crates.sh` to crates.io, then tag `v0.3.128`, then verify `cargo install mockforge-cli@0.3.128 --force` against the published binary

Refs #79