### PR TITLE
feat(ci): production smoke test workflow against api.mockforge.dev (#452)

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,184 @@
+name: Production Smoke Test
+
+# Runs end-to-end against api.mockforge.dev every 15 minutes. Catches regressions
+# that ship past release.yml's gates and surface only when real customers hit them.
+#
+# Each run exercises: health → register → login → list hosted-mocks → billing/subscription.
+# If any step fails, the workflow opens a GitHub issue (deduped by title) so it
+# pages whoever's watching notifications.
+
+on:
+  schedule:
+    # Every 15 minutes.
+    - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+# Only one smoke at a time; if a previous run is still going (rare, but the
+# runner queue can stall), cancel it and start fresh — staleness compounds.
+concurrency:
+  group: production-smoke
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  smoke:
+    name: Smoke api.mockforge.dev
+    runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout (for issue-creation script)
+        uses: actions/checkout@v6
+
+      - name: Run smoke checks
+        id: smoke
+        # Don't fail the job on first error — we want to capture which step
+        # failed for the issue body. The composite step below fails the job
+        # if `failure_step` got written.
+        continue-on-error: true
+        env:
+          BASE_URL: https://api.mockforge.dev
+        run: |
+          set +e
+          fail() {
+            echo "::error::Smoke failed at step: $1"
+            echo "failure_step=$1" >> "$GITHUB_OUTPUT"
+            echo "failure_detail<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$2" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            exit 1
+          }
+
+          # 1) Health endpoint — fastest signal, runs first.
+          HEALTH=$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 10 "$BASE_URL/metrics/health" || echo "000")
+          if [ "$HEALTH" != "200" ]; then
+            fail "health" "GET /metrics/health returned $HEALTH; body: $(cat /tmp/health.json 2>/dev/null | head -c 200)"
+          fi
+          echo "OK health -> $HEALTH"
+
+          # 2) Register a throwaway smoke user. Tag with the run id so each
+          # invocation has a unique account that won't collide.
+          TS=$(date +%s)
+          USERNAME="smoke_${TS}_${GITHUB_RUN_ID}"
+          EMAIL="smoke_${TS}_${GITHUB_RUN_ID}@smoke.mockforge.dev"
+          PASSWORD="Smoke-$(openssl rand -hex 8)"
+
+          REG=$(curl -sS -o /tmp/reg.json -w '%{http_code}' --max-time 15 \
+            -X POST "$BASE_URL/api/v1/auth/register" \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"$USERNAME\",\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+            || echo "000")
+          if [ "$REG" != "200" ] && [ "$REG" != "201" ]; then
+            fail "register" "POST /api/v1/auth/register returned $REG; body: $(cat /tmp/reg.json 2>/dev/null | head -c 300)"
+          fi
+          ACCESS_TOKEN=$(jq -r '.access_token // .token // empty' /tmp/reg.json)
+          if [ -z "$ACCESS_TOKEN" ]; then
+            fail "register-token" "Register succeeded but no access_token in response: $(cat /tmp/reg.json | head -c 300)"
+          fi
+          echo "OK register -> $REG"
+
+          # 3) Login with the just-registered user — proves bcrypt verify + JWT issue path.
+          LOGIN=$(curl -sS -o /tmp/login.json -w '%{http_code}' --max-time 15 \
+            -X POST "$BASE_URL/api/v1/auth/login" \
+            -H 'Content-Type: application/json' \
+            -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+            || echo "000")
+          if [ "$LOGIN" != "200" ]; then
+            fail "login" "POST /api/v1/auth/login returned $LOGIN; body: $(cat /tmp/login.json 2>/dev/null | head -c 300)"
+          fi
+          echo "OK login -> $LOGIN"
+
+          # 4) List hosted-mocks — proves auth middleware + a real DB query work.
+          # Empty list (200) is success; we don't actually deploy a mock from
+          # the smoke because that costs Fly compute and leaves dangling state.
+          # If/when there's a cheap deploy+teardown path, fold it in here.
+          LIST=$(curl -sS -o /tmp/list.json -w '%{http_code}' --max-time 15 \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            "$BASE_URL/api/v1/hosted-mocks" \
+            || echo "000")
+          if [ "$LIST" != "200" ]; then
+            fail "hosted-mocks-list" "GET /api/v1/hosted-mocks returned $LIST; body: $(cat /tmp/list.json 2>/dev/null | head -c 300)"
+          fi
+          echo "OK hosted-mocks list -> $LIST"
+
+          # 5) Subscription info — touches the billing handler path so a regression
+          # in the Stripe glue surfaces here, not at the first customer signup.
+          SUB=$(curl -sS -o /tmp/sub.json -w '%{http_code}' --max-time 15 \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            "$BASE_URL/api/v1/billing/subscription" \
+            || echo "000")
+          # 404 is acceptable here (no subscription yet for a fresh free user, depending on impl).
+          if [ "$SUB" != "200" ] && [ "$SUB" != "404" ]; then
+            fail "billing-subscription" "GET /api/v1/billing/subscription returned $SUB; body: $(cat /tmp/sub.json 2>/dev/null | head -c 300)"
+          fi
+          echo "OK subscription -> $SUB"
+
+          echo "All smoke checks passed."
+
+      - name: Open GitHub issue on failure
+        # Open an issue when the smoke step set a failure_step. Dedupe by
+        # rotating the title day-by-day so a sustained outage doesn't spam
+        # the tracker, but a return-to-failure after recovery still pages.
+        if: steps.smoke.outputs.failure_step != ''
+        uses: actions/github-script@v9
+        env:
+          STEP: ${{ steps.smoke.outputs.failure_step }}
+          DETAIL: ${{ steps.smoke.outputs.failure_detail }}
+          RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+        with:
+          script: |
+            const step = process.env.STEP;
+            const detail = process.env.DETAIL || '(no detail)';
+            const runUrl = process.env.RUN_URL;
+            const today = new Date().toISOString().slice(0, 10);
+            const title = `Production smoke: ${step} failing on api.mockforge.dev (${today})`;
+
+            // Dedupe: search for an open issue with the same title today.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'production-smoke',
+              per_page: 50,
+            });
+            const dup = existing.data.find(i => i.title === title);
+            const body = [
+              `**Production smoke test failed at step: \`${step}\`**`,
+              ``,
+              `Run: ${runUrl}`,
+              ``,
+              `Detail:`,
+              '```',
+              detail.slice(0, 4000),
+              '```',
+              ``,
+              `_This is an automated production-smoke alert. The smoke workflow runs every 15 minutes against \`api.mockforge.dev\`. If this is the first occurrence today, expect the workflow to retry shortly — close this issue when the next run passes._`,
+            ].join('\n');
+
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body: `Still failing on run ${runUrl}.\n\nDetail:\n\`\`\`\n${detail.slice(0, 4000)}\n\`\`\``,
+              });
+              console.log(`Commented on existing issue #${dup.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['production-smoke', 'bug'],
+              });
+              console.log(`Opened issue #${created.data.number}`);
+            }
+
+      - name: Fail job if smoke detected a problem
+        if: steps.smoke.outputs.failure_step != ''
+        run: |
+          echo "Smoke step '${{ steps.smoke.outputs.failure_step }}' failed — see issue tracker."
+          exit 1


### PR DESCRIPTION
Closes #452.

## What this adds

A new \`.github/workflows/production-smoke.yml\` that runs every 15 minutes against \`api.mockforge.dev\` and opens a GitHub issue when any step fails. Catches regressions that ship past \`release.yml\` and only surface when real customers hit them.

## What the smoke does, in order

1. **Health check** — \`GET /metrics/health\` → expect 200
2. **Register** — \`POST /api/v1/auth/register\` with a throwaway smoke user (run-id-tagged email to avoid collisions across runs) → expect 200/201 with \`access_token\` in body
3. **Login** — \`POST /api/v1/auth/login\` with the just-registered creds → expect 200 (proves bcrypt verify + JWT issue path)
4. **List hosted-mocks** — \`GET /api/v1/hosted-mocks\` → expect 200 (proves auth middleware + DB query)
5. **Subscription info** — \`GET /api/v1/billing/subscription\` → expect 200 or 404 (the latter is acceptable for a fresh free user; touches the billing handler path so a regression in the Stripe glue surfaces here)

## What it deliberately doesn't do

- **Doesn't deploy a hosted mock.** Each deploy costs Fly compute + leaves dangling state (the smoke user can't easily clean up). If a cheap deploy+teardown harness lands later, fold it in.
- **Doesn't hit \`<slug>.mocks.mockforge.dev\`.** Same reason — would require deploying first.
- **Doesn't run cron from a fork or non-main branch.** GitHub Actions doesn't run scheduled workflows from non-default branches anyway.

## Failure behavior

When any step fails, the workflow:

1. Sets \`failure_step\` + \`failure_detail\` outputs from the failing step
2. Opens a GitHub issue titled \`Production smoke: <step> failing on api.mockforge.dev (<today>)\` with labels \`production-smoke\`, \`bug\`
3. **Dedupes** by exact title — if a failure happens repeatedly the same day, subsequent runs comment on the existing issue rather than spam the tracker
4. Fails the job (so the workflow run shows red in the Actions tab too)

## Throwaway-user hygiene

Each run creates a fresh user with email \`smoke_<ts>_<run_id>@smoke.mockforge.dev\` — 96 runs/day = 96 throwaway accounts. They're harmless (Free plan, no resources deployed) but if you want to GC them, a periodic cleanup job filtering on \`@smoke.mockforge.dev\` would work.

## Verification

- YAML parses (\`yaml.safe_load\` clean)
- Runs on \`[self-hosted, linux, x64, rust]\` so deps (curl, jq, openssl) are already on the runner

This PR touches a workflow file, so my OAuth token can't auto-merge it. **Manual merge required** once you're happy with the design.

## Test plan

- [ ] Merge this PR — first scheduled run will fire within 15 minutes
- [ ] Trigger manually via \`workflow_dispatch\` to verify it passes a green run
- [ ] To verify failure path, temporarily point \`BASE_URL\` at a broken endpoint and confirm an issue gets opened