### PR TITLE
feat(registry,test-runner): AI-assisted contract drift second pass (#348)

### DIFF
--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -53,6 +53,10 @@ jobs:
       AWS_ACCESS_KEY_ID: "minioadmin"
       AWS_SECRET_ACCESS_KEY: "minioadmin"
       REGISTRY_URL: "http://localhost:58080"
+      # Shared bearer token between the registry server and the E2E
+      # tests that hit `/api/v1/internal/*`. Kept literal so both
+      # processes see the same value.
+      MOCKFORGE_INTERNAL_API_TOKEN: "e2e-internal-token-do-not-use-in-prod"
 
     steps:
       - name: Checkout
@@ -140,6 +144,7 @@ jobs:
             --test signup_flow_e2e \
             --test marketplace_e2e \
             --test cloud_verification_e2e \
+            --test cloud_ai_contract_diff_e2e \
             -- --ignored --nocapture --test-threads=1
 
       - name: Dump registry-server log on failure

--- a/crates/mockforge-registry-server/src/ai/contract_diff.rs
+++ b/crates/mockforge-registry-server/src/ai/contract_diff.rs
@@ -1,0 +1,410 @@
+//! AI-assisted contract drift scoring (#348).
+//!
+//! The structural `ContractExecutor` in `mockforge-test-runner` already
+//! computes which declared spec endpoints have traffic vs. which are
+//! orphaned, and which traffic endpoints aren't declared at all. That's
+//! cheap and free.
+//!
+//! What this module adds is a *second pass* that takes a small sample
+//! of recent captured exchanges per declared endpoint and asks an LLM
+//! to score how the actual request/response shape compares to what the
+//! spec promises. Findings come back tagged
+//! `breaking | non_breaking | cosmetic` plus a confidence score.
+//!
+//! ## Why this is opt-in
+//!
+//! - Costs real LLM tokens (BYOK or platform credits, depending on the
+//!   org's setup).
+//! - Sampling captures means full request/response bodies leave the
+//!   registry's network, so users with strict data-handling rules
+//!   should be able to keep it disabled.
+//!
+//! Both are surfaced as a `ai_drift_enabled: bool` flag on the
+//! `test_suite.config` blob; the runner only fires the scoring callback
+//! when set true.
+//!
+//! ## What lives here vs. what lives in the handler
+//!
+//! Everything in this module is pure (no DB, no HTTP) so the prompt
+//! template, sample-shaping, and LLM-response parsing are unit-testable
+//! without fixtures. The HTTP handler at
+//! `handlers::internal_contract_diff` owns the orchestration: pulling
+//! sample captures, calling `run_completion_for_org`, and recording
+//! usage.
+
+use serde::{Deserialize, Serialize};
+
+/// Severity buckets returned by the AI scorer. Matches the existing
+/// `severity` field on `diff_finding` events so the UI's
+/// severity-grouped renderer renders both structural and AI findings
+/// without code changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DriftSeverity {
+    /// Behaviour observed in traffic that the spec explicitly forbids
+    /// (missing required field, wrong type, status code outside the
+    /// declared set, removed-but-still-served endpoint).
+    Breaking,
+    /// Behaviour the spec doesn't strictly forbid but that real
+    /// consumers would notice (added optional field in a response,
+    /// looser validation than declared).
+    NonBreaking,
+    /// Stylistic drift only (case differences, whitespace, ordering of
+    /// optional fields). Not actionable, kept so the model can flag
+    /// without distorting severity counts.
+    Cosmetic,
+}
+
+impl DriftSeverity {
+    /// Wire string used in `diff_finding` event payloads.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DriftSeverity::Breaking => "breaking",
+            DriftSeverity::NonBreaking => "non_breaking",
+            DriftSeverity::Cosmetic => "cosmetic",
+        }
+    }
+}
+
+/// One AI-scored drift finding for a single endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiFinding {
+    /// `breaking | non_breaking | cosmetic`.
+    pub severity: DriftSeverity,
+    /// `"POST /api/checkout"` — same shape the structural pass uses.
+    pub endpoint: String,
+    /// Short, human-readable description of the drift.
+    pub description: String,
+    /// Model's self-reported confidence in `[0.0, 1.0]`. Out-of-range
+    /// values are clamped on parse.
+    pub confidence: f64,
+    /// Free-text rationale the UI can show on click-through. Empty
+    /// string when the model didn't supply one.
+    #[serde(default)]
+    pub rationale: String,
+}
+
+/// One sampled exchange that the scorer can reason about. Bodies are
+/// the verbatim request/response strings from `runtime_captures` —
+/// already filtered to JSON-shaped payloads upstream.
+#[derive(Debug, Clone, Serialize)]
+pub struct SampledExchange {
+    pub method: String,
+    pub path: String,
+    pub status_code: Option<i32>,
+    /// Truncated to a safe length before being included in the prompt
+    /// (see [`MAX_BODY_CHARS`]). The truncation is stable so the model
+    /// gets a deterministic view across re-runs.
+    pub request_body: Option<String>,
+    pub response_body: Option<String>,
+}
+
+/// Cap per-body characters embedded in the prompt. Picked to stay well
+/// inside even Haiku-class context windows once the system prompt and
+/// spec excerpt are added: 6KB × ~10 exchanges ≈ 60KB of body data,
+/// plus ~10KB of spec excerpt and prompt ≈ 70KB total. Comfortable
+/// margin under a 128k context.
+pub const MAX_BODY_CHARS: usize = 6_000;
+
+/// Marker appended to truncated bodies so the model can tell it didn't
+/// see the whole thing. Length deliberately stable so
+/// [`truncate_body`] can reserve space for it.
+const TRUNCATION_MARKER: &str = "\n… (truncated)";
+
+/// Truncate a body string at a UTF-8 boundary, appending an
+/// `… (truncated)` marker so the model knows it didn't see the whole
+/// thing. Returns the original string when it's already small enough.
+/// Reserves space for the marker so the result is always shorter than
+/// the input — even when the original was barely over `max_chars`.
+pub fn truncate_body(body: &str, max_chars: usize) -> String {
+    if body.chars().count() <= max_chars {
+        return body.to_string();
+    }
+    // Reserve room for the marker so the final length stays under the
+    // input's. Saturating-sub guards against pathologically tiny
+    // `max_chars` values (anything < marker length collapses to a
+    // bare marker, which is fine — the model still gets the signal).
+    let marker_len = TRUNCATION_MARKER.chars().count();
+    let take = max_chars.saturating_sub(marker_len);
+    let mut out: String = body.chars().take(take).collect();
+    out.push_str(TRUNCATION_MARKER);
+    out
+}
+
+/// Build the system + user prompts the LLM sees. Pure function so the
+/// shape can be locked down in tests.
+///
+/// The system prompt teaches the model:
+/// 1. The severity vocabulary it must emit (breaking / non_breaking /
+///    cosmetic).
+/// 2. The strict JSON-array output format.
+/// 3. How to weigh sample size when reporting confidence.
+///
+/// The user prompt carries the spec excerpt followed by the
+/// per-endpoint sample exchanges, formatted as a fenced JSON block so
+/// the model can scan them mechanically.
+pub fn build_prompt(spec_excerpt: &str, exchanges: &[SampledExchange]) -> (String, String) {
+    let system = "You are a contract-drift reviewer for OpenAPI APIs. Compare actual \
+HTTP exchanges against the declared spec and report only meaningful drift.\n\n\
+You MUST emit a single JSON array (no prose, no markdown fences) where each \
+element has these exact keys: severity (\"breaking\" | \"non_breaking\" | \
+\"cosmetic\"), endpoint (\"METHOD /path\"), description (one short sentence), \
+confidence (0.0 to 1.0), rationale (one or two sentences explaining what \
+you observed).\n\n\
+Severity rules:\n\
+- breaking: required field missing, wrong type, undeclared status code, \
+endpoint serving traffic that the spec forbids.\n\
+- non_breaking: extra optional field present, loosened validation, \
+behaviour the spec doesn't forbid.\n\
+- cosmetic: case-only differences, ordering, whitespace, trailing slashes.\n\n\
+Confidence rules: If you saw fewer than 2 exchanges for an endpoint, cap \
+confidence at 0.6. If exchanges all show the same drift, use 0.85+. If \
+exchanges disagree with each other, drop to 0.5.\n\n\
+If you find no drift at all, emit an empty array `[]`."
+        .to_string();
+
+    let mut user = String::new();
+    user.push_str("# Declared OpenAPI spec (excerpt)\n\n```yaml\n");
+    user.push_str(spec_excerpt);
+    user.push_str("\n```\n\n# Sampled exchanges\n\n");
+
+    if exchanges.is_empty() {
+        user.push_str("(no exchanges sampled — declared endpoints had no recent traffic)\n");
+    } else {
+        for ex in exchanges {
+            user.push_str(&format!(
+                "## {} {}\nstatus: {}\n",
+                ex.method,
+                ex.path,
+                ex.status_code.map(|s| s.to_string()).unwrap_or_else(|| "?".to_string()),
+            ));
+            if let Some(body) = &ex.request_body {
+                user.push_str("\n### request body\n```\n");
+                user.push_str(&truncate_body(body, MAX_BODY_CHARS));
+                user.push_str("\n```\n");
+            }
+            if let Some(body) = &ex.response_body {
+                user.push_str("\n### response body\n```\n");
+                user.push_str(&truncate_body(body, MAX_BODY_CHARS));
+                user.push_str("\n```\n");
+            }
+            user.push('\n');
+        }
+    }
+
+    user.push_str(
+        "\n# Task\n\nEmit the JSON array of findings. No other output. \
+If nothing drifted, emit `[]`.",
+    );
+
+    (system, user)
+}
+
+/// Parse the model's response into structured findings. Tolerates:
+/// - Plain JSON arrays.
+/// - JSON arrays inside ```json``` fences (handled by
+///   [`crate::handlers::ai_studio::extract_json_payload`] upstream).
+/// - Single-object responses where the model forgot the array wrapper
+///   (we wrap it for them).
+/// - Out-of-range confidence values (clamped to `[0.0, 1.0]`).
+/// - Unknown severity strings (entry skipped with a warning).
+///
+/// Returns an empty vec when nothing usable was found — the executor
+/// emits a degraded-but-fine "AI scoring returned no findings" log
+/// rather than failing the whole run.
+pub fn parse_findings(json: &serde_json::Value) -> Vec<AiFinding> {
+    let raw_array: Vec<serde_json::Value> = match json {
+        serde_json::Value::Array(items) => items.clone(),
+        // Single-object response — wrap it.
+        obj @ serde_json::Value::Object(_) => vec![obj.clone()],
+        _ => return Vec::new(),
+    };
+
+    let mut out = Vec::with_capacity(raw_array.len());
+    for item in raw_array {
+        let severity_str = item.get("severity").and_then(|v| v.as_str()).unwrap_or("");
+        let severity = match severity_str {
+            "breaking" => DriftSeverity::Breaking,
+            "non_breaking" => DriftSeverity::NonBreaking,
+            "cosmetic" => DriftSeverity::Cosmetic,
+            _ => continue, // unknown severity — drop the entry rather than guess
+        };
+        let endpoint = item
+            .get("endpoint")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+        let Some(endpoint) = endpoint else { continue };
+        let description = item
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .unwrap_or("")
+            .to_string();
+        let raw_conf = item.get("confidence").and_then(|v| v.as_f64()).unwrap_or(0.5);
+        let confidence = raw_conf.clamp(0.0, 1.0);
+        let rationale = item
+            .get("rationale")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .unwrap_or("")
+            .to_string();
+
+        out.push(AiFinding {
+            severity,
+            endpoint,
+            description,
+            confidence,
+            rationale,
+        });
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ex(method: &str, path: &str, body: &str) -> SampledExchange {
+        SampledExchange {
+            method: method.to_string(),
+            path: path.to_string(),
+            status_code: Some(200),
+            request_body: None,
+            response_body: Some(body.to_string()),
+        }
+    }
+
+    #[test]
+    fn truncate_short_body_unchanged() {
+        let s = "abc";
+        assert_eq!(truncate_body(s, 100), "abc");
+    }
+
+    #[test]
+    fn truncate_appends_marker() {
+        let s = "x".repeat(MAX_BODY_CHARS + 10);
+        let out = truncate_body(&s, MAX_BODY_CHARS);
+        assert!(out.ends_with("… (truncated)"));
+        // Original body chars + marker
+        assert!(out.chars().count() < s.chars().count());
+    }
+
+    #[test]
+    fn truncate_handles_multibyte_at_boundary() {
+        // Marker chars: emoji plus surrounding text. Must not split codepoints.
+        let s = "héllo wörld 🎉".repeat(2_000);
+        let out = truncate_body(&s, 100);
+        assert!(out.is_char_boundary(out.len()));
+    }
+
+    #[test]
+    fn build_prompt_with_no_exchanges() {
+        let (system, user) = build_prompt("paths: {}", &[]);
+        assert!(system.contains("contract-drift"));
+        assert!(user.contains("(no exchanges sampled"));
+        assert!(user.contains("paths: {}"));
+    }
+
+    #[test]
+    fn build_prompt_includes_method_path_status() {
+        let (_system, user) =
+            build_prompt("openapi: 3.0.0", &[ex("POST", "/api/checkout", r#"{"item":"x"}"#)]);
+        assert!(user.contains("POST /api/checkout"));
+        assert!(user.contains("status: 200"));
+        assert!(user.contains(r#"{"item":"x"}"#));
+    }
+
+    #[test]
+    fn parse_findings_well_formed_array() {
+        let json = serde_json::json!([
+            {
+                "severity": "breaking",
+                "endpoint": "POST /api/checkout",
+                "description": "Required field missing",
+                "confidence": 0.9,
+                "rationale": "All 3 sampled responses omitted `created_at`."
+            },
+            {
+                "severity": "cosmetic",
+                "endpoint": "GET /api/users",
+                "description": "Trailing slash in path",
+                "confidence": 0.4,
+                "rationale": ""
+            }
+        ]);
+        let findings = parse_findings(&json);
+        assert_eq!(findings.len(), 2);
+        assert_eq!(findings[0].severity, DriftSeverity::Breaking);
+        assert_eq!(findings[0].endpoint, "POST /api/checkout");
+        assert!((findings[0].confidence - 0.9).abs() < 0.001);
+        assert_eq!(findings[1].severity, DriftSeverity::Cosmetic);
+        assert!(findings[1].rationale.is_empty());
+    }
+
+    #[test]
+    fn parse_findings_clamps_confidence_out_of_range() {
+        let json = serde_json::json!([
+            { "severity": "breaking", "endpoint": "GET /a", "description": "x", "confidence": 1.7 },
+            { "severity": "breaking", "endpoint": "GET /b", "description": "y", "confidence": -0.5 }
+        ]);
+        let findings = parse_findings(&json);
+        assert_eq!(findings.len(), 2);
+        assert!((findings[0].confidence - 1.0).abs() < 0.001);
+        assert!(findings[1].confidence.abs() < 0.001);
+    }
+
+    #[test]
+    fn parse_findings_drops_unknown_severity() {
+        let json = serde_json::json!([
+            { "severity": "blocker", "endpoint": "GET /a", "description": "x", "confidence": 0.5 },
+            { "severity": "breaking", "endpoint": "GET /b", "description": "y", "confidence": 0.5 }
+        ]);
+        let findings = parse_findings(&json);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].endpoint, "GET /b");
+    }
+
+    #[test]
+    fn parse_findings_drops_missing_endpoint() {
+        let json = serde_json::json!([
+            { "severity": "breaking", "description": "x", "confidence": 0.5 }
+        ]);
+        assert!(parse_findings(&json).is_empty());
+    }
+
+    #[test]
+    fn parse_findings_wraps_single_object() {
+        let json = serde_json::json!({
+            "severity": "non_breaking",
+            "endpoint": "GET /a",
+            "description": "Extra optional field",
+            "confidence": 0.7
+        });
+        let findings = parse_findings(&json);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, DriftSeverity::NonBreaking);
+    }
+
+    #[test]
+    fn parse_findings_empty_array() {
+        let json = serde_json::json!([]);
+        assert!(parse_findings(&json).is_empty());
+    }
+
+    #[test]
+    fn parse_findings_non_array_non_object_returns_empty() {
+        assert!(parse_findings(&serde_json::json!("nope")).is_empty());
+        assert!(parse_findings(&serde_json::json!(42)).is_empty());
+        assert!(parse_findings(&serde_json::json!(null)).is_empty());
+    }
+
+    #[test]
+    fn drift_severity_wire_strings() {
+        assert_eq!(DriftSeverity::Breaking.as_str(), "breaking");
+        assert_eq!(DriftSeverity::NonBreaking.as_str(), "non_breaking");
+        assert_eq!(DriftSeverity::Cosmetic.as_str(), "cosmetic");
+    }
+}

--- a/crates/mockforge-registry-server/src/ai/mod.rs
+++ b/crates/mockforge-registry-server/src/ai/mod.rs
@@ -7,6 +7,7 @@
 //! See `docs/cloud/CLOUD_AI_STUDIO_DESIGN.md` for the full design.
 
 pub mod client;
+pub mod contract_diff;
 pub mod provider;
 pub mod quota;
 

--- a/crates/mockforge-registry-server/src/handlers/ai_studio.rs
+++ b/crates/mockforge-registry-server/src/handlers/ai_studio.rs
@@ -451,36 +451,47 @@ pub(crate) async fn run_completion(
     headers: &HeaderMap,
     prompt: PromptInputs,
 ) -> ApiResult<(String, UsageMeta)> {
-    // 1. Auth + plan info.
     let org_ctx = resolve_org_context(state, user_id, headers, None)
         .await
         .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    run_completion_for_org(state, &org_ctx.org, prompt).await
+}
 
-    // 2. BYOK lookup.
-    let byok = load_byok_config(state, org_ctx.org_id).await?;
+/// Same pipeline as [`run_completion`] but skips the user→org resolution
+/// and operates on a known [`Organization`]. Internal callers (e.g. the
+/// runner-facing `/api/v1/internal/contract-diff/score` endpoint, where
+/// the auth model is a shared internal token rather than a user
+/// session) use this entry point.
+pub(crate) async fn run_completion_for_org(
+    state: &AppState,
+    org: &mockforge_registry_core::models::Organization,
+    prompt: PromptInputs,
+) -> ApiResult<(String, UsageMeta)> {
+    // 1. BYOK lookup.
+    let byok = load_byok_config(state, org.id).await?;
 
-    // 3. Provider routing (pure).
-    let is_paid_plan = matches!(org_ctx.org.plan(), Plan::Pro | Plan::Team);
+    // 2. Provider routing (pure).
+    let is_paid_plan = matches!(org.plan(), Plan::Pro | Plan::Team);
     let provider = pick_provider(is_paid_plan, byok);
 
-    // 4. Pre-call quota check.
-    let quota = check_ai_quota(state, &org_ctx.org, provider.selection()).await?;
+    // 3. Pre-call quota check.
+    let quota = check_ai_quota(state, org, provider.selection()).await?;
     if !quota.allowed {
         return Err(quota.into_error());
     }
 
-    // 5. Build LLM call.
+    // 4. Build LLM call.
     let selection = provider.selection();
     let llm_call = build_llm_call(&provider, prompt)?;
 
-    // 6. Call.
+    // 5. Call.
     let result = call_llm(llm_call).await?;
 
-    // 7. Meter (Platform only; BYOK skips the platform quota).
+    // 6. Meter (Platform only; BYOK skips the platform quota).
     let total_tokens = result.total_tokens();
-    record_ai_usage(state, org_ctx.org_id, selection, total_tokens as i64).await?;
+    record_ai_usage(state, org.id, selection, total_tokens as i64).await?;
 
-    // 8. Build response metadata.
+    // 7. Build response metadata.
     let billed_now = if matches!(selection, ProviderSelection::Platform) {
         total_tokens as i64
     } else {

--- a/crates/mockforge-registry-server/src/handlers/internal_contract_diff.rs
+++ b/crates/mockforge-registry-server/src/handlers/internal_contract_diff.rs
@@ -1,0 +1,257 @@
+//! Internal endpoint for the AI-assisted contract drift second pass
+//! (#348).
+//!
+//! `mockforge-test-runner`'s `ContractExecutor` calls this endpoint
+//! after its structural diff so we can pick up sampled exchanges,
+//! run them through an LLM, and return scored drift findings the
+//! runner emits as additional `diff_finding` events. The runner can't
+//! call the LLM itself because the BYOK key + platform key live on
+//! the registry side and we don't want to plumb decryption through the
+//! queue payload.
+//!
+//! Auth model: shared internal bearer token (`MOCKFORGE_INTERNAL_API_TOKEN`),
+//! same as every other handler under `/api/v1/internal/*`.
+
+use axum::{extract::State, http::HeaderMap, Json};
+use chrono::{DateTime, Utc};
+use mockforge_registry_core::models::Organization;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    ai::contract_diff::{build_prompt, parse_findings, AiFinding, SampledExchange},
+    error::{ApiError, ApiResult},
+    handlers::ai_studio::{extract_json_payload, run_completion_for_org, PromptInputs},
+    AppState,
+};
+
+/// Per-endpoint sample cap. The model needs at least 2-3 exchanges to
+/// confidently call out drift; more than 5 just inflates the prompt
+/// without much marginal signal. Hard-capped server-side so a runner
+/// can't burn LLM credits by asking for hundreds of samples.
+const MAX_SAMPLES_PER_ENDPOINT: i64 = 5;
+const DEFAULT_SAMPLES_PER_ENDPOINT: i64 = 3;
+
+/// How many endpoints we'll sample at once. The structural pass can
+/// emit hundreds of findings on a busy workspace; AI scoring all of
+/// them on every run is expensive. The runner is expected to send a
+/// representative subset (e.g. the structural pass's "declared with
+/// traffic" set, capped at this many).
+const MAX_ENDPOINTS_PER_REQUEST: usize = 25;
+
+#[derive(Debug, Deserialize)]
+pub struct EndpointSpec {
+    /// HTTP method (case-insensitive — normalised to uppercase before
+    /// the runtime_captures lookup).
+    pub method: String,
+    /// Path as the spec declares it. Matched literally against
+    /// `runtime_captures.path`; we don't expand parameter templates
+    /// (`/users/{id}` → `/users/42`) here because the runner is in a
+    /// better position to resolve them via its own pattern matching.
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScoreRequest {
+    pub org_id: Uuid,
+    pub workspace_id: Uuid,
+    /// Excerpt of the OpenAPI spec scoped to the endpoints under
+    /// review. The runner trims this to keep the prompt bounded.
+    pub spec_excerpt: String,
+    pub endpoints: Vec<EndpointSpec>,
+    /// Optional override; defaults to [`DEFAULT_SAMPLES_PER_ENDPOINT`]
+    /// and is hard-capped at [`MAX_SAMPLES_PER_ENDPOINT`].
+    #[serde(default)]
+    pub max_samples_per_endpoint: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScoreResponse {
+    pub findings: Vec<AiFinding>,
+    /// Tokens consumed by this scoring call. Mostly informational for
+    /// the runner so it can log it; metering already happened
+    /// server-side via `record_ai_usage`.
+    pub tokens_used: u64,
+    /// `byok` | `platform` | `disabled` — same set used by AI Studio.
+    pub provider: &'static str,
+    /// `true` when no exchanges were found across any endpoint, so the
+    /// runner can emit a "skipped — no traffic" log instead of a noisy
+    /// empty result.
+    pub no_traffic: bool,
+}
+
+fn require_internal_auth(headers: &HeaderMap) -> ApiResult<()> {
+    let configured = match std::env::var("MOCKFORGE_INTERNAL_API_TOKEN") {
+        Ok(v) if !v.is_empty() => v,
+        _ => {
+            return Err(ApiError::Internal(anyhow::anyhow!(
+                "MOCKFORGE_INTERNAL_API_TOKEN not configured"
+            )));
+        }
+    };
+    let provided = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .ok_or_else(|| ApiError::InvalidRequest("Not found".into()))?;
+    if !constant_time_eq(provided.as_bytes(), configured.as_bytes()) {
+        return Err(ApiError::InvalidRequest("Not found".into()));
+    }
+    Ok(())
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Sub-set of `runtime_captures` columns the AI scorer cares about.
+/// Anything outside this list (headers, query_params, request_id,
+/// trace_id, etc.) is intentionally dropped — the model only consults
+/// method, path, status, and bodies, so widening the row type would
+/// just inflate token cost.
+#[derive(sqlx::FromRow)]
+struct SampleRow {
+    method: String,
+    path: String,
+    status_code: Option<i32>,
+    request_body: Option<String>,
+    response_body: Option<String>,
+    #[allow(dead_code)] // ordering only; not embedded in the prompt
+    occurred_at: DateTime<Utc>,
+}
+
+/// Pull up to `limit` recent capture rows for one (workspace, method,
+/// path) tuple. Newest first. Bodies come back verbatim — the prompt
+/// builder handles truncation.
+async fn fetch_samples(
+    state: &AppState,
+    workspace_id: Uuid,
+    method: &str,
+    path: &str,
+    limit: i64,
+) -> ApiResult<Vec<SampledExchange>> {
+    let rows: Vec<SampleRow> = sqlx::query_as(
+        r#"
+        SELECT method,
+               path,
+               status_code,
+               request_body,
+               response_body,
+               occurred_at
+          FROM runtime_captures
+         WHERE workspace_id = $1
+           AND UPPER(method) = $2
+           AND path = $3
+           AND occurred_at >= NOW() - INTERVAL '24 hours'
+         ORDER BY occurred_at DESC
+         LIMIT $4
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(method.to_uppercase())
+    .bind(path)
+    .bind(limit)
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| SampledExchange {
+            method: r.method,
+            path: r.path,
+            status_code: r.status_code,
+            request_body: r.request_body,
+            response_body: r.response_body,
+        })
+        .collect())
+}
+
+/// `POST /api/v1/internal/contract-diff/score`
+///
+/// Internal — runner-only. Returns a structured set of LLM-scored
+/// drift findings the runner emits as `diff_finding` events.
+pub async fn score_contract_drift(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<ScoreRequest>,
+) -> ApiResult<Json<ScoreResponse>> {
+    require_internal_auth(&headers)?;
+
+    if request.endpoints.is_empty() {
+        return Ok(Json(ScoreResponse {
+            findings: Vec::new(),
+            tokens_used: 0,
+            provider: "disabled",
+            no_traffic: true,
+        }));
+    }
+
+    let endpoints: Vec<EndpointSpec> =
+        request.endpoints.into_iter().take(MAX_ENDPOINTS_PER_REQUEST).collect();
+
+    let limit = request
+        .max_samples_per_endpoint
+        .unwrap_or(DEFAULT_SAMPLES_PER_ENDPOINT)
+        .clamp(1, MAX_SAMPLES_PER_ENDPOINT);
+
+    // Pull samples for each endpoint, then flatten into one big list
+    // for the prompt. The model ranks per-endpoint via the
+    // (method, path) header in each block, so flattening doesn't lose
+    // the grouping.
+    let mut all_samples: Vec<SampledExchange> = Vec::new();
+    for ep in &endpoints {
+        let mut samples =
+            fetch_samples(&state, request.workspace_id, &ep.method, &ep.path, limit).await?;
+        all_samples.append(&mut samples);
+    }
+
+    if all_samples.is_empty() {
+        return Ok(Json(ScoreResponse {
+            findings: Vec::new(),
+            tokens_used: 0,
+            provider: "disabled",
+            no_traffic: true,
+        }));
+    }
+
+    let org = Organization::find_by_id(state.db.pool(), request.org_id)
+        .await
+        .map_err(ApiError::Database)?
+        .ok_or_else(|| ApiError::InvalidRequest("Organization not found".into()))?;
+
+    let (system, user) = build_prompt(&request.spec_excerpt, &all_samples);
+
+    // Conservative budget: the system prompt teaches the model to emit
+    // a small JSON array, and we only sample up to ~25 endpoints × 5
+    // exchanges, so 4k completion tokens is plenty. Temperature kept
+    // low so the model treats this as classification rather than
+    // creative writing.
+    let prompt = PromptInputs {
+        system,
+        user,
+        model: None,
+        temperature: 0.2,
+        max_tokens: 4096,
+    };
+    let (raw_text, meta) = run_completion_for_org(&state, &org, prompt).await?;
+
+    let findings = match extract_json_payload(&raw_text) {
+        Some(json) => parse_findings(&json),
+        None => Vec::new(),
+    };
+
+    Ok(Json(ScoreResponse {
+        findings,
+        tokens_used: meta.tokens_used,
+        provider: meta.provider,
+        no_traffic: false,
+    }))
+}

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -20,6 +20,7 @@ pub mod flows;
 pub mod health;
 pub mod hosted_mocks;
 pub mod incidents;
+pub mod internal_contract_diff;
 pub mod internal_test_runs;
 pub mod legal;
 pub mod mockai;

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -123,6 +123,11 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/internal/tunnel-reservations/by-subdomain/{subdomain}",
             get(handlers::internal_test_runs::get_tunnel_reservation_by_subdomain),
         )
+        // AI-assisted contract drift scoring (#348). Runner-only.
+        .route(
+            "/api/v1/internal/contract-diff/score",
+            post(handlers::internal_contract_diff::score_contract_drift),
+        )
         // Marketplace: scenarios (public)
         .route("/api/v1/marketplace/scenarios/search", post(handlers::scenarios::search_scenarios))
         .route("/api/v1/marketplace/scenarios/{name}", get(handlers::scenarios::get_scenario))

--- a/crates/mockforge-registry-server/tests/cloud_ai_contract_diff_e2e.rs
+++ b/crates/mockforge-registry-server/tests/cloud_ai_contract_diff_e2e.rs
@@ -1,0 +1,333 @@
+//! End-to-end test for the AI-assisted contract drift second pass
+//! added in #348.
+//!
+//! Covers the runner-facing internal endpoint contract:
+//! `POST /api/v1/internal/contract-diff/score`.
+//!
+//! What we *can* exercise in CI:
+//!   - Internal-auth gate (missing/wrong bearer token → "Not found").
+//!   - Empty `endpoints` → no LLM call, returns `no_traffic=true`.
+//!   - Endpoints set but no captured exchanges in `runtime_captures`
+//!     → no LLM call, returns `no_traffic=true`.
+//!   - Free-tier org (no BYOK, no platform credits) → LLM is gated by
+//!     `check_ai_quota` and the endpoint surfaces a 403 with the same
+//!     "AI features are not available" copy AI Studio uses.
+//!
+//! What we deliberately do NOT exercise:
+//!   - A real LLM call. CI doesn't have a valid
+//!     `MOCKFORGE_PLATFORM_LLM_API_KEY` and we don't want this test
+//!     silently burning real credits when it does. The pure
+//!     prompt-building + finding-parsing is unit-tested in
+//!     `mockforge-registry-server::ai::contract_diff::tests`.
+//!
+//! Requires:
+//!   - PostgreSQL (docker-compose up db)
+//!   - Registry server running with `MOCKFORGE_INTERNAL_API_TOKEN` set
+//!     (the e2e workflow already wires this).
+//!
+//! Run with:
+//!   REGISTRY_URL=http://localhost:8080 \
+//!   DATABASE_URL=postgres://postgres:password@localhost:55432/mockforge_registry \
+//!   MOCKFORGE_INTERNAL_API_TOKEN=test-internal-token \
+//!   cargo test --test cloud_ai_contract_diff_e2e -- --ignored --nocapture
+
+use chrono::Utc;
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+struct E2e {
+    client: Client,
+    // Carried for completeness/symmetry with other e2e tests; the
+    // contract-diff tests build URLs from `base_url` arg directly.
+    #[allow(dead_code)]
+    base_url: String,
+    access_token: String,
+    org_id: String,
+    workspace_id: String,
+    pool: PgPool,
+}
+
+async fn register_and_setup(base_url: &str, pool: &PgPool) -> E2e {
+    let client = Client::new();
+    let ts = Utc::now().timestamp_micros();
+    let username = format!("aidiff_{}", ts);
+    let email = format!("aidiff_{}@e2e-test.local", ts);
+    let password = "SecureP@ssw0rd!2024";
+
+    let res = client
+        .post(format!("{}/api/v1/auth/register", base_url))
+        .json(&json!({ "username": username, "email": email, "password": password }))
+        .send()
+        .await
+        .expect("register failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("register not JSON");
+    assert!(status.is_success(), "register {}: {}", status, body);
+    let access_token = body["access_token"]
+        .as_str()
+        .or_else(|| body["token"].as_str())
+        .expect("no access token")
+        .to_string();
+
+    let org_slug = format!("aidiff-{}", ts);
+    let res = client
+        .post(format!("{}/api/v1/organizations", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .json(&json!({ "name": format!("AI Diff Test Org {}", ts), "slug": org_slug }))
+        .send()
+        .await
+        .expect("create org failed");
+    let body: Value = res.json().await.expect("org not JSON");
+    let org_id = body["id"].as_str().expect("no org id").to_string();
+
+    let res = client
+        .post(format!("{}/api/v1/workspaces", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("X-Organization-Id", &org_id)
+        .json(&json!({ "name": "ai-diff-e2e", "description": "e2e fixture" }))
+        .send()
+        .await
+        .expect("create workspace failed");
+    let body: Value = res.json().await.expect("ws not JSON");
+    let workspace_id = body["id"].as_str().expect("no ws id").to_string();
+
+    E2e {
+        client,
+        base_url: base_url.to_string(),
+        access_token,
+        org_id,
+        workspace_id,
+        pool: pool.clone(),
+    }
+}
+
+fn internal_token() -> String {
+    std::env::var("MOCKFORGE_INTERNAL_API_TOKEN").expect("MOCKFORGE_INTERNAL_API_TOKEN must be set")
+}
+
+#[tokio::test]
+#[ignore]
+async fn rejects_missing_internal_auth() {
+    let base_url = std::env::var("REGISTRY_URL").expect("REGISTRY_URL must be set");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+    let e = register_and_setup(&base_url, &pool).await;
+
+    // No bearer at all — handler should reject before doing any DB
+    // work, returning the same opaque "Not found" the other internal
+    // endpoints use.
+    let res = e
+        .client
+        .post(format!("{}/api/v1/internal/contract-diff/score", base_url))
+        .json(&json!({
+            "org_id": e.org_id,
+            "workspace_id": e.workspace_id,
+            "spec_excerpt": "openapi: 3.0.0",
+            "endpoints": [{"method": "GET", "path": "/x"}],
+        }))
+        .send()
+        .await
+        .expect("post failed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    // Wrong bearer.
+    let res = e
+        .client
+        .post(format!("{}/api/v1/internal/contract-diff/score", base_url))
+        .header("Authorization", "Bearer wrong-token")
+        .json(&json!({
+            "org_id": e.org_id,
+            "workspace_id": e.workspace_id,
+            "spec_excerpt": "openapi: 3.0.0",
+            "endpoints": [{"method": "GET", "path": "/x"}],
+        }))
+        .send()
+        .await
+        .expect("post failed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    // Use the user's session token (also wrong — internal endpoints
+    // don't accept user tokens).
+    let res = e
+        .client
+        .post(format!("{}/api/v1/internal/contract-diff/score", base_url))
+        .header("Authorization", format!("Bearer {}", e.access_token))
+        .json(&json!({
+            "org_id": e.org_id,
+            "workspace_id": e.workspace_id,
+            "spec_excerpt": "openapi: 3.0.0",
+            "endpoints": [{"method": "GET", "path": "/x"}],
+        }))
+        .send()
+        .await
+        .expect("post failed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ignore]
+async fn empty_endpoints_short_circuits_no_llm_call() {
+    let base_url = std::env::var("REGISTRY_URL").expect("REGISTRY_URL must be set");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+    let e = register_and_setup(&base_url, &pool).await;
+
+    let res = e
+        .client
+        .post(format!("{}/api/v1/internal/contract-diff/score", base_url))
+        .header("Authorization", format!("Bearer {}", internal_token()))
+        .json(&json!({
+            "org_id": e.org_id,
+            "workspace_id": e.workspace_id,
+            "spec_excerpt": "openapi: 3.0.0\npaths: {}",
+            "endpoints": [],
+        }))
+        .send()
+        .await
+        .expect("post failed");
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "empty endpoints should short-circuit OK: {:?}",
+        res.text().await.unwrap_or_default()
+    );
+    let body: Value = res.json().await.expect("not JSON");
+    assert_eq!(body["no_traffic"], json!(true));
+    assert_eq!(body["tokens_used"], json!(0));
+    assert!(body["findings"].as_array().expect("findings array").is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn no_captured_exchanges_short_circuits_no_llm_call() {
+    // Ask to score endpoints that no `runtime_captures` rows exist for.
+    // Should return no_traffic=true without invoking the LLM (which
+    // would otherwise 403 on a free-tier org without BYOK).
+    let base_url = std::env::var("REGISTRY_URL").expect("REGISTRY_URL must be set");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+    let e = register_and_setup(&base_url, &pool).await;
+
+    let res = e
+        .client
+        .post(format!("{}/api/v1/internal/contract-diff/score", base_url))
+        .header("Authorization", format!("Bearer {}", internal_token()))
+        .json(&json!({
+            "org_id": e.org_id,
+            "workspace_id": e.workspace_id,
+            "spec_excerpt": "openapi: 3.0.0\npaths:\n  /api/users:\n    get: {}",
+            "endpoints": [{"method": "GET", "path": "/api/users"}],
+        }))
+        .send()
+        .await
+        .expect("post failed");
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: Value = res.json().await.expect("not JSON");
+    assert_eq!(body["no_traffic"], json!(true));
+    assert_eq!(body["tokens_used"], json!(0));
+    assert!(body["findings"].as_array().expect("findings array").is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn free_plan_without_byok_is_quota_blocked_when_traffic_exists() {
+    // Seed a runtime_capture row so the endpoint reaches the LLM
+    // gate. Then the free-tier org without BYOK should be denied
+    // with the standard "AI features are not available" copy.
+    let base_url = std::env::var("REGISTRY_URL").expect("REGISTRY_URL must be set");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+    let e = register_and_setup(&base_url, &pool).await;
+
+    // Insert a hosted_mock so runtime_captures.deployment_id FK is
+    // satisfied (CASCADE on delete from hosted_mocks).
+    let org_uuid = Uuid::parse_str(&e.org_id).expect("org id not UUID");
+    let workspace_uuid = Uuid::parse_str(&e.workspace_id).expect("ws id not UUID");
+    let deployment_id = Uuid::new_v4();
+    let ts = Utc::now().timestamp_micros();
+    sqlx::query(
+        r#"
+        INSERT INTO hosted_mocks (id, org_id, name, slug, config_json, status)
+        VALUES ($1, $2, $3, $4, '{}'::jsonb, 'active')
+        "#,
+    )
+    .bind(deployment_id)
+    .bind(org_uuid)
+    .bind("ai-diff-fixture")
+    .bind(format!("aifix-{}", ts))
+    .execute(&e.pool)
+    .await
+    .expect("insert hosted_mock failed");
+
+    let capture_id = Uuid::new_v4().to_string();
+    sqlx::query(
+        r#"
+        INSERT INTO runtime_captures (
+            deployment_id, capture_id, protocol, occurred_at, method, path,
+            request_headers, request_body_encoding, status_code,
+            workspace_id, source
+        )
+        VALUES (
+            $1, $2, 'http', NOW(), 'POST', '/api/checkout',
+            '{}', 'utf8', 200,
+            $3, 'hosted'
+        )
+        "#,
+    )
+    .bind(deployment_id)
+    .bind(&capture_id)
+    .bind(workspace_uuid)
+    .execute(&e.pool)
+    .await
+    .expect("insert runtime_capture failed");
+
+    let res = e
+        .client
+        .post(format!("{}/api/v1/internal/contract-diff/score", base_url))
+        .header("Authorization", format!("Bearer {}", internal_token()))
+        .json(&json!({
+            "org_id": e.org_id,
+            "workspace_id": e.workspace_id,
+            "spec_excerpt": "openapi: 3.0.0",
+            "endpoints": [{"method": "POST", "path": "/api/checkout"}],
+        }))
+        .send()
+        .await
+        .expect("post failed");
+    let status = res.status();
+    let body = res.text().await.unwrap_or_default();
+    // Free + no BYOK → ProviderSelection::Disabled → 403
+    // ResourceLimitExceeded with the "AI features are not available"
+    // message. (Same code path AI Studio's chat endpoint hits.)
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "expected 403 quota block, got {}: {}",
+        status,
+        body
+    );
+    assert!(
+        body.to_lowercase().contains("ai")
+            && (body.to_lowercase().contains("byok") || body.to_lowercase().contains("plan")),
+        "expected quota error mentioning AI/BYOK/plan, got: {body}"
+    );
+}

--- a/crates/mockforge-test-runner/src/callbacks.rs
+++ b/crates/mockforge-test-runner/src/callbacks.rs
@@ -133,6 +133,26 @@ impl RegistryCallbacks {
         Ok(rows)
     }
 
+    /// Run the AI-assisted contract drift second pass (#348). The
+    /// registry samples recent captures for each (method, path), feeds
+    /// them to an LLM with the spec excerpt, and returns scored
+    /// `breaking | non_breaking | cosmetic` findings the runner emits
+    /// as additional `diff_finding` events. Returns an empty findings
+    /// list (with `no_traffic=true`) when no exchanges were captured —
+    /// the structural pass already handled the "spec without traffic"
+    /// case so this is just a quiet skip.
+    pub async fn score_contract_drift(
+        &self,
+        body: &ContractDriftScoreRequest,
+    ) -> Result<ContractDriftScoreResponse> {
+        let url =
+            format!("{}/api/v1/internal/contract-diff/score", self.base_url.trim_end_matches('/'),);
+        let resp = self.http.post(&url).bearer_auth(&self.token).json(body).send().await?;
+        let resp = resp.error_for_status()?;
+        let payload: ContractDriftScoreResponse = resp.json().await?;
+        Ok(payload)
+    }
+
     /// Fetch a fitness function definition (id, name, kind, config)
     /// for the FitnessExecutor (#355). Called once per run before
     /// dispatching to the kind-specific evaluator.
@@ -236,6 +256,52 @@ pub struct EndpointHit {
     pub method: String,
     pub path: String,
     pub hits: i64,
+}
+
+/// Endpoint identifier the AI scoring callback samples captures for.
+/// Format matches what `runtime_captures` stores: method case-
+/// insensitive, path matched literally.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ContractDriftEndpoint {
+    pub method: String,
+    pub path: String,
+}
+
+/// Body for `POST /api/v1/internal/contract-diff/score`.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ContractDriftScoreRequest {
+    pub org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub spec_excerpt: String,
+    pub endpoints: Vec<ContractDriftEndpoint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_samples_per_endpoint: Option<i64>,
+}
+
+/// One AI-scored finding mirrored from
+/// `crates/mockforge-registry-server/src/ai/contract_diff.rs::AiFinding`.
+/// Kept in lockstep so the runner can emit the same shape directly.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AiContractFinding {
+    pub severity: String,
+    pub endpoint: String,
+    pub description: String,
+    pub confidence: f64,
+    #[serde(default)]
+    pub rationale: String,
+}
+
+/// Response from the AI scoring endpoint.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContractDriftScoreResponse {
+    pub findings: Vec<AiContractFinding>,
+    pub tokens_used: u64,
+    pub provider: String,
+    pub no_traffic: bool,
 }
 
 /// Subset of `FitnessFunction` the runner needs to dispatch + evaluate.

--- a/crates/mockforge-test-runner/src/executors/contract.rs
+++ b/crates/mockforge-test-runner/src/executors/contract.rs
@@ -15,7 +15,7 @@
 use async_trait::async_trait;
 use std::time::Instant;
 
-use crate::callbacks::RegistryCallbacks;
+use crate::callbacks::{ContractDriftEndpoint, ContractDriftScoreRequest, RegistryCallbacks};
 use crate::error::Result;
 use crate::executors::{Executor, JobOutcome, JobStatus, RunJob};
 
@@ -285,12 +285,67 @@ async fn run_real_contract_diff(
         }
     }
 
+    // Optional AI-assisted second pass (#348). Opt-in via the suite
+    // config's `ai_drift_enabled` flag. Scores parameter / schema /
+    // response-shape drift on declared endpoints that actually have
+    // traffic — orphaned and undeclared ones already have clear
+    // severity from the structural pass. Failures from the AI call
+    // are non-fatal: a missing BYOK / exhausted quota / timeout
+    // degrades to "no AI findings" rather than failing the run.
+    let mut ai_findings_count = 0u32;
+    let ai_breaking_count = match (uses_ai_drift_scoring(&job.payload), workspace_id) {
+        (true, Some(wid)) => {
+            let candidates: Vec<ContractDriftEndpoint> = endpoints
+                .iter()
+                .filter(|(method, path)| {
+                    hits_by_endpoint.contains_key(&(method.clone(), path.clone()))
+                })
+                .map(|(method, path)| ContractDriftEndpoint {
+                    method: method.clone(),
+                    path: path.clone(),
+                })
+                .collect();
+
+            if candidates.is_empty() {
+                callbacks
+                    .run_event(
+                        job.run_id,
+                        next_seq,
+                        "log",
+                        serde_json::json!({
+                            "level": "info",
+                            "message": "AI drift scoring skipped: no declared endpoints with recent traffic",
+                            "ai_phase": true,
+                        }),
+                    )
+                    .await?;
+                // Function returns shortly after; we don't bump
+                // next_seq because nothing else in this scope reads
+                // it (clippy::unused_assignments).
+                0u32
+            } else {
+                run_ai_second_pass(
+                    &job,
+                    callbacks,
+                    &mut next_seq,
+                    &mut ai_findings_count,
+                    wid,
+                    &spec_text,
+                    candidates,
+                )
+                .await
+            }
+        }
+        _ => 0u32,
+    };
+
     let elapsed = started.elapsed();
     let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
     // Pass when the spec covers everything the workspace has been
-    // serving. Failed when undeclared traffic shows up — that's
-    // breaking drift the operator needs to address.
-    let status = if undeclared_count == 0 {
+    // serving AND the AI pass didn't surface any new breaking
+    // findings. AI cosmetic / non_breaking findings don't fail the
+    // run — they're informational.
+    let status = if undeclared_count == 0 && ai_breaking_count == 0 {
         JobStatus::Passed
     } else {
         JobStatus::Failed
@@ -310,10 +365,124 @@ async fn run_real_contract_diff(
             "declared_count": declared_count,
             "unused_count": unused_count,
             "undeclared_count": undeclared_count,
+            "ai_findings_count": ai_findings_count,
+            "ai_breaking_count": ai_breaking_count,
             "wall_ms": elapsed.as_millis() as u64,
-            "note": "AI-assisted scoring (param/schema/response drift) is the follow-up via mockforge-ai-contract-diff",
         })),
     })
+}
+
+/// Did the suite config opt into AI drift scoring? Stored on the
+/// suite's `config` JSON as `ai_drift_enabled: bool` (default false).
+fn uses_ai_drift_scoring(payload: &serde_json::Value) -> bool {
+    payload.get("ai_drift_enabled").and_then(|v| v.as_bool()).unwrap_or(false)
+}
+
+/// Run the AI scoring callback and emit one `diff_finding` event per
+/// finding. Returns the count of `breaking`-severity findings so the
+/// caller can decide whether to fail the run.
+async fn run_ai_second_pass(
+    job: &RunJob,
+    callbacks: &RegistryCallbacks,
+    next_seq: &mut u32,
+    ai_findings_count: &mut u32,
+    workspace_id: uuid::Uuid,
+    spec_text: &str,
+    endpoints: Vec<ContractDriftEndpoint>,
+) -> u32 {
+    let body = ContractDriftScoreRequest {
+        org_id: job.org_id,
+        workspace_id,
+        spec_excerpt: spec_text.to_string(),
+        endpoints,
+        max_samples_per_endpoint: None,
+    };
+
+    let response = match callbacks.score_contract_drift(&body).await {
+        Ok(r) => r,
+        Err(e) => {
+            // Non-fatal — log and continue. Common causes: free plan
+            // without BYOK (registry returns 403), platform LLM key
+            // unset on the registry, transient HTTP error.
+            let _ = callbacks
+                .run_event(
+                    job.run_id,
+                    *next_seq,
+                    "log",
+                    serde_json::json!({
+                        "level": "warn",
+                        "message": format!("AI drift scoring failed: {e}"),
+                        "ai_phase": true,
+                    }),
+                )
+                .await;
+            *next_seq += 1;
+            return 0;
+        }
+    };
+
+    if response.no_traffic {
+        let _ = callbacks
+            .run_event(
+                job.run_id,
+                *next_seq,
+                "log",
+                serde_json::json!({
+                    "level": "info",
+                    "message": "AI drift scoring skipped: no captured exchanges to sample",
+                    "ai_phase": true,
+                }),
+            )
+            .await;
+        *next_seq += 1;
+        return 0;
+    }
+
+    let _ = callbacks
+        .run_event(
+            job.run_id,
+            *next_seq,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!(
+                    "AI drift scoring returned {} findings ({} tokens, provider={})",
+                    response.findings.len(),
+                    response.tokens_used,
+                    response.provider,
+                ),
+                "ai_phase": true,
+                "tokens_used": response.tokens_used,
+                "provider": response.provider,
+            }),
+        )
+        .await;
+    *next_seq += 1;
+
+    let mut breaking_count = 0u32;
+    for finding in response.findings {
+        if finding.severity == "breaking" {
+            breaking_count += 1;
+        }
+        *ai_findings_count += 1;
+        let _ = callbacks
+            .run_event(
+                job.run_id,
+                *next_seq,
+                "diff_finding",
+                serde_json::json!({
+                    "severity": finding.severity,
+                    "endpoint": finding.endpoint,
+                    "description": finding.description,
+                    "confidence": finding.confidence,
+                    "rationale": finding.rationale,
+                    "ai": true,
+                }),
+            )
+            .await;
+        *next_seq += 1;
+    }
+    breaking_count
 }
 
 /// Walk an OpenAPI 3.x document and collect (method, path) tuples for


### PR DESCRIPTION
Closes #348.

## Summary
- Plugs an LLM-scored "second pass" into the existing structural `ContractExecutor`, so contract_diff runs can flag parameter / schema / response-shape drift the structural diff can't see (optional vs required fields, response-body shape changes, error-class drift).
- Opt-in per suite via `config.ai_drift_enabled = true`. AI failures are non-fatal — a missing BYOK / exhausted quota / transient HTTP error degrades to "no AI findings" rather than failing the run.

## Architecture decision
The new module lives **server-side** (`mockforge-registry-server::ai::contract_diff`), not in a separate crate. Reasoning: the runner can't depend circularly on registry-server, and the registry already owns BYOK key decryption + LLM provider routing. Extracting `mockforge-ai-contract-diff` as a shared crate is a pure refactor — happy to do as a follow-up if/when a second consumer materialises.

## Backend (`mockforge-registry-server`)
- `ai::contract_diff` module: pure functions for prompt building + LLM-response parsing. **13 unit tests** covering truncation edge cases, malformed JSON, out-of-range confidence values, unknown severities, single-object wrap, etc.
- `handlers::internal_contract_diff::score_contract_drift` at `POST /api/v1/internal/contract-diff/score`. Pulls samples from `runtime_captures` for each (workspace, method, path), runs the existing `run_completion_for_org` pipeline (which already enforces BYOK / platform routing + per-org token quotas), parses findings.
- **Short-circuits before the LLM call** when `endpoints` is empty or no captures match — both return `no_traffic=true`, so a free-tier org without BYOK isn't charged a 403 just to hear "we have nothing to score."
- **Hard caps:** 25 endpoints/request, 5 samples/endpoint, bodies truncated to 6 KB each before embedding.
- Refactored `ai_studio::run_completion` to delegate to a new `pub(crate) run_completion_for_org` so internal callers (no user session) reuse the same provider/quota/metering pipeline.

## Runner (`mockforge-test-runner`)
- `RegistryCallbacks::score_contract_drift` POSTs to the new internal endpoint.
- `ContractExecutor` runs the AI pass after structural findings, gated on `config.ai_drift_enabled`. Each AI finding emits as a `diff_finding` event with `ai: true` + confidence so the existing UI renderer picks them up unchanged.
- AI `breaking` findings count toward run pass/fail; `non_breaking` and `cosmetic` are informational.

## Tests
- `crates/mockforge-registry-server/tests/cloud_ai_contract_diff_e2e.rs` — **4 e2e tests, all green** against a live registry:
  - `rejects_missing_internal_auth` — no/wrong/user-token bearer all rejected
  - `empty_endpoints_short_circuits_no_llm_call` — no LLM call, `no_traffic=true`
  - `no_captured_exchanges_short_circuits_no_llm_call` — no LLM call, `no_traffic=true`
  - `free_plan_without_byok_is_quota_blocked_when_traffic_exists` — 403 with correct quota copy when org reaches the LLM gate
- Wired into `registry-e2e.yml`. Workflow env now includes `MOCKFORGE_INTERNAL_API_TOKEN` so the registry-server and the test process share the same bearer.

## Out of scope (deferred follow-ups)
- A real LLM call in CI (would burn credits + flake on transient provider issues). Unit tests cover prompt-building + response-parsing exhaustively; e2e covers the surrounding pipeline.
- UI surfacing of the `ai: true` flag (CloudTestRunsPage already renders `diff_finding` as generic JSON; a richer per-finding card view can come later).
- Extracting `mockforge-ai-contract-diff` as a shared crate.

## Test plan
- [x] `cargo clippy -p mockforge-test-runner -p mockforge-registry-server --all-targets -- -D warnings` — clean
- [x] `cargo test -p mockforge-registry-server --lib` — **361 passing** (13 new in `ai::contract_diff::tests`)
- [x] `cargo test -p mockforge-test-runner --lib` — **79 passing**
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test -p mockforge-registry-server --test cloud_ai_contract_diff_e2e -- --ignored` against a live Postgres + registry — **4/4 pass**
- [ ] Manual smoke against deployed registry post-merge: trigger a `kind=contract_diff` run with `ai_drift_enabled=true`, confirm `diff_finding` events with `ai: true` appear and the metering counter ticks.