### PR TITLE
feat(registry,ui): cloud-mode request verification (#390)

### DIFF
--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -139,6 +139,7 @@ jobs:
             --test workspace_content_e2e \
             --test signup_flow_e2e \
             --test marketplace_e2e \
+            --test cloud_verification_e2e \
             -- --ignored --nocapture --test-threads=1
 
       - name: Dump registry-server log on failure

--- a/crates/mockforge-core/src/verification.rs
+++ b/crates/mockforge-core/src/verification.rs
@@ -284,24 +284,25 @@ fn matches_body_pattern(body: &str, pattern: &str) -> bool {
     }
 }
 
-/// Verify requests against a pattern and count assertion
-pub async fn verify_requests(
-    logger: &crate::request_logger::CentralizedRequestLogger,
+/// Run the count-based verification logic against an explicit slice of
+/// log entries. The logger-backed `verify_requests` and the registry's
+/// cloud verification endpoint both funnel through this so behavior is
+/// bit-for-bit identical.
+///
+/// `entries` should be in any order (matching is per-row); `count` is
+/// the total of matching rows in the slice.
+pub fn verify_entries(
+    entries: &[RequestLogEntry],
     pattern: &VerificationRequest,
     expected: VerificationCount,
 ) -> VerificationResult {
-    // Get all logs
-    let logs = logger.get_recent_logs(None).await;
-
-    // Find matching requests
-    let matches: Vec<RequestLogEntry> = logs
-        .into_iter()
+    let matches: Vec<RequestLogEntry> = entries
+        .iter()
         .filter(|entry| matches_verification_pattern(entry, pattern))
+        .cloned()
         .collect();
 
     let count = matches.len();
-
-    // Check count assertion
     let matched = match &expected {
         VerificationCount::Exactly(n) => count == *n,
         VerificationCount::AtLeast(n) => count >= *n,
@@ -321,43 +322,20 @@ pub async fn verify_requests(
     }
 }
 
-/// Verify that a request was never made
-pub async fn verify_never(
-    logger: &crate::request_logger::CentralizedRequestLogger,
-    pattern: &VerificationRequest,
-) -> VerificationResult {
-    verify_requests(logger, pattern, VerificationCount::Never).await
-}
-
-/// Verify that a request was made at least N times
-pub async fn verify_at_least(
-    logger: &crate::request_logger::CentralizedRequestLogger,
-    pattern: &VerificationRequest,
-    min: usize,
-) -> VerificationResult {
-    verify_requests(logger, pattern, VerificationCount::AtLeast(min)).await
-}
-
-/// Verify that requests occurred in a specific sequence
-pub async fn verify_sequence(
-    logger: &crate::request_logger::CentralizedRequestLogger,
+/// Sequence verification against an explicit slice of log entries.
+/// `entries` must be in chronological order (oldest first).
+pub fn verify_sequence_entries(
+    entries: &[RequestLogEntry],
     patterns: &[VerificationRequest],
 ) -> VerificationResult {
-    // Get all logs (most recent first)
-    let mut logs = logger.get_recent_logs(None).await;
-    // Reverse to get chronological order (oldest first) for sequence verification
-    logs.reverse();
-
-    // Find matches for each pattern in order
     let mut log_idx = 0;
     let mut all_matches = Vec::new();
 
     for pattern in patterns {
-        // Find the next matching request after the last match
         let mut found = false;
-        while log_idx < logs.len() {
-            if matches_verification_pattern(&logs[log_idx], pattern) {
-                all_matches.push(logs[log_idx].clone());
+        while log_idx < entries.len() {
+            if matches_verification_pattern(&entries[log_idx], pattern) {
+                all_matches.push(entries[log_idx].clone());
                 log_idx += 1;
                 found = true;
                 break;
@@ -384,6 +362,43 @@ pub async fn verify_sequence(
         VerificationCount::Exactly(patterns.len()),
         all_matches,
     )
+}
+
+/// Verify requests against a pattern and count assertion
+pub async fn verify_requests(
+    logger: &crate::request_logger::CentralizedRequestLogger,
+    pattern: &VerificationRequest,
+    expected: VerificationCount,
+) -> VerificationResult {
+    let logs = logger.get_recent_logs(None).await;
+    verify_entries(&logs, pattern, expected)
+}
+
+/// Verify that a request was never made
+pub async fn verify_never(
+    logger: &crate::request_logger::CentralizedRequestLogger,
+    pattern: &VerificationRequest,
+) -> VerificationResult {
+    verify_requests(logger, pattern, VerificationCount::Never).await
+}
+
+/// Verify that a request was made at least N times
+pub async fn verify_at_least(
+    logger: &crate::request_logger::CentralizedRequestLogger,
+    pattern: &VerificationRequest,
+    min: usize,
+) -> VerificationResult {
+    verify_requests(logger, pattern, VerificationCount::AtLeast(min)).await
+}
+
+/// Verify that requests occurred in a specific sequence
+pub async fn verify_sequence(
+    logger: &crate::request_logger::CentralizedRequestLogger,
+    patterns: &[VerificationRequest],
+) -> VerificationResult {
+    let mut logs = logger.get_recent_logs(None).await;
+    logs.reverse();
+    verify_sequence_entries(&logs, patterns)
 }
 
 #[cfg(test)]

--- a/crates/mockforge-core/src/verification.rs
+++ b/crates/mockforge-core/src/verification.rs
@@ -44,10 +44,12 @@ pub struct VerificationRequest {
 
     /// Query parameters to match (all must be present and match).
     /// If empty, query parameters are not checked.
+    #[serde(default)]
     pub query_params: HashMap<String, String>,
 
     /// Headers to match (all must be present and match). Case-insensitive header names.
     /// If empty, headers are not checked.
+    #[serde(default)]
     pub headers: HashMap<String, String>,
 
     /// Request body pattern to match. Supports exact match or regex.
@@ -55,9 +57,14 @@ pub struct VerificationRequest {
     pub body_pattern: Option<String>,
 }
 
-/// Count assertion for verification
+/// Count assertion for verification.
+///
+/// Wire format is adjacently tagged (`{ "type": "exactly", "value": 3 }`)
+/// so it round-trips with the TypeScript client which sends
+/// `{ type, value? }`. Variants without a payload (`Never`,
+/// `AtLeastOnce`) omit the `value` field.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum VerificationCount {
     /// Request must be made exactly N times
     Exactly(usize),

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -35,6 +35,7 @@ pub mod pillar_analytics;
 pub mod plugins;
 pub mod projects;
 pub mod public_keys;
+pub mod request_verification;
 pub mod reviews;
 pub mod routing_rules;
 pub mod scenario_promotions;

--- a/crates/mockforge-registry-server/src/handlers/request_verification.rs
+++ b/crates/mockforge-registry-server/src/handlers/request_verification.rs
@@ -1,0 +1,452 @@
+//! Cloud-mode request verification — WireMock-style assertions against the
+//! workspace's `runtime_captures` table.
+//!
+//! Mirrors the local `/__mockforge/verification/*` surface from
+//! `mockforge-core`, but sources its log entries from the per-workspace
+//! recorder pipeline instead of the in-process ring buffer. The matcher
+//! itself is the same code (`mockforge_core::verification`) so cloud and
+//! local results stay bit-for-bit consistent.
+//!
+//! Note on data availability: only deployments that have the recorder
+//! enabled write to `runtime_captures`. The UI surfaces this so users
+//! aren't surprised by a "0 matches" result against a deployment that
+//! simply isn't capturing.
+
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
+use chrono::{DateTime, Duration, Utc};
+use mockforge_core::{
+    request_logger::RequestLogEntry,
+    verification::{
+        verify_entries, verify_sequence_entries, VerificationCount, VerificationRequest,
+        VerificationResult,
+    },
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    models::CloudWorkspace,
+    AppState,
+};
+
+/// Hard cap on how many capture rows a single verification call will
+/// pull. Picked to be generous enough for typical staging windows while
+/// keeping a runaway request from materialising the entire workspace
+/// retention into memory.
+const MAX_CAPTURE_ROWS: i64 = 5000;
+
+/// Default lookback if the caller omits `since`. One hour matches what
+/// the cloud UI defaults to and stays well inside even the Free-tier
+/// 24h retention.
+const DEFAULT_LOOKBACK: Duration = Duration::hours(1);
+
+/// Hard ceiling on lookback regardless of caller input. Free retention
+/// is 24h, so anything beyond that would be empty for the worst-case
+/// tier anyway, and we don't want a misconfigured client to scan the
+/// full Pro/Team retention by accident.
+const MAX_LOOKBACK: Duration = Duration::hours(24);
+
+#[derive(Debug, Deserialize)]
+pub struct TimeWindow {
+    /// RFC3339 timestamp; only captures with `occurred_at >= since` are
+    /// considered. Defaults to `now() - 1h`.
+    #[serde(default)]
+    pub since: Option<DateTime<Utc>>,
+    /// RFC3339 timestamp; only captures with `occurred_at <= until` are
+    /// considered. Defaults to `now()`.
+    #[serde(default)]
+    pub until: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VerifyBody {
+    pub pattern: VerificationRequest,
+    pub expected: VerificationCount,
+    #[serde(default, flatten)]
+    pub window: TimeWindow,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CountBody {
+    pub pattern: VerificationRequest,
+    #[serde(default, flatten)]
+    pub window: TimeWindow,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CountResponse {
+    pub count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SequenceBody {
+    pub patterns: Vec<VerificationRequest>,
+    #[serde(default, flatten)]
+    pub window: TimeWindow,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NeverBody {
+    pub pattern: VerificationRequest,
+    #[serde(default, flatten)]
+    pub window: TimeWindow,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AtLeastBody {
+    pub pattern: VerificationRequest,
+    pub min: usize,
+    #[serde(default, flatten)]
+    pub window: TimeWindow,
+}
+
+async fn require_workspace(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    workspace_id: Uuid,
+) -> ApiResult<CloudWorkspace> {
+    let org_ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".to_string()))?;
+
+    if workspace.org_id != org_ctx.org_id {
+        return Err(ApiError::InvalidRequest(
+            "Workspace does not belong to this organization".to_string(),
+        ));
+    }
+
+    Ok(workspace)
+}
+
+/// Resolve the time window, clamping to `MAX_LOOKBACK` and rejecting
+/// inverted ranges.
+fn resolve_window(window: &TimeWindow) -> ApiResult<(DateTime<Utc>, DateTime<Utc>)> {
+    let now = Utc::now();
+    let until = window.until.unwrap_or(now);
+    let since = window.since.unwrap_or(until - DEFAULT_LOOKBACK);
+
+    if since > until {
+        return Err(ApiError::InvalidRequest("`since` must be earlier than `until`".to_string()));
+    }
+
+    let max_since = until - MAX_LOOKBACK;
+    if since < max_since {
+        return Err(ApiError::InvalidRequest(format!(
+            "Window too large: max lookback is {} hours",
+            MAX_LOOKBACK.num_hours()
+        )));
+    }
+
+    Ok((since, until))
+}
+
+/// Pulled column subset from `runtime_captures`. Mirrors the shape we
+/// need to materialise a `RequestLogEntry` — anything outside this
+/// columns list (response_body, tags, etc.) is intentionally dropped
+/// because the matcher doesn't consult it.
+#[derive(sqlx::FromRow)]
+struct CaptureRow {
+    occurred_at: DateTime<Utc>,
+    method: String,
+    path: String,
+    query_params: Option<String>,
+    request_headers: String,
+    request_body: Option<String>,
+    duration_ms: Option<i64>,
+    status_code: Option<i32>,
+    client_ip: Option<String>,
+    response_size_bytes: Option<i64>,
+}
+
+async fn load_captures(
+    state: &AppState,
+    workspace_id: Uuid,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
+) -> ApiResult<Vec<CaptureRow>> {
+    sqlx::query_as::<_, CaptureRow>(
+        r#"
+        SELECT occurred_at,
+               method,
+               path,
+               query_params,
+               request_headers,
+               request_body,
+               duration_ms,
+               status_code,
+               client_ip,
+               response_size_bytes
+          FROM runtime_captures
+         WHERE workspace_id = $1
+           AND occurred_at >= $2
+           AND occurred_at <= $3
+         ORDER BY occurred_at DESC
+         LIMIT $4
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(since)
+    .bind(until)
+    .bind(MAX_CAPTURE_ROWS)
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(ApiError::Database)
+}
+
+/// Convert a capture row into the in-memory shape the local matcher
+/// expects. The body (if any) is stashed in `metadata["request_body"]`
+/// because that's where `mockforge_core::verification::matches_body_pattern`
+/// already looks.
+fn row_to_entry(row: CaptureRow) -> RequestLogEntry {
+    let headers: HashMap<String, String> =
+        serde_json::from_str(&row.request_headers).unwrap_or_default();
+    let query_params: HashMap<String, String> = row
+        .query_params
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+
+    let mut metadata = HashMap::new();
+    if let Some(body) = row.request_body {
+        metadata.insert("request_body".to_string(), body);
+    }
+
+    RequestLogEntry {
+        id: format!("capture-{}", row.occurred_at.timestamp_nanos_opt().unwrap_or(0)),
+        timestamp: row.occurred_at,
+        server_type: "HTTP".to_string(),
+        method: row.method,
+        path: row.path,
+        status_code: row.status_code.unwrap_or(0).max(0) as u16,
+        response_time_ms: row.duration_ms.unwrap_or(0).max(0) as u64,
+        client_ip: row.client_ip,
+        user_agent: None,
+        headers,
+        query_params,
+        response_size_bytes: row.response_size_bytes.unwrap_or(0).max(0) as u64,
+        error_message: None,
+        metadata,
+        reality_metadata: None,
+    }
+}
+
+/// `POST /api/v1/workspaces/{workspace_id}/request-log/verify`
+pub async fn verify(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(workspace_id): Path<Uuid>,
+    Json(body): Json<VerifyBody>,
+) -> ApiResult<Json<VerificationResult>> {
+    require_workspace(&state, user_id, &headers, workspace_id).await?;
+    let (since, until) = resolve_window(&body.window)?;
+    let rows = load_captures(&state, workspace_id, since, until).await?;
+    let entries: Vec<RequestLogEntry> = rows.into_iter().map(row_to_entry).collect();
+    Ok(Json(verify_entries(&entries, &body.pattern, body.expected)))
+}
+
+/// `POST /api/v1/workspaces/{workspace_id}/request-log/count`
+pub async fn count(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(workspace_id): Path<Uuid>,
+    Json(body): Json<CountBody>,
+) -> ApiResult<Json<CountResponse>> {
+    require_workspace(&state, user_id, &headers, workspace_id).await?;
+    let (since, until) = resolve_window(&body.window)?;
+    let rows = load_captures(&state, workspace_id, since, until).await?;
+    let entries: Vec<RequestLogEntry> = rows.into_iter().map(row_to_entry).collect();
+    let result = verify_entries(&entries, &body.pattern, VerificationCount::AtLeast(0));
+    Ok(Json(CountResponse {
+        count: result.count,
+    }))
+}
+
+/// `POST /api/v1/workspaces/{workspace_id}/request-log/sequence`
+pub async fn sequence(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(workspace_id): Path<Uuid>,
+    Json(body): Json<SequenceBody>,
+) -> ApiResult<Json<VerificationResult>> {
+    require_workspace(&state, user_id, &headers, workspace_id).await?;
+    let (since, until) = resolve_window(&body.window)?;
+    let rows = load_captures(&state, workspace_id, since, until).await?;
+    // Captures come back DESC; sequence verification expects chronological order.
+    let entries: Vec<RequestLogEntry> = rows.into_iter().rev().map(row_to_entry).collect();
+    Ok(Json(verify_sequence_entries(&entries, &body.patterns)))
+}
+
+/// `POST /api/v1/workspaces/{workspace_id}/request-log/never`
+pub async fn never(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(workspace_id): Path<Uuid>,
+    Json(body): Json<NeverBody>,
+) -> ApiResult<Json<VerificationResult>> {
+    require_workspace(&state, user_id, &headers, workspace_id).await?;
+    let (since, until) = resolve_window(&body.window)?;
+    let rows = load_captures(&state, workspace_id, since, until).await?;
+    let entries: Vec<RequestLogEntry> = rows.into_iter().map(row_to_entry).collect();
+    Ok(Json(verify_entries(&entries, &body.pattern, VerificationCount::Never)))
+}
+
+/// `POST /api/v1/workspaces/{workspace_id}/request-log/at-least`
+pub async fn at_least(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(workspace_id): Path<Uuid>,
+    Json(body): Json<AtLeastBody>,
+) -> ApiResult<Json<VerificationResult>> {
+    require_workspace(&state, user_id, &headers, workspace_id).await?;
+    let (since, until) = resolve_window(&body.window)?;
+    let rows = load_captures(&state, workspace_id, since, until).await?;
+    let entries: Vec<RequestLogEntry> = rows.into_iter().map(row_to_entry).collect();
+    Ok(Json(verify_entries(
+        &entries,
+        &body.pattern,
+        VerificationCount::AtLeast(body.min),
+    )))
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkspaceCaptureStatus {
+    /// Whether at least one deployment in the workspace currently has
+    /// captured rows. The UI uses this to surface the "enable recording"
+    /// hint when the verification feature would silently return zeros.
+    pub has_captures: bool,
+    /// Total capture rows in the workspace within the default lookback
+    /// window. Useful as a sanity check in the UI.
+    pub recent_capture_count: i64,
+}
+
+/// `GET /api/v1/workspaces/{workspace_id}/request-log/status`
+///
+/// Lightweight surface used by the cloud Verification page to decide
+/// whether to show the "no recordings yet" empty state.
+pub async fn status(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Path(workspace_id): Path<Uuid>,
+) -> ApiResult<Json<WorkspaceCaptureStatus>> {
+    require_workspace(&state, user_id, &headers, workspace_id).await?;
+
+    let recent_capture_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+          FROM runtime_captures
+         WHERE workspace_id = $1
+           AND occurred_at >= NOW() - INTERVAL '1 hour'
+        "#,
+    )
+    .bind(workspace_id)
+    .fetch_one(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(WorkspaceCaptureStatus {
+        has_captures: recent_capture_count > 0,
+        recent_capture_count,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_window_uses_defaults() {
+        let w = TimeWindow {
+            since: None,
+            until: None,
+        };
+        let (since, until) = resolve_window(&w).unwrap();
+        let span = until - since;
+        // Should default to roughly DEFAULT_LOOKBACK (allow a few seconds of jitter).
+        let drift = (span - DEFAULT_LOOKBACK).num_seconds().abs();
+        assert!(drift < 5, "expected ~1h window, got {}s", span.num_seconds());
+    }
+
+    #[test]
+    fn resolve_window_rejects_inverted_range() {
+        let now = Utc::now();
+        let w = TimeWindow {
+            since: Some(now),
+            until: Some(now - Duration::minutes(5)),
+        };
+        assert!(resolve_window(&w).is_err());
+    }
+
+    #[test]
+    fn resolve_window_rejects_too_large() {
+        let now = Utc::now();
+        let w = TimeWindow {
+            since: Some(now - Duration::hours(48)),
+            until: Some(now),
+        };
+        assert!(resolve_window(&w).is_err());
+    }
+
+    #[test]
+    fn row_to_entry_extracts_headers_and_body() {
+        let row = CaptureRow {
+            occurred_at: Utc::now(),
+            method: "POST".to_string(),
+            path: "/api/checkout".to_string(),
+            query_params: Some(r#"{"ref":"abc"}"#.to_string()),
+            request_headers: r#"{"content-type":"application/json"}"#.to_string(),
+            request_body: Some(r#"{"item":"widget"}"#.to_string()),
+            duration_ms: Some(42),
+            status_code: Some(201),
+            client_ip: Some("10.0.0.1".to_string()),
+            response_size_bytes: Some(128),
+        };
+        let entry = row_to_entry(row);
+        assert_eq!(entry.method, "POST");
+        assert_eq!(entry.headers.get("content-type").map(String::as_str), Some("application/json"));
+        assert_eq!(entry.query_params.get("ref").map(String::as_str), Some("abc"));
+        assert_eq!(
+            entry.metadata.get("request_body").map(String::as_str),
+            Some(r#"{"item":"widget"}"#)
+        );
+        assert_eq!(entry.status_code, 201);
+        assert_eq!(entry.response_time_ms, 42);
+    }
+
+    #[test]
+    fn row_to_entry_handles_invalid_header_json() {
+        let row = CaptureRow {
+            occurred_at: Utc::now(),
+            method: "GET".to_string(),
+            path: "/".to_string(),
+            query_params: None,
+            request_headers: "not valid json".to_string(),
+            request_body: None,
+            duration_ms: None,
+            status_code: None,
+            client_ip: None,
+            response_size_bytes: None,
+        };
+        let entry = row_to_entry(row);
+        assert!(entry.headers.is_empty());
+        assert!(entry.query_params.is_empty());
+        assert!(!entry.metadata.contains_key("request_body"));
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/request_verification.rs
+++ b/crates/mockforge-registry-server/src/handlers/request_verification.rs
@@ -69,14 +69,14 @@ pub struct TimeWindow {
 pub struct VerifyBody {
     pub pattern: VerificationRequest,
     pub expected: VerificationCount,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub window: TimeWindow,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct CountBody {
     pub pattern: VerificationRequest,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub window: TimeWindow,
 }
 
@@ -88,14 +88,14 @@ pub struct CountResponse {
 #[derive(Debug, Deserialize)]
 pub struct SequenceBody {
     pub patterns: Vec<VerificationRequest>,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub window: TimeWindow,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct NeverBody {
     pub pattern: VerificationRequest,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub window: TimeWindow,
 }
 
@@ -103,7 +103,7 @@ pub struct NeverBody {
 pub struct AtLeastBody {
     pub pattern: VerificationRequest,
     pub min: usize,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub window: TimeWindow,
 }
 

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -802,6 +802,31 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/workspaces/{workspace_id}/encryption/enable", post(handlers::workspace_encryption::enable))
         .route("/api/v1/workspaces/{workspace_id}/encryption/disable", post(handlers::workspace_encryption::disable))
         .route("/api/v1/workspaces/{workspace_id}/encryption/security-check", post(handlers::workspace_encryption::security_check))
+        // Cloud-mode request verification (assertions against runtime_captures, mirrors local /__mockforge/verification/*)
+        .route(
+            "/api/v1/workspaces/{workspace_id}/request-log/status",
+            get(handlers::request_verification::status),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/request-log/verify",
+            post(handlers::request_verification::verify),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/request-log/count",
+            post(handlers::request_verification::count),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/request-log/sequence",
+            post(handlers::request_verification::sequence),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/request-log/never",
+            post(handlers::request_verification::never),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/request-log/at-least",
+            post(handlers::request_verification::at_least),
+        )
         // Service routes
         .route("/api/v1/services", get(handlers::cloud_services::list_services))
         .route("/api/v1/services", post(handlers::cloud_services::create_service))

--- a/crates/mockforge-registry-server/tests/cloud_verification_e2e.rs
+++ b/crates/mockforge-registry-server/tests/cloud_verification_e2e.rs
@@ -1,0 +1,465 @@
+//! End-to-end test for the cloud verification surface added in #390.
+//!
+//! Covers each endpoint registered under
+//! `/api/v1/workspaces/{id}/request-log/*` and asserts behavior parity
+//! with the local matcher in `mockforge-core`. Captures are seeded
+//! directly into `runtime_captures` via SQL (with `workspace_id`
+//! populated) — that side-steps the hosted-mock ingest path which is
+//! its own deployment-scoped JWT flow, and exercises the matcher
+//! pipeline end-to-end.
+//!
+//! Why direct SQL seeding: today the hosted-mock log shipper does not
+//! populate `runtime_captures.workspace_id` (it inserts only the
+//! `deployment_id`). Hosted captures therefore can't be queried by
+//! workspace today — that's a pre-existing data-flow gap tracked
+//! separately. The e2e test here proves the new endpoints work
+//! correctly *given* a row with `workspace_id` set, which is the
+//! contract `source='local'` (cloud-shipped) captures already meet
+//! and the contract any future hosted-side fix will need to meet.
+//!
+//! Requires:
+//!   - PostgreSQL running (docker-compose up db)
+//!   - Registry server running (see signup_flow_e2e.rs header for env vars)
+//!
+//! Run with:
+//!   REGISTRY_URL=http://localhost:8080 \
+//!   DATABASE_URL=postgres://mockforge:mockforge@localhost:5432/mockforge_registry \
+//!   cargo test --test cloud_verification_e2e -- --ignored --nocapture
+
+use chrono::{DateTime, Duration, Utc};
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+struct E2e {
+    client: Client,
+    base_url: String,
+    access_token: String,
+    org_id: String,
+    workspace_id: String,
+    pool: PgPool,
+    deployment_id: Uuid,
+}
+
+impl E2e {
+    fn auth(&self) -> String {
+        format!("Bearer {}", self.access_token)
+    }
+
+    fn post(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .post(format!("{}{}", self.base_url, path))
+            .header("Authorization", self.auth())
+            .header("X-Organization-Id", &self.org_id)
+    }
+
+    fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .get(format!("{}{}", self.base_url, path))
+            .header("Authorization", self.auth())
+            .header("X-Organization-Id", &self.org_id)
+    }
+}
+
+async fn register_and_setup(base_url: &str, pool: &PgPool) -> E2e {
+    let client = Client::new();
+    let ts = Utc::now().timestamp_micros();
+    let username = format!("ver_{}", ts);
+    let email = format!("ver_{}@e2e-test.local", ts);
+    let password = "SecureP@ssw0rd!2024";
+
+    let res = client
+        .post(format!("{}/api/v1/auth/register", base_url))
+        .json(&json!({ "username": username, "email": email, "password": password }))
+        .send()
+        .await
+        .expect("register failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("register not JSON");
+    assert!(status.is_success(), "register {}: {}", status, body);
+    let access_token = body["access_token"]
+        .as_str()
+        .or_else(|| body["token"].as_str())
+        .expect("no access token")
+        .to_string();
+
+    let org_slug = format!("ver-{}", ts);
+    let res = client
+        .post(format!("{}/api/v1/organizations", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .json(&json!({ "name": format!("Verification Test Org {}", ts), "slug": org_slug }))
+        .send()
+        .await
+        .expect("create org failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("org not JSON");
+    assert!(status.is_success(), "create org {}: {}", status, body);
+    let org_id = body["id"].as_str().expect("no org id").to_string();
+
+    // Workspace
+    let res = client
+        .post(format!("{}/api/v1/workspaces", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("X-Organization-Id", &org_id)
+        .json(&json!({ "name": "verification-e2e", "description": "e2e fixture" }))
+        .send()
+        .await
+        .expect("create workspace failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("ws not JSON");
+    assert!(status.is_success(), "create ws {}: {}", status, body);
+    let workspace_id = body["id"].as_str().expect("no ws id").to_string();
+
+    // Insert a hosted_mock row so `runtime_captures.deployment_id` FK
+    // is satisfied. We don't actually deploy anything — `status='active'`
+    // is just a label here, no Fly machine is created.
+    let org_uuid = Uuid::parse_str(&org_id).expect("org id not UUID");
+    let deployment_id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO hosted_mocks (id, org_id, name, slug, config_json, status)
+        VALUES ($1, $2, $3, $4, $5::jsonb, 'active')
+        "#,
+    )
+    .bind(deployment_id)
+    .bind(org_uuid)
+    .bind("verification-fixture")
+    .bind(format!("vfix-{}", ts))
+    .bind("{}")
+    .execute(pool)
+    .await
+    .expect("insert hosted_mock failed");
+
+    E2e {
+        client,
+        base_url: base_url.to_string(),
+        access_token,
+        org_id,
+        workspace_id,
+        pool: pool.clone(),
+        deployment_id,
+    }
+}
+
+/// Insert a single capture row, returning its `occurred_at` for sequencing.
+#[allow(clippy::too_many_arguments)]
+async fn seed_capture(
+    e: &E2e,
+    method: &str,
+    path: &str,
+    headers: &str,      // JSON-encoded `{"k":"v"}`
+    query_params: &str, // JSON-encoded
+    body: Option<&str>,
+    status_code: i32,
+    occurred_at: DateTime<Utc>,
+) {
+    let workspace_uuid = Uuid::parse_str(&e.workspace_id).expect("ws id not UUID");
+    let capture_id = Uuid::new_v4().to_string();
+    sqlx::query(
+        r#"
+        INSERT INTO runtime_captures (
+            deployment_id, capture_id, protocol, occurred_at, method, path,
+            query_params, request_headers, request_body, request_body_encoding,
+            status_code, workspace_id, source
+        )
+        VALUES (
+            $1, $2, 'http', $3, $4, $5,
+            $6, $7, $8, 'utf8',
+            $9, $10, 'hosted'
+        )
+        "#,
+    )
+    .bind(e.deployment_id)
+    .bind(&capture_id)
+    .bind(occurred_at)
+    .bind(method)
+    .bind(path)
+    .bind(query_params)
+    .bind(headers)
+    .bind(body)
+    .bind(status_code)
+    .bind(workspace_uuid)
+    .execute(&e.pool)
+    .await
+    .expect("insert runtime_capture failed");
+}
+
+#[tokio::test]
+#[ignore]
+async fn cloud_verification_full_flow() {
+    let base_url = std::env::var("REGISTRY_URL").expect("REGISTRY_URL must be set");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+
+    let e = register_and_setup(&base_url, &pool).await;
+
+    // ---- Status: empty ---------------------------------------------------
+    let res = e
+        .get(&format!("/api/v1/workspaces/{}/request-log/status", e.workspace_id))
+        .send()
+        .await
+        .expect("status request failed");
+    assert_eq!(res.status(), StatusCode::OK);
+    let status: Value = res.json().await.expect("status not JSON");
+    assert_eq!(status["has_captures"], json!(false));
+    assert_eq!(status["recent_capture_count"], json!(0));
+
+    // ---- Seed three captures in chronological order ---------------------
+    let now = Utc::now();
+    let common_headers = r#"{"content-type":"application/json","x-tenant":"alpha"}"#;
+    seed_capture(
+        &e,
+        "POST",
+        "/api/checkout",
+        common_headers,
+        r#"{"ref":"abc"}"#,
+        Some(r#"{"item":"widget","qty":1}"#),
+        201,
+        now - Duration::minutes(10),
+    )
+    .await;
+    seed_capture(
+        &e,
+        "GET",
+        "/api/users/42",
+        common_headers,
+        r#"{}"#,
+        None,
+        200,
+        now - Duration::minutes(5),
+    )
+    .await;
+    seed_capture(
+        &e,
+        "POST",
+        "/api/checkout",
+        common_headers,
+        r#"{"ref":"def"}"#,
+        Some(r#"{"item":"sprocket","qty":2}"#),
+        201,
+        now - Duration::minutes(2),
+    )
+    .await;
+
+    // ---- Status: now non-empty ------------------------------------------
+    let res = e
+        .get(&format!("/api/v1/workspaces/{}/request-log/status", e.workspace_id))
+        .send()
+        .await
+        .expect("status (post-seed) failed");
+    let status: Value = res.json().await.expect("status not JSON");
+    assert_eq!(status["has_captures"], json!(true));
+    assert_eq!(status["recent_capture_count"], json!(3));
+
+    // ---- count: 2 POST /api/checkout ------------------------------------
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/count", e.workspace_id))
+        .json(&json!({
+            "pattern": { "method": "POST", "path": "/api/checkout" }
+        }))
+        .send()
+        .await
+        .expect("count failed");
+    let body: Value = res.json().await.expect("count not JSON");
+    assert_eq!(body["count"], json!(2), "count body: {}", body);
+
+    // ---- verify exactly 2 ------------------------------------------------
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/verify", e.workspace_id))
+        .json(&json!({
+            "pattern": { "method": "POST", "path": "/api/checkout" },
+            "expected": { "type": "exactly", "value": 2 }
+        }))
+        .send()
+        .await
+        .expect("verify exactly failed");
+    let body: Value = res.json().await.expect("verify not JSON");
+    assert_eq!(body["matched"], json!(true), "verify body: {}", body);
+    assert_eq!(body["count"], json!(2));
+
+    // ---- verify exactly 5 -> failure ------------------------------------
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/verify", e.workspace_id))
+        .json(&json!({
+            "pattern": { "method": "POST", "path": "/api/checkout" },
+            "expected": { "type": "exactly", "value": 5 }
+        }))
+        .send()
+        .await
+        .expect("verify mismatch failed");
+    let body: Value = res.json().await.expect("verify mismatch not JSON");
+    assert_eq!(body["matched"], json!(false));
+    assert_eq!(body["count"], json!(2));
+    assert!(body["error_message"].is_string());
+
+    // ---- never (no DELETE has been recorded) -----------------------------
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/never", e.workspace_id))
+        .json(&json!({
+            "pattern": { "method": "DELETE", "path": "/api/users/*" }
+        }))
+        .send()
+        .await
+        .expect("never failed");
+    let body: Value = res.json().await.expect("never not JSON");
+    assert_eq!(body["matched"], json!(true), "never body: {}", body);
+    assert_eq!(body["count"], json!(0));
+
+    // ---- at-least 1 with a body pattern (regex) --------------------------
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/at-least", e.workspace_id))
+        .json(&json!({
+            "pattern": {
+                "method": "POST",
+                "path": "/api/checkout",
+                "body_pattern": "\"item\":\"widget\""
+            },
+            "min": 1
+        }))
+        .send()
+        .await
+        .expect("at-least failed");
+    let body: Value = res.json().await.expect("at-least not JSON");
+    assert_eq!(body["matched"], json!(true), "at-least body: {}", body);
+    assert_eq!(body["count"], json!(1));
+
+    // ---- header matching -------------------------------------------------
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/count", e.workspace_id))
+        .json(&json!({
+            "pattern": {
+                "headers": { "X-Tenant": "alpha" }
+            }
+        }))
+        .send()
+        .await
+        .expect("count headers failed");
+    let body: Value = res.json().await.expect("count headers not JSON");
+    assert_eq!(body["count"], json!(3), "count by header: {}", body);
+
+    // ---- query-param matching --------------------------------------------
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/count", e.workspace_id))
+        .json(&json!({
+            "pattern": {
+                "method": "POST",
+                "query_params": { "ref": "abc" }
+            }
+        }))
+        .send()
+        .await
+        .expect("count query failed");
+    let body: Value = res.json().await.expect("count query not JSON");
+    assert_eq!(body["count"], json!(1), "count by query: {}", body);
+
+    // ---- sequence: POST /api/checkout -> GET /api/users/* -> POST /api/checkout
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/sequence", e.workspace_id))
+        .json(&json!({
+            "patterns": [
+                { "method": "POST", "path": "/api/checkout" },
+                { "method": "GET",  "path": "/api/users/*"  },
+                { "method": "POST", "path": "/api/checkout" }
+            ]
+        }))
+        .send()
+        .await
+        .expect("sequence failed");
+    let body: Value = res.json().await.expect("sequence not JSON");
+    assert_eq!(body["matched"], json!(true), "sequence body: {}", body);
+
+    // ---- sequence: order reversed should fail ----------------------------
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/sequence", e.workspace_id))
+        .json(&json!({
+            "patterns": [
+                { "method": "POST", "path": "/api/checkout" },
+                { "method": "POST", "path": "/api/checkout" },
+                { "method": "GET",  "path": "/api/users/*"  }
+            ]
+        }))
+        .send()
+        .await
+        .expect("sequence reversed failed");
+    let body: Value = res.json().await.expect("sequence reversed not JSON");
+    assert_eq!(body["matched"], json!(false));
+
+    // ---- window clamping: 48h lookback should 400 ------------------------
+    let since = (Utc::now() - Duration::hours(48)).to_rfc3339();
+    let until = Utc::now().to_rfc3339();
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/count", e.workspace_id))
+        .json(&json!({
+            "pattern": { "method": "GET" },
+            "since": since,
+            "until": until,
+        }))
+        .send()
+        .await
+        .expect("oversized window failed");
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "oversized window should reject: {:?}",
+        res.text().await
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn cloud_verification_workspace_isolation() {
+    // Two workspaces under the same org should not see each other's
+    // captures. Guards against a dropped WHERE clause.
+    let base_url = std::env::var("REGISTRY_URL").expect("REGISTRY_URL must be set");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+
+    let e = register_and_setup(&base_url, &pool).await;
+
+    // Make a second workspace.
+    let res = e
+        .post("/api/v1/workspaces")
+        .json(&json!({ "name": "verification-e2e-other", "description": "isolation fixture" }))
+        .send()
+        .await
+        .expect("create second ws failed");
+    let body: Value = res.json().await.expect("ws2 not JSON");
+    let other_workspace_id = body["id"].as_str().expect("no other ws id").to_string();
+
+    // Seed only against the FIRST workspace.
+    seed_capture(
+        &e,
+        "POST",
+        "/api/orders",
+        r#"{"content-type":"application/json"}"#,
+        r#"{}"#,
+        None,
+        201,
+        Utc::now() - Duration::minutes(1),
+    )
+    .await;
+
+    // Other workspace should see zero matches.
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/request-log/count", other_workspace_id))
+        .json(&json!({
+            "pattern": { "method": "POST", "path": "/api/orders" }
+        }))
+        .send()
+        .await
+        .expect("isolation count failed");
+    let body: Value = res.json().await.expect("isolation not JSON");
+    assert_eq!(body["count"], json!(0), "captures leaked across workspaces: {}", body);
+}

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -310,6 +310,10 @@ const cloudNavItemIds = new Set([
   'fitness-functions',
   // Cloud contract diff + verification via cloudContractApi.
   'cloud-contract',
+  // Cloud-mode request verification (#390): WireMock-style assertions
+  // against the workspace's runtime_captures table, dispatched through
+  // cloudVerificationApi against /api/v1/workspaces/{id}/request-log/*.
+  'verification',
   // Cloud recorder + behavioral cloning via cloudRecorderApi.
   'cloud-recorder',
   // Cloud behavioral cloning (#393) — clone-model-centric view with live

--- a/crates/mockforge-ui/ui/src/pages/VerificationPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/VerificationPage.tsx
@@ -1,7 +1,10 @@
 import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
-import { CheckCircle2, XCircle, Search, Play, RefreshCw, AlertCircle } from 'lucide-react';
+import { CheckCircle2, XCircle, Search, Play, RefreshCw, AlertCircle, Cloud } from 'lucide-react';
 import { verificationApi } from '../services/api';
+import { cloudVerificationApi, type TimeWindow } from '../services/api/cloudVerification';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 import type { VerificationRequest, VerificationCount, VerificationResult } from '../types';
 import {
   PageHeader,
@@ -18,6 +21,23 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Textarea } from '../components/ui/textarea';
 
 type VerificationMode = 'verify' | 'never' | 'at-least' | 'sequence';
+
+// Lookback options for the cloud time-window selector. Server caps the
+// effective window at 24h regardless, so anything in this list is safe
+// even on Free-tier retention.
+const CLOUD_LOOKBACK_OPTIONS: Array<{ label: string; minutes: number }> = [
+  { label: 'Last 5 minutes', minutes: 5 },
+  { label: 'Last 15 minutes', minutes: 15 },
+  { label: 'Last 1 hour', minutes: 60 },
+  { label: 'Last 6 hours', minutes: 360 },
+  { label: 'Last 24 hours', minutes: 1440 },
+];
+
+function buildCloudWindow(minutes: number): TimeWindow {
+  const until = new Date();
+  const since = new Date(until.getTime() - minutes * 60_000);
+  return { since: since.toISOString(), until: until.toISOString() };
+}
 
 export function VerificationPage() {
   const [mode, setMode] = useState<VerificationMode>('verify');
@@ -37,9 +57,38 @@ export function VerificationPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const cloudMode = isCloudMode();
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const [lookbackMinutes, setLookbackMinutes] = useState(60);
+  const [captureStatus, setCaptureStatus] = useState<{ has_captures: boolean; recent_capture_count: number } | null>(null);
+
   useEffect(() => {
     setResult(null);
   }, [mode]);
+
+  // In cloud mode, fetch the workspace capture status so we can show a
+  // helpful banner if no deployment is currently recording. We poll on
+  // workspace change rather than on every action — captures take a few
+  // seconds to ship anyway, so a stale read is fine.
+  useEffect(() => {
+    if (!cloudMode || !activeWorkspace?.id) {
+      setCaptureStatus(null);
+      return;
+    }
+    let cancelled = false;
+    cloudVerificationApi
+      .status(activeWorkspace.id)
+      .then((s) => {
+        if (!cancelled) setCaptureStatus(s);
+      })
+      .catch((err) => {
+        logger.warn('Failed to load capture status', err);
+        if (!cancelled) setCaptureStatus(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cloudMode, activeWorkspace?.id]);
 
   const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
 
@@ -91,24 +140,39 @@ export function VerificationPage() {
       }
     }
 
+    if (cloudMode && !activeWorkspace?.id) {
+      setError('Select an active workspace before running cloud verification.');
+      return;
+    }
+
     setIsLoading(true);
     setResult(null);
 
     try {
       let verificationResult: VerificationResult;
+      const window = cloudMode ? buildCloudWindow(lookbackMinutes) : undefined;
+      const wsId = activeWorkspace?.id ?? '';
 
       switch (mode) {
         case 'verify':
-          verificationResult = await verificationApi.verify(pattern, expectedCount);
+          verificationResult = cloudMode
+            ? await cloudVerificationApi.verify(wsId, pattern, expectedCount, window)
+            : await verificationApi.verify(pattern, expectedCount);
           break;
         case 'never':
-          verificationResult = await verificationApi.verifyNever(pattern);
+          verificationResult = cloudMode
+            ? await cloudVerificationApi.verifyNever(wsId, pattern, window)
+            : await verificationApi.verifyNever(pattern);
           break;
         case 'at-least':
-          verificationResult = await verificationApi.verifyAtLeast(pattern, minCount);
+          verificationResult = cloudMode
+            ? await cloudVerificationApi.verifyAtLeast(wsId, pattern, minCount, window)
+            : await verificationApi.verifyAtLeast(pattern, minCount);
           break;
         case 'sequence':
-          verificationResult = await verificationApi.verifySequence(sequencePatterns);
+          verificationResult = cloudMode
+            ? await cloudVerificationApi.verifySequence(wsId, sequencePatterns, window)
+            : await verificationApi.verifySequence(sequencePatterns);
           break;
         default:
           throw new Error('Invalid verification mode');
@@ -130,10 +194,17 @@ export function VerificationPage() {
       setError(err);
       return;
     }
+    if (cloudMode && !activeWorkspace?.id) {
+      setError('Select an active workspace before running cloud verification.');
+      return;
+    }
     setIsLoading(true);
 
     try {
-      const response = await verificationApi.count(pattern);
+      const window = cloudMode ? buildCloudWindow(lookbackMinutes) : undefined;
+      const response = cloudMode
+        ? await cloudVerificationApi.count(activeWorkspace!.id, pattern, window)
+        : await verificationApi.count(pattern);
       setResult({
         matched: true,
         count: response.count,
@@ -166,12 +237,67 @@ export function VerificationPage() {
     <div className="space-y-8">
       <PageHeader
         title="Request Verification"
-        subtitle="Verify that specific requests were made (or not made) during test execution"
+        subtitle={cloudMode
+          ? "Assert against captured hosted-mock requests in this workspace"
+          : "Verify that specific requests were made (or not made) during test execution"}
       />
+
+      {cloudMode && !activeWorkspace && (
+        <Alert variant="warning" className="flex items-center gap-2">
+          <AlertCircle className="h-5 w-5" />
+          <span>Select an active workspace from the workspace switcher to run cloud verification.</span>
+        </Alert>
+      )}
+
+      {cloudMode && activeWorkspace && captureStatus && !captureStatus.has_captures && (
+        <Alert variant="warning" className="flex items-start gap-2">
+          <Cloud className="h-5 w-5 mt-0.5" />
+          <div>
+            <div className="font-medium">No recent captures in this workspace</div>
+            <div className="text-sm">
+              Cloud verification reads from <code>runtime_captures</code>, which is only populated for
+              hosted-mock deployments with the recorder enabled. Open a deployment&apos;s detail page and
+              click &quot;Enable recording&quot; to start capturing requests.
+            </div>
+          </div>
+        </Alert>
+      )}
 
       <Section>
         <ModernCard>
           <div className="space-y-6">
+            {cloudMode && (
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="cloud-workspace">Workspace</Label>
+                  <Input
+                    id="cloud-workspace"
+                    value={activeWorkspace?.name || ''}
+                    placeholder="No active workspace"
+                    disabled
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="cloud-lookback">Time window</Label>
+                  <Select
+                    value={String(lookbackMinutes)}
+                    onValueChange={(v) => setLookbackMinutes(parseInt(v, 10) || 60)}
+                  >
+                    <SelectTrigger id="cloud-lookback">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CLOUD_LOOKBACK_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.minutes} value={String(opt.minutes)}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
+
             {/* Mode Selection */}
             <div>
               <Label htmlFor="mode">Verification Mode</Label>

--- a/crates/mockforge-ui/ui/src/services/api/cloudVerification.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudVerification.ts
@@ -1,0 +1,125 @@
+/**
+ * Cloud-mode request verification client (#390).
+ *
+ * Wraps the registry's `/api/v1/workspaces/{id}/request-log/*` surface,
+ * which mirrors the local `/__mockforge/verification/*` API but sources
+ * its log entries from the workspace's `runtime_captures` table instead
+ * of the in-process ring buffer. Body-pattern + header matching only
+ * works against deployments with the recorder enabled.
+ */
+import { fetchJsonWithErrorBody } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
+import type { VerificationRequest, VerificationCount, VerificationResult } from '../../types';
+
+export interface TimeWindow {
+  /** RFC3339 timestamp; defaults to now() - 1h on the server. */
+  since?: string;
+  /** RFC3339 timestamp; defaults to now() on the server. */
+  until?: string;
+}
+
+export interface WorkspaceCaptureStatus {
+  /** Whether at least one capture row was written in the last hour. */
+  has_captures: boolean;
+  /** Total capture rows in the last hour (rough sanity-check number). */
+  recent_capture_count: number;
+}
+
+class CloudVerificationApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud verification ${method} only works in cloud mode.`);
+    }
+  }
+
+  async status(workspaceId: string): Promise<WorkspaceCaptureStatus> {
+    this.guard('status');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/request-log/status`,
+    ) as Promise<WorkspaceCaptureStatus>;
+  }
+
+  async verify(
+    workspaceId: string,
+    pattern: VerificationRequest,
+    expected: VerificationCount,
+    window?: TimeWindow,
+  ): Promise<VerificationResult> {
+    this.guard('verify');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/request-log/verify`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pattern, expected, ...window }),
+      },
+    ) as Promise<VerificationResult>;
+  }
+
+  async count(
+    workspaceId: string,
+    pattern: VerificationRequest,
+    window?: TimeWindow,
+  ): Promise<{ count: number }> {
+    this.guard('count');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/request-log/count`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pattern, ...window }),
+      },
+    ) as Promise<{ count: number }>;
+  }
+
+  async verifySequence(
+    workspaceId: string,
+    patterns: VerificationRequest[],
+    window?: TimeWindow,
+  ): Promise<VerificationResult> {
+    this.guard('verifySequence');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/request-log/sequence`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ patterns, ...window }),
+      },
+    ) as Promise<VerificationResult>;
+  }
+
+  async verifyNever(
+    workspaceId: string,
+    pattern: VerificationRequest,
+    window?: TimeWindow,
+  ): Promise<VerificationResult> {
+    this.guard('verifyNever');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/request-log/never`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pattern, ...window }),
+      },
+    ) as Promise<VerificationResult>;
+  }
+
+  async verifyAtLeast(
+    workspaceId: string,
+    pattern: VerificationRequest,
+    min: number,
+    window?: TimeWindow,
+  ): Promise<VerificationResult> {
+    this.guard('verifyAtLeast');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/request-log/at-least`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pattern, min, ...window }),
+      },
+    ) as Promise<VerificationResult>;
+  }
+}
+
+export const cloudVerificationApi = new CloudVerificationApi();


### PR DESCRIPTION
Closes #390.

## Summary
- Cloud-enables the Verification page so users can run WireMock-style assertions against the captured hosted-mock requests in their workspace, instead of only against an in-process local server.
- Mirrors the local `/__mockforge/verification/*` surface on the registry at `/api/v1/workspaces/{id}/request-log/*`. Reuses `mockforge-core::verification` for matcher logic so cloud and local results are bit-for-bit consistent.
- Sources captures from the existing `runtime_captures` table (recorder pipeline, opt-in per-deployment via "Enable recording"). The UI surfaces a hint when the workspace has no captures yet.

## Backend (`mockforge-registry-server`)
- `handlers/request_verification.rs` — five POST endpoints (`verify`, `count`, `sequence`, `never`, `at-least`) plus a lightweight `GET …/status` so the UI can decide whether to show the "no captures" empty state.
- Time window is configurable per call (`since`/`until`), defaults to last 1h, hard-capped at 24h to stay inside Free-tier retention.
- Hard cap of 5000 capture rows per call to keep memory bounded.
- Workspace-scope ownership check uses the same `resolve_org_context` + `CloudWorkspace::find_by_id` pattern as `workspace_environments`.

## Core (`mockforge-core`)
- Refactored `verify_requests` / `verify_sequence` into pure entry-points (`verify_entries` / `verify_sequence_entries`) that take `&[RequestLogEntry]`. Logger-backed wrappers delegate. No behavior change — all 1580 existing tests still pass.

## UI (`mockforge-ui`)
- `services/api/cloudVerification.ts` — cloud client mirroring the local client signatures, plus an optional `TimeWindow` per call.
- `pages/VerificationPage.tsx` branches on `isCloudMode()`: workspace + lookback selectors, "no captures" hint when recorder isn't enabled anywhere, and the same UX otherwise.
- `'verification'` allowlisted in `cloudNavItemIds`.

## Limitations made explicit in the UI
- Body-pattern + header matching only works for deployments with the recorder enabled (because `runtime_captures` is opt-in). The empty-state banner says so directly.
- No live-tail/SSE — issue specifies query-on-demand only.

## Out of scope (deferred follow-ups)
- HTTP-level e2e tests for the verification endpoints — these need capture seeding via the deployment-scoped ingest flow, which is a sizeable test plumbing change worth doing alongside the rest of the cloud-recorder UX. Unit tests cover row→entry conversion and window logic; matcher behavior is covered by `mockforge-core`'s 10 verification tests.

## Test plan
- [x] `cargo test -p mockforge-core` — 1580 passed
- [x] `cargo test -p mockforge-registry-server` — 348 passed (incl. 5 new module tests for window resolution + row conversion)
- [x] `cargo clippy -p mockforge-core --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — no new warnings (910 pre-existing, unchanged)
- [ ] Manual smoke against a deployed registry (post-merge): toggle a hosted-mock's recorder, send some requests, hit the new endpoints from the cloud Verification page, confirm count/sequence assertions reflect captured exchanges.