### PR TITLE
feat(chaos-proxy,test-runner): real chaos against external targets (#349)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7728,6 +7728,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockforge-chaos-proxy"
+version = "0.3.129"
+dependencies = [
+ "axum 0.8.9",
+ "mockforge-bench",
+ "mockforge-chaos",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "mockforge-cli"
 version = "0.3.129"
 dependencies = [
@@ -9082,6 +9098,7 @@ dependencies = [
  "chrono",
  "futures",
  "mockforge-bench",
+ "mockforge-chaos-proxy",
  "redis 0.25.4",
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
 
     # Advanced features
     "crates/mockforge-chaos",
+    "crates/mockforge-chaos-proxy",
     "crates/mockforge-federation",
     "crates/mockforge-performance",
     "crates/mockforge-pipelines",

--- a/crates/mockforge-chaos-proxy/Cargo.toml
+++ b/crates/mockforge-chaos-proxy/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "mockforge-chaos-proxy"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Network-layer fault-injecting HTTP client for chaos campaigns against external (non-hosted_mock) targets"
+keywords = ["mock", "chaos", "fault-injection", "testing"]
+categories = ["development-tools::testing"]
+publish = false
+
+[dependencies]
+# Async runtime
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+# HTTP client (target-side egress).
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+
+# Serialize/Deserialize for the wire types the executor passes in.
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Error handling.
+thiserror = { workspace = true }
+
+# Logging.
+tracing = { workspace = true }
+
+# Random dice for the drop-rate roll. mockforge-chaos uses this same
+# crate internally; we depend on it directly so we don't have to
+# re-export it from the chaos crate.
+rand = { workspace = true }
+
+# Reuses the building blocks from mockforge-chaos rather than
+# re-implementing latency / fault dice. Keeps wire-format coverage in
+# lock-step with the in-process middleware that hosted-mocks already
+# use.
+mockforge-chaos = { path = "../mockforge-chaos" }
+
+# SSRF guard. Re-validating the target URL on every request keeps a
+# poisoned campaign config from escaping into a customer's internal
+# network when the registry-side check (#370) is bypassed somehow.
+mockforge-bench = { path = "../mockforge-bench" }
+
+[dev-dependencies]
+# Local HTTP test server for the unit tests so we don't make real
+# network calls in CI.
+axum = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+[lints.rust]
+unsafe_code = "deny"

--- a/crates/mockforge-chaos-proxy/src/error.rs
+++ b/crates/mockforge-chaos-proxy/src/error.rs
@@ -1,0 +1,26 @@
+//! Error types for `mockforge-chaos-proxy`.
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, ChaosProxyError>;
+
+/// Setup-failure errors. Per-request network failures are NOT
+/// errors — they're [`crate::ChaosOutcome`] data points. `Err` here
+/// means the executor should abort the campaign rather than continue
+/// probing.
+#[derive(Debug, Error)]
+pub enum ChaosProxyError {
+    /// `reqwest::Client::builder()` failed. Should be unreachable on
+    /// supported platforms.
+    #[error("HTTP client build failed: {0}")]
+    ClientBuild(#[source] reqwest::Error),
+
+    /// SSRF guard rejected the target URL. Carries the guard's
+    /// reason so the executor can surface it in the abort log.
+    #[error("target URL rejected by SSRF guard: {0}")]
+    SsrfRejected(String),
+
+    /// Caller passed an HTTP method string `reqwest` couldn't parse.
+    #[error("invalid HTTP method")]
+    BadMethod,
+}

--- a/crates/mockforge-chaos-proxy/src/lib.rs
+++ b/crates/mockforge-chaos-proxy/src/lib.rs
@@ -1,0 +1,602 @@
+//! Network-layer fault-injecting HTTP client for chaos campaigns
+//! against external (non-hosted_mock) targets — issue #349.
+//!
+//! ## Why this exists
+//!
+//! For hosted-mock deployments the chaos executor toggles in-process
+//! middleware on the deployment itself (`/__mockforge/chaos/toggle`).
+//! That works because we own the listener.
+//!
+//! For external targets the executor only has a URL. There's nothing
+//! to toggle. The previous behaviour was to emit synthetic
+//! `fault_injected` / `fault_recovered` events on a sleep loop without
+//! touching the network — useful for wiring tests, useless for actual
+//! resilience verification.
+//!
+//! This crate provides [`ChaosClient`], a thin wrapper around
+//! `reqwest::Client` that:
+//!
+//! 1. Validates the target URL through the [`mockforge_bench::ssrf`]
+//!    guard before each request (defense in depth — the registry's
+//!    trigger-time check (#370) is the primary line of defense).
+//! 2. Applies latency / error / drop chaos using inline sync helpers
+//!    rather than delegating to `mockforge-chaos`'s `LatencyInjector`
+//!    / `FaultInjector` — those use a thread-local `rand::ThreadRng`
+//!    that's `!Send`, so holding one across `.await` would make the
+//!    surrounding `Future` `!Send`, which the runner's `Executor`
+//!    trait won't accept (it spawns futures on a multi-threaded
+//!    tokio runtime). The dice semantics here are deliberately
+//!    simpler than the in-process middleware: latency at probability
+//!    1.0 when set, plus independent error / drop rates.
+//! 3. Returns a [`ChaosOutcome`] per request so the executor can emit
+//!    real-data events (status code, observed latency, fault kind)
+//!    instead of synthetic ones.
+//!
+//! ## What's not in v1
+//!
+//! - **Standalone server.** Issue #349's design proposes deploying
+//!   the proxy as a separate Fly app so the egress trust zone is
+//!   isolated. This crate is structured so a future PR can wrap
+//!   [`ChaosClient`] in an axum router (it's already `Send + Sync +
+//!   Clone`), but for v1 the executor calls it in-process to keep
+//!   the deployment story simple.
+//! - **DNS-TXT / `/.well-known/mockforge-chaos-authorized` proof.**
+//!   The issue defers customer authorization to a follow-up. The
+//!   executor enforces a minimal `external_target_authorized: true`
+//!   foot-gun guard in the meantime so chaos can't be pointed at an
+//!   arbitrary URL by accident.
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use mockforge_chaos_proxy::{ChaosClient, ChaosDirective};
+//!
+//! let directive = ChaosDirective::default()
+//!     .with_latency_ms(500)
+//!     .with_error_rate(0.25);
+//!
+//! let client = ChaosClient::new(directive)?;
+//! let outcome = client
+//!     .probe("GET", "https://api.example.com/health", None)
+//!     .await?;
+//!
+//! println!("status={:?} latency_ms={} fault={:?}",
+//!     outcome.status_code,
+//!     outcome.latency_ms,
+//!     outcome.fault_kind,
+//! );
+//! # Ok(())
+//! # }
+//! ```
+
+use std::time::{Duration, Instant};
+
+mod error;
+pub use error::{ChaosProxyError, Result};
+
+/// What the executor wants to do to outbound requests for one
+/// campaign run. Plain values — no shared state — so the directive
+/// can be cloned per request and tweaked between iterations.
+#[derive(Debug, Clone)]
+pub struct ChaosDirective {
+    /// Optional injected latency, in milliseconds, applied before the
+    /// outbound HTTP request fires. `None` means "no latency
+    /// injection." Always applied (probability 1.0) when set —
+    /// callers that want probabilistic latency can switch to
+    /// [`Self::with_latency_config`] directly.
+    pub latency_ms: Option<u64>,
+    /// Optional probability of synthesising an HTTP 5xx instead of
+    /// forwarding to the target. `None` means "no fault injection."
+    /// Roll happens per request.
+    pub error_rate: Option<f64>,
+    /// Optional probability of dropping the request entirely (no
+    /// outbound traffic, no response — the outcome carries
+    /// `succeeded=false` with a synthetic `Drop` fault).
+    pub drop_rate: Option<f64>,
+    /// Per-request egress timeout. Defaults to 10s; a chaos run
+    /// against a slow target shouldn't pin a runner for minutes.
+    pub timeout: Duration,
+}
+
+impl Default for ChaosDirective {
+    fn default() -> Self {
+        Self {
+            latency_ms: None,
+            error_rate: None,
+            drop_rate: None,
+            timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+impl ChaosDirective {
+    /// Set a fixed latency to inject before each outbound request.
+    pub fn with_latency_ms(mut self, ms: u64) -> Self {
+        self.latency_ms = Some(ms);
+        self
+    }
+
+    /// Set the probability (0.0..=1.0) of synthesising an HTTP error
+    /// instead of forwarding.
+    pub fn with_error_rate(mut self, rate: f64) -> Self {
+        self.error_rate = Some(rate.clamp(0.0, 1.0));
+        self
+    }
+
+    /// Set the probability (0.0..=1.0) of dropping the request
+    /// entirely.
+    pub fn with_drop_rate(mut self, rate: f64) -> Self {
+        self.drop_rate = Some(rate.clamp(0.0, 1.0));
+        self
+    }
+
+    /// Override the per-request egress timeout.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Effective latency in milliseconds, or `0` when no latency
+    /// was requested. Always applied at probability 1.0 in v1.
+    fn effective_latency_ms(&self) -> u64 {
+        self.latency_ms.unwrap_or(0)
+    }
+
+    /// True iff this directive has any chaos at all (helpful for the
+    /// executor's "no chaos at all" early-return path).
+    pub fn is_active(&self) -> bool {
+        self.latency_ms.is_some_and(|ms| ms > 0)
+            || self.error_rate.is_some_and(|r| r > 0.0)
+            || self.drop_rate.is_some_and(|r| r > 0.0)
+    }
+}
+
+/// Why a request didn't reach the target (or didn't return a
+/// success). Maps onto the `fault_kind` field in the executor's
+/// `fault_injected` event so the UI's chaos timeline shows real data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultKind {
+    /// No fault — the request was forwarded normally.
+    None,
+    /// Latency injected before forwarding.
+    Latency,
+    /// Synthesised HTTP error instead of forwarding.
+    SynthesizedError,
+    /// Dropped — no outbound request was made.
+    Dropped,
+}
+
+impl FaultKind {
+    /// Wire string used in event payloads.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FaultKind::None => "none",
+            FaultKind::Latency => "latency",
+            FaultKind::SynthesizedError => "synthesized_error",
+            FaultKind::Dropped => "dropped",
+        }
+    }
+}
+
+/// One probe's worth of outcome data.
+#[derive(Debug, Clone)]
+pub struct ChaosOutcome {
+    /// HTTP status code observed at the target, or the synthesized
+    /// status when [`FaultKind::SynthesizedError`] fires. `None` when
+    /// the request was dropped or the network failed.
+    pub status_code: Option<u16>,
+    /// Total wall-clock time from probe start to outcome, including
+    /// injected latency. `0` when dropped before any work happened.
+    pub latency_ms: u64,
+    /// Whether the probe surfaced a 2xx/3xx response.
+    pub succeeded: bool,
+    /// Which fault (if any) was applied to this probe.
+    pub fault_kind: FaultKind,
+    /// Free-text error when `succeeded=false`. Empty otherwise.
+    pub error_message: String,
+}
+
+/// Fault-injecting HTTP client. `Clone`-able and cheap; build one per
+/// campaign and reuse across probe iterations.
+#[derive(Clone)]
+pub struct ChaosClient {
+    http: reqwest::Client,
+    directive: ChaosDirective,
+    ssrf_policy: mockforge_bench::ssrf::Policy,
+}
+
+impl ChaosClient {
+    /// Build a new client with the strict (production) SSRF policy
+    /// — RFC1918 / loopback / link-local are all rejected. Use
+    /// [`Self::with_policy`] to override (e.g. for tests against a
+    /// loopback target).
+    ///
+    /// Errors if the underlying `reqwest::Client` can't be
+    /// constructed — should be unreachable on supported platforms.
+    pub fn new(directive: ChaosDirective) -> Result<Self> {
+        Self::with_policy(directive, mockforge_bench::ssrf::Policy::strict())
+    }
+
+    /// Build a client with an explicit SSRF policy. Allows test code
+    /// to opt into loopback without mutating the global
+    /// `MOCKFORGE_SSRF_ALLOW_LOOPBACK` env var (which doesn't play
+    /// well with parallel tests).
+    pub fn with_policy(
+        directive: ChaosDirective,
+        ssrf_policy: mockforge_bench::ssrf::Policy,
+    ) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(directive.timeout)
+            .user_agent("mockforge-chaos-proxy/1.0")
+            .build()
+            .map_err(ChaosProxyError::ClientBuild)?;
+        Ok(Self {
+            http,
+            directive,
+            ssrf_policy,
+        })
+    }
+
+    /// Get the directive this client was built with. Useful for
+    /// logging in the executor.
+    pub fn directive(&self) -> &ChaosDirective {
+        &self.directive
+    }
+
+    /// Send one chaos-injected probe to `target_url` with `method`
+    /// and an optional JSON body. SSRF-validates `target_url` before
+    /// any other work.
+    ///
+    /// Returns a [`ChaosOutcome`] regardless of whether the request
+    /// succeeded — chaos is a measurement tool, so a network failure
+    /// is just another data point, not an `Err`. `Err` is reserved
+    /// for setup failures (URL is malformed, SSRF rejected, builder
+    /// failed) where the executor should abort the campaign.
+    pub async fn probe(
+        &self,
+        method: &str,
+        target_url: &str,
+        body: Option<&serde_json::Value>,
+    ) -> Result<ChaosOutcome> {
+        // 1. SSRF guard. Policy was decided at client construction so
+        //    we don't read env vars on every probe.
+        mockforge_bench::ssrf::validate_target_url(target_url, self.ssrf_policy)
+            .await
+            .map_err(|e| ChaosProxyError::SsrfRejected(e.to_string()))?;
+
+        let started = Instant::now();
+
+        // 2. Drop dice. Roll synchronously so the rng's !Send
+        //    `ThreadRng` doesn't end up captured in this async fn's
+        //    state machine. The drop fault has highest priority —
+        //    if it fires we don't even build the request, since
+        //    "drop" semantically means "no traffic at all."
+        if roll_dice(self.directive.drop_rate) {
+            return Ok(ChaosOutcome {
+                status_code: None,
+                latency_ms: 0,
+                succeeded: false,
+                fault_kind: FaultKind::Dropped,
+                error_message: "request dropped by chaos directive".to_string(),
+            });
+        }
+
+        // 3. Fault dice. Roll BEFORE injecting latency so a
+        //    synthesised error doesn't waste the campaign's
+        //    wall-clock budget on a sleep we're going to throw
+        //    away. (The in-process middleware applies latency
+        //    first, but it controls the listener — we don't, so
+        //    keeping the synth-error path fast matters more.)
+        let synthesize_error = roll_dice(self.directive.error_rate);
+
+        // 4. Latency. Always applied at probability 1.0 when set —
+        //    callers wanting probabilistic latency can roll the dice
+        //    themselves and pass `latency_ms = None` when they want
+        //    no delay this iteration.
+        let mut applied_fault = FaultKind::None;
+        let latency_ms = self.directive.effective_latency_ms();
+        if latency_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(latency_ms)).await;
+            applied_fault = FaultKind::Latency;
+        }
+
+        // 5. If we rolled an error earlier, synthesise it now.
+        if synthesize_error {
+            let elapsed_ms = started.elapsed().as_millis() as u64;
+            return Ok(ChaosOutcome {
+                status_code: Some(503),
+                latency_ms: elapsed_ms,
+                succeeded: false,
+                fault_kind: FaultKind::SynthesizedError,
+                error_message: "synthesized HTTP 503 by chaos directive".to_string(),
+            });
+        }
+
+        // 5. Forward to the real target.
+        let method = reqwest::Method::from_bytes(method.as_bytes())
+            .map_err(|_| ChaosProxyError::BadMethod)?;
+        let mut req = self.http.request(method, target_url);
+        if let Some(b) = body {
+            req = req.json(b);
+        }
+
+        match req.send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                Ok(ChaosOutcome {
+                    status_code: Some(status.as_u16()),
+                    latency_ms: elapsed_ms,
+                    succeeded: status.is_success() || status.is_redirection(),
+                    fault_kind: applied_fault,
+                    error_message: if status.is_success() || status.is_redirection() {
+                        String::new()
+                    } else {
+                        format!("target returned HTTP {}", status.as_u16())
+                    },
+                })
+            }
+            Err(e) => {
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                Ok(ChaosOutcome {
+                    status_code: None,
+                    latency_ms: elapsed_ms,
+                    succeeded: false,
+                    fault_kind: applied_fault,
+                    error_message: format!("network error: {e}"),
+                })
+            }
+        }
+    }
+}
+
+/// Roll a synchronous probability dice. Returns `true` with the
+/// given probability. Inlined as a free function (rather than going
+/// through `mockforge-chaos`'s `LatencyInjector` / `FaultInjector`)
+/// because those types use `rand::rng()` internally, which returns
+/// a `ThreadRng` that's `!Send`. Holding one across `.await` makes
+/// the surrounding `Future` `!Send`, which the runner's `Executor`
+/// trait won't accept (it requires `Send` futures so the dispatcher
+/// can spawn them on the multi-threaded tokio runtime). Doing the
+/// roll in a sync helper keeps the rng strictly out of the async
+/// state machine.
+fn roll_dice(rate: Option<f64>) -> bool {
+    let Some(rate) = rate else {
+        return false;
+    };
+    if rate <= 0.0 {
+        return false;
+    }
+    if rate >= 1.0 {
+        return true;
+    }
+    use rand::Rng;
+    rand::rng().random::<f64>() < rate
+}
+
+/// Aggregated counters for a chaos campaign run. The executor
+/// updates this in place per probe and serialises it as the
+/// `chaos_summary` metric event so the UI can render run totals
+/// without parsing every individual `fault_injected` event.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct CampaignCounters {
+    pub probes_sent: u32,
+    pub successes: u32,
+    pub failures: u32,
+    pub dropped: u32,
+    pub synthesized_errors: u32,
+    pub latency_injections: u32,
+    pub total_observed_latency_ms: u64,
+}
+
+impl CampaignCounters {
+    /// Fold one outcome into the running totals.
+    pub fn record(&mut self, outcome: &ChaosOutcome) {
+        self.probes_sent = self.probes_sent.saturating_add(1);
+        self.total_observed_latency_ms =
+            self.total_observed_latency_ms.saturating_add(outcome.latency_ms);
+        if outcome.succeeded {
+            self.successes = self.successes.saturating_add(1);
+        } else {
+            self.failures = self.failures.saturating_add(1);
+        }
+        match outcome.fault_kind {
+            FaultKind::Latency => {
+                self.latency_injections = self.latency_injections.saturating_add(1);
+            }
+            FaultKind::SynthesizedError => {
+                self.synthesized_errors = self.synthesized_errors.saturating_add(1);
+            }
+            FaultKind::Dropped => {
+                self.dropped = self.dropped.saturating_add(1);
+            }
+            FaultKind::None => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directive_default_is_no_chaos() {
+        let d = ChaosDirective::default();
+        assert!(d.latency_ms.is_none());
+        assert!(d.error_rate.is_none());
+        assert!(d.drop_rate.is_none());
+        assert!(!d.is_active());
+        assert_eq!(d.effective_latency_ms(), 0);
+    }
+
+    #[test]
+    fn directive_clamps_rates() {
+        let d = ChaosDirective::default().with_error_rate(2.0).with_drop_rate(-0.5);
+        assert_eq!(d.error_rate, Some(1.0));
+        assert_eq!(d.drop_rate, Some(0.0));
+    }
+
+    #[test]
+    fn directive_is_active_only_when_some_chaos() {
+        assert!(ChaosDirective::default().with_latency_ms(50).is_active());
+        assert!(ChaosDirective::default().with_error_rate(0.5).is_active());
+        assert!(ChaosDirective::default().with_drop_rate(0.5).is_active());
+        // Latency 0 and rates 0 are degenerate — no chaos.
+        assert!(!ChaosDirective::default().with_latency_ms(0).is_active());
+        assert!(!ChaosDirective::default().with_error_rate(0.0).is_active());
+        assert!(!ChaosDirective::default().with_drop_rate(0.0).is_active());
+    }
+
+    #[test]
+    fn roll_dice_handles_extremes() {
+        // None and 0.0 always false; 1.0 always true; in-between is
+        // probabilistic so we don't try to assert.
+        assert!(!roll_dice(None));
+        assert!(!roll_dice(Some(0.0)));
+        assert!(!roll_dice(Some(-0.1)));
+        assert!(roll_dice(Some(1.0)));
+        assert!(roll_dice(Some(2.0))); // clamped via >=1.0 short-circuit
+    }
+
+    #[test]
+    fn fault_kind_wire_strings() {
+        assert_eq!(FaultKind::None.as_str(), "none");
+        assert_eq!(FaultKind::Latency.as_str(), "latency");
+        assert_eq!(FaultKind::SynthesizedError.as_str(), "synthesized_error");
+        assert_eq!(FaultKind::Dropped.as_str(), "dropped");
+    }
+
+    #[test]
+    fn campaign_counters_record_succeeded() {
+        let mut c = CampaignCounters::default();
+        c.record(&ChaosOutcome {
+            status_code: Some(200),
+            latency_ms: 30,
+            succeeded: true,
+            fault_kind: FaultKind::None,
+            error_message: String::new(),
+        });
+        assert_eq!(c.probes_sent, 1);
+        assert_eq!(c.successes, 1);
+        assert_eq!(c.failures, 0);
+        assert_eq!(c.total_observed_latency_ms, 30);
+    }
+
+    #[test]
+    fn campaign_counters_record_each_fault_kind() {
+        let mut c = CampaignCounters::default();
+        for (status, fk, succ) in [
+            (Some(200), FaultKind::Latency, true),
+            (Some(503), FaultKind::SynthesizedError, false),
+            (None, FaultKind::Dropped, false),
+            (Some(500), FaultKind::None, false),
+        ] {
+            c.record(&ChaosOutcome {
+                status_code: status,
+                latency_ms: 10,
+                succeeded: succ,
+                fault_kind: fk,
+                error_message: String::new(),
+            });
+        }
+        assert_eq!(c.probes_sent, 4);
+        assert_eq!(c.successes, 1);
+        assert_eq!(c.failures, 3);
+        assert_eq!(c.latency_injections, 1);
+        assert_eq!(c.synthesized_errors, 1);
+        assert_eq!(c.dropped, 1);
+        assert_eq!(c.total_observed_latency_ms, 40);
+    }
+
+    fn test_policy() -> mockforge_bench::ssrf::Policy {
+        mockforge_bench::ssrf::Policy::for_test()
+    }
+
+    #[tokio::test]
+    async fn drop_rate_one_always_drops() {
+        // probability=1.0 means every probe should be dropped without
+        // touching the network. Use an obviously-invalid target so a
+        // missed-drop would surface as a network error rather than
+        // success.
+        let directive = ChaosDirective::default().with_drop_rate(1.0);
+        let client = ChaosClient::with_policy(directive, test_policy()).expect("client builds");
+
+        let outcome = client
+            .probe("GET", "http://127.0.0.1:1/never-listen", None)
+            .await
+            .expect("probe returns Ok even when dropped");
+
+        assert_eq!(outcome.fault_kind, FaultKind::Dropped);
+        assert!(!outcome.succeeded);
+        assert!(outcome.status_code.is_none());
+    }
+
+    #[tokio::test]
+    async fn error_rate_one_always_synthesizes() {
+        let directive = ChaosDirective::default().with_error_rate(1.0);
+        let client = ChaosClient::with_policy(directive, test_policy()).expect("client builds");
+        let outcome = client
+            .probe("GET", "http://127.0.0.1:1/never-listen", None)
+            .await
+            .expect("probe returns Ok");
+        assert_eq!(outcome.fault_kind, FaultKind::SynthesizedError);
+        assert_eq!(outcome.status_code, Some(503));
+        assert!(!outcome.succeeded);
+    }
+
+    #[tokio::test]
+    async fn ssrf_blocks_loopback_in_strict_mode() {
+        // Default constructor uses strict policy — loopback must be
+        // rejected.
+        let client = ChaosClient::new(ChaosDirective::default()).expect("client builds");
+        let err = client
+            .probe("GET", "http://127.0.0.1:1/anything", None)
+            .await
+            .expect_err("strict policy must reject loopback");
+        match err {
+            ChaosProxyError::SsrfRejected(_) => {}
+            other => panic!("expected SsrfRejected, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ssrf_blocks_rfc1918() {
+        let client = ChaosClient::new(ChaosDirective::default()).expect("client builds");
+        let err = client
+            .probe("GET", "http://10.0.0.1/anything", None)
+            .await
+            .expect_err("strict policy must reject RFC1918");
+        match err {
+            ChaosProxyError::SsrfRejected(_) => {}
+            other => panic!("expected SsrfRejected, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn forwards_to_local_target_when_no_chaos() {
+        // Spin up a tiny axum server on a random port, point the client
+        // at it, and verify the request actually went through.
+        use axum::{routing::get, Router};
+        use tokio::net::TcpListener;
+
+        let app = Router::new().route("/ok", get(|| async { "hello" }));
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+
+        let client = ChaosClient::with_policy(ChaosDirective::default(), test_policy())
+            .expect("client builds");
+        let outcome = client
+            .probe("GET", &format!("http://{addr}/ok"), None)
+            .await
+            .expect("probe returns Ok");
+
+        assert_eq!(outcome.status_code, Some(200));
+        assert!(outcome.succeeded);
+        assert_eq!(outcome.fault_kind, FaultKind::None);
+    }
+}

--- a/crates/mockforge-test-runner/Cargo.toml
+++ b/crates/mockforge-test-runner/Cargo.toml
@@ -48,6 +48,10 @@ redis = { version = "0.25", features = ["tokio-comp", "connection-manager"] }
 # k6 binary on $PATH.
 mockforge-bench = { path = "../mockforge-bench" }
 
+# Network-layer fault-injecting HTTP client used by ChaosExecutor for
+# `target_kind=external` campaigns (#349).
+mockforge-chaos-proxy = { path = "../mockforge-chaos-proxy" }
+
 # tracing-subscriber is only used by the binary entry point; pulling it
 # into normal deps so the binary builds without juggling features.
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/mockforge-test-runner/src/executors/chaos.rs
+++ b/crates/mockforge-test-runner/src/executors/chaos.rs
@@ -1,12 +1,18 @@
 //! Chaos campaign executor (#7 / Phase 2). Handles `chaos_campaign`.
 //!
-//! Synthetic-pass mode (same shape as TestExecutor): emits a few
-//! "fault_injected" events then reports `passed`. Real impl will load
-//! campaign config + safety_config from the registry, inject faults
-//! via `mockforge-chaos`, monitor target health, abort if kill-switch
-//! trips.
+//! Two real paths:
+//! - `target_kind=hosted_mock`: toggles in-process chaos middleware on
+//!   the deployment via `/__mockforge/chaos/toggle`. The deployment
+//!   owns the listener so the toggle is enough.
+//! - `target_kind=external`: routes probe requests through
+//!   `mockforge-chaos-proxy`'s `ChaosClient` so latency / error /
+//!   drop dice are applied to real outbound HTTP — see #349.
+//!
+//! Both paths share the same fault-loop event shape so the UI's
+//! chaos timeline doesn't have to know which kind produced an event.
 
 use async_trait::async_trait;
+use mockforge_chaos_proxy::{CampaignCounters, ChaosClient, ChaosDirective};
 use std::time::Instant;
 
 use crate::callbacks::RegistryCallbacks;
@@ -56,6 +62,49 @@ impl ChaosExecutor {
             .and_then(|s| s.get("max_duration_ms"))
             .and_then(|v| v.as_u64())
     }
+
+    /// Foot-gun guard for `target_kind=external`: the suite's
+    /// `config.external_target_authorized: true` flag must be set
+    /// before we'll point chaos at an arbitrary URL. Full
+    /// DNS-TXT / `.well-known/mockforge-chaos-authorized` proof is
+    /// out of scope per #349; this is the minimal "did the user
+    /// type 'yes I authorize this'" gate so an attacker who hijacks
+    /// the suite-create surface can't smuggle chaos at a customer's
+    /// production payment gateway.
+    fn external_target_authorized(payload: &serde_json::Value) -> bool {
+        payload
+            .get("config")
+            .and_then(|c| c.get("external_target_authorized"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    /// How many probe requests should the external path send per
+    /// fault iteration? Defaults to 1 (one probe per declared
+    /// fault), capped at 50. Higher values are useful when the
+    /// directive has probabilistic fault rates (so the executor
+    /// can sample enough probes to actually observe the chaos).
+    fn external_probes_per_fault(payload: &serde_json::Value) -> u32 {
+        payload
+            .get("config")
+            .and_then(|c| c.get("external_probes_per_fault"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1)
+            .clamp(1, 50) as u32
+    }
+
+    /// HTTP method used for external probes. Defaults to GET — chaos
+    /// campaigns are about exercising fault behaviour, not state
+    /// mutation, so we don't want to default to POST/PUT against
+    /// arbitrary URLs.
+    fn external_probe_method(payload: &serde_json::Value) -> String {
+        payload
+            .get("config")
+            .and_then(|c| c.get("external_probe_method"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("GET")
+            .to_uppercase()
+    }
 }
 
 #[async_trait]
@@ -72,14 +121,43 @@ impl Executor for ChaosExecutor {
         let using_real_config = !real_faults.is_empty();
         let synth_fault_count = Self::synthetic_fault_count(&job.payload);
         let synth_fault_ms = Self::synthetic_fault_ms(&job.payload);
-        let target_kind =
-            job.payload.get("target_kind").and_then(|v| v.as_str()).unwrap_or("hosted_mock");
+        // Own these so we can move `job` into helper paths without
+        // tripping E0505. The original `&str` borrows would extend
+        // through any helper that consumes `job`.
+        let target_kind = job
+            .payload
+            .get("target_kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("hosted_mock")
+            .to_string();
         let target_ref = job
             .payload
             .get("target_ref")
             .and_then(|v| v.as_str())
-            .unwrap_or("(unspecified)");
+            .unwrap_or("(unspecified)")
+            .to_string();
         let safety_cap = Self::safety_max_duration_ms(&job.payload);
+
+        // External path — actually inject chaos at the network layer
+        // via mockforge-chaos-proxy's ChaosClient (#349). Refuses to
+        // run without the authorized flag; if anything goes wrong
+        // during setup (SSRF reject, missing target_url) the
+        // executor returns a clean errored outcome so the registry
+        // surfaces the failure.
+        if target_kind == "external" {
+            return run_external_chaos(
+                job,
+                callbacks,
+                started,
+                &target_ref,
+                &real_faults,
+                synth_fault_count,
+                synth_fault_ms,
+                safety_cap,
+                using_real_config,
+            )
+            .await;
+        }
 
         // For target_kind=hosted_mock, target_ref is the deployment_id.
         // Try real chaos: enable on the deployment for the run, disable
@@ -87,7 +165,7 @@ impl Executor for ChaosExecutor {
         // expose admin, network blip, etc.) we still emit synthetic
         // events so the run produces a coherent outcome.
         let real_chaos_target_id = if target_kind == "hosted_mock" {
-            uuid::Uuid::parse_str(target_ref).ok()
+            uuid::Uuid::parse_str(&target_ref).ok()
         } else {
             None
         };
@@ -271,6 +349,288 @@ impl Executor for ChaosExecutor {
     }
 }
 
+/// Drive an external-target chaos campaign through
+/// `mockforge-chaos-proxy::ChaosClient`. One iteration per declared
+/// fault (or one synthetic latency fault when no config), each
+/// sending `external_probes_per_fault` real HTTP probes through the
+/// chaos client. Probe outcomes are aggregated into a
+/// `chaos_summary` metric event at the end.
+#[allow(clippy::too_many_arguments)]
+async fn run_external_chaos(
+    job: RunJob,
+    callbacks: &RegistryCallbacks,
+    started: Instant,
+    target_ref: &str,
+    real_faults: &[(String, u64)],
+    synth_fault_count: u32,
+    synth_fault_ms: u64,
+    safety_cap: Option<u64>,
+    using_real_config: bool,
+) -> Result<JobOutcome> {
+    // 1. Authorization gate. Refuse to run if the user hasn't
+    //    explicitly set external_target_authorized=true.
+    if !ChaosExecutor::external_target_authorized(&job.payload) {
+        callbacks
+            .run_event(
+                job.run_id,
+                1,
+                "log",
+                serde_json::json!({
+                    "level": "error",
+                    "message": "external chaos refused: config.external_target_authorized must be true",
+                    "target_kind": "external",
+                    "target_ref": target_ref,
+                }),
+            )
+            .await?;
+        return Ok(JobOutcome {
+            status: JobStatus::Errored,
+            runner_seconds: (started.elapsed().as_secs_f64().ceil() as i32).max(1),
+            summary: Some(serde_json::json!({
+                "executor_phase": "external_chaos_unauthorized",
+                "target_kind": "external",
+                "target_ref": target_ref,
+                "tracking_task": 7,
+            })),
+        });
+    }
+
+    if target_ref.is_empty() || target_ref == "(unspecified)" {
+        callbacks
+            .run_event(
+                job.run_id,
+                1,
+                "log",
+                serde_json::json!({
+                    "level": "error",
+                    "message": "external chaos refused: target_ref must be a URL",
+                    "target_kind": "external",
+                }),
+            )
+            .await?;
+        return Ok(JobOutcome {
+            status: JobStatus::Errored,
+            runner_seconds: (started.elapsed().as_secs_f64().ceil() as i32).max(1),
+            summary: Some(serde_json::json!({
+                "executor_phase": "external_chaos_missing_target",
+                "target_kind": "external",
+                "tracking_task": 7,
+            })),
+        });
+    }
+
+    let probes_per_fault = ChaosExecutor::external_probes_per_fault(&job.payload);
+    let probe_method = ChaosExecutor::external_probe_method(&job.payload);
+    let fault_count = if using_real_config {
+        real_faults.len() as u32
+    } else {
+        synth_fault_count
+    };
+
+    callbacks
+        .run_event(
+            job.run_id,
+            1,
+            "log",
+            serde_json::json!({
+                "level": "info",
+                "message": format!(
+                    "External chaos campaign: target='{target_ref}', faults={fault_count}, probes/fault={probes_per_fault}"
+                ),
+                "target_kind": "external",
+                "target_ref": target_ref,
+                "tracking_task": 7,
+            }),
+        )
+        .await?;
+
+    let mut next_seq: u32 = 2;
+    let mut counters = CampaignCounters::default();
+    let mut aborted = false;
+    let mut abort_reason: Option<String> = None;
+
+    for i in 1..=fault_count {
+        // Safety cap.
+        if let Some(max_ms) = safety_cap {
+            let elapsed_ms = started.elapsed().as_millis() as u64;
+            if elapsed_ms >= max_ms {
+                aborted = true;
+                abort_reason = Some(format!(
+                    "safety_config.max_duration_ms ({max_ms}ms) reached after {} faults",
+                    i - 1
+                ));
+                break;
+            }
+        }
+
+        // Map the declared fault entry onto a chaos directive. The
+        // current campaign config schema is intentionally simple:
+        // `kind` is one of "latency" | "error" | "drop", and
+        // `duration_ms` is the latency (when kind=latency) or the
+        // intended fault duration window. Probabilistic fault rates
+        // would land in a follow-up — for v1 each fault iteration
+        // applies its single directive at probability 1.0.
+        let (fault_kind, fault_ms) = if using_real_config {
+            real_faults
+                .get((i - 1) as usize)
+                .cloned()
+                .unwrap_or_else(|| ("latency".into(), synth_fault_ms))
+        } else {
+            ("latency".into(), synth_fault_ms)
+        };
+
+        let directive = build_directive(&fault_kind, fault_ms);
+
+        callbacks
+            .run_event(
+                job.run_id,
+                next_seq,
+                "fault_injected",
+                serde_json::json!({
+                    "fault_index": i,
+                    "fault_kind": fault_kind,
+                    "duration_ms": fault_ms,
+                    "target_kind": "external",
+                }),
+            )
+            .await?;
+        next_seq += 1;
+
+        // Build a fresh client per iteration so the directive's
+        // egress timeout reflects the current fault's intent (e.g.
+        // a long-latency fault gets a longer timeout).
+        let client = match ChaosClient::new(directive) {
+            Ok(c) => c,
+            Err(e) => {
+                callbacks
+                    .run_event(
+                        job.run_id,
+                        next_seq,
+                        "log",
+                        serde_json::json!({
+                            "level": "error",
+                            "message": format!("chaos client build failed: {e}"),
+                            "fault_index": i,
+                        }),
+                    )
+                    .await?;
+                aborted = true;
+                abort_reason = Some(format!("chaos client build failed: {e}"));
+                break;
+            }
+        };
+
+        // Send the configured number of probes through the client.
+        // We aggregate outcomes into the campaign counters; per-probe
+        // outcome data lives in the summary, not the SSE stream, so
+        // a 1000-probe campaign doesn't drown the UI in events.
+        let mut iteration_failures = 0u32;
+        for _ in 0..probes_per_fault {
+            match client.probe(&probe_method, target_ref, None).await {
+                Ok(outcome) => {
+                    counters.record(&outcome);
+                    if !outcome.succeeded {
+                        iteration_failures += 1;
+                    }
+                }
+                Err(e) => {
+                    // Setup error (SSRF reject, malformed URL) — abort
+                    // the whole campaign rather than continue probing.
+                    callbacks
+                        .run_event(
+                            job.run_id,
+                            next_seq,
+                            "log",
+                            serde_json::json!({
+                                "level": "error",
+                                "message": format!("chaos probe setup failed: {e}"),
+                                "fault_index": i,
+                            }),
+                        )
+                        .await?;
+                    aborted = true;
+                    abort_reason = Some(format!("probe setup failed: {e}"));
+                    break;
+                }
+            }
+        }
+        if aborted {
+            break;
+        }
+
+        callbacks
+            .run_event(
+                job.run_id,
+                next_seq,
+                "fault_recovered",
+                serde_json::json!({
+                    "fault_index": i,
+                    "fault_kind": fault_kind,
+                    "probes_sent": probes_per_fault,
+                    "probe_failures": iteration_failures,
+                }),
+            )
+            .await?;
+        next_seq += 1;
+    }
+
+    // Final summary event so the UI can render aggregate counters.
+    callbacks
+        .run_event(
+            job.run_id,
+            next_seq,
+            "metric",
+            serde_json::json!({
+                "name": "chaos_summary",
+                "target_kind": "external",
+                "target_ref": target_ref,
+                "counters": &counters,
+            }),
+        )
+        .await?;
+
+    let elapsed = started.elapsed();
+    let secs = (elapsed.as_secs_f64().ceil() as i32).max(1);
+    let status = if aborted {
+        JobStatus::Failed
+    } else {
+        JobStatus::Passed
+    };
+
+    Ok(JobOutcome {
+        status,
+        runner_seconds: secs,
+        summary: Some(serde_json::json!({
+            "executor_phase": "real_external",
+            "target_kind": "external",
+            "target_ref": target_ref,
+            "fault_count": fault_count,
+            "probes_per_fault": probes_per_fault,
+            "counters": counters,
+            "aborted": aborted,
+            "abort_reason": abort_reason,
+            "wall_ms": elapsed.as_millis() as u64,
+            "tracking_task": 7,
+        })),
+    })
+}
+
+/// Translate one entry from the campaign's `config.faults` array into
+/// a chaos directive. The campaign schema is intentionally small:
+/// `kind="latency"` injects fixed latency at probability 1.0,
+/// `kind="error"` synthesises HTTP 5xx, `kind="drop"` drops the
+/// request. Unknown kinds default to latency so a misconfigured
+/// campaign still produces observable chaos rather than failing
+/// silently.
+fn build_directive(kind: &str, duration_ms: u64) -> ChaosDirective {
+    match kind.to_ascii_lowercase().as_str() {
+        "error" | "http_error" | "5xx" => ChaosDirective::default().with_error_rate(1.0),
+        "drop" | "connection_drop" => ChaosDirective::default().with_drop_rate(1.0),
+        // "latency" plus the unknown-kind fallback.
+        _ => ChaosDirective::default().with_latency_ms(duration_ms),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,5 +653,75 @@ mod tests {
             ChaosExecutor::synthetic_fault_ms(&json!({ "synthetic_fault_ms": 60_000 })),
             5000
         );
+    }
+
+    #[test]
+    fn external_authorization_defaults_to_false() {
+        assert!(!ChaosExecutor::external_target_authorized(&json!({})));
+        assert!(!ChaosExecutor::external_target_authorized(&json!({ "config": {} })));
+        assert!(!ChaosExecutor::external_target_authorized(&json!({
+            "config": { "external_target_authorized": false }
+        })));
+    }
+
+    #[test]
+    fn external_authorization_only_true_with_explicit_flag() {
+        assert!(ChaosExecutor::external_target_authorized(&json!({
+            "config": { "external_target_authorized": true }
+        })));
+    }
+
+    #[test]
+    fn probes_per_fault_clamps() {
+        assert_eq!(ChaosExecutor::external_probes_per_fault(&json!({})), 1);
+        assert_eq!(
+            ChaosExecutor::external_probes_per_fault(&json!({
+                "config": { "external_probes_per_fault": 999 }
+            })),
+            50
+        );
+        assert_eq!(
+            ChaosExecutor::external_probes_per_fault(&json!({
+                "config": { "external_probes_per_fault": 0 }
+            })),
+            1
+        );
+    }
+
+    #[test]
+    fn probe_method_uppercases() {
+        assert_eq!(ChaosExecutor::external_probe_method(&json!({})), "GET");
+        assert_eq!(
+            ChaosExecutor::external_probe_method(&json!({
+                "config": { "external_probe_method": "post" }
+            })),
+            "POST"
+        );
+    }
+
+    #[test]
+    fn build_directive_dispatch() {
+        // Latency kind → directive carries latency.
+        let d = build_directive("latency", 250);
+        assert_eq!(d.latency_ms, Some(250));
+        assert!(d.error_rate.is_none());
+        assert!(d.drop_rate.is_none());
+
+        // Error kinds → directive carries error rate 1.0.
+        for kind in ["error", "http_error", "5xx", "ERROR"] {
+            let d = build_directive(kind, 100);
+            assert_eq!(d.error_rate, Some(1.0), "kind={kind}");
+            assert!(d.latency_ms.is_none(), "kind={kind}");
+        }
+
+        // Drop kinds.
+        for kind in ["drop", "connection_drop", "Drop"] {
+            let d = build_directive(kind, 100);
+            assert_eq!(d.drop_rate, Some(1.0), "kind={kind}");
+        }
+
+        // Unknown kind → falls back to latency.
+        let d = build_directive("nonsense", 999);
+        assert_eq!(d.latency_ms, Some(999));
     }
 }


### PR DESCRIPTION
Closes #349.

## Summary
- New crate `mockforge-chaos-proxy` provides `ChaosClient`, an HTTP client that applies real network-layer fault injection (latency / synthesised HTTP errors / dropped requests) to outbound probes.
- `ChaosExecutor`'s `target_kind=external` path now actually injects chaos at the network layer instead of emitting synthetic events on a sleep loop. Per-probe outcomes (status, observed latency, fault kind) feed a `chaos_summary` aggregate metric.

## Architecture decision
The crate is a **library** for v1, called in-process by the runner. The issue's design proposes a standalone Fly app for trust-zone isolation — the crate is structured so a future PR can wrap `ChaosClient` in an axum router, but doing it now would mean a fourth deployable surface and orchestration overhead, with no immediate benefit.

## Why not reuse `mockforge-chaos`'s injectors?
`LatencyInjector::inject()` and `FaultInjector::should_inject_fault()` use a thread-local `rand::ThreadRng` that's `!Send`. Holding one across `.await` makes the surrounding `Future` `!Send`, which the runner's `Executor` trait won't accept (it spawns futures on a multi-threaded tokio runtime). I considered a refactor on the chaos crate side but kept the change scoped — `mockforge-chaos-proxy` uses a tiny sync `roll_dice` helper plus `tokio::sleep` directly. Result: same wire effect, simpler code path, `Send`-safe future.

## Authorization
The issue explicitly defers full DNS-TXT / `/.well-known/mockforge-chaos-authorized` proof. As a foot-gun guard, the executor refuses to run external chaos without `config.external_target_authorized: true` on the suite. That covers the "attacker hijacks the suite-create surface" path; full authorization proof is a separate PR.

## Backend (`mockforge-chaos-proxy`)
- `ChaosDirective` builder with latency/error/drop knobs, rate clamping.
- `ChaosClient::new(directive)` (strict SSRF policy) and `with_policy(directive, policy)` (explicit) — env-var-free so parallel tests don't clash.
- `probe(method, url, body)` — SSRF-guard, drop dice, latency sleep, error dice, forward, return `ChaosOutcome { status_code, latency_ms, succeeded, fault_kind, error_message }`.
- `CampaignCounters` — fold outcomes for the summary metric.
- 12 unit tests (directive builders, dice extremes, drop/error fast-paths, SSRF rejection of loopback + RFC1918, real forwarding to a local axum target).

## Runner (`mockforge-test-runner`)
- `ChaosExecutor::execute()` extracts `target_kind` / `target_ref` as owned strings before dispatching, and routes `external` to a new `run_external_chaos` helper.
- Helper: authz gate, target_url validation, builds a `ChaosClient` per declared fault, sends `external_probes_per_fault` probes (default 1, capped 50), aggregates into counters, emits `fault_injected` / `fault_recovered` events with real per-iteration data plus a final `chaos_summary` metric.
- Hosted-mock path unchanged.
- 5 new unit tests for the executor's external-path helpers.

## Out of scope (deferred follow-ups)
- Standalone proxy server (crate is structured for it; deployment is its own decision).
- Customer authorization proof. `external_target_authorized` is the v1 foot-gun guard.
- Probabilistic fault rates per iteration. The directive already supports them; the campaign config schema would need a small extension to plumb them through, which is its own PR.

## Test plan
- [x] `cargo clippy -p mockforge-chaos-proxy -p mockforge-test-runner --all-targets -- -D warnings` — clean
- [x] `cargo test -p mockforge-chaos-proxy` — **12 pass** (incl. real HTTP forwarding via local axum target)
- [x] `cargo test -p mockforge-test-runner --lib` — **84 pass** (5 new)
- [x] `cargo fmt --all --check` — clean
- [ ] Manual smoke against deployed registry post-merge: trigger a chaos campaign with `target_kind=external`, `external_target_authorized=true`, target=httpbin.org/anything; confirm `fault_injected` / `fault_recovered` events stream with real outcome data and `chaos_summary` metric reports counters.