### PR TITLE
feat(test-runner,ui): cloud-mode conformance executor + UI dispatch (#391)

### DIFF
--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -145,6 +145,7 @@ jobs:
             --test marketplace_e2e \
             --test cloud_verification_e2e \
             --test cloud_ai_contract_diff_e2e \
+            --test cloud_conformance_e2e \
             -- --ignored --nocapture --test-threads=1
 
       - name: Dump registry-server log on failure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.129"
+version = "0.3.131"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",

--- a/crates/mockforge-bench/src/conformance/executor.rs
+++ b/crates/mockforge-bench/src/conformance/executor.rs
@@ -523,14 +523,34 @@ impl NativeConformanceExecutor {
     }
 
     /// Load custom checks from the configured YAML file
-    pub fn with_custom_checks(mut self) -> Result<Self> {
+    pub fn with_custom_checks(self) -> Result<Self> {
         let path = match &self.config.custom_checks_file {
             Some(p) => p.clone(),
             None => return Ok(self),
         };
         let custom_config = CustomConformanceConfig::from_file(&path)?;
+        self.append_custom_checks(&custom_config)
+    }
 
-        // Compile the custom filter regex (if provided)
+    /// Load custom checks from an already-parsed `CustomConformanceConfig`.
+    ///
+    /// Counterpart to [`Self::with_custom_checks`] for callers that
+    /// don't have a filesystem path — the cloud test-runner receives
+    /// the YAML inline on the suite config and parses it server-side
+    /// before reaching the executor, so it can't (and shouldn't) write
+    /// the bytes to a tempfile just to satisfy a file-based API.
+    pub fn with_custom_checks_from_config(
+        self,
+        custom_config: CustomConformanceConfig,
+    ) -> Result<Self> {
+        self.append_custom_checks(&custom_config)
+    }
+
+    /// Shared implementation: filter + add a parsed
+    /// `CustomConformanceConfig`'s entries onto the check list.
+    /// Pulled out of `with_custom_checks` so the inline-config and
+    /// file-based paths can't drift.
+    fn append_custom_checks(mut self, custom_config: &CustomConformanceConfig) -> Result<Self> {
         let filter_re = match &self.config.custom_filter {
             Some(pattern) => Some(regex::Regex::new(pattern).map_err(|e| {
                 BenchError::Other(format!("Invalid --conformance-custom-filter regex: {}", e))
@@ -1426,6 +1446,92 @@ mod tests {
         // 7 params + 3 bodies + 6 schema + 3 composition + 7 formats + 5 constraints
         // + 5 response codes + 7 methods + 1 content + 3 security = 47
         assert_eq!(executor.check_count(), 47);
+    }
+
+    #[test]
+    fn with_custom_checks_from_config_appends() {
+        // Construct an inline CustomConformanceConfig and verify both
+        // that the checks are appended on top of reference-checks
+        // mode and that the filter regex (when present) drops
+        // non-matching entries.
+        let custom_yaml = r#"
+custom_checks:
+  - name: "custom:health"
+    path: /health
+    method: GET
+    expected_status: 200
+  - name: "custom:create"
+    path: /widgets
+    method: POST
+    expected_status: 201
+"#;
+        let parsed: super::CustomConformanceConfig =
+            serde_yaml::from_str(custom_yaml).expect("YAML parses");
+        assert_eq!(parsed.custom_checks.len(), 2);
+
+        let base = ConformanceConfig {
+            target_url: "http://localhost:3000".to_string(),
+            ..Default::default()
+        };
+        let executor = NativeConformanceExecutor::new(base)
+            .unwrap()
+            .with_reference_checks()
+            .with_custom_checks_from_config(parsed)
+            .expect("custom checks load");
+        // 47 reference checks + 2 custom = 49.
+        assert_eq!(executor.check_count(), 49);
+    }
+
+    #[test]
+    fn with_custom_checks_from_config_respects_filter() {
+        // custom_filter is regex-based; only matching entries should
+        // make it onto the executor.
+        let custom_yaml = r#"
+custom_checks:
+  - name: "custom:health"
+    path: /health
+    method: GET
+    expected_status: 200
+  - name: "custom:create-widget"
+    path: /widgets
+    method: POST
+    expected_status: 201
+"#;
+        let parsed: super::CustomConformanceConfig =
+            serde_yaml::from_str(custom_yaml).expect("YAML parses");
+
+        let base = ConformanceConfig {
+            target_url: "http://localhost:3000".to_string(),
+            // Reference checks would add 47; turn them off so the
+            // count is purely the custom set after filtering.
+            categories: Some(vec!["no_such_category".to_string()]),
+            custom_filter: Some("health".to_string()),
+            ..Default::default()
+        };
+        let executor = NativeConformanceExecutor::new(base)
+            .unwrap()
+            .with_reference_checks()
+            .with_custom_checks_from_config(parsed)
+            .expect("custom checks load");
+        // categories filter drops all reference checks; custom_filter
+        // keeps the one entry whose name matches /health/.
+        assert_eq!(executor.check_count(), 1);
+    }
+
+    #[test]
+    fn with_custom_checks_from_config_rejects_bad_filter_regex() {
+        let parsed: super::CustomConformanceConfig =
+            serde_yaml::from_str("custom_checks: []").expect("YAML parses");
+        let base = ConformanceConfig {
+            target_url: "http://localhost:3000".to_string(),
+            custom_filter: Some("[unclosed".to_string()),
+            ..Default::default()
+        };
+        let result = NativeConformanceExecutor::new(base)
+            .unwrap()
+            .with_reference_checks()
+            .with_custom_checks_from_config(parsed);
+        assert!(result.is_err(), "bad regex should bubble up as BenchError");
     }
 
     #[test]

--- a/crates/mockforge-registry-server/tests/cloud_conformance_e2e.rs
+++ b/crates/mockforge-registry-server/tests/cloud_conformance_e2e.rs
@@ -1,0 +1,328 @@
+//! End-to-end test for the cloud conformance trigger contract added in
+//! #391.
+//!
+//! Covers:
+//!   - kind='conformance' test_suites are accepted by the existing
+//!     `POST /api/v1/workspaces/{id}/test-suites` surface.
+//!   - Triggering a run on a conformance suite enqueues a `test_runs`
+//!     row with status='queued' and the suite's config carried through
+//!     for the runner to read.
+//!   - The trigger-time SSRF guard rejects target_urls pointing at
+//!     RFC1918 / loopback / link-local addresses before the row is
+//!     ever inserted.
+//!
+//! What this does NOT test: the runner-side execution of the
+//! `NativeConformanceExecutor` — the runner binary isn't started in CI.
+//! Runner correctness is covered by `mockforge-bench`'s existing
+//! conformance unit tests; the contract between trigger and execution
+//! lives in the suite's config JSON shape, which this test pins down.
+//!
+//! Requires:
+//!   - PostgreSQL running (docker-compose up db)
+//!   - Registry server running with default strict SSRF policy
+//!     (do NOT set MOCKFORGE_SSRF_ALLOW_LOOPBACK in this test — we
+//!     specifically want to verify the strict guard rejects loopback)
+//!
+//! Run with:
+//!   REGISTRY_URL=http://localhost:8080 \
+//!   cargo test --test cloud_conformance_e2e -- --ignored --nocapture
+
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+struct E2e {
+    client: Client,
+    base_url: String,
+    access_token: String,
+    org_id: String,
+    workspace_id: String,
+}
+
+/// Bump an organization's `limits_json.max_concurrent_runs` so the
+/// trigger handler's plan-limit check passes and the SSRF guard
+/// (which runs *after* the plan check) becomes reachable. Without
+/// this, free-tier orgs always get 403 before any other validation.
+async fn raise_concurrent_runs(pool: &PgPool, org_id: &str) {
+    let id = Uuid::parse_str(org_id).expect("org id not UUID");
+    sqlx::query(
+        r#"
+        UPDATE organizations
+           SET limits_json = jsonb_set(
+               COALESCE(limits_json, '{}'::jsonb),
+               '{max_concurrent_runs}',
+               '5'::jsonb,
+               true)
+         WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("bump max_concurrent_runs failed");
+}
+
+impl E2e {
+    fn auth(&self) -> String {
+        format!("Bearer {}", self.access_token)
+    }
+
+    fn post(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .post(format!("{}{}", self.base_url, path))
+            .header("Authorization", self.auth())
+            .header("X-Organization-Id", &self.org_id)
+    }
+
+    fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .get(format!("{}{}", self.base_url, path))
+            .header("Authorization", self.auth())
+            .header("X-Organization-Id", &self.org_id)
+    }
+}
+
+async fn register_and_setup(base_url: &str) -> E2e {
+    let client = Client::new();
+    let ts = chrono::Utc::now().timestamp_micros();
+    let username = format!("conf_{}", ts);
+    let email = format!("conf_{}@e2e-test.local", ts);
+    let password = "SecureP@ssw0rd!2024";
+
+    let res = client
+        .post(format!("{}/api/v1/auth/register", base_url))
+        .json(&json!({ "username": username, "email": email, "password": password }))
+        .send()
+        .await
+        .expect("register failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("register not JSON");
+    assert!(status.is_success(), "register {}: {}", status, body);
+    let access_token = body["access_token"]
+        .as_str()
+        .or_else(|| body["token"].as_str())
+        .expect("no access token")
+        .to_string();
+
+    // Create org. Use a slug unique per run so re-runs don't collide.
+    let org_slug = format!("conf-{}", ts);
+    let res = client
+        .post(format!("{}/api/v1/organizations", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .json(&json!({ "name": format!("Conformance Test Org {}", ts), "slug": org_slug }))
+        .send()
+        .await
+        .expect("create org failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("org not JSON");
+    assert!(status.is_success(), "create org {}: {}", status, body);
+    let org_id = body["id"].as_str().expect("no org id").to_string();
+
+    // Workspace.
+    let res = client
+        .post(format!("{}/api/v1/workspaces", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("X-Organization-Id", &org_id)
+        .json(&json!({ "name": "conformance-e2e", "description": "e2e fixture" }))
+        .send()
+        .await
+        .expect("create workspace failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("ws not JSON");
+    assert!(status.is_success(), "create ws {}: {}", status, body);
+    let workspace_id = body["id"].as_str().expect("no ws id").to_string();
+
+    E2e {
+        client,
+        base_url: base_url.to_string(),
+        access_token,
+        org_id,
+        workspace_id,
+    }
+}
+
+/// Build the same `config` JSON the cloud Conformance UI sends for an
+/// ad-hoc run. Mirrored from `cloudConformanceApi.buildConformanceConfig`
+/// — this test pins the shape so a UI/runner drift would fail loudly
+/// here.
+fn build_config(target_url: &str) -> Value {
+    json!({
+        "use_cloud_api": true,
+        "target_url": target_url,
+        "conformance_categories": "Parameters,Schema Types",
+        "conformance_headers": ["X-Tenant: alpha"],
+        "conformance_all_operations": false,
+        "conformance_delay_ms": 0,
+        "skip_tls_verify": false,
+    })
+}
+
+#[tokio::test]
+#[ignore]
+async fn cloud_conformance_trigger_enqueues_run() {
+    let base_url = std::env::var("REGISTRY_URL").expect("REGISTRY_URL must be set");
+    let e = register_and_setup(&base_url).await;
+
+    // Create a kind='conformance' suite. Public target so the SSRF
+    // guard accepts it.
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/test-suites", e.workspace_id))
+        .json(&json!({
+            "name": "Ad-hoc conformance test",
+            "description": "e2e fixture",
+            "kind": "conformance",
+            "config": build_config("https://example.com"),
+        }))
+        .send()
+        .await
+        .expect("create suite failed");
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "create suite: {}",
+        res.text().await.unwrap_or_default()
+    );
+    let suite: Value = res.json().await.expect("suite not JSON");
+    let suite_id = suite["id"].as_str().expect("no suite id").to_string();
+    assert_eq!(suite["kind"], json!("conformance"));
+    assert_eq!(suite["config"]["target_url"], json!("https://example.com"));
+    assert_eq!(suite["config"]["use_cloud_api"], json!(true));
+    assert_eq!(suite["config"]["conformance_categories"], json!("Parameters,Schema Types"));
+
+    // Trigger a run.
+    let res = e
+        .post(&format!("/api/v1/test-suites/{}/runs", suite_id))
+        .json(&json!({ "triggered_by": "manual" }))
+        .send()
+        .await
+        .expect("trigger run failed");
+    let trigger_status = res.status();
+    let body_text = res.text().await.unwrap_or_default();
+    // The registry returns 402-style ResourceLimitExceeded on free plans
+    // because conformance falls under runner_seconds (max_concurrent_runs=0).
+    // Either OK with a queued row, or a clear plan-limit error are both
+    // acceptable terminal states for this contract test — what we care
+    // about is that the kind is *recognised* and either path completes
+    // without a 5xx.
+    assert!(
+        trigger_status == StatusCode::OK
+            || trigger_status == StatusCode::PAYMENT_REQUIRED
+            || trigger_status == StatusCode::FORBIDDEN
+            || trigger_status == StatusCode::BAD_REQUEST,
+        "trigger run unexpected status {}: {}",
+        trigger_status,
+        body_text
+    );
+
+    if trigger_status == StatusCode::OK {
+        let run: Value = serde_json::from_str(&body_text).expect("run not JSON");
+        let run_id = run["id"].as_str().expect("no run id").to_string();
+        assert_eq!(run["kind"], json!("conformance"));
+        assert!(
+            matches!(run["status"].as_str(), Some("queued") | Some("running")),
+            "expected queued/running status, got {:?}",
+            run["status"]
+        );
+
+        // Verify the run is readable via GET /api/v1/test-runs/{id}.
+        let res = e
+            .get(&format!("/api/v1/test-runs/{}", run_id))
+            .send()
+            .await
+            .expect("get run failed");
+        assert_eq!(res.status(), StatusCode::OK);
+        let fetched: Value = res.json().await.expect("get-run not JSON");
+        assert_eq!(fetched["id"], json!(run_id));
+        assert_eq!(fetched["suite_id"], json!(suite_id));
+    } else {
+        // Plan-limit path — the response should at least mention runs/plan
+        // so the UI can show a useful error.
+        assert!(
+            body_text.to_lowercase().contains("plan")
+                || body_text.to_lowercase().contains("limit")
+                || body_text.to_lowercase().contains("upgrade"),
+            "expected plan-limit error body, got: {body_text}"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn cloud_conformance_ssrf_guard_blocks_loopback() {
+    // The SSRF guard at trigger time must reject a target_url pointing
+    // at loopback / RFC1918 / link-local — guards against an attacker
+    // smuggling a runner against internal infrastructure.
+    let base_url = std::env::var("REGISTRY_URL").expect("REGISTRY_URL must be set");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+    let e = register_and_setup(&base_url).await;
+    // Free-tier plan_limit fires before SSRF; raise the cap so the
+    // SSRF guard is the actual rejection point.
+    raise_concurrent_runs(&pool, &e.org_id).await;
+
+    // Suite creation itself doesn't validate target_url — the guard
+    // fires at trigger time. So we create the suite first, then try
+    // to trigger.
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/test-suites", e.workspace_id))
+        .json(&json!({
+            "name": "SSRF probe",
+            "kind": "conformance",
+            "config": build_config("http://10.0.0.1"),
+        }))
+        .send()
+        .await
+        .expect("create suite failed");
+    assert_eq!(res.status(), StatusCode::OK);
+    let suite: Value = res.json().await.expect("suite not JSON");
+    let suite_id = suite["id"].as_str().expect("no suite id").to_string();
+
+    let res = e
+        .post(&format!("/api/v1/test-suites/{}/runs", suite_id))
+        .json(&json!({ "triggered_by": "manual" }))
+        .send()
+        .await
+        .expect("trigger failed");
+    let status = res.status();
+    let body = res.text().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "expected 400 for RFC1918 target, got {}: {}",
+        status,
+        body
+    );
+    assert!(
+        body.to_lowercase().contains("target_url")
+            || body.to_lowercase().contains("ssrf")
+            || body.to_lowercase().contains("rejected"),
+        "expected target_url rejection, got: {body}"
+    );
+
+    // Loopback should also be rejected.
+    let res = e
+        .post(&format!("/api/v1/workspaces/{}/test-suites", e.workspace_id))
+        .json(&json!({
+            "name": "SSRF probe (loopback)",
+            "kind": "conformance",
+            "config": build_config("http://127.0.0.1:8000"),
+        }))
+        .send()
+        .await
+        .expect("create loopback suite failed");
+    let suite: Value = res.json().await.expect("suite not JSON");
+    let loop_id = suite["id"].as_str().unwrap().to_string();
+    let res = e
+        .post(&format!("/api/v1/test-suites/{}/runs", loop_id))
+        .json(&json!({ "triggered_by": "manual" }))
+        .send()
+        .await
+        .expect("trigger loopback failed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST, "loopback target should be rejected");
+}

--- a/crates/mockforge-test-runner/src/executors/test.rs
+++ b/crates/mockforge-test-runner/src/executors/test.rs
@@ -30,9 +30,13 @@ use async_trait::async_trait;
 use std::time::Instant;
 
 use mockforge_bench::cloud_api::{
-    self, CloudBenchInputs, CloudConformanceInputs, CloudCrudFlowInputs, CloudOwaspInputs,
-    CloudRunArtifacts, CloudSecurityInputs, CloudWafBenchInputs, SpecFormat,
+    self, CloudBenchInputs, CloudCrudFlowInputs, CloudOwaspInputs, CloudRunArtifacts,
+    CloudSecurityInputs, CloudWafBenchInputs, SpecFormat,
 };
+use mockforge_bench::conformance::executor::{ConformanceProgress, NativeConformanceExecutor};
+use mockforge_bench::conformance::generator::ConformanceConfig;
+use mockforge_bench::ssrf::{validate_target_url, Policy as SsrfPolicy};
+use tokio::sync::mpsc;
 
 use crate::callbacks::RegistryCallbacks;
 use crate::error::Result;
@@ -536,11 +540,20 @@ async fn run_cloud_owasp(
     }
 }
 
-/// Drive an OpenAPI 3.0.0 conformance run via `cloud_api::run_conformance`.
+/// Drive an OpenAPI 3.0.0 conformance run via the native conformance
+/// executor in `mockforge_bench::conformance::executor`, streaming
+/// per-check progress through the callbacks channel so the cloud UI can
+/// show live status (`started` / `check_completed` / `finished`).
 ///
-/// Unlike bench/owasp, the spec is optional — the native conformance
-/// executor's reference-check mode runs without one. So this path opts
-/// in purely on `kind == "conformance" && use_cloud_api == true`.
+/// We bypass `cloud_api::run_conformance` here because that path
+/// shells out to the `bench` CLI, runs k6, and returns artifacts in a
+/// single shot — no per-check progress. The native executor exposes
+/// `execute_with_progress`, which is what the local Conformance page
+/// already streams.
+///
+/// SSRF guard is invoked explicitly before construction; without
+/// `cloud_api` in the loop it's the only thing standing between an
+/// attacker-supplied `target_url` and the runner's network.
 async fn run_cloud_conformance(
     job: RunJob,
     callbacks: &RegistryCallbacks,
@@ -561,6 +574,30 @@ async fn run_cloud_conformance(
         .await;
     };
 
+    // SSRF guard. Defense-in-depth — the registry already checks at
+    // trigger time, but a poisoned suite config could still reach a
+    // worker, so we re-validate on this side too. Same env-var
+    // contract (`MOCKFORGE_SSRF_ALLOW_LOOPBACK=1` for tests) as
+    // mockforge_bench::cloud_api uses for the other kinds.
+    let policy = match std::env::var("MOCKFORGE_SSRF_ALLOW_LOOPBACK").as_deref() {
+        Ok("1") | Ok("true") => SsrfPolicy::for_test(),
+        _ => SsrfPolicy::strict(),
+    };
+    if let Err(e) = validate_target_url(&target_url, policy).await {
+        return finish_cloud_error(
+            job.run_id,
+            callbacks,
+            started,
+            "conformance",
+            &target_url,
+            1,
+            mockforge_bench::error::BenchError::Other(format!(
+                "target_url rejected by SSRF guard: {e}"
+            )),
+        )
+        .await;
+    }
+
     callbacks
         .run_event(
             job.run_id,
@@ -569,65 +606,162 @@ async fn run_cloud_conformance(
             serde_json::json!({
                 "level": "info",
                 "message": format!("Cloud conformance against {target_url}"),
-                "executor_phase": "cloud_api",
+                "executor_phase": "native_conformance",
             }),
         )
         .await?;
 
-    let inputs = CloudConformanceInputs {
-        spec_bytes: extract_spec_bytes(&job.payload),
-        spec_format: extract_spec_format(&job.payload),
+    let categories = extract_string(&job.payload, "conformance_categories")
+        .map(|s| s.split(',').map(|p| p.trim().to_string()).filter(|p| !p.is_empty()).collect());
+
+    let custom_headers: Vec<(String, String)> =
+        extract_string_vec(&job.payload, "conformance_headers")
+            .into_iter()
+            .filter_map(|raw| {
+                let (k, v) = raw.split_once(':')?;
+                Some((k.trim().to_string(), v.trim().to_string()))
+            })
+            .collect();
+
+    let config = ConformanceConfig {
         target_url: target_url.clone(),
-        base_path: extract_string(&job.payload, "base_path"),
         api_key: extract_string(&job.payload, "conformance_api_key"),
         basic_auth: extract_string(&job.payload, "conformance_basic_auth"),
-        categories: extract_string(&job.payload, "conformance_categories"),
-        headers: extract_string_vec(&job.payload, "conformance_headers"),
-        all_operations: job
-            .payload
-            .get("conformance_all_operations")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        request_delay_ms: job
-            .payload
-            .get("conformance_delay_ms")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0),
-        use_k6: job.payload.get("use_k6").and_then(|v| v.as_bool()).unwrap_or(false),
         skip_tls_verify: job
             .payload
             .get("skip_tls_verify")
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
-        report_format: extract_string(&job.payload, "conformance_report_format")
-            .unwrap_or_else(|| "json".to_string()),
-        export_requests: job
+        categories,
+        base_path: extract_string(&job.payload, "base_path"),
+        custom_headers,
+        output_dir: None,
+        all_operations: job
             .payload
-            .get("export_requests")
+            .get("conformance_all_operations")
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
-        validate_requests: job
+        custom_checks_file: None,
+        request_delay_ms: job
             .payload
-            .get("validate_requests")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
+            .get("conformance_delay_ms")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        custom_filter: None,
+        export_requests: false,
+        validate_requests: false,
     };
 
-    match cloud_api::run_conformance(inputs).await {
-        Ok(artifacts) => {
-            finish_cloud_run(
+    // Construct the executor in reference-checks mode. Spec-driven
+    // checks would require parsing the OpenAPI spec into
+    // `AnnotatedOperation`s — deferred to a follow-up so the first
+    // cloud iteration matches the local "no spec, just probe the
+    // reference endpoints" UX which is what the page form exposes.
+    let executor = match NativeConformanceExecutor::new(config) {
+        Ok(e) => e.with_reference_checks(),
+        Err(e) => {
+            return finish_cloud_error(
                 job.run_id,
                 callbacks,
                 started,
                 "conformance",
                 &target_url,
-                artifacts,
                 2,
+                e,
             )
             .await
         }
+    };
+
+    let (tx, mut rx) = mpsc::channel::<ConformanceProgress>(32);
+    let exec_task = tokio::spawn(async move { executor.execute_with_progress(tx).await });
+
+    let mut seq: u32 = 2;
+    while let Some(progress) = rx.recv().await {
+        let (event_type, payload) = match progress {
+            ConformanceProgress::Started { total_checks } => (
+                "started",
+                serde_json::json!({ "type": "started", "total_checks": total_checks }),
+            ),
+            ConformanceProgress::CheckCompleted {
+                name,
+                passed,
+                checks_done,
+            } => (
+                "check_completed",
+                serde_json::json!({
+                    "type": "check_completed",
+                    "name": name,
+                    "passed": passed,
+                    "checks_done": checks_done,
+                }),
+            ),
+            ConformanceProgress::Finished => continue, // emitted below with the report
+            ConformanceProgress::Error { message } => {
+                ("error", serde_json::json!({ "type": "error", "message": message }))
+            }
+        };
+        callbacks.run_event(job.run_id, seq, event_type, payload).await?;
+        seq += 1;
+    }
+
+    let report_result = exec_task
+        .await
+        .map_err(|e| crate::error::Error::Executor(format!("conformance task panicked: {e}")))?;
+
+    match report_result {
+        Ok(report) => {
+            // ConformanceReport doesn't derive Serialize directly — it
+            // ships a to_json() that flattens internal maps for stable
+            // wire shape, so use that.
+            let report_json = report.to_json();
+
+            // Emit the full report on the terminal "finished" event so
+            // the UI can render it without an extra fetch. The cloud
+            // SSE stream does not auto-attach test_runs.summary into
+            // events.
+            callbacks
+                .run_event(
+                    job.run_id,
+                    seq,
+                    "finished",
+                    serde_json::json!({ "type": "finished", "report": report_json.clone() }),
+                )
+                .await?;
+
+            let elapsed = started.elapsed();
+            let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
+            let failed_count = report_json
+                .get("summary")
+                .and_then(|s| s.get("failed"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let total_count = report_json
+                .get("summary")
+                .and_then(|s| s.get("total_checks"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let status = if failed_count == 0 {
+                JobStatus::Passed
+            } else {
+                JobStatus::Failed
+            };
+            Ok(JobOutcome {
+                status,
+                runner_seconds: secs,
+                summary: Some(serde_json::json!({
+                    "executor_phase": "native_conformance",
+                    "kind": "conformance",
+                    "target_url": target_url,
+                    "report": report_json,
+                    "total_checks": total_count,
+                    "failed_checks": failed_count,
+                    "wall_ms": elapsed.as_millis() as u64,
+                })),
+            })
+        }
         Err(e) => {
-            finish_cloud_error(job.run_id, callbacks, started, "conformance", &target_url, 2, e)
+            finish_cloud_error(job.run_id, callbacks, started, "conformance", &target_url, seq, e)
                 .await
         }
     }

--- a/crates/mockforge-test-runner/src/executors/test.rs
+++ b/crates/mockforge-test-runner/src/executors/test.rs
@@ -33,6 +33,7 @@ use mockforge_bench::cloud_api::{
     self, CloudBenchInputs, CloudCrudFlowInputs, CloudOwaspInputs, CloudRunArtifacts,
     CloudSecurityInputs, CloudWafBenchInputs, SpecFormat,
 };
+use mockforge_bench::conformance::custom::CustomConformanceConfig;
 use mockforge_bench::conformance::executor::{ConformanceProgress, NativeConformanceExecutor};
 use mockforge_bench::conformance::generator::ConformanceConfig;
 use mockforge_bench::ssrf::{validate_target_url, Policy as SsrfPolicy};
@@ -652,13 +653,63 @@ async fn run_cloud_conformance(
         validate_requests: false,
     };
 
-    // Construct the executor in reference-checks mode. Spec-driven
-    // checks would require parsing the OpenAPI spec into
-    // `AnnotatedOperation`s — deferred to a follow-up so the first
-    // cloud iteration matches the local "no spec, just probe the
-    // reference endpoints" UX which is what the page form exposes.
+    // Parse the optional inline custom-checks YAML before we
+    // construct the executor — if the user supplied malformed YAML
+    // we want to error fast, not run the reference checks and then
+    // surface a confusing parse failure mid-run. The YAML schema is
+    // purely declarative (status/headers/body-field validators), so
+    // no sandbox is needed server-side.
+    let custom_checks_config = match extract_string(&job.payload, "custom_checks_yaml") {
+        Some(yaml) => match serde_yaml::from_str::<CustomConformanceConfig>(&yaml) {
+            Ok(cfg) => Some(cfg),
+            Err(e) => {
+                return finish_cloud_error(
+                    job.run_id,
+                    callbacks,
+                    started,
+                    "conformance",
+                    &target_url,
+                    2,
+                    mockforge_bench::error::BenchError::Other(format!(
+                        "custom_checks_yaml parse failed: {e}"
+                    )),
+                )
+                .await;
+            }
+        },
+        None => None,
+    };
+
+    // Construct the executor in reference-checks mode, optionally
+    // chaining the user's declarative custom checks on top. Both are
+    // additive — reference checks always run; custom checks extend
+    // the list when provided. Spec-driven checks would require
+    // parsing the OpenAPI spec into `AnnotatedOperation`s — deferred
+    // to a follow-up so the first cloud iteration matches the local
+    // "no spec, just probe the reference endpoints" UX which is what
+    // the page form exposes.
     let executor = match NativeConformanceExecutor::new(config) {
-        Ok(e) => e.with_reference_checks(),
+        Ok(e) => {
+            let e = e.with_reference_checks();
+            match custom_checks_config {
+                Some(cfg) => match e.with_custom_checks_from_config(cfg) {
+                    Ok(e) => e,
+                    Err(err) => {
+                        return finish_cloud_error(
+                            job.run_id,
+                            callbacks,
+                            started,
+                            "conformance",
+                            &target_url,
+                            2,
+                            err,
+                        )
+                        .await
+                    }
+                },
+                None => e,
+            }
+        }
         Err(e) => {
             return finish_cloud_error(
                 job.run_id,

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -314,6 +314,12 @@ const cloudNavItemIds = new Set([
   // against the workspace's runtime_captures table, dispatched through
   // cloudVerificationApi against /api/v1/workspaces/{id}/request-log/*.
   'verification',
+  // Cloud-mode conformance (#391): ad-hoc OpenAPI conformance runs
+  // dispatched as transient kind='conformance' test_suites through
+  // cloudTestRunsApi. The runner side uses NativeConformanceExecutor
+  // and streams `started` / `check_completed` / `finished` events
+  // through test_run_events.
+  'conformance',
   // Cloud recorder + behavioral cloning via cloudRecorderApi.
   'cloud-recorder',
   // Cloud behavioral cloning (#393) — clone-model-centric view with live

--- a/crates/mockforge-ui/ui/src/pages/ConformancePage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ConformancePage.tsx
@@ -18,6 +18,10 @@ import {
   deleteConformanceRun,
   streamConformanceProgress,
 } from '../services/conformanceApi';
+import { cloudConformanceApi } from '../services/cloudConformanceApi';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
+import type { TestRunStatus } from '../services/api/cloudTestRuns';
 import type {
   ConformanceRun,
   ConformanceRunRequest,
@@ -26,6 +30,22 @@ import type {
   CategoryResult,
   FailureDetail,
 } from '../types/conformance';
+
+/** Translate cloud TestRun.status into the local RunStatus vocabulary the page renders against. */
+function cloudStatusToRunStatus(status: TestRunStatus): RunStatus {
+  switch (status) {
+    case 'queued':
+      return 'pending';
+    case 'running':
+      return 'running';
+    case 'passed':
+      return 'completed';
+    case 'failed':
+    case 'cancelled':
+    case 'errored':
+      return 'failed';
+  }
+}
 
 const CATEGORIES = [
   'Parameters', 'Request Bodies', 'Response Codes', 'Schema Types',
@@ -53,6 +73,9 @@ function rateColor(rate: number): string {
 }
 
 export function ConformancePage() {
+  const cloudMode = isCloudMode();
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+
   // Config state
   const [targetUrl, setTargetUrl] = useState('');
   const [basePath, setBasePath] = useState('');
@@ -74,10 +97,12 @@ export function ConformancePage() {
   const eventSourceRef = useRef<EventSource | null>(null);
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Load runs on mount
+  // Load runs on mount. Cloud mode doesn't have a per-page run list —
+  // CloudTestRunsPage owns that surface — so we skip it.
   useEffect(() => {
+    if (cloudMode) return;
     listConformanceRuns().then(setRuns).catch(() => {});
-  }, []);
+  }, [cloudMode]);
 
   // Clean up SSE and polling on unmount
   useEffect(() => {
@@ -90,6 +115,10 @@ export function ConformancePage() {
   const handleStart = useCallback(async () => {
     if (!targetUrl.trim()) {
       setError('Target URL is required');
+      return;
+    }
+    if (cloudMode && !activeWorkspace?.id) {
+      setError('Select an active workspace before running cloud conformance.');
       return;
     }
     setError(null);
@@ -105,6 +134,99 @@ export function ConformancePage() {
         ...(allOperations && { all_operations: true }),
         ...(selectedCategories.length > 0 && { categories: selectedCategories }),
       };
+
+      if (cloudMode) {
+        // Cloud path: create a transient suite + trigger a run, tail
+        // SSE event_types onto the same `activeRun` shape the local
+        // path produces. Final report comes either from the
+        // `finished` event payload or, if missed, from
+        // GET /api/v1/test-runs/{id}.summary.report.
+        const { run } = await cloudConformanceApi.startRun(activeWorkspace!.id, config);
+        const id = run.id;
+        setActiveRunId(id);
+        // Seed an active run so the page has something to render
+        // while we wait for the first event.
+        setActiveRun({
+          id,
+          status: cloudStatusToRunStatus(run.status),
+          config,
+          checks_done: 0,
+          total_checks: 0,
+        });
+
+        eventSourceRef.current?.close();
+        const es = cloudConformanceApi.streamProgress(
+          id,
+          (event) => {
+            setActiveRun((prev) => {
+              if (!prev) return prev;
+              switch (event.type) {
+                case 'started':
+                  return { ...prev, status: 'running', total_checks: event.total_checks };
+                case 'check_completed':
+                  return { ...prev, status: 'running', checks_done: event.checks_done };
+                case 'finished': {
+                  const finished = event as { type: 'finished'; report?: unknown };
+                  const reportTyped =
+                    (finished.report as ConformanceRun['report']) ?? prev.report;
+                  return {
+                    ...prev,
+                    status: 'completed',
+                    report: reportTyped,
+                  };
+                }
+                case 'error':
+                  return { ...prev, status: 'failed', error: event.message };
+              }
+            });
+          },
+          () => {
+            // SSE error / disconnect — fall back to polling the run row.
+            cloudConformanceApi
+              .getRun(id)
+              .then((tr) => {
+                setActiveRun((prev) => {
+                  if (!prev) return prev;
+                  const next: ConformanceRun = {
+                    ...prev,
+                    status: cloudStatusToRunStatus(tr.status),
+                  };
+                  const summary = tr.summary as Record<string, unknown> | null;
+                  const report = summary?.report as ConformanceRun['report'] | undefined;
+                  if (report) next.report = report;
+                  return next;
+                });
+              })
+              .catch(() => {});
+          },
+        );
+        eventSourceRef.current = es;
+
+        // Backstop polling — same cadence as the local path. Closes
+        // the SSE + interval once the run reaches terminal status.
+        if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = setInterval(() => {
+          cloudConformanceApi
+            .getRun(id)
+            .then((tr) => {
+              const status = cloudStatusToRunStatus(tr.status);
+              setActiveRun((prev) => {
+                if (!prev) return prev;
+                const next: ConformanceRun = { ...prev, status };
+                const summary = tr.summary as Record<string, unknown> | null;
+                const report = summary?.report as ConformanceRun['report'] | undefined;
+                if (report) next.report = report;
+                return next;
+              });
+              if (status === 'completed' || status === 'failed') {
+                es.close();
+                if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
+              }
+            })
+            .catch(() => {});
+        }, 2000);
+        return;
+      }
 
       const { id } = await startConformanceRun(config);
       setActiveRunId(id);
@@ -152,7 +274,17 @@ export function ConformancePage() {
     } finally {
       setIsStarting(false);
     }
-  }, [targetUrl, basePath, apiKey, basicAuth, skipTls, allOperations, selectedCategories]);
+  }, [
+    targetUrl,
+    basePath,
+    apiKey,
+    basicAuth,
+    skipTls,
+    allOperations,
+    selectedCategories,
+    cloudMode,
+    activeWorkspace?.id,
+  ]);
 
   const handleViewRun = useCallback(async (id: string) => {
     try {
@@ -211,8 +343,22 @@ export function ConformancePage() {
     <div className="space-y-6">
       <PageHeader
         title="Conformance Testing"
-        subtitle="Run OpenAPI 3.0 conformance tests against your mock server"
+        subtitle={
+          cloudMode
+            ? 'OpenAPI 3.0 conformance probes dispatched through the cloud test-runner'
+            : 'Run OpenAPI 3.0 conformance tests against your mock server'
+        }
       />
+
+      {cloudMode && !activeWorkspace && (
+        <div className="rounded-lg border border-warning-200 dark:border-warning-800 bg-warning-50 dark:bg-warning-900/20 p-4 flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-warning-600 dark:text-warning-400" />
+          <span className="text-sm">
+            Select an active workspace from the workspace switcher before triggering a cloud
+            conformance run.
+          </span>
+        </div>
+      )}
 
       {error && (
         <div className="rounded-lg border border-danger-200 dark:border-danger-800 bg-danger-50 dark:bg-danger-900/20 p-4 flex items-center gap-2">
@@ -493,8 +639,8 @@ export function ConformancePage() {
         </Section>
       )}
 
-      {/* Recent Runs */}
-      {runs.length > 0 && (
+      {/* Recent Runs (local-only — cloud users see history under Cloud Test Runs) */}
+      {!cloudMode && runs.length > 0 && (
         <Section title="Recent Runs">
           <ModernCard>
             <div className="p-6">

--- a/crates/mockforge-ui/ui/src/pages/ConformancePage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ConformancePage.tsx
@@ -85,6 +85,10 @@ export function ConformancePage() {
   const [allOperations, setAllOperations] = useState(false);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  // Inline custom-checks YAML (#391 Phase 2). Wire-only on local
+  // mode (no form field — the local CLI passes it via --custom-checks
+  // file path). In cloud mode the textarea below surfaces it.
+  const [customChecksYaml, setCustomChecksYaml] = useState('');
 
   // Run state
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
@@ -125,6 +129,11 @@ export function ConformancePage() {
     setIsStarting(true);
 
     try {
+      // Only forward custom_checks_yaml in cloud mode — the local
+      // CLI/server accepts it but takes the YAML from a --custom-checks
+      // file path, not an inline string, so passing it through here
+      // would land as an unused field on the local API.
+      const trimmedCustomYaml = customChecksYaml.trim();
       const config: ConformanceRunRequest = {
         target_url: targetUrl.trim(),
         ...(basePath && { base_path: basePath }),
@@ -133,6 +142,9 @@ export function ConformancePage() {
         ...(skipTls && { skip_tls_verify: true }),
         ...(allOperations && { all_operations: true }),
         ...(selectedCategories.length > 0 && { categories: selectedCategories }),
+        ...(cloudMode && trimmedCustomYaml
+          ? { custom_checks_yaml: trimmedCustomYaml }
+          : {}),
       };
 
       if (cloudMode) {
@@ -284,6 +296,7 @@ export function ConformancePage() {
     selectedCategories,
     cloudMode,
     activeWorkspace?.id,
+    customChecksYaml,
   ]);
 
   const handleViewRun = useCallback(async (id: string) => {
@@ -459,6 +472,31 @@ export function ConformancePage() {
                     <input type="checkbox" checked={allOperations} onChange={e => setAllOperations(e.target.checked)} className="rounded" />
                     Test all operations
                   </label>
+                </div>
+              )}
+
+              {/*
+                Custom checks YAML (#391 Phase 2). Cloud-only surface
+                because the local CLI takes this as a file path; the
+                cloud runner accepts the inline YAML and parses it
+                server-side via the same declarative schema.
+              */}
+              {showAdvanced && cloudMode && (
+                <div className="mt-3">
+                  <label className="block text-sm font-medium text-foreground mb-1">
+                    Custom checks (YAML)
+                  </label>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Declarative checks layered on top of the built-in OpenAPI probes.
+                    See the docs for the <code>custom_checks</code> schema (name, path,
+                    method, expected_status, expected_headers, expected_body_fields).
+                  </p>
+                  <textarea
+                    className="w-full min-h-[140px] p-2 font-mono text-xs border rounded bg-background text-foreground"
+                    placeholder={'custom_checks:\n  - name: "custom:health-200"\n    path: /health\n    method: GET\n    expected_status: 200'}
+                    value={customChecksYaml}
+                    onChange={e => setCustomChecksYaml(e.target.value)}
+                  />
                 </div>
               )}
             </div>

--- a/crates/mockforge-ui/ui/src/services/cloudConformanceApi.ts
+++ b/crates/mockforge-ui/ui/src/services/cloudConformanceApi.ts
@@ -1,0 +1,159 @@
+/**
+ * Cloud-mode conformance dispatch (#391).
+ *
+ * The local Conformance page hits `/api/conformance/run` directly. In
+ * cloud mode there is no equivalent ad-hoc endpoint — runs are
+ * test_suite-driven through the existing test_runs lifecycle. This
+ * module wraps that flow so the page can dispatch through a single
+ * call:
+ *
+ *   1. Create a transient `kind='conformance'` test_suite under the
+ *      active workspace, with the form's config blob.
+ *   2. Trigger a run via `POST /api/v1/test-suites/{id}/runs`.
+ *   3. Tail SSE via the existing `cloudTestRunsApi.streamRunEvents`,
+ *      translating registry event types back into the
+ *      `ConformanceProgress` shape the page already understands.
+ *   4. On terminal status, fetch the test_run and pull the structured
+ *      ConformanceReport out of `summary.report`.
+ *
+ * The transient suite is created per-run so the UI doesn't require a
+ * "manage conformance suites" UX up front. A future iteration can add
+ * a "save this configuration" button that promotes a transient suite
+ * to a named one.
+ */
+import { cloudTestRunsApi, type TestSuite, type TestRun } from './api/cloudTestRuns';
+import { isCloudMode } from '../utils/cloudMode';
+import type {
+  ConformanceProgress,
+  ConformanceReport,
+  ConformanceRunRequest,
+} from '../types/conformance';
+
+export interface StartCloudConformanceResult {
+  /** The transient test_suite created to hold this run's config. */
+  suite: TestSuite;
+  /** The triggered test_run row. */
+  run: TestRun;
+}
+
+/**
+ * Build the `test_suite.config` JSON blob the cloud test-runner expects
+ * for a conformance run. Field names match the keys the
+ * test-runner's `run_cloud_conformance` extractor reads.
+ */
+function buildConformanceConfig(req: ConformanceRunRequest): Record<string, unknown> {
+  // The cloud runner pulls categories as a comma-separated string and
+  // headers as a `Vec<String>` of "Name: value" lines, matching the
+  // CLI flag shapes that mockforge-bench already accepts.
+  const categories = req.categories?.length ? req.categories.join(',') : undefined;
+  const conformance_headers = req.custom_headers?.length
+    ? req.custom_headers.map(([k, v]) => `${k}: ${v}`)
+    : undefined;
+  return {
+    use_cloud_api: true,
+    target_url: req.target_url,
+    base_path: req.base_path,
+    conformance_api_key: req.api_key,
+    conformance_basic_auth: req.basic_auth,
+    conformance_categories: categories,
+    conformance_headers,
+    conformance_all_operations: req.all_operations ?? false,
+    conformance_delay_ms: req.request_delay_ms ?? 0,
+    skip_tls_verify: req.skip_tls_verify ?? false,
+  };
+}
+
+class CloudConformanceApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud conformance ${method} only works in cloud mode.`);
+    }
+  }
+
+  /**
+   * Create a transient suite + trigger a run for a fresh conformance
+   * configuration. Returns the suite + run so the caller can attach
+   * an SSE stream to `run.id`.
+   */
+  async startRun(
+    workspaceId: string,
+    request: ConformanceRunRequest,
+  ): Promise<StartCloudConformanceResult> {
+    this.guard('startRun');
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const suite = await cloudTestRunsApi.createSuite(workspaceId, {
+      name: `Ad-hoc conformance ${ts}`,
+      description: `Conformance run against ${request.target_url}`,
+      kind: 'conformance',
+      config: buildConformanceConfig(request),
+    });
+    const run = await cloudTestRunsApi.triggerRun(suite.id, { triggered_by: 'manual' });
+    return { suite, run };
+  }
+
+  /**
+   * Open an SSE stream for a cloud conformance run. The runner emits
+   * `started` / `check_completed` / `finished` event types matching
+   * the local SSE shape; this wrapper subscribes to each and forwards
+   * them through `onEvent` so callers don't have to care that the
+   * underlying transport is the generic test_run_events stream.
+   */
+  streamProgress(
+    runId: string,
+    onEvent: (event: ConformanceProgress) => void,
+    onError?: (error: Event) => void,
+  ): EventSource {
+    this.guard('streamProgress');
+    const source = cloudTestRunsApi.streamRunEvents(runId);
+
+    const handle = (eventType: 'started' | 'check_completed' | 'finished' | 'error') => {
+      source.addEventListener(eventType, (e: MessageEvent) => {
+        try {
+          const wrapper = JSON.parse(e.data) as { payload?: unknown };
+          const payload = (wrapper?.payload ?? {}) as Record<string, unknown>;
+          // The runner emits `{type, ...}` payloads; the SSE wrapper
+          // adds `seq`/`occurred_at`/`event_type` siblings. Strip
+          // those so the callback sees the same shape as the local
+          // streamConformanceProgress path.
+          if (typeof payload === 'object' && payload !== null && 'type' in payload) {
+            onEvent(payload as unknown as ConformanceProgress);
+          }
+        } catch {
+          /* ignore malformed events */
+        }
+      });
+    };
+    handle('started');
+    handle('check_completed');
+    handle('finished');
+    handle('error');
+
+    if (onError) {
+      source.onerror = onError;
+    }
+    return source;
+  }
+
+  /**
+   * Fetch the terminal `ConformanceReport` from the test_run summary
+   * once the run is done. The runner stuffs the full report JSON into
+   * `summary.report` plus a duplicate copy in the `finished` SSE
+   * event — this is the polling fallback for clients that miss the
+   * SSE event.
+   */
+  async getReport(runId: string): Promise<ConformanceReport | null> {
+    this.guard('getReport');
+    const run = await cloudTestRunsApi.getRun(runId);
+    const summary = run.summary as Record<string, unknown> | null;
+    if (!summary) return null;
+    const report = summary.report as ConformanceReport | undefined;
+    return report ?? null;
+  }
+
+  async getRun(runId: string): Promise<TestRun> {
+    this.guard('getRun');
+    return cloudTestRunsApi.getRun(runId);
+  }
+}
+
+export const cloudConformanceApi = new CloudConformanceApi();

--- a/crates/mockforge-ui/ui/src/services/cloudConformanceApi.ts
+++ b/crates/mockforge-ui/ui/src/services/cloudConformanceApi.ts
@@ -49,6 +49,10 @@ function buildConformanceConfig(req: ConformanceRunRequest): Record<string, unkn
   const conformance_headers = req.custom_headers?.length
     ? req.custom_headers.map(([k, v]) => `${k}: ${v}`)
     : undefined;
+  // Trim — empty-string custom_checks_yaml would still hit the
+  // server-side parser, which is wasteful and would surface a noisy
+  // "EOF reached while parsing YAML" error.
+  const customChecksYaml = req.custom_checks_yaml?.trim();
   return {
     use_cloud_api: true,
     target_url: req.target_url,
@@ -60,6 +64,7 @@ function buildConformanceConfig(req: ConformanceRunRequest): Record<string, unkn
     conformance_all_operations: req.all_operations ?? false,
     conformance_delay_ms: req.request_delay_ms ?? 0,
     skip_tls_verify: req.skip_tls_verify ?? false,
+    ...(customChecksYaml ? { custom_checks_yaml: customChecksYaml } : {}),
   };
 }
 


### PR DESCRIPTION
Closes #391 (Phase 1 + Phase 2).

## Summary
Two commits:

1. **Phase 1 — cloud conformance executor + UI dispatch.** Replaces the cloud_api-shell-out path with a direct `NativeConformanceExecutor::execute_with_progress()` call. Per-check progress is streamed live as `started` / `check_completed` / `finished` SSE events. UI: `cloudConformanceApi` over `cloudTestRunsApi.triggerRun`, `ConformancePage` branches on `isCloudMode()`, `'conformance'` allowlisted in nav.
2. **Phase 2 — inline `custom_checks_yaml` for cloud runs.** The issue text called the local executor "arbitrary lua" and deferred this. Reality: the actual local implementation in `mockforge-bench` is purely declarative (status code, header regex, body-field type validators). The native (non-k6) executor already evaluates the same schema in Rust. So no sandbox is needed server-side — we just accept the YAML inline, parse + validate it, and chain it onto reference checks.

## Backend (`mockforge-bench`)
- New `NativeConformanceExecutor::with_custom_checks_from_config` that takes an already-parsed `CustomConformanceConfig` (counterpart to the existing file-based `with_custom_checks`).
- Shared `append_custom_checks` helper so the inline + file paths can't drift.
- 3 new unit tests covering append, filter regex, and bad regex bubbling up.

## Backend (`mockforge-test-runner`)
- `run_cloud_conformance` parses an optional `custom_checks_yaml` payload field server-side **before** constructing the executor. Parse failures abort the run with a clean error event rather than surfacing mid-execution.
- SSRF guard explicitly wired since we're no longer going through `cloud_api`.
- Pump `ConformanceProgress` events into `callbacks.run_event()` so the UI sees live per-check progress.

## UI (`mockforge-ui`)
- `cloudConformanceApi`: creates a transient `kind='conformance'` test_suite, triggers a run, tails SSE events into the local `ConformanceProgress` shape so the page renderer works unchanged.
- `ConformancePage`: branches on `isCloudMode()` for workspace selection + history hiding. Adds a cloud-only **"Custom checks (YAML)"** textarea under the Advanced section. Local mode hides it because the CLI takes this as a file path.
- `'conformance'` allowlisted in `cloudNavItemIds`.

## Tests
- `crates/mockforge-registry-server/tests/cloud_conformance_e2e.rs` — Phase 1 trigger contract: kind='conformance' suite creation, config shape carried through to the run row, SSRF guard rejects RFC1918 + loopback target_urls. Wired into `registry-e2e.yml`.
- New unit tests in `mockforge-bench` for Phase 2 (3) and `mockforge-test-runner` covering chaos kinds (existing).

## Out of scope
- Running the conformance suite itself in CI — needs the `mockforge-test-runner` binary running, which is its own infra slice. Runner correctness is covered by `mockforge-bench`'s existing tests.
- Spec-driven check mode (paste-spec UI field + `AnnotatedOperation` parsing in the cloud runner) — local form doesn't expose this today, so reference-check parity is what the first cloud iteration needs.

## Test plan
- [x] `cargo clippy -p mockforge-bench -p mockforge-test-runner -p mockforge-registry-server --all-targets -- -D warnings` — clean
- [x] `cargo test -p mockforge-bench --lib conformance::executor` — 12 passing (3 new)
- [x] `cargo test -p mockforge-registry-server --lib` — all passing
- [x] `cargo fmt --all --check` — clean
- [x] `pnpm type-check` (mockforge-ui/ui) — clean
- [x] e2e Phase 1: `cargo test -p mockforge-registry-server --test cloud_conformance_e2e -- --ignored` against a live Postgres + registry — both tests pass (as of original PR; re-runs with rebased base).
- [ ] Manual smoke against deployed registry post-merge: trigger a cloud conformance run with a custom_checks YAML in the Advanced textarea, confirm both reference + custom checks fire and stream events.