### PR TITLE
fix(observability,chaos): chaos counters in /metrics + partial YAML parse (#79 → 0.3.130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.130] - 2026-05-10
+
+### Fixed
+
+- **[Reality]** `mockforge_chaos_*` counters silently absent from `/metrics` (#79 follow-up, Srikanth's 3rd-round reply)
+  - Root cause: chaos counters register against `prometheus::default_registry()` (via `register_counter_vec!`), but the `/metrics` exporter gathered only from a *separate* local `MetricsRegistry` created in `mockforge-observability`. The two registries were disjoint, so even when `record_fault(...)` fired (wired in 0.3.128), nothing appeared at `/metrics` — Srikanth ran a bench that produced 80 failures and `curl /metrics | grep mockforge_chaos_` returned empty.
+  - Fix: `metrics_handler` now extends the local registry's metric families with `prometheus::default_registry().gather()` before encoding, so both registries surface in the same response. No format change for clients — chaos metrics now appear alongside protocol metrics.
+- **[Reality]** Chaos sub-configs (`LatencyInjectionConfig`, `RateLimitingConfig`, `NetworkShapingConfig`) failed YAML parse if any field was omitted (#79 follow-up)
+  - All three structs lacked `Default` and `#[serde(default)]`, so a `traffic_shaping:` block missing `max_connections` would fail the whole config load. Srikanth hit this and worked around it manually. Adding the derives makes partial YAML parse cleanly with sensible zero defaults.
+
 ## [0.3.129] - 2026-05-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7652,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7862,7 +7862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7883,7 +7883,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7954,7 +7954,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7987,7 +7987,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8090,7 +8090,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8171,7 +8171,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8250,7 +8250,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8297,7 +8297,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8312,7 +8312,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8334,7 +8334,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8361,7 +8361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8386,7 +8386,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8552,7 +8552,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8573,7 +8573,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8650,7 +8650,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8675,7 +8675,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8689,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8722,7 +8722,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8862,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8884,7 +8884,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8949,7 +8949,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8979,7 +8979,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9006,7 +9006,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9030,14 +9030,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9064,7 +9064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9075,7 +9075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9096,7 +9096,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9137,7 +9137,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9168,7 +9168,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -14969,7 +14969,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.129"
+version = "0.3.130"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.129"
+version = "0.3.130"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,14 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.130] - 2026-05-10
+
+### Fixed
+
+- **[Reality]** `mockforge_chaos_*` counters silently absent from `/metrics` (#79 follow-up)
+  - Chaos counters register against the global `prometheus::default_registry()`; `/metrics` was exporting only the local `MetricsRegistry`. The two were disjoint, so chaos counters never surfaced. `metrics_handler` now gathers from both. No format change for scrapers.
+- **[Reality]** `LatencyInjectionConfig` / `RateLimitingConfig` / `NetworkShapingConfig` rejected partial YAML
+  - Missing fields broke the whole config load (e.g. `traffic_shaping:` without `max_connections`). Adding `Default` + `#[serde(default)]` makes partial YAML parse cleanly.
+
 ## [0.3.129] - 2026-05-09
 
 ### Added

--- a/crates/mockforge-core/src/config/operational.rs
+++ b/crates/mockforge-core/src/config/operational.rs
@@ -1135,7 +1135,8 @@ pub struct ChaosEngConfig {
 }
 
 /// Latency injection configuration for chaos engineering
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct LatencyInjectionConfig {
     /// Enable latency injection
@@ -1310,7 +1311,8 @@ pub struct FaultConfig {
 }
 
 /// Rate limiting configuration for traffic control
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct RateLimitingConfig {
     /// Enable rate limiting
@@ -1326,7 +1328,8 @@ pub struct RateLimitingConfig {
 }
 
 /// Network shaping configuration for simulating network conditions
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct NetworkShapingConfig {
     /// Enable network shaping
@@ -1428,6 +1431,60 @@ timeout_probability: 0.0
         assert!(!parsed.payload_corruption);
         assert!(parsed.error_pattern.is_none());
         assert!(parsed.request_matcher.is_none());
+    }
+
+    /// Same yaml that the live server failed on — read from disk via the
+    /// production config-loader path (load_config), not just inline string.
+    #[test]
+    fn fault_config_via_load_config_from_disk() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("chaos.yaml");
+        std::fs::write(&path, "observability:\n  chaos:\n    enabled: true\n    fault_injection:\n      enabled: true\n      http_errors: [503]\n      http_error_probability: 1.0\n      connection_errors: false\n      connection_error_probability: 0.0\n      timeout_errors: false\n      timeout_ms: 5000\n      timeout_probability: 0.0\n").unwrap();
+        let cfg = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(crate::config::load_config(&path))
+            .expect("load");
+        let fi = cfg
+            .observability
+            .chaos
+            .expect("chaos")
+            .fault_injection
+            .expect("fault_injection");
+        assert_eq!(fi.http_error_probability, 1.0);
+        assert_eq!(fi.timeout_ms, 5000);
+    }
+
+    /// Issue #79 follow-up (Srikanth's 3rd-round reply):
+    /// my reply pointed at `--config chaos.yaml` for the new chaos fields,
+    /// but his live server reports `http_error_probability: 0.05` even
+    /// though the YAML says `1.0`. Reproduce against the real
+    /// `ServerConfig` deserialization path that mockforge uses at startup,
+    /// not just the inner FaultConfig in isolation.
+    #[test]
+    fn fault_config_through_server_config_observability_chaos() {
+        let yaml = r#"
+observability:
+  chaos:
+    enabled: true
+    fault_injection:
+      enabled: true
+      http_errors: [503]
+      http_error_probability: 1.0
+      connection_errors: false
+      connection_error_probability: 0.0
+      timeout_errors: false
+      timeout_ms: 5000
+      timeout_probability: 0.0
+"#;
+        let cfg: crate::config::ServerConfig = serde_yaml::from_str(yaml).expect("parse");
+        let chaos = cfg.observability.chaos.expect("chaos present");
+        assert!(chaos.enabled);
+        let fi = chaos.fault_injection.expect("fault_injection present");
+        assert_eq!(
+            fi.http_error_probability, 1.0,
+            "http_error_probability lost during nested deserialization"
+        );
+        assert_eq!(fi.timeout_ms, 5000, "timeout_ms lost during nested deserialization");
     }
 
     /// The connection_error_kind enum must serialize as snake_case strings

--- a/crates/mockforge-observability/src/prometheus/exporter.rs
+++ b/crates/mockforge-observability/src/prometheus/exporter.rs
@@ -15,14 +15,25 @@ use tracing::{debug, error};
 
 use super::metrics::MetricsRegistry;
 
-/// Handler for the /metrics endpoint
+/// Handler for the /metrics endpoint.
+///
+/// Gathers from two registries: the local `MetricsRegistry` (HTTP request
+/// counters, protocol metrics, etc., wired by the observability layer) and
+/// `prometheus::default_registry()` (where `mockforge-chaos` registers its
+/// `mockforge_chaos_*` counters via `register_counter_vec!`). Without this
+/// merge, chaos counters were silently dropped from `/metrics` even when
+/// they were being incremented — issue #79 follow-up: Srikanth ran a bench
+/// that triggered 80 fault injections but
+/// `curl /metrics | grep mockforge_chaos_` returned nothing because the
+/// two registries were disjoint.
 pub async fn metrics_handler(
     State(registry): State<Arc<MetricsRegistry>>,
 ) -> Result<impl IntoResponse, MetricsError> {
     debug!("Serving Prometheus metrics");
 
     let encoder = TextEncoder::new();
-    let metric_families = registry.registry().gather();
+    let mut metric_families = registry.registry().gather();
+    metric_families.extend(prometheus::default_registry().gather());
 
     let mut buffer = Vec::new();
     encoder.encode(&metric_families, &mut buffer).map_err(|e| {


### PR DESCRIPTION
## Summary

Issue #79 follow-up — Srikanth's 3rd-round reply ([2026-05-10](https://github.com/SaaSy-Solutions/mockforge/issues/79#issuecomment-4413792712)) reported that `mockforge_chaos_*` counters wired in 0.3.128 don't appear at `/metrics`, and that a chaos.yaml missing `traffic_shaping.max_connections` fails to load. Both fixed here.

**1. `/metrics` doesn't show chaos counters**
Chaos counters register against `prometheus::default_registry()` (`register_counter_vec!`), but `metrics_handler` gathered only from a local `MetricsRegistry`. Two disjoint registries → chaos metrics silently absent even when firing. Fix: `metrics_handler` extends its `gather()` result with `default_registry().gather()` before encoding. No format change for scrapers.

**2. Chaos sub-configs reject partial YAML**
`LatencyInjectionConfig` / `RateLimitingConfig` / `NetworkShapingConfig` lacked `Default` + `#[serde(default)]`, so any missing field rejected the whole config. Adding the derives makes partial YAML parse cleanly with sensible zero defaults.

Bundles the version bump to **0.3.130** so it ships in one PR.

## Test plan

- [x] 5 yaml round-trip tests in `mockforge-core::config::operational::fault_config_yaml_tests` (2 new: `fault_config_through_server_config_observability_chaos`, `fault_config_via_load_config_from_disk` — both go through the production `ServerConfig` / `load_config` paths, not just inner FaultConfig in isolation)
- [x] `cargo clippy -p mockforge-core -p mockforge-observability -p mockforge-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] CI green
- [ ] After merge: `scripts/publish-crates.sh` to crates.io, then tag `v0.3.130`

Refs #79