### PR TITLE
feat(registry,ui): cloud-mode Observability — execute saved queries (#465)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/observability.rs
+++ b/crates/mockforge-registry-server/src/handlers/observability.rs
@@ -426,3 +426,273 @@ pub async fn query_traces(
 
     Ok(Json(rows))
 }
+
+// --- saved-query execution (#465) ------------------------------------------
+
+/// One result bucket. `label` is the group key for grouped queries
+/// (e.g. status code "200", "404") or `"all"` for ungrouped totals.
+#[derive(Debug, serde::Serialize)]
+pub struct QueryBucket {
+    pub label: String,
+    pub count: i64,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct ExecuteQueryResponse {
+    pub metric: String,
+    pub total: i64,
+    pub window_minutes: i64,
+    pub series: Vec<QueryBucket>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ExecuteQueryRequest {
+    /// Override the saved query's workspace scope. None falls back to
+    /// `SavedQuery.workspace_id`. None on both means org-wide.
+    #[serde(default)]
+    pub workspace_id: Option<Uuid>,
+    /// Override the window encoded in `filters.window_minutes` for ad-hoc
+    /// time-range tweaks from the UI.
+    #[serde(default)]
+    pub window_minutes: Option<i64>,
+}
+
+/// `POST /api/v1/observability/saved-queries/{id}/execute`
+///
+/// Runs the saved query's `filters` payload against runtime data and
+/// returns a flat `{ metric, total, window_minutes, series }` shape the
+/// UI's tile components consume directly. Phase 1 supports three
+/// `filters.kind` shapes — `request_count`, `request_count_by_status`,
+/// `incident_count` — each with an optional `window_minutes`.
+pub async fn execute_saved_query(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+    body: Option<Json<ExecuteQueryRequest>>,
+) -> ApiResult<Json<ExecuteQueryResponse>> {
+    let req = body.map(|Json(b)| b).unwrap_or_default();
+    let query = load_authorized_query(&state, user_id, &headers, id).await?;
+
+    let kind = query
+        .filters
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            ApiError::InvalidRequest("Saved query filters missing required `kind`".into())
+        })?
+        .to_string();
+    let window_minutes = req
+        .window_minutes
+        .or_else(|| query.filters.get("window_minutes").and_then(|v| v.as_i64()))
+        .unwrap_or(15)
+        .clamp(1, 24 * 60);
+    let workspace_filter = req.workspace_id.or(query.workspace_id);
+
+    let pool = state.db.pool();
+    let response = match kind.as_str() {
+        "request_count" => run_request_count(pool, query.org_id, workspace_filter, window_minutes)
+            .await
+            .map_err(ApiError::Database)?,
+        "request_count_by_status" => {
+            run_request_count_by_status(pool, query.org_id, workspace_filter, window_minutes)
+                .await
+                .map_err(ApiError::Database)?
+        }
+        "incident_count" => {
+            run_incident_count(pool, query.org_id, workspace_filter, window_minutes)
+                .await
+                .map_err(ApiError::Database)?
+        }
+        other => {
+            return Err(ApiError::InvalidRequest(format!(
+                "Unsupported saved-query kind '{other}'. Supported: request_count, request_count_by_status, incident_count"
+            )));
+        }
+    };
+
+    Ok(Json(response))
+}
+
+/// Total request count over the window. Workspace-scoped when
+/// `workspace_id` is set; otherwise the `runtime_captures.workspace_id`
+/// filter is dropped (org-wide).
+///
+/// Note (#462): captures shipped from in-container hosted-mocks land
+/// with `workspace_id IS NULL` today, so workspace-scoped counts only
+/// reflect `--cloud-ship` traffic until the shipper backfill ships.
+async fn run_request_count(
+    pool: &sqlx::PgPool,
+    org_id: Uuid,
+    workspace_id: Option<Uuid>,
+    window_minutes: i64,
+) -> sqlx::Result<ExecuteQueryResponse> {
+    let total: i64 = if let Some(ws) = workspace_id {
+        sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)::BIGINT
+            FROM runtime_captures
+            WHERE workspace_id = $1
+              AND occurred_at >= NOW() - make_interval(mins => $2::int)
+            "#,
+        )
+        .bind(ws)
+        .bind(window_minutes as i32)
+        .fetch_one(pool)
+        .await?
+    } else {
+        sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)::BIGINT
+            FROM runtime_captures rc
+            JOIN hosted_mocks hm ON hm.id = rc.deployment_id
+            WHERE hm.org_id = $1
+              AND rc.occurred_at >= NOW() - make_interval(mins => $2::int)
+            "#,
+        )
+        .bind(org_id)
+        .bind(window_minutes as i32)
+        .fetch_one(pool)
+        .await?
+    };
+
+    Ok(ExecuteQueryResponse {
+        metric: "request_count".into(),
+        total,
+        window_minutes,
+        series: vec![QueryBucket {
+            label: "all".into(),
+            count: total,
+        }],
+    })
+}
+
+async fn run_request_count_by_status(
+    pool: &sqlx::PgPool,
+    org_id: Uuid,
+    workspace_id: Option<Uuid>,
+    window_minutes: i64,
+) -> sqlx::Result<ExecuteQueryResponse> {
+    // `COALESCE(response_status_code, status_code)` mirrors what the
+    // request-log endpoint surfaces — a "request that never got a
+    // response" still has a status_code on the request side.
+    let rows: Vec<(Option<i32>, i64)> = if let Some(ws) = workspace_id {
+        sqlx::query_as(
+            r#"
+            SELECT COALESCE(response_status_code, status_code) AS status,
+                   COUNT(*)::BIGINT
+            FROM runtime_captures
+            WHERE workspace_id = $1
+              AND occurred_at >= NOW() - make_interval(mins => $2::int)
+            GROUP BY status
+            ORDER BY status NULLS LAST
+            "#,
+        )
+        .bind(ws)
+        .bind(window_minutes as i32)
+        .fetch_all(pool)
+        .await?
+    } else {
+        sqlx::query_as(
+            r#"
+            SELECT COALESCE(rc.response_status_code, rc.status_code) AS status,
+                   COUNT(*)::BIGINT
+            FROM runtime_captures rc
+            JOIN hosted_mocks hm ON hm.id = rc.deployment_id
+            WHERE hm.org_id = $1
+              AND rc.occurred_at >= NOW() - make_interval(mins => $2::int)
+            GROUP BY status
+            ORDER BY status NULLS LAST
+            "#,
+        )
+        .bind(org_id)
+        .bind(window_minutes as i32)
+        .fetch_all(pool)
+        .await?
+    };
+
+    let total = rows.iter().map(|(_, c)| *c).sum();
+    let series = rows
+        .into_iter()
+        .map(|(status, count)| QueryBucket {
+            label: status.map(|s| s.to_string()).unwrap_or_else(|| "unknown".into()),
+            count,
+        })
+        .collect();
+
+    Ok(ExecuteQueryResponse {
+        metric: "request_count_by_status".into(),
+        total,
+        window_minutes,
+        series,
+    })
+}
+
+async fn run_incident_count(
+    pool: &sqlx::PgPool,
+    org_id: Uuid,
+    workspace_id: Option<Uuid>,
+    window_minutes: i64,
+) -> sqlx::Result<ExecuteQueryResponse> {
+    let rows: Vec<(String, i64)> = if let Some(ws) = workspace_id {
+        sqlx::query_as(
+            r#"
+            SELECT severity, COUNT(*)::BIGINT
+            FROM incidents
+            WHERE workspace_id = $1
+              AND created_at >= NOW() - make_interval(mins => $2::int)
+              AND status != 'resolved'
+            GROUP BY severity
+            ORDER BY CASE severity
+                       WHEN 'critical' THEN 0
+                       WHEN 'high' THEN 1
+                       WHEN 'medium' THEN 2
+                       WHEN 'low' THEN 3
+                       ELSE 4
+                     END
+            "#,
+        )
+        .bind(ws)
+        .bind(window_minutes as i32)
+        .fetch_all(pool)
+        .await?
+    } else {
+        sqlx::query_as(
+            r#"
+            SELECT severity, COUNT(*)::BIGINT
+            FROM incidents
+            WHERE org_id = $1
+              AND created_at >= NOW() - make_interval(mins => $2::int)
+              AND status != 'resolved'
+            GROUP BY severity
+            ORDER BY CASE severity
+                       WHEN 'critical' THEN 0
+                       WHEN 'high' THEN 1
+                       WHEN 'medium' THEN 2
+                       WHEN 'low' THEN 3
+                       ELSE 4
+                     END
+            "#,
+        )
+        .bind(org_id)
+        .bind(window_minutes as i32)
+        .fetch_all(pool)
+        .await?
+    };
+
+    let total = rows.iter().map(|(_, c)| *c).sum();
+    let series = rows
+        .into_iter()
+        .map(|(severity, count)| QueryBucket {
+            label: severity,
+            count,
+        })
+        .collect();
+
+    Ok(ExecuteQueryResponse {
+        metric: "incident_count".into(),
+        total,
+        window_minutes,
+        series,
+    })
+}

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -563,6 +563,14 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/organizations/{org_id}/observability/traces/query",
             post(handlers::observability::query_traces),
         )
+        // Saved-query execution (#465). Phase 1 supports three `kind`
+        // shapes in the saved query's `filters` payload: `request_count`,
+        // `request_count_by_status`, `incident_count`. Returns a flat
+        // {metric, total, window_minutes, series:[{label,count}]}.
+        .route(
+            "/api/v1/observability/saved-queries/{id}/execute",
+            post(handlers::observability::execute_saved_query),
+        )
         // Chaos campaigns + resilience patterns (cloud-enablement #7 / Phase 1).
         // Run trigger / kill-switch worker / target authorization land
         // in follow-up slices once #4 worker pool is up.

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -289,6 +289,10 @@ const cloudNavItemIds = new Set([
   // clustered by the active workspace. Phase 1 returns no edges; SSE
   // updates are local-only for now (cloud falls back to 30s polling).
   'graph',
+  // Observability dashboard (#465) — Phase 1 lists the org's saved
+  // queries and runs them on-demand via cloudObservabilityApi.execute
+  // SavedQuery. Live dashboard tiles + event stream are a follow-up.
+  'observability',
   // Scenario Studio uses cloudFlowsApi with kind='scenario'. Each flow
   // version stores the full {flow_type, steps, connections, tags}
   // payload as the FlowVersion config; runs queue through test_runs.

--- a/crates/mockforge-ui/ui/src/pages/ObservabilityPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ObservabilityPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Activity, Layers, AlertCircle, TrendingUp, Clock, Zap } from 'lucide-react';
+import { Activity, Layers, AlertCircle, TrendingUp, Clock, Zap, Play, Loader2 } from 'lucide-react';
 import {
   PageHeader,
   ModernCard,
@@ -8,7 +8,16 @@ import {
   Section,
   ModernBadge
 } from '../components/ui/DesignSystem';
+import { Button } from '../components/ui/button';
 import { useWebSocket } from '../hooks/useWebSocket';
+import { isCloudMode } from '../utils/cloudMode';
+import { useCloudOrgId } from '../hooks/useCloudOrgId';
+import {
+  cloudObservabilityApi,
+  type ObservabilitySavedQuery,
+  type ExecuteSavedQueryResponse,
+} from '../services/api/cloudObservability';
+import { useQuery } from '@tanstack/react-query';
 
 interface DashboardStats {
   timestamp: string;
@@ -43,6 +52,13 @@ interface MetricsBucket {
 }
 
 export function ObservabilityPage() {
+  if (isCloudMode()) {
+    return <CloudObservabilityView />;
+  }
+  return <LocalObservabilityView />;
+}
+
+function LocalObservabilityView() {
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [alerts, setAlerts] = useState<AlertData[]>([]);
   const [recentMetrics, setRecentMetrics] = useState<MetricsBucket[]>([]);
@@ -270,6 +286,137 @@ export function ObservabilityPage() {
           />
         </div>
       </Section>
+    </div>
+  );
+}
+
+// --- Cloud-mode view (#465) -----------------------------------------------
+//
+// Lists the org's saved queries and lets the user run any of them
+// on-demand. Phase 1 supports three `kind`s in the saved query's
+// `filters` payload — `request_count`, `request_count_by_status`,
+// `incident_count` — and renders the flat
+// {metric,total,window_minutes,series:[{label,count}]} response as a
+// small bar list. Live event-stream tiles + dashboard layouts land in a
+// follow-up slice.
+function CloudObservabilityView() {
+  const orgId = useCloudOrgId();
+  const savedQueriesQuery = useQuery({
+    queryKey: ['cloud', 'observability', 'saved-queries', orgId],
+    queryFn: () => cloudObservabilityApi.listSavedQueries(orgId!),
+    enabled: !!orgId,
+  });
+
+  if (!orgId) {
+    return (
+      <div className="space-y-8">
+        <PageHeader title="Observability" subtitle="Run saved queries against your cloud workspace data." />
+        <Alert type="info" message="No active organization. Sign in or select an org to view saved queries." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Observability"
+        subtitle="Saved queries over request captures and incidents. Execute on-demand; live tiles ship in a follow-up."
+      />
+      <Section title="Saved queries">
+        <ModernCard>
+          {savedQueriesQuery.isLoading ? (
+            <div className="flex items-center justify-center py-8 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin mr-2" /> Loading saved queries…
+            </div>
+          ) : savedQueriesQuery.error ? (
+            <Alert type="error" message={`Failed to load saved queries: ${(savedQueriesQuery.error as Error).message}`} />
+          ) : (savedQueriesQuery.data ?? []).length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              No saved queries yet. Create one with{' '}
+              <code className="text-xs bg-muted px-1 py-0.5 rounded">
+                POST /api/v1/organizations/{'{'}org_id{'}'}/observability/saved-queries
+              </code>{' '}
+              and it will appear here.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {savedQueriesQuery.data!.map((q) => (
+                <SavedQueryCard key={q.id} query={q} />
+              ))}
+            </div>
+          )}
+        </ModernCard>
+      </Section>
+    </div>
+  );
+}
+
+function SavedQueryCard({ query }: { query: ObservabilitySavedQuery }) {
+  const [result, setResult] = useState<ExecuteSavedQueryResponse | null>(null);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const kind = (query.filters?.kind as string | undefined) ?? null;
+  const supportedKinds = ['request_count', 'request_count_by_status', 'incident_count'];
+  const isSupported = !!kind && supportedKinds.includes(kind);
+
+  const onRun = async () => {
+    setRunning(true);
+    setError(null);
+    try {
+      const res = await cloudObservabilityApi.executeSavedQuery(query.id);
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Execute failed');
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="border border-border rounded-md p-4 space-y-3">
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <div className="font-medium truncate">{query.name}</div>
+          {query.description && (
+            <div className="text-sm text-muted-foreground truncate">{query.description}</div>
+          )}
+          <div className="text-xs text-muted-foreground mt-1">
+            kind: <code>{kind ?? '(missing)'}</code>
+            {!isSupported && (
+              <span className="ml-2 text-warning-700 dark:text-warning-400">
+                (Phase 1 supports {supportedKinds.join(', ')})
+              </span>
+            )}
+          </div>
+        </div>
+        <Button onClick={onRun} disabled={running || !isSupported} size="sm">
+          {running ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <>
+              <Play className="h-4 w-4 mr-1" /> Run
+            </>
+          )}
+        </Button>
+      </div>
+      {error && <Alert type="error" message={error} />}
+      {result && (
+        <div className="text-sm space-y-2">
+          <div>
+            <span className="text-muted-foreground">total over {result.window_minutes}m:</span>{' '}
+            <span className="font-medium">{result.total.toLocaleString()}</span>
+          </div>
+          <div className="space-y-1">
+            {result.series.map((s) => (
+              <div key={s.label} className="flex justify-between text-xs">
+                <code className="text-muted-foreground">{s.label}</code>
+                <span>{s.count.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/crates/mockforge-ui/ui/src/services/api/cloudObservability.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudObservability.ts
@@ -121,6 +121,44 @@ class CloudObservabilityApi {
       },
     ) as Promise<TraceSpanRow[]>;
   }
+
+  /**
+   * Execute a saved query. Phase 1 supports `filters.kind` of
+   * `request_count`, `request_count_by_status`, or `incident_count`.
+   * Optional body lets a tile override the saved window / workspace
+   * without rewriting the underlying SavedQuery row.
+   */
+  async executeSavedQuery(
+    queryId: string,
+    body: ExecuteSavedQueryRequest = {},
+  ): Promise<ExecuteSavedQueryResponse> {
+    this.guard('executeSavedQuery');
+    return fetchJsonWithErrorBody(
+      `/api/v1/observability/saved-queries/${queryId}/execute`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    ) as Promise<ExecuteSavedQueryResponse>;
+  }
+}
+
+export interface ExecuteSavedQueryRequest {
+  workspace_id?: string;
+  window_minutes?: number;
+}
+
+export interface ExecuteSavedQueryBucket {
+  label: string;
+  count: number;
+}
+
+export interface ExecuteSavedQueryResponse {
+  metric: string;
+  total: number;
+  window_minutes: number;
+  series: ExecuteSavedQueryBucket[];
 }
 
 export const cloudObservabilityApi = new CloudObservabilityApi();


### PR DESCRIPTION
Closes #465 (Phase 1). Third cloud-parity item from #459 with new functionality.

The Observability page was disabled with "Local only" because the local \`/api/observability/ws\` WebSocket stream doesn't exist on the registry server. Saved-queries / dashboards CRUD already shipped in cloud-enablement #2 Phase 1 but had no execution path — saved queries were inert until now.

## Summary

**Server**
- \`POST /api/v1/observability/saved-queries/{id}/execute\` — loads the SavedQuery (org-authorized), dispatches on \`filters.kind\`, returns a flat \`{metric, total, window_minutes, series:[{label, count}]}\` shape.
- Optional body lets the UI override \`workspace_id\` / \`window_minutes\` for ad-hoc tile tweaks without rewriting the row.
- Phase 1 supports three kinds:
  - \`request_count\` — total over the window from \`runtime_captures\`. Workspace-scoped when set; otherwise joins through \`hosted_mocks\` for org-wide.
  - \`request_count_by_status\` — grouped by \`COALESCE(response_status_code, status_code)\`.
  - \`incident_count\` — grouped by severity over \`incidents\`, excluding resolved.

**UI**
- \`cloudObservabilityApi.executeSavedQuery(queryId, body?)\` mirrors the server contract.
- \`ObservabilityPage\` branches on \`isCloudMode()\` — Local view keeps the existing WebSocket-driven render; the new cloud view lists the org's saved queries with a per-row "Run" button.
- \`observability\` allowlisted in \`cloudNavItemIds\`.

## Known data gap (same as #462)

\`runtime_captures.workspace_id\` is NULL for hosted-mock captures today — the in-container shipper doesn't populate it. Workspace-scoped \`request_count\` therefore under-reports for hosted deployments until the shipper backfill lands. Org-wide totals use the deployment-join fallback and are unaffected.

## Out of scope (follow-up)

- Live event stream (SSE) for dashboard tiles — Phase 1 re-runs queries on user click.
- Cloud Dashboard layout rendering — Phase 1 ignores \`cloud_dashboards\` CRUD payload.
- Time-bucketed histograms over time.

## Test plan

- [x] \`cargo clippy -p mockforge-registry-server --all-targets -- -D warnings\` passes
- [x] \`cargo test -p mockforge-registry-server --lib\` — 361 passed
- [x] \`cargo fmt --all --check\` passes
- [x] \`pnpm type-check\` passes
- [x] \`pnpm lint\` — 0 errors
- [x] typos / pre-commit hooks pass
- [ ] Browser verification at app.mockforge.dev (post-deploy)