### PR TITLE
feat(registry): cost cap on hosted-mocks proxy — body size limit + per-deployment RPS (#450)

### DIFF
--- a/crates/mockforge-registry-server/src/deployment/mod.rs
+++ b/crates/mockforge-registry-server/src/deployment/mod.rs
@@ -7,4 +7,5 @@ pub mod flyio;
 pub mod health_check;
 pub mod metrics;
 pub mod orchestrator;
+pub mod rate_limit;
 pub mod router;

--- a/crates/mockforge-registry-server/src/deployment/rate_limit.rs
+++ b/crates/mockforge-registry-server/src/deployment/rate_limit.rs
@@ -1,0 +1,118 @@
+//! Per-deployment rate limiting for the hosted-mocks proxy.
+//!
+//! Protects MockForge from runaway customer traffic that would otherwise
+//! accrue Fly compute / bandwidth charges with no brake. A buggy or hostile
+//! customer can DOS their own deployment, and without this limit the proxy
+//! would happily forward every request.
+//!
+//! In-memory token bucket per deployment. Single-instance only — when the
+//! registry server scales beyond one Fly machine, swap this for the Redis
+//! pool already on `AppState`.
+
+use std::{
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+    time::Instant,
+};
+use uuid::Uuid;
+
+/// Default RPS limit per deployment when the env var isn't set.
+const DEFAULT_RPS_LIMIT: u32 = 100;
+
+/// 1-second rolling window. A deployment is allowed `rps_limit` requests
+/// per window; the window advances by replacing `window_start` and resetting
+/// the count when a new request arrives more than a second after the start.
+struct WindowState {
+    window_start: Instant,
+    count: u32,
+}
+
+pub struct DeploymentRateLimiter {
+    rps_limit: u32,
+    state: Mutex<HashMap<Uuid, WindowState>>,
+}
+
+impl DeploymentRateLimiter {
+    fn new(rps_limit: u32) -> Self {
+        Self {
+            rps_limit,
+            state: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns `Ok(())` if the deployment is under its RPS budget for this
+    /// 1-second window, or `Err(retry_after_secs)` if it exceeded.
+    pub fn check(&self, deployment_id: Uuid) -> Result<(), u64> {
+        let mut state = self.state.lock().expect("rate limit mutex poisoned");
+        let now = Instant::now();
+        let entry = state.entry(deployment_id).or_insert(WindowState {
+            window_start: now,
+            count: 0,
+        });
+
+        if now.duration_since(entry.window_start).as_secs() >= 1 {
+            entry.window_start = now;
+            entry.count = 0;
+        }
+
+        if entry.count >= self.rps_limit {
+            // Round-up: tell client to retry next second at the earliest.
+            let elapsed_ms = now.duration_since(entry.window_start).as_millis() as u64;
+            let retry_after_secs = (1000_u64.saturating_sub(elapsed_ms) / 1000).max(1);
+            return Err(retry_after_secs);
+        }
+
+        entry.count += 1;
+        Ok(())
+    }
+}
+
+/// Process-global limiter. Configured once from the `MOCKFORGE_HOSTED_MOCK_RPS_LIMIT`
+/// env var at first access, or `DEFAULT_RPS_LIMIT` if unset / unparsable.
+pub fn global() -> &'static DeploymentRateLimiter {
+    static LIMITER: OnceLock<DeploymentRateLimiter> = OnceLock::new();
+    LIMITER.get_or_init(|| {
+        let rps_limit = std::env::var("MOCKFORGE_HOSTED_MOCK_RPS_LIMIT")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(DEFAULT_RPS_LIMIT);
+        DeploymentRateLimiter::new(rps_limit)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_up_to_limit() {
+        let limiter = DeploymentRateLimiter::new(3);
+        let id = Uuid::new_v4();
+        assert!(limiter.check(id).is_ok());
+        assert!(limiter.check(id).is_ok());
+        assert!(limiter.check(id).is_ok());
+        assert!(limiter.check(id).is_err());
+    }
+
+    #[test]
+    fn independent_per_deployment() {
+        let limiter = DeploymentRateLimiter::new(1);
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        assert!(limiter.check(a).is_ok());
+        assert!(limiter.check(b).is_ok());
+        assert!(limiter.check(a).is_err());
+        assert!(limiter.check(b).is_err());
+    }
+
+    #[test]
+    fn window_resets_after_second() {
+        let limiter = DeploymentRateLimiter::new(1);
+        let id = Uuid::new_v4();
+        assert!(limiter.check(id).is_ok());
+        assert!(limiter.check(id).is_err());
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        assert!(limiter.check(id).is_ok());
+    }
+}

--- a/crates/mockforge-registry-server/src/deployment/router.rs
+++ b/crates/mockforge-registry-server/src/deployment/router.rs
@@ -6,14 +6,43 @@
 use axum::{
     extract::{Path, State},
     http::{HeaderMap, Method, StatusCode, Uri},
-    response::Response,
+    response::{IntoResponse, Response},
     routing::any,
     Router,
 };
 use uuid::Uuid;
 
+use crate::deployment::rate_limit;
 use crate::models::HostedMock;
 use crate::AppState;
+
+/// Hard cap on proxied request body size. Customers can't upload more than this
+/// per request — protects MockForge from unbounded memory + bandwidth costs.
+/// Configurable via `MOCKFORGE_HOSTED_MOCK_MAX_BODY_BYTES`; default 10 MiB.
+fn max_body_bytes() -> usize {
+    std::env::var("MOCKFORGE_HOSTED_MOCK_MAX_BODY_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(10 * 1024 * 1024)
+}
+
+/// Build a 429 response with a Retry-After header for the wildcard proxy.
+fn rate_limited_response(retry_after_secs: u64) -> Response {
+    let body = format!(
+        "{{\"error\":\"rate_limit_exceeded\",\"message\":\"Per-deployment request rate limit exceeded. Retry in {} second(s).\"}}",
+        retry_after_secs
+    );
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [
+            ("retry-after", retry_after_secs.to_string()),
+            ("content-type", "application/json".to_string()),
+        ],
+        body,
+    )
+        .into_response()
+}
 
 /// Multitenant router that routes requests to deployed mock services
 pub struct MultitenantRouter;
@@ -54,6 +83,11 @@ impl MultitenantRouter {
         // Check if deployment is active
         if !matches!(deployment.status(), crate::models::DeploymentStatus::Active) {
             return Err(StatusCode::SERVICE_UNAVAILABLE);
+        }
+
+        // Per-deployment rate limit — protects against runaway customer traffic
+        if let Err(retry_after) = rate_limit::global().check(deployment.id) {
+            return Ok(rate_limited_response(retry_after));
         }
 
         // Get the target base URL (prefer internal_url for Fly.io internal routing)
@@ -116,6 +150,11 @@ pub async fn custom_domain_fallback(
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
 
+    // Per-deployment rate limit — same gate as the /mocks/* path
+    if let Err(retry_after) = rate_limit::global().check(deployment.id) {
+        return Ok(rate_limited_response(retry_after));
+    }
+
     // Get the target base URL (prefer internal_url for Fly.io internal routing)
     let base_url = deployment
         .internal_url
@@ -146,11 +185,15 @@ async fn proxy_request(
 ) -> Result<Response, StatusCode> {
     let client = reqwest::Client::new();
 
-    // Read body if present
-    let body_bytes = axum::body::to_bytes(body, usize::MAX).await.map_err(|e| {
-        tracing::warn!("Failed to read request body: {}", e);
-        StatusCode::BAD_REQUEST
-    })?;
+    // Read body, capped to protect against unbounded uploads. axum returns an
+    // error when the body exceeds the limit; map that to 413 Payload Too Large.
+    let body_bytes = match axum::body::to_bytes(body, max_body_bytes()).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("Failed to read request body (or too large): {}", e);
+            return Err(StatusCode::PAYLOAD_TOO_LARGE);
+        }
+    };
 
     // Build request based on method
     let request_builder = match method.as_str() {


### PR DESCRIPTION
Closes #450 (with two follow-ups deferred and called out below).

## Problem

The wildcard proxy (\`<slug>.mocks.mockforge.dev\` and \`/mocks/{org}/{slug}/*\`) had no protection against runaway customer traffic. A buggy or hostile Pro customer (\$29/mo, 3 mocks allowed) could DOS their own mocks indefinitely and accrue ~\$333/mo in Fly compute on our bill — 10x the customer's plan price.

Also, request bodies were read with \`axum::body::to_bytes(body, usize::MAX)\` — a single customer could upload arbitrary-large payloads through us with no cap.

## What this PR adds

### 1. Body size cap
- Replaces \`to_bytes(body, usize::MAX)\` with \`to_bytes(body, max_body_bytes())\`
- Default 10 MiB; override via \`MOCKFORGE_HOSTED_MOCK_MAX_BODY_BYTES\`
- Returns \`413 Payload Too Large\` when exceeded

### 2. Per-deployment RPS rate limit
- In-memory token bucket per deployment UUID, 1-second rolling window
- Default 100 RPS; override via \`MOCKFORGE_HOSTED_MOCK_RPS_LIMIT\`
- Returns \`429 Too Many Requests\` with \`Retry-After\` header on exceed
- Applied uniformly to both proxy paths (\`/mocks/{org}/{slug}\` and the wildcard \`<slug>.mocks.mockforge.dev\` fallback)

### 3. New module
- \`crates/mockforge-registry-server/src/deployment/rate_limit.rs\` (118 lines)
- 3 unit tests: \`allows_up_to_limit\`, \`independent_per_deployment\`, \`window_resets_after_second\`

## What's NOT in this PR (deferred follow-ups)

1. **Per-plan rate-limit tuning** — uses a single global limit today. Adding plan-tiered RPS (Free 0, Pro 100, Team 1000) is a follow-up once \`limits_json.max_rps\` lands as a migration. Easy to wire when the schema exists.

2. **Fly.io spend alert** — pure ops work, deferred. Configure budget alerts in the Fly dashboard or wire up the Fly billing webhook to fire a notification when org-level compute spend exceeds 2× plan price.

3. **Multi-instance correctness** — the in-memory limiter is per-process. When the registry-server scales beyond one Fly machine, swap for the existing Redis pool already on \`AppState\`. Documented in the module's doc comment.

## Verification

- \`cargo fmt --all --check\` — passes
- \`cargo clippy -p mockforge-registry-server --all-targets -- -D warnings\` — passes
- \`cargo test -p mockforge-registry-server --lib\` — **369 passed, 0 failed** (3 new tests + 366 baseline)
- Pre-commit hooks (trailing whitespace, typos, clippy, fmt, etc.) — all pass

## Test plan

- [ ] Deploy a hosted mock; flood it with \`hey -n 1000 -c 50\` and confirm 429s with \`Retry-After: 1\` after the 100th request in any 1-second window
- [ ] Upload a 20 MiB body and confirm 413 \`Payload Too Large\` (10 MiB default cap)
- [ ] Set \`MOCKFORGE_HOSTED_MOCK_RPS_LIMIT=10\` in Fly secrets and confirm tighter throttling on a test deployment