### PR TITLE
feat(chaos): wire all FaultConfig fields through YAML loader (#79) → 0.3.129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.3.129] - 2026-05-09
+
+### Added
+
+- **[Reality]** YAML config now exposes every chaos `fault_injection` field (#79 follow-up)
+  - `mockforge_core::config::FaultConfig` gains the fields it was missing relative to `mockforge_chaos::config::FaultInjectionConfig`: `connection_error_kind` (`http_503` / `tcp_reset` / `tcp_close`), `partial_responses` + `partial_response_probability`, `payload_corruption` + `payload_corruption_probability`, `corruption_type` (`none` / `random_bytes` / `truncate` / `bit_flip`), `error_pattern` (Burst / Random / Sequential), `mockai_enabled`, and `request_matcher` (source IPs, headers, body-size bounds, chunked-only). All new fields use `#[serde(default)]` so existing chaos.yaml files continue to parse unchanged.
+  - The bridge in `serve.rs` (`fault_config_to_chaos`) now maps every field through to the chaos crate's runtime `FaultInjectionConfig`. Previously `--config chaos.yaml` set them to defaults silently and operators had to use the `PUT /api/chaos/config/faults` REST API to configure them.
+  - Tests cover round-trip parsing of the full YAML shape from the issue-#79 reply, backward-compat parsing of legacy YAML without the new fields, snake_case enum encoding, and end-to-end bridge preservation of every new field.
+
 ## [0.3.128] - 2026-05-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7652,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7862,7 +7862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7883,7 +7883,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7954,7 +7954,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7987,7 +7987,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8090,7 +8090,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8171,7 +8171,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8250,7 +8250,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8297,7 +8297,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8312,7 +8312,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8334,7 +8334,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8361,7 +8361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8386,7 +8386,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8552,7 +8552,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8573,7 +8573,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8650,7 +8650,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8675,7 +8675,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8689,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8722,7 +8722,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8862,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8884,7 +8884,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8949,7 +8949,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8979,7 +8979,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9006,7 +9006,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9030,14 +9030,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9064,7 +9064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9075,7 +9075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9096,7 +9096,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9137,7 +9137,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9168,7 +9168,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -14969,7 +14969,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.128"
+version = "0.3.129"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,13 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.129] - 2026-05-09
+
+### Added
+
+- **[Reality]** YAML config now exposes every chaos `fault_injection` field (#79 follow-up)
+  - `mockforge_core::config::FaultConfig` gains `connection_error_kind`, `partial_responses` + `partial_response_probability`, `payload_corruption` + `payload_corruption_probability`, `corruption_type`, `error_pattern` (Burst / Random / Sequential), `mockai_enabled`, and `request_matcher`. All `#[serde(default)]` so existing chaos.yaml files keep parsing.
+  - The bridge in `serve.rs` now maps every field through to `mockforge_chaos::config::FaultInjectionConfig`; previously these were silently defaulted at YAML load time and only the `PUT /api/chaos/config/faults` REST API could set them.
+
 ## [0.3.128] - 2026-05-09
 
 ### Fixed

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -407,6 +407,7 @@ pub(crate) async fn build_server_config_from_cli(serve_args: &ServeArgs) -> Serv
                 timeout_errors: false,
                 timeout_ms: 30000,
                 timeout_probability: 0.0,
+                ..Default::default()
             });
         }
 
@@ -1723,27 +1724,7 @@ pub async fn handle_serve(
                     probability: l.probability,
                 }
             }),
-            fault_injection: chaos_eng_config.fault_injection.as_ref().map(|f| {
-                mockforge_chaos::config::FaultInjectionConfig {
-                    enabled: f.enabled,
-                    http_errors: f.http_errors.clone(),
-                    http_error_probability: f.http_error_probability,
-                    connection_errors: f.connection_errors,
-                    connection_error_probability: f.connection_error_probability,
-                    connection_error_kind: mockforge_chaos::config::ConnectionErrorKind::Http503,
-                    timeout_errors: f.timeout_errors,
-                    timeout_ms: f.timeout_ms,
-                    timeout_probability: f.timeout_probability,
-                    partial_responses: false,
-                    partial_response_probability: 0.0,
-                    payload_corruption: false,
-                    payload_corruption_probability: 0.0,
-                    corruption_type: mockforge_chaos::config::CorruptionType::None,
-                    error_pattern: None,
-                    mockai_enabled: false,
-                    request_matcher: None,
-                }
-            }),
+            fault_injection: chaos_eng_config.fault_injection.as_ref().map(fault_config_to_chaos),
             rate_limit: chaos_eng_config.rate_limit.as_ref().map(|r| {
                 mockforge_chaos::config::RateLimitConfig {
                     enabled: r.enabled,
@@ -3016,5 +2997,161 @@ pub async fn handle_serve(
         Err(error.into())
     } else {
         Ok(())
+    }
+}
+
+/// Convert YAML-loaded `mockforge_core::config::FaultConfig` into the chaos
+/// crate's runtime `FaultInjectionConfig`. Issue #79 follow-up: prior to this,
+/// the new fields (`connection_error_kind`, `request_matcher`,
+/// `partial_responses`, `payload_corruption`, `error_pattern`) were hardcoded
+/// to defaults during the bridge — only the runtime REST API (`PUT
+/// /api/chaos/config/faults`) could set them. They now flow from `--config`.
+fn fault_config_to_chaos(
+    f: &mockforge_core::config::FaultConfig,
+) -> mockforge_chaos::config::FaultInjectionConfig {
+    use mockforge_chaos::config::{
+        ConnectionErrorKind, CorruptionType, ErrorPattern, FaultInjectionConfig,
+    };
+    use mockforge_chaos::request_matcher::{HeaderMatch, RequestMatcher};
+    use mockforge_core::config::{
+        ConnectionErrorKindConfig, CorruptionTypeConfig, ErrorPatternConfig,
+    };
+    FaultInjectionConfig {
+        enabled: f.enabled,
+        http_errors: f.http_errors.clone(),
+        http_error_probability: f.http_error_probability,
+        connection_errors: f.connection_errors,
+        connection_error_probability: f.connection_error_probability,
+        connection_error_kind: match f.connection_error_kind {
+            ConnectionErrorKindConfig::Http503 => ConnectionErrorKind::Http503,
+            ConnectionErrorKindConfig::TcpReset => ConnectionErrorKind::TcpReset,
+            ConnectionErrorKindConfig::TcpClose => ConnectionErrorKind::TcpClose,
+        },
+        timeout_errors: f.timeout_errors,
+        timeout_ms: f.timeout_ms,
+        timeout_probability: f.timeout_probability,
+        partial_responses: f.partial_responses,
+        partial_response_probability: f.partial_response_probability,
+        payload_corruption: f.payload_corruption,
+        payload_corruption_probability: f.payload_corruption_probability,
+        corruption_type: match f.corruption_type {
+            CorruptionTypeConfig::None => CorruptionType::None,
+            CorruptionTypeConfig::RandomBytes => CorruptionType::RandomBytes,
+            CorruptionTypeConfig::Truncate => CorruptionType::Truncate,
+            CorruptionTypeConfig::BitFlip => CorruptionType::BitFlip,
+        },
+        error_pattern: f.error_pattern.as_ref().map(|p| match p {
+            ErrorPatternConfig::Burst { count, interval_ms } => ErrorPattern::Burst {
+                count: *count,
+                interval_ms: *interval_ms,
+            },
+            ErrorPatternConfig::Random { probability } => ErrorPattern::Random {
+                probability: *probability,
+            },
+            ErrorPatternConfig::Sequential { sequence } => ErrorPattern::Sequential {
+                sequence: sequence.clone(),
+            },
+        }),
+        mockai_enabled: f.mockai_enabled,
+        request_matcher: f.request_matcher.as_ref().map(|m| RequestMatcher {
+            source_ips: m.source_ips.clone(),
+            headers: m
+                .headers
+                .iter()
+                .map(|h| HeaderMatch {
+                    name: h.name.clone(),
+                    value: h.value.clone(),
+                })
+                .collect(),
+            min_body_size_bytes: m.min_body_size_bytes,
+            max_body_size_bytes: m.max_body_size_bytes,
+            chunked_only: m.chunked_only,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod chaos_yaml_bridge_tests {
+    use super::*;
+    use mockforge_chaos::config::{ConnectionErrorKind, CorruptionType, ErrorPattern};
+    use mockforge_core::config::{
+        ConnectionErrorKindConfig, CorruptionTypeConfig, ErrorPatternConfig, FaultConfig,
+        HeaderMatchConfig, RequestMatcherConfig,
+    };
+
+    /// Issue #79 follow-up: the bridge that runs at server startup must
+    /// preserve every YAML-loadable field, not silently default new fields
+    /// to their no-op values like the previous version did.
+    #[test]
+    fn bridge_preserves_every_new_field() {
+        let yaml = FaultConfig {
+            enabled: true,
+            http_errors: vec![503],
+            http_error_probability: 0.5,
+            connection_errors: true,
+            connection_error_probability: 0.05,
+            connection_error_kind: ConnectionErrorKindConfig::TcpReset,
+            timeout_errors: true,
+            timeout_ms: 30000,
+            timeout_probability: 0.1,
+            partial_responses: true,
+            partial_response_probability: 0.2,
+            payload_corruption: true,
+            payload_corruption_probability: 0.07,
+            corruption_type: CorruptionTypeConfig::BitFlip,
+            error_pattern: Some(ErrorPatternConfig::Burst {
+                count: 5,
+                interval_ms: 1000,
+            }),
+            mockai_enabled: false,
+            request_matcher: Some(RequestMatcherConfig {
+                source_ips: vec!["10.0.0.0/8".into(), "192.168.1.42".into()],
+                headers: vec![HeaderMatchConfig {
+                    name: "x-test".into(),
+                    value: Some("yes".into()),
+                }],
+                min_body_size_bytes: Some(1_048_576),
+                max_body_size_bytes: None,
+                chunked_only: Some(true),
+            }),
+        };
+
+        let bridged = fault_config_to_chaos(&yaml);
+
+        assert!(bridged.enabled);
+        assert_eq!(bridged.connection_error_kind, ConnectionErrorKind::TcpReset);
+        assert!(bridged.partial_responses);
+        assert_eq!(bridged.partial_response_probability, 0.2);
+        assert!(bridged.payload_corruption);
+        assert_eq!(bridged.corruption_type, CorruptionType::BitFlip);
+        match bridged.error_pattern.as_ref().expect("error_pattern present") {
+            ErrorPattern::Burst { count, interval_ms } => {
+                assert_eq!(*count, 5);
+                assert_eq!(*interval_ms, 1000);
+            }
+            other => panic!("expected Burst, got {other:?}"),
+        }
+        let m = bridged.request_matcher.expect("matcher present");
+        assert_eq!(m.source_ips, vec!["10.0.0.0/8", "192.168.1.42"]);
+        assert_eq!(m.headers.len(), 1);
+        assert_eq!(m.headers[0].name, "x-test");
+        assert_eq!(m.headers[0].value.as_deref(), Some("yes"));
+        assert_eq!(m.min_body_size_bytes, Some(1_048_576));
+        assert_eq!(m.chunked_only, Some(true));
+    }
+
+    /// Default `FaultConfig` (e.g., when the user omits new fields) must bridge
+    /// to the same shape the pre-fix code produced — preserves back-compat for
+    /// existing chaos.yaml files.
+    #[test]
+    fn bridge_default_matches_legacy_behavior() {
+        let bridged = fault_config_to_chaos(&FaultConfig::default());
+        assert_eq!(bridged.connection_error_kind, ConnectionErrorKind::Http503);
+        assert!(!bridged.partial_responses);
+        assert_eq!(bridged.partial_response_probability, 0.0);
+        assert!(!bridged.payload_corruption);
+        assert_eq!(bridged.corruption_type, CorruptionType::None);
+        assert!(bridged.error_pattern.is_none());
+        assert!(bridged.request_matcher.is_none());
     }
 }

--- a/crates/mockforge-core/src/config/operational.rs
+++ b/crates/mockforge-core/src/config/operational.rs
@@ -1150,26 +1150,163 @@ pub struct LatencyInjectionConfig {
     pub probability: f64,
 }
 
-/// Fault injection configuration for chaos engineering
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// What "connection error" means at the wire level when injected.
+///
+/// Mirrors `mockforge_chaos::config::ConnectionErrorKind` so the YAML
+/// loader can stay dep-free of the chaos crate. The bridge in `serve.rs`
+/// converts to the chaos type at runtime.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ConnectionErrorKindConfig {
+    /// HTTP 503 on a healthy connection (default, back-compat).
+    #[default]
+    Http503,
+    /// TCP RST at accept time (`SO_LINGER=0` + drop).
+    TcpReset,
+    /// TCP FIN at accept time (clean drop, client sees EOF).
+    TcpClose,
+}
+
+/// Payload corruption type. Mirrors `mockforge_chaos::config::CorruptionType`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum CorruptionTypeConfig {
+    /// No corruption.
+    #[default]
+    None,
+    /// Replace random bytes with random values.
+    RandomBytes,
+    /// Truncate payload at random position.
+    Truncate,
+    /// Flip random bits in the payload.
+    BitFlip,
+}
+
+/// Error injection pattern. Mirrors `mockforge_chaos::config::ErrorPattern`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ErrorPatternConfig {
+    /// Burst pattern: inject N errors within a time interval.
+    Burst {
+        /// Number of errors to inject in the burst.
+        count: usize,
+        /// Time interval in milliseconds for the burst.
+        interval_ms: u64,
+    },
+    /// Random pattern: inject errors with a probability.
+    Random {
+        /// Probability of injecting an error (0.0-1.0).
+        probability: f64,
+    },
+    /// Sequential pattern: inject errors in a specific sequence.
+    Sequential {
+        /// Sequence of status codes to inject in order.
+        sequence: Vec<u16>,
+    },
+}
+
+/// Header presence / exact-value filter for the request matcher.
+/// Mirrors `mockforge_chaos::request_matcher::HeaderMatch`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct HeaderMatchConfig {
+    /// Header name (case-insensitive).
+    pub name: String,
+    /// Optional exact value. `None` = match on presence only.
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
+/// Per-request matcher gating chaos injection.
+/// Mirrors `mockforge_chaos::request_matcher::RequestMatcher`.
+///
+/// AND across populated fields; within a list, OR. Empty matcher = match all.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RequestMatcherConfig {
+    /// CIDR ranges to match against the client IP. A bare IP without prefix
+    /// is treated as `/32` (v4) or `/128` (v6). Empty = match any IP.
+    #[serde(default)]
+    pub source_ips: Vec<String>,
+    /// Required headers. All entries must be satisfied (AND across the list).
+    #[serde(default)]
+    pub headers: Vec<HeaderMatchConfig>,
+    /// Minimum request body size in bytes (inclusive).
+    #[serde(default)]
+    pub min_body_size_bytes: Option<usize>,
+    /// Maximum request body size in bytes (inclusive).
+    #[serde(default)]
+    pub max_body_size_bytes: Option<usize>,
+    /// `Some(true)` matches only chunked requests, `Some(false)` only
+    /// non-chunked, `None` matches either.
+    #[serde(default)]
+    pub chunked_only: Option<bool>,
+}
+
+/// Fault injection configuration for chaos engineering.
+///
+/// Field set mirrors `mockforge_chaos::config::FaultInjectionConfig` so that
+/// `--config chaos.yaml` can configure every fault knob the chaos middleware
+/// understands. The bridge in `serve.rs` converts this to the chaos crate's
+/// type at runtime.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct FaultConfig {
-    /// Enable fault injection
+    /// Enable fault injection.
     pub enabled: bool,
-    /// HTTP status codes to randomly return (e.g., [500, 502, 503])
+    /// HTTP status codes to randomly return (e.g., `[500, 502, 503]`).
     pub http_errors: Vec<u16>,
-    /// Probability of returning HTTP errors (0.0 to 1.0)
+    /// Probability of returning HTTP errors (0.0 to 1.0).
     pub http_error_probability: f64,
-    /// Enable connection errors (connection refused, reset, etc.)
+    /// Enable connection errors.
     pub connection_errors: bool,
-    /// Probability of connection errors (0.0 to 1.0)
+    /// Probability of connection errors (0.0 to 1.0).
     pub connection_error_probability: f64,
-    /// Enable timeout errors
+    /// What "connection error" means at the wire level — HTTP 503 (default,
+    /// back-compat), TCP RST, or TCP FIN. The TCP variants require the chaos
+    /// listener wrapper, which the bridge installs automatically when
+    /// connection_errors is enabled and this is `tcp_reset` / `tcp_close`.
+    #[serde(default)]
+    pub connection_error_kind: ConnectionErrorKindConfig,
+    /// Enable timeout errors.
     pub timeout_errors: bool,
-    /// Timeout duration in milliseconds
+    /// Timeout duration in milliseconds.
     pub timeout_ms: u64,
-    /// Probability of timeout errors (0.0 to 1.0)
+    /// Probability of timeout errors (0.0 to 1.0).
     pub timeout_probability: f64,
+    /// Enable partial-response truncation. Non-chunked responses keep the
+    /// original `Content-Length` so clients see an unexpected EOF; chunked
+    /// responses end without the terminating `0\r\n\r\n`.
+    #[serde(default)]
+    pub partial_responses: bool,
+    /// Probability of truncating a response (0.0 to 1.0).
+    #[serde(default)]
+    pub partial_response_probability: f64,
+    /// Enable payload corruption (post-response, before send).
+    #[serde(default)]
+    pub payload_corruption: bool,
+    /// Probability of corrupting a response payload (0.0 to 1.0).
+    #[serde(default)]
+    pub payload_corruption_probability: f64,
+    /// Type of corruption to apply when `payload_corruption` fires.
+    #[serde(default)]
+    pub corruption_type: CorruptionTypeConfig,
+    /// Optional structured pattern for error injection (Burst / Random /
+    /// Sequential). When `None`, the per-fault probabilities above govern
+    /// firing independently.
+    #[serde(default)]
+    pub error_pattern: Option<ErrorPatternConfig>,
+    /// Enable MockAI-driven dynamic error generation (advanced).
+    #[serde(default)]
+    pub mockai_enabled: bool,
+    /// Optional per-request matcher. When set, faults only fire for
+    /// requests that match (AND across populated fields). `None` = always.
+    #[serde(default)]
+    pub request_matcher: Option<RequestMatcherConfig>,
 }
 
 /// Rate limiting configuration for traffic control
@@ -1200,4 +1337,107 @@ pub struct NetworkShapingConfig {
     pub packet_loss_percent: f64,
     /// Maximum concurrent connections allowed
     pub max_connections: u32,
+}
+
+#[cfg(test)]
+mod fault_config_yaml_tests {
+    use super::*;
+
+    /// The YAML shape promised in the issue-#79 reply must round-trip cleanly,
+    /// including the new fields (`request_matcher`, `connection_error_kind`,
+    /// `partial_responses`, `payload_corruption`, `error_pattern`).
+    #[test]
+    fn full_yaml_roundtrip() {
+        let yaml = r#"
+enabled: true
+http_errors: [503]
+http_error_probability: 0.5
+connection_errors: true
+connection_error_probability: 0.05
+connection_error_kind: tcp_reset
+timeout_errors: true
+timeout_ms: 30000
+timeout_probability: 0.1
+partial_responses: true
+partial_response_probability: 0.1
+payload_corruption: true
+payload_corruption_probability: 0.05
+corruption_type: bit_flip
+error_pattern:
+  type: burst
+  count: 5
+  interval_ms: 1000
+mockai_enabled: false
+request_matcher:
+  source_ips: ["10.0.0.0/8", "192.168.1.42"]
+  headers:
+    - name: x-test
+      value: yes
+    - name: x-debug
+  min_body_size_bytes: 1048576
+  chunked_only: true
+"#;
+        let parsed: FaultConfig = serde_yaml::from_str(yaml).expect("parse YAML");
+        assert!(parsed.enabled);
+        assert_eq!(parsed.http_errors, vec![503]);
+        assert_eq!(parsed.connection_error_kind, ConnectionErrorKindConfig::TcpReset);
+        assert!(parsed.partial_responses);
+        assert_eq!(parsed.partial_response_probability, 0.1);
+        assert!(parsed.payload_corruption);
+        assert_eq!(parsed.corruption_type, CorruptionTypeConfig::BitFlip);
+        match parsed.error_pattern.as_ref().expect("error_pattern present") {
+            ErrorPatternConfig::Burst { count, interval_ms } => {
+                assert_eq!(*count, 5);
+                assert_eq!(*interval_ms, 1000);
+            }
+            other => panic!("expected Burst, got {other:?}"),
+        }
+        let m = parsed.request_matcher.expect("matcher present");
+        assert_eq!(m.source_ips, vec!["10.0.0.0/8", "192.168.1.42"]);
+        assert_eq!(m.headers.len(), 2);
+        assert_eq!(m.headers[0].name, "x-test");
+        // YAML `yes` parses as bool true; serde-yaml puts it back as the
+        // string "true" when typed as Option<String>. The exact value is
+        // implementation-dependent; assert it's *some* non-empty value.
+        assert!(m.headers[0].value.as_deref().is_some_and(|s| !s.is_empty()));
+        assert!(m.headers[1].value.is_none());
+        assert_eq!(m.min_body_size_bytes, Some(1048576));
+        assert_eq!(m.chunked_only, Some(true));
+    }
+
+    /// Backward-compat: a YAML file written for the old (pre-0.3.129) FaultConfig
+    /// must still parse without listing any of the new fields.
+    #[test]
+    fn legacy_yaml_without_new_fields_still_parses() {
+        let yaml = r#"
+enabled: true
+http_errors: [500, 502, 503]
+http_error_probability: 0.1
+connection_errors: false
+connection_error_probability: 0.0
+timeout_errors: false
+timeout_ms: 5000
+timeout_probability: 0.0
+"#;
+        let parsed: FaultConfig = serde_yaml::from_str(yaml).expect("parse legacy YAML");
+        assert!(parsed.enabled);
+        assert_eq!(parsed.http_errors, vec![500, 502, 503]);
+        // New fields default cleanly.
+        assert_eq!(parsed.connection_error_kind, ConnectionErrorKindConfig::Http503);
+        assert!(!parsed.partial_responses);
+        assert!(!parsed.payload_corruption);
+        assert!(parsed.error_pattern.is_none());
+        assert!(parsed.request_matcher.is_none());
+    }
+
+    /// The connection_error_kind enum must serialize as snake_case strings
+    /// (not the Rust variant name) for YAML compatibility with the chaos crate's
+    /// own enum. Same for corruption_type.
+    #[test]
+    fn enum_serde_uses_snake_case() {
+        let cek = ConnectionErrorKindConfig::TcpClose;
+        assert_eq!(serde_yaml::to_string(&cek).unwrap().trim(), "tcp_close");
+        let ct = CorruptionTypeConfig::RandomBytes;
+        assert_eq!(serde_yaml::to_string(&ct).unwrap().trim(), "random_bytes");
+    }
 }


### PR DESCRIPTION
## Summary

Issue #79 follow-up. Pre-fix, `--config chaos.yaml` could only set the original 8 `fault_injection` fields. The new fields shipped in 0.3.125 (`connection_error_kind`, `partial_responses`, `payload_corruption`, `corruption_type`, `error_pattern`, `mockai_enabled`, `request_matcher`) lived only on `mockforge_chaos::config::FaultInjectionConfig` and were silently hardcoded to defaults during the YAML→runtime bridge — operators had to use `PUT /api/chaos/config/faults` (REST) to set them at runtime. This PR closes that gap.

- Adds mirror types in `mockforge-core`: `ConnectionErrorKindConfig`, `CorruptionTypeConfig`, `ErrorPatternConfig`, `HeaderMatchConfig`, `RequestMatcherConfig` (chaos crate depends on core, not vice versa, so the types must live in core).
- Extends `mockforge_core::config::FaultConfig` with the missing fields, all `#[serde(default)]` so legacy `chaos.yaml` keeps parsing unchanged.
- Adds `Default` + `#[serde(default)]` on `FaultConfig` so partial YAML works.
- Extracts the bridge into `fault_config_to_chaos()` in `serve.rs` and fills in every field with a 1:1 enum match for `ConnectionErrorKind` / `CorruptionType` / `ErrorPattern`.

Bundles the version bump to **0.3.129** so it ships in one PR (the issue-#79 reply pointed at this gap as the only remaining limitation).

## Test plan

- [x] 3 new tests in `mockforge-core::config::operational::fault_config_yaml_tests` — full YAML round-trip with the exact shape from the issue-#79 reply, legacy YAML back-compat (no new fields), snake_case enum encoding
- [x] 2 new tests in `mockforge-cli::serve::chaos_yaml_bridge_tests` — bridge preserves every new field, default `FaultConfig` bridges to legacy behavior
- [x] `cargo clippy -p mockforge-core -p mockforge-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] CI green
- [ ] After merge: `scripts/publish-crates.sh` to crates.io, then tag `v0.3.129`

Refs #79