### PR TITLE
fix(ui,docs): reconcile pricing to Pro $29 / Team $99 (#445)

### DIFF
--- a/crates/mockforge-ui/ui/src/pages/BillingPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/BillingPage.tsx
@@ -744,7 +744,7 @@ export function BillingPage() {
             <Card className={subscription.plan === 'pro' ? 'border-primary' : ''}>
               <CardHeader>
                 <CardTitle>Pro</CardTitle>
-                <div className="text-3xl font-bold">$19</div>
+                <div className="text-3xl font-bold">$29</div>
                 <CardDescription>per month</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -794,7 +794,7 @@ export function BillingPage() {
             <Card className={subscription.plan === 'team' ? 'border-primary' : ''}>
               <CardHeader>
                 <CardTitle>Team</CardTitle>
-                <div className="text-3xl font-bold">$79</div>
+                <div className="text-3xl font-bold">$99</div>
                 <CardDescription>per month</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">

--- a/crates/mockforge-ui/ui/src/pages/PricingPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PricingPage.tsx
@@ -86,7 +86,7 @@ export function PricingPage() {
           <CardHeader>
             <CardTitle className="text-2xl">Pro</CardTitle>
             <div className="mt-4">
-              <span className="text-4xl font-bold">$19</span>
+              <span className="text-4xl font-bold">$29</span>
               <span className="text-muted-foreground">/month</span>
             </div>
             <CardDescription>For professional developers</CardDescription>
@@ -138,7 +138,7 @@ export function PricingPage() {
           <CardHeader>
             <CardTitle className="text-2xl">Team</CardTitle>
             <div className="mt-4">
-              <span className="text-4xl font-bold">$79</span>
+              <span className="text-4xl font-bold">$99</span>
               <span className="text-muted-foreground">/month</span>
             </div>
             <CardDescription>For growing teams</CardDescription>
@@ -292,12 +292,6 @@ export function PricingPage() {
             <h3 className="font-semibold mb-2">Do unused requests roll over?</h3>
             <p className="text-muted-foreground">
               No, limits reset each billing cycle. Unused capacity does not roll over to the next month.
-            </p>
-          </div>
-          <div>
-            <h3 className="font-semibold mb-2">Is there a free trial?</h3>
-            <p className="text-muted-foreground">
-              Yes! All paid plans include a 14-day free trial. No credit card required for trial.
             </p>
           </div>
           <div>

--- a/docs/cloud/PRICING.md
+++ b/docs/cloud/PRICING.md
@@ -42,7 +42,7 @@ MockForge Cloud offers three pricing tiers designed to meet the needs of individ
 
 ### Pro Plan
 
-**$19/month** - For professional developers and small teams
+**$29/month** - For professional developers and small teams
 
 **Everything in Free, plus:**
 - ✅ **250,000 API requests** per month (25x more)
@@ -70,7 +70,7 @@ MockForge Cloud offers three pricing tiers designed to meet the needs of individ
 
 ### Team Plan
 
-**$79/month** - For growing teams and organizations
+**$99/month** - For growing teams and organizations
 
 **Everything in Pro, plus:**
 - ✅ **1,000,000 API requests** per month (100x Free)
@@ -304,10 +304,6 @@ Need more than Team plan offers? Contact us for custom enterprise solutions:
 ### What payment methods do you accept?
 
 We accept all major credit and debit cards through Stripe. We're working on adding more payment methods (PayPal, bank transfer for enterprise).
-
-### Is there a free trial for paid plans?
-
-**Yes!** All paid plans include a 14-day free trial. No credit card required for trial. Cancel anytime during trial with no charges.
 
 ### Can I get a refund?
 


### PR DESCRIPTION
Closes #445.

The admin UI's `PricingPage.tsx` and `BillingPage.tsx` showed Pro $19 / Team $79, while the marketing site (https://mockforge.dev/pricing.html), `deploy/PRODUCTION_SETUP.md`, and `ROADMAP.md` all listed Pro $29 / Team $99. Stripe products and price IDs in production setup docs are configured for $29/$99, so a customer clicking "Upgrade to Pro" in the admin UI would have seen a different price at the Stripe checkout page than what the app advertised.

## Changes

- `crates/mockforge-ui/ui/src/pages/PricingPage.tsx`: Pro $19 → $29, Team $79 → $99
- `crates/mockforge-ui/ui/src/pages/BillingPage.tsx`: Pro $19 → $29, Team $79 → $99
- `docs/cloud/PRICING.md`: Pro $19 → $29, Team $79 → $99
- Removed the "14-day free trial" FAQ from both `PricingPage.tsx` and `docs/cloud/PRICING.md` — the registry server has no trial code (`SubscriptionStatus::Trialing` exists in the model but is never set by checkout), so the promise was never deliverable. The Stripe `Trialing` enum stays in the data model so we display it correctly if Stripe ever sends it.

Money-back guarantee FAQ (also 14 days) is untouched — that's a refund policy, not a trial.

## Verification

- `pnpm type-check` — passes
- `pnpm test --run src/pages/__tests__/TestingPage.test.tsx` — 22/22 pass
- `grep -rn '\$19\|\$79' --include='*.tsx' --include='*.ts' --include='*.md'` (excluding `node_modules`, `target`, `.git`, archived docs) — clean, only matches left are SQL parameter placeholders in postgres queries

## Test plan

- [ ] Verify pricing page in deployed admin UI shows $29/$99
- [ ] Click "Upgrade to Pro" → confirm Stripe checkout shows $29/mo
- [ ] No mention of "14-day free trial" anywhere user-visible