### PR TITLE
feat(tui,chaos): surface fault-injection counts in TUI Chaos screen (#79 → 0.3.131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.3.131] - 2026-05-10
+
+### Added
+
+- **[Reality]** TUI Chaos screen now surfaces live fault-injection counts (#79 follow-up)
+  - New `mockforge_chaos::metrics::ChaosStatsSnapshot` — JSON-serializable view of `CHAOS_METRICS` keyed by `fault_type → endpoint → count`, plus per-type totals, grand total, rate-limit violations, and latency injection sample counts.
+  - New `GET /api/chaos/stats` (chaos crate) and `GET /__mockforge/chaos/stats` (admin passthrough) endpoints expose the snapshot as JSON.
+  - `ChaosScreen` adds a **Fault Stats** panel below Settings showing total faults, per-type counts (sorted desc by frequency), rate-limit violations, and latency injection samples. Best-effort: older servers without the new endpoint fall back to the existing 2-panel layout, so client/server version mismatches don't break the screen.
+
 ## [0.3.130] - 2026-05-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7652,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7862,7 +7862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7883,7 +7883,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7954,7 +7954,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7987,7 +7987,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8090,7 +8090,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8171,7 +8171,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8250,7 +8250,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8297,7 +8297,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8312,7 +8312,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8334,7 +8334,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8361,7 +8361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8386,7 +8386,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8552,7 +8552,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8573,7 +8573,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8650,7 +8650,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8675,7 +8675,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8689,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8722,7 +8722,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8862,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8884,7 +8884,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8949,7 +8949,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8979,7 +8979,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9006,7 +9006,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9030,14 +9030,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9064,7 +9064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9075,7 +9075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9096,7 +9096,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9137,7 +9137,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9168,7 +9168,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -14969,7 +14969,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.130"
+version = "0.3.131"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.130"
+version = "0.3.131"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,13 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.131] - 2026-05-10
+
+### Added
+
+- **[Reality]** TUI Chaos screen now surfaces live fault-injection counts (#79 follow-up)
+  - New `ChaosStatsSnapshot` and `GET /api/chaos/stats` (+ admin passthrough at `/__mockforge/chaos/stats`).
+  - Fault Stats panel below Settings shows totals + per-fault-type counts. Older servers without the endpoint fall back to the 2-panel layout.
+
 ## [0.3.130] - 2026-05-10
 
 ### Fixed

--- a/crates/mockforge-chaos/src/api.rs
+++ b/crates/mockforge-chaos/src/api.rs
@@ -193,6 +193,10 @@ pub fn create_chaos_api_router(
         // Metrics endpoints
         .route("/api/chaos/metrics/latency", get(get_latency_metrics))
         .route("/api/chaos/metrics/latency/stats", get(get_latency_stats))
+        // JSON snapshot of fault-injection counters (issue-#79 follow-up;
+        // gives the TUI a structured view of the same data exposed in
+        // Prometheus exposition format at /metrics).
+        .route("/api/chaos/stats", get(get_fault_stats))
 
         // Profile management endpoints
         .route("/api/chaos/profiles", get(list_profiles))
@@ -1654,6 +1658,14 @@ async fn get_latency_stats(
 ) -> Json<crate::latency_metrics::LatencyStats> {
     let stats = state.latency_tracker.get_stats();
     Json(stats)
+}
+
+/// Snapshot of the chaos prometheus counters in JSON form. State is unused;
+/// the snapshot reads directly from the global `CHAOS_METRICS`.
+async fn get_fault_stats(
+    State(_state): State<ChaosApiState>,
+) -> Json<crate::metrics::ChaosStatsSnapshot> {
+    Json(crate::metrics::CHAOS_METRICS.snapshot())
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/mockforge-chaos/src/metrics.rs
+++ b/crates/mockforge-chaos/src/metrics.rs
@@ -5,9 +5,11 @@
 
 use once_cell::sync::Lazy;
 use prometheus::{
-    register_counter_vec, register_gauge_vec, register_histogram_vec, CounterVec, GaugeVec,
-    HistogramVec, Registry,
+    proto::MetricFamily, register_counter_vec, register_gauge_vec, register_histogram_vec,
+    CounterVec, GaugeVec, HistogramVec, Registry,
 };
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Chaos orchestration metrics
 pub struct ChaosMetrics {
@@ -215,6 +217,103 @@ impl ChaosMetrics {
     pub fn update_impact_score(&self, time_window: &str, score: f64) {
         self.chaos_impact_score.with_label_values(&[time_window]).set(score);
     }
+
+    /// Snapshot the active counter values as a JSON-serializable struct.
+    ///
+    /// Issue #79 follow-up: the prometheus counters were wired in 0.3.128 but
+    /// only readable via `/metrics` (Prometheus exposition format). This gives
+    /// the TUI / dashboard a structured JSON view of fault injections,
+    /// rate-limit violations, and latency injection counts — keyed by
+    /// fault_type and endpoint.
+    pub fn snapshot(&self) -> ChaosStatsSnapshot {
+        use prometheus::core::Collector;
+
+        let mut faults_by_type: HashMap<String, HashMap<String, u64>> = HashMap::new();
+        let mut faults_total_by_type: HashMap<String, u64> = HashMap::new();
+        let mut faults_grand_total: u64 = 0;
+        for fam in self.faults_injected_total.collect() {
+            walk_counter(&fam, |labels, count| {
+                let fault_type =
+                    labels.get("fault_type").cloned().unwrap_or_else(|| "unknown".to_string());
+                let endpoint =
+                    labels.get("endpoint").cloned().unwrap_or_else(|| "unknown".to_string());
+                faults_by_type.entry(fault_type.clone()).or_default().insert(endpoint, count);
+                *faults_total_by_type.entry(fault_type).or_default() += count;
+                faults_grand_total += count;
+            });
+        }
+
+        let mut rate_limit_by_endpoint: HashMap<String, u64> = HashMap::new();
+        let mut rate_limit_total: u64 = 0;
+        for fam in self.rate_limit_violations_total.collect() {
+            walk_counter(&fam, |labels, count| {
+                let endpoint =
+                    labels.get("endpoint").cloned().unwrap_or_else(|| "unknown".to_string());
+                rate_limit_by_endpoint.insert(endpoint, count);
+                rate_limit_total += count;
+            });
+        }
+
+        let mut latency_samples_by_endpoint: HashMap<String, u64> = HashMap::new();
+        for fam in self.latency_injected.collect() {
+            for m in fam.get_metric() {
+                let endpoint = m
+                    .get_label()
+                    .iter()
+                    .find(|l| l.name() == "endpoint")
+                    .map(|l| l.value().to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                let count = m.get_histogram().sample_count();
+                latency_samples_by_endpoint.insert(endpoint, count);
+            }
+        }
+
+        ChaosStatsSnapshot {
+            faults_by_type,
+            faults_total_by_type,
+            faults_grand_total,
+            rate_limit_violations_by_endpoint: rate_limit_by_endpoint,
+            rate_limit_violations_total: rate_limit_total,
+            latency_samples_by_endpoint,
+        }
+    }
+}
+
+/// Iterate counter samples in a metric family, calling `visit(labels, value)`
+/// for each. Only valid for counter-typed families; histograms have a
+/// different shape and we read those inline in `snapshot()`.
+fn walk_counter<F>(fam: &MetricFamily, mut visit: F)
+where
+    F: FnMut(HashMap<String, String>, u64),
+{
+    for m in fam.get_metric() {
+        let labels: HashMap<String, String> = m
+            .get_label()
+            .iter()
+            .map(|l| (l.name().to_string(), l.value().to_string()))
+            .collect();
+        let count = m.get_counter().value() as u64;
+        visit(labels, count);
+    }
+}
+
+/// Structured snapshot of the chaos counter state. Returned by the
+/// `/api/chaos/stats` endpoint and consumed by the TUI Chaos screen.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ChaosStatsSnapshot {
+    /// faults_by_type[fault_type][endpoint] = count. Empty when chaos has
+    /// never fired since process start.
+    pub faults_by_type: HashMap<String, HashMap<String, u64>>,
+    /// Total faults per fault_type, summed across endpoints.
+    pub faults_total_by_type: HashMap<String, u64>,
+    /// Total fault injections across all types and endpoints.
+    pub faults_grand_total: u64,
+    /// Rate-limit violations per endpoint.
+    pub rate_limit_violations_by_endpoint: HashMap<String, u64>,
+    /// Total rate-limit violations.
+    pub rate_limit_violations_total: u64,
+    /// Number of latency-injection samples per endpoint (histogram count).
+    pub latency_samples_by_endpoint: HashMap<String, u64>,
 }
 
 impl Default for ChaosMetrics {
@@ -261,5 +360,49 @@ mod tests {
     fn test_record_latency() {
         CHAOS_METRICS.record_latency("/api/test", 100.0);
         // Just ensure it doesn't panic
+    }
+
+    /// Issue #79 follow-up: snapshot must reflect counter increments and the
+    /// label-keyed nesting (fault_type → endpoint → count) the TUI uses.
+    #[test]
+    fn snapshot_reflects_counter_increments() {
+        // Use a unique endpoint label so this test doesn't race with other
+        // tests against the global CHAOS_METRICS singleton.
+        let endpoint = "/api/test_snapshot_endpoint_unique_xyz";
+        let baseline = CHAOS_METRICS.snapshot();
+        let baseline_count = baseline
+            .faults_by_type
+            .get("http_error")
+            .and_then(|m| m.get(endpoint))
+            .copied()
+            .unwrap_or(0);
+
+        CHAOS_METRICS.record_fault("http_error", endpoint);
+        CHAOS_METRICS.record_fault("http_error", endpoint);
+        CHAOS_METRICS.record_rate_limit_violation(endpoint);
+        CHAOS_METRICS.record_latency(endpoint, 42.0);
+
+        let snap = CHAOS_METRICS.snapshot();
+        assert_eq!(
+            snap.faults_by_type
+                .get("http_error")
+                .and_then(|m| m.get(endpoint))
+                .copied()
+                .unwrap_or(0),
+            baseline_count + 2,
+            "fault count for {endpoint} did not advance by 2"
+        );
+        assert!(
+            snap.faults_total_by_type.get("http_error").copied().unwrap_or(0) >= 2,
+            "faults_total_by_type[http_error] should reflect the inc"
+        );
+        assert!(
+            snap.rate_limit_violations_by_endpoint.get(endpoint).copied().unwrap_or(0) >= 1,
+            "rate_limit_violations_by_endpoint did not record"
+        );
+        assert!(
+            snap.latency_samples_by_endpoint.get(endpoint).copied().unwrap_or(0) >= 1,
+            "latency histogram count did not record"
+        );
     }
 }

--- a/crates/mockforge-tui/src/api/client.rs
+++ b/crates/mockforge-tui/src/api/client.rs
@@ -303,6 +303,11 @@ impl MockForgeClient {
         self.get_api("/__mockforge/chaos").await
     }
 
+    /// Snapshot of chaos fault-injection counters (issue-#79 follow-up).
+    pub async fn get_chaos_stats(&self) -> Result<serde_json::Value> {
+        self.get_api("/__mockforge/chaos/stats").await
+    }
+
     pub async fn toggle_chaos(&self, enabled: bool) -> Result<String> {
         self.post_api("/__mockforge/chaos/toggle", &serde_json::json!({ "enabled": enabled }))
             .await

--- a/crates/mockforge-tui/src/screens/chaos.rs
+++ b/crates/mockforge-tui/src/screens/chaos.rs
@@ -36,6 +36,9 @@ enum PendingAction {
 
 pub struct ChaosScreen {
     data: Option<serde_json::Value>,
+    /// Chaos fault counter snapshot (issue-#79 follow-up). Fetched alongside
+    /// status; renders into a third panel beneath Settings.
+    stats: Option<serde_json::Value>,
     error: Option<String>,
     last_fetch: Option<Instant>,
     pending_action: Option<PendingAction>,
@@ -52,6 +55,7 @@ impl ChaosScreen {
     pub fn new() -> Self {
         Self {
             data: None,
+            stats: None,
             error: None,
             last_fetch: None,
             pending_action: None,
@@ -209,8 +213,20 @@ impl Screen for ChaosScreen {
         let cols = Layout::horizontal([Constraint::Percentage(40), Constraint::Percentage(60)])
             .split(area);
 
+        // Right column: Settings on top, Stats below (if available).
+        let right_rows = if self.stats.is_some() {
+            Layout::vertical([Constraint::Percentage(60), Constraint::Percentage(40)])
+                .split(cols[1])
+        } else {
+            // No stats yet — settings takes the whole right column.
+            Layout::vertical([Constraint::Percentage(100)]).split(cols[1])
+        };
+
         self.render_status(frame, cols[0], data);
-        self.render_settings(frame, cols[1], data);
+        self.render_settings(frame, right_rows[0], data);
+        if let Some(ref stats) = self.stats {
+            self.render_stats(frame, right_rows[1], stats);
+        }
 
         // Preset picker overlay.
         if self.preset_picker {
@@ -284,28 +300,52 @@ impl Screen for ChaosScreen {
         let client = client.clone();
         let tx = tx.clone();
         tokio::spawn(async move {
-            match client.get_chaos_status().await {
-                Ok(data) => {
-                    let json = serde_json::to_string(&data).unwrap_or_default();
-                    let _ = tx.send(Event::Data {
-                        screen: "chaos",
-                        payload: json,
-                    });
-                }
+            // Status is required; stats are best-effort. If stats fail (e.g. older
+            // server without /__mockforge/chaos/stats), we still render the
+            // existing Status + Settings panels with stats.is_none().
+            let status = match client.get_chaos_status().await {
+                Ok(data) => data,
                 Err(e) => {
                     let _ = tx.send(Event::ApiError {
                         screen: "chaos",
                         message: e.to_string(),
                     });
+                    return;
                 }
-            }
+            };
+            let stats = client.get_chaos_stats().await.ok();
+            let payload = serde_json::json!({
+                "status": status,
+                "stats": stats,
+            });
+            let _ = tx.send(Event::Data {
+                screen: "chaos",
+                payload: serde_json::to_string(&payload).unwrap_or_default(),
+            });
         });
     }
 
     fn on_data(&mut self, payload: &str) {
         match serde_json::from_str::<serde_json::Value>(payload) {
-            Ok(data) => {
-                self.data = Some(data);
+            Ok(combined) => {
+                // tick() now packs {status, stats}; back-compat: if the payload
+                // looks like the old shape (no "status" key), treat the whole
+                // thing as status data and leave stats unchanged.
+                if let Some(status) = combined.get("status").cloned() {
+                    self.data = Some(status);
+                    if let Some(stats) = combined.get("stats").cloned() {
+                        // The endpoint envelope is {success, data, error, ...};
+                        // unwrap to the inner snapshot for rendering.
+                        let snapshot = stats.get("data").cloned().unwrap_or(stats);
+                        self.stats = if snapshot.is_null() {
+                            None
+                        } else {
+                            Some(snapshot)
+                        };
+                    }
+                } else {
+                    self.data = Some(combined);
+                }
                 self.error = None;
             }
             Err(e) => {
@@ -461,6 +501,80 @@ impl ChaosScreen {
         let visible_lines: Vec<Line> = lines.into_iter().skip(self.detail_scroll).collect();
 
         let paragraph = Paragraph::new(visible_lines).block(block);
+        frame.render_widget(paragraph, area);
+    }
+
+    /// Issue-#79 follow-up: show per-fault-type counts from the chaos
+    /// prometheus counters. Sourced from `/__mockforge/chaos/stats` →
+    /// `mockforge_chaos::metrics::CHAOS_METRICS::snapshot()`.
+    fn render_stats(&self, frame: &mut Frame, area: Rect, stats: &serde_json::Value) {
+        let block = Block::default()
+            .title(" Fault Stats ")
+            .title_style(Theme::title())
+            .borders(Borders::ALL)
+            .border_style(Theme::dim())
+            .style(Theme::surface());
+
+        let mut lines: Vec<Line> = Vec::new();
+
+        let grand_total = stats.get("faults_grand_total").and_then(|v| v.as_u64()).unwrap_or(0);
+        lines.push(Line::from(vec![
+            Span::styled("  Total faults injected: ", Theme::dim()),
+            Span::styled(
+                grand_total.to_string(),
+                Style::default().fg(Theme::FG).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+
+        // Per-fault-type totals. Sort descending by count so the noisiest
+        // fault floats to the top.
+        let by_type = stats.get("faults_total_by_type").and_then(|v| v.as_object());
+        if let Some(map) = by_type {
+            let mut entries: Vec<(&String, u64)> =
+                map.iter().filter_map(|(k, v)| v.as_u64().map(|n| (k, n))).collect();
+            entries.sort_by(|a, b| b.1.cmp(&a.1));
+            if entries.is_empty() {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled("  No faults injected yet.", Theme::dim())));
+            } else {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    "  Per fault_type:",
+                    Style::default().fg(Theme::BLUE).add_modifier(Modifier::BOLD),
+                )));
+                for (fault_type, count) in entries {
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("    {fault_type:<22}"), Theme::dim()),
+                        Span::styled(count.to_string(), Style::default().fg(Theme::FG)),
+                    ]));
+                }
+            }
+        }
+
+        // Rate-limit violations summary.
+        let rl_total =
+            stats.get("rate_limit_violations_total").and_then(|v| v.as_u64()).unwrap_or(0);
+        if rl_total > 0 {
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("  Rate-limit violations:  ", Theme::dim()),
+                Span::styled(rl_total.to_string(), Style::default().fg(Theme::FG)),
+            ]));
+        }
+
+        // Latency injection sample count.
+        if let Some(samples) = stats.get("latency_samples_by_endpoint").and_then(|v| v.as_object())
+        {
+            let total: u64 = samples.values().filter_map(|v| v.as_u64()).sum();
+            if total > 0 {
+                lines.push(Line::from(vec![
+                    Span::styled("  Latency injections:     ", Theme::dim()),
+                    Span::styled(total.to_string(), Style::default().fg(Theme::FG)),
+                ]));
+            }
+        }
+
+        let paragraph = Paragraph::new(lines).block(block);
         frame.render_widget(paragraph, area);
     }
 

--- a/crates/mockforge-ui/src/handlers/chaos_api.rs
+++ b/crates/mockforge-ui/src/handlers/chaos_api.rs
@@ -138,6 +138,25 @@ pub async fn start_chaos_scenario(
     }
 }
 
+/// JSON snapshot of chaos fault-injection counters (issue-#79 follow-up).
+///
+/// Returns `mockforge_chaos::metrics::ChaosStatsSnapshot` read from the global
+/// `CHAOS_METRICS` prometheus state. The counters track everything the
+/// chaos middleware records regardless of whether a scenario is configured —
+/// so this endpoint works even when chaos has never been enabled.
+pub async fn get_chaos_stats(State(_state): State<AdminState>) -> impl IntoResponse {
+    let snapshot = mockforge_chaos::metrics::CHAOS_METRICS.snapshot();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "success": true,
+            "data": snapshot,
+            "error": null,
+            "timestamp": chrono::Utc::now().to_rfc3339()
+        })),
+    )
+}
+
 /// Stop a chaos scenario by name
 pub async fn stop_chaos_scenario(
     State(state): State<AdminState>,

--- a/crates/mockforge-ui/src/routes.rs
+++ b/crates/mockforge-ui/src/routes.rs
@@ -365,6 +365,7 @@ pub fn create_admin_router(
         .route("/startupz", get(health::startup_probe))
         // Chaos engineering routes (TUI dashboard)
         .route("/__mockforge/chaos", get(chaos_api::get_chaos_status))
+        .route("/__mockforge/chaos/stats", get(chaos_api::get_chaos_stats))
         .route("/__mockforge/chaos/toggle", post(chaos_api::toggle_chaos))
         .route("/__mockforge/chaos/scenarios/predefined", get(chaos_api::get_chaos_scenarios_predefined))
         .route("/__mockforge/chaos/scenarios/{name}", post(chaos_api::start_chaos_scenario))


### PR DESCRIPTION
## Summary

Issue #79 follow-up — final piece of the chaos observability work. The Prometheus counters wired in 0.3.128 and the `/metrics` exposure fix in 0.3.130 mean fault counts are now collected and scrapeable, but the TUI Chaos screen still only renders config — *what* chaos is configured, not *how often* it's actually firing. This adds a Fault Stats panel.

- New `mockforge_chaos::metrics::ChaosStatsSnapshot` — JSON-serializable view of `CHAOS_METRICS` keyed by `fault_type → endpoint → count`, plus per-type totals, grand total, rate-limit violations, and latency injection sample counts. Reads via `prometheus::core::Collector::collect()` so it's always in sync with `/metrics`.
- New `GET /api/chaos/stats` (chaos crate) and `GET /__mockforge/chaos/stats` (admin passthrough wrapped in the standard `{success, data, error, timestamp}` envelope).
- New `MockForgeClient::get_chaos_stats()` typed client method on the TUI side.
- `ChaosScreen` now fetches stats alongside status and renders a **Fault Stats** panel below Settings. Per-fault-type counts are sorted descending so the noisiest fault floats to the top. Best-effort: older servers without the new endpoint fall back to the existing 2-panel layout (no version-mismatch breakage).

Bundles the version bump to **0.3.131** so it ships in one PR.

## Test plan

- [x] Unit test in `mockforge-chaos`: `snapshot_reflects_counter_increments` pins the `fault_type → endpoint → count` nesting plus rate-limit and latency sample counters against `record_fault` / `record_rate_limit_violation` / `record_latency` calls on the global `CHAOS_METRICS`.
- [x] `cargo test -p mockforge-chaos --lib metrics::` — 4 tests pass (1 new)
- [x] `cargo clippy -p mockforge-chaos -p mockforge-ui -p mockforge-tui --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] CI green
- [ ] After merge: `scripts/publish-crates.sh`, tag `v0.3.131`, post acknowledgement in issue #79

Refs #79