### PR TITLE
chore(ui): hide cloud-redundant Metrics + Performance nav items (#463, #467)

### DIFF
--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -370,6 +370,10 @@ const cloudHiddenNavItemIds = new Set([
   'plugins',                // → plugin-registry (cloud-side plugin discovery)
   'test-execution',         // → cloud-test-runs (TestExecutionDashboard is mock-data only)
   'analytics',              // → pillar-analytics (request-traffic analytics is local-only)
+  // The next two (#463, #467) are redundant with pages that are already
+  // cloud-enabled — keeping both visible just adds sidebar noise.
+  'metrics',                // → pillar-analytics (request rate / latency / errors live there)
+  'performance',            // → cloud-test-runs (k6 / load runs already covered)
 ]);
 
 // In cloud mode, items outside the allowlist are shown as disabled "Local only"


### PR DESCRIPTION
Closes #463, closes #467.

The local Metrics page and Performance page both have cloud equivalents that already work:

- **Metrics** → \`pillar-analytics\` already surfaces request rate / latency / errors in cloud mode (the local \`analytics\` nav item is similarly hidden today in favor of pillar-analytics).
- **Performance** → \`cloud-test-runs\` covers k6 / load runs.

Showing both versions in the sidebar adds noise without adding capability, so this moves them to \`cloudHiddenNavItemIds\` to match how we already handle \`analytics\`, \`test-execution\`, \`chaos\`, etc.

Part of the cleanup tracked in #459.

## Test plan

- [x] \`pnpm type-check\` passes
- [x] \`pnpm lint\` — 0 errors