### PR TITLE
feat(registry,ui): cloud-mode workspace graph (#460)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/graph.rs
+++ b/crates/mockforge-registry-server/src/handlers/graph.rs
@@ -1,0 +1,157 @@
+//! Workspace graph handler (#460) — read-only view of services + flows in a
+//! workspace. Returns a `GraphData` payload shaped to match the local
+//! `/__mockforge/graph` endpoint so the same `GraphPage` UI can render either
+//! mode.
+//!
+//! Phase 1: nodes only (one per service, one per flow), single workspace
+//! cluster, no edges. Edge derivation from flow.config refs is a follow-up.
+//!
+//! Route: `GET /api/v1/workspaces/{workspace_id}/graph`
+
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    models::{cloud_service::CloudService, CloudWorkspace, Flow},
+    AppState,
+};
+
+#[derive(Debug, Serialize)]
+pub struct GraphData {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    pub clusters: Vec<GraphCluster>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GraphNode {
+    pub id: String,
+    pub label: String,
+    #[serde(rename = "nodeType")]
+    pub node_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GraphEdge {
+    pub from: String,
+    pub to: String,
+    #[serde(rename = "edgeType")]
+    pub edge_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GraphCluster {
+    pub id: String,
+    pub label: String,
+    #[serde(rename = "clusterType")]
+    pub cluster_type: String,
+    #[serde(rename = "nodeIds")]
+    pub node_ids: Vec<String>,
+    pub metadata: serde_json::Value,
+}
+
+pub async fn get_workspace_graph(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<GraphData>> {
+    let workspace = authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+
+    let services = CloudService::find_by_workspace(state.db.pool(), workspace.org_id, workspace_id)
+        .await
+        .map_err(ApiError::Database)?;
+    let flows = Flow::list_by_workspace(state.db.pool(), workspace_id, None)
+        .await
+        .map_err(ApiError::Database)?;
+
+    let mut nodes: Vec<GraphNode> = Vec::with_capacity(services.len() + flows.len());
+    let mut node_ids: Vec<String> = Vec::with_capacity(services.len() + flows.len());
+
+    for s in &services {
+        let id = format!("service:{}", s.id);
+        node_ids.push(id.clone());
+        nodes.push(GraphNode {
+            id,
+            label: s.name.clone(),
+            node_type: "service".into(),
+            protocol: derive_service_protocol(s),
+            metadata: serde_json::json!({
+                "kind": "service",
+                "description": s.description,
+                "base_url": s.base_url,
+                "enabled": s.enabled,
+            }),
+        });
+    }
+
+    for f in &flows {
+        let id = format!("flow:{}", f.id);
+        node_ids.push(id.clone());
+        nodes.push(GraphNode {
+            id,
+            label: f.name.clone(),
+            node_type: "service".into(),
+            protocol: None,
+            metadata: serde_json::json!({
+                "kind": "flow",
+                "flow_kind": f.kind,
+                "description": f.description,
+            }),
+        });
+    }
+
+    let clusters = vec![GraphCluster {
+        id: format!("workspace:{}", workspace_id),
+        label: workspace.name.clone(),
+        cluster_type: "workspace".into(),
+        node_ids,
+        metadata: serde_json::json!({ "workspace_id": workspace_id }),
+    }];
+
+    Ok(Json(GraphData {
+        nodes,
+        edges: Vec::new(),
+        clusters,
+    }))
+}
+
+fn derive_service_protocol(s: &CloudService) -> Option<String> {
+    s.routes
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|r| r.get("protocol"))
+        .and_then(|p| p.as_str())
+        .map(str::to_lowercase)
+}
+
+async fn authorize_workspace(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    workspace_id: Uuid,
+) -> ApiResult<CloudWorkspace> {
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != workspace.org_id {
+        return Err(ApiError::InvalidRequest("Workspace not found".into()));
+    }
+    Ok(workspace)
+}

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -17,6 +17,7 @@ pub mod contract_verification;
 pub mod faq;
 pub mod federations;
 pub mod flows;
+pub mod graph;
 pub mod health;
 pub mod hosted_mocks;
 pub mod incidents;

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -530,6 +530,13 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/flow-versions/{version_id}",
             get(handlers::flows::get_flow_version),
         )
+        // Workspace dependency graph (#460) — services + flows as nodes,
+        // clustered by workspace. Phase 1 returns no edges; edge derivation
+        // from flow.config refs is a follow-up.
+        .route(
+            "/api/v1/workspaces/{workspace_id}/graph",
+            get(handlers::graph::get_workspace_graph),
+        )
         // Observability saved-queries + dashboards (cloud-enablement #2 / Phase 1).
         // Cross-deployment query handlers come in a follow-up slice.
         .route(

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -285,6 +285,10 @@ const cloudNavItemIds = new Set([
   // Chains share the flows resource (kind='chain') and are executed by
   // the ChainExecutor in mockforge-test-runner (#354).
   'chains',
+  // Workspace dependency graph (#460) — services + flows as nodes,
+  // clustered by the active workspace. Phase 1 returns no edges; SSE
+  // updates are local-only for now (cloud falls back to 30s polling).
+  'graph',
   // Scenario Studio uses cloudFlowsApi with kind='scenario'. Each flow
   // version stores the full {flow_type, steps, connections, tags}
   // payload as the FlowVersion config; runs queue through test_runs.

--- a/crates/mockforge-ui/ui/src/pages/GraphPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/GraphPage.tsx
@@ -19,6 +19,9 @@ import type {
 import { Loader2 } from 'lucide-react';
 import { Card, CardContent } from '../components/ui/Card';
 import { apiService } from '../services/api';
+import { cloudGraphApi } from '../services/api/cloudGraph';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 import type { GraphData, GraphNode, GraphEdge } from '../types/graph';
 import { EndpointNode } from '../components/graph/EndpointNode';
 import { ServiceNode } from '../components/graph/ServiceNode';
@@ -39,6 +42,8 @@ const nodeTypes: NodeTypes = {
 };
 
 export const GraphPage: React.FC<GraphPageProps> = ({ className }) => {
+  const cloudMode = isCloudMode();
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
   const [graphData, setGraphData] = useState<GraphData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -53,11 +58,12 @@ export const GraphPage: React.FC<GraphPageProps> = ({ className }) => {
   const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const [useRealtime, setUseRealtime] = useState(true);
 
-  // SSE for real-time updates
+  // SSE for real-time updates — local only. Cloud mode polls instead;
+  // a workspace-scoped SSE endpoint is a follow-up to the read endpoint.
   const { data: sseData, isConnected: sseConnected } = useSSE<GraphData>(
     '/__mockforge/graph/sse',
     {
-      autoConnect: useRealtime,
+      autoConnect: useRealtime && !cloudMode,
       retry: {
         enabled: true,
         maxAttempts: 5,
@@ -70,7 +76,16 @@ export const GraphPage: React.FC<GraphPageProps> = ({ className }) => {
     try {
       setLoading(true);
       setError(null);
-      const response = await apiService.getGraph();
+      if (cloudMode && !activeWorkspace?.id) {
+        setGraphData(null);
+        setNodes([]);
+        setEdges([]);
+        setError('Select a workspace to view its dependency graph.');
+        return;
+      }
+      const response = cloudMode
+        ? await cloudGraphApi.getWorkspaceGraph(activeWorkspace!.id)
+        : await apiService.getGraph();
       setGraphData(response);
 
       // Apply filters
@@ -123,7 +138,7 @@ export const GraphPage: React.FC<GraphPageProps> = ({ className }) => {
     } finally {
       setLoading(false);
     }
-  }, [setNodes, setEdges, layout, nodeFilter, protocolFilter]);
+  }, [setNodes, setEdges, layout, nodeFilter, protocolFilter, cloudMode, activeWorkspace?.id]);
 
   useEffect(() => {
     fetchGraphData();

--- a/crates/mockforge-ui/ui/src/services/api/cloudGraph.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudGraph.ts
@@ -1,0 +1,31 @@
+/**
+ * Cloud graph API client (#460).
+ *
+ * Read-only workspace dependency graph view. Returns nodes for every
+ * `service` and `flow` in the workspace, clustered as a single workspace
+ * cluster. Phase 1 returns no edges; cross-flow / service-call edge
+ * derivation is a follow-up.
+ *
+ * The response shape mirrors the local `/__mockforge/graph` payload so the
+ * existing `GraphPage` UI renders either mode unchanged.
+ */
+import { fetchJsonWithErrorBody } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
+import type { GraphData } from '../../types/graph';
+
+class CloudGraphApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud graph ${method} only works in cloud mode.`);
+    }
+  }
+
+  async getWorkspaceGraph(workspaceId: string): Promise<GraphData> {
+    this.guard('getWorkspaceGraph');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/graph`,
+    ) as Promise<GraphData>;
+  }
+}
+
+export const cloudGraphApi = new CloudGraphApi();


### PR DESCRIPTION
Closes #460. First of the 14 cloud-parity items tracked in #459.

The Graph page was disabled with "Local only" at app.mockforge.dev because the local `/__mockforge/graph` endpoint queries an in-process route registry that doesn't exist on the registry server.

## Summary

- New endpoint `GET /api/v1/workspaces/{workspace_id}/graph` on the registry server returns a `GraphData` payload shaped identically to the local one (nodes / edges / clusters), so the existing `GraphPage` renders either mode.
- Phase 1 derives nodes from the `services` and `flows` tables (both workspace-scoped). Edges are empty for now — cross-flow ref derivation from `FlowVersion.config` is a follow-up.
- One workspace cluster groups every node.
- UI: `cloudGraphApi.getWorkspaceGraph(workspaceId)`, GraphPage branches on `isCloudMode()`, falls back to "select a workspace" when none is active.
- SSE auto-connect gated to local mode — cloud uses the existing 30s polling fallback. Adding a cloud SSE endpoint is left for when we have live signals worth streaming.
- `graph` is allowlisted in `cloudNavItemIds` so the badge goes away.

## Out of scope (follow-ups)

- Edge derivation from flow.config refs
- Cloud SSE stream for live graph updates
- Endpoint-level (vs service-level) nodes (`hosted_mocks` are org-scoped today)

## Test plan

- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` passes
- [x] `cargo test -p mockforge-registry-server --lib` — 361 passed, 0 failed
- [x] `cargo fmt --all --check` passes
- [x] `pnpm type-check` passes in `crates/mockforge-ui/ui`
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [ ] Browser verification at app.mockforge.dev (will validate post-deploy)