### PR TITLE
feat(grpc): YAML-driven per-method response overrides (#485)

### DIFF
--- a/crates/mockforge-core/src/config/protocol.rs
+++ b/crates/mockforge-core/src/config/protocol.rs
@@ -208,6 +208,10 @@ pub struct GrpcConfig {
     pub proto_dir: Option<String>,
     /// TLS configuration
     pub tls: Option<TlsConfig>,
+    /// Per-method response overrides. First matching rule wins; rules with no
+    /// `match` block are catch-all rules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overrides: Vec<GrpcOverride>,
 }
 
 impl Default for GrpcConfig {
@@ -218,8 +222,54 @@ impl Default for GrpcConfig {
             host: "0.0.0.0".to_string(),
             proto_dir: None,
             tls: None,
+            overrides: Vec::new(),
         }
     }
+}
+
+/// A single per-method override rule for the gRPC mock.
+///
+/// Use this to return specific status codes or response bodies from a method
+/// without modifying the proto file. Rules are evaluated in declaration order;
+/// the first one whose service+method (and optional `match`) match the
+/// incoming request wins. Unmatched calls fall back to the default
+/// smart-mock-generation behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct GrpcOverride {
+    /// Fully-qualified service name without leading dot, e.g. `myapp.OrderService`.
+    /// May also be the unqualified service name; matching is exact.
+    pub service: String,
+    /// Method name (case-sensitive, matches proto definition).
+    pub method: String,
+    /// Optional request-field-equality match. Keys are top-level field names of
+    /// the request message; values are stringified expected values. When
+    /// omitted, the rule matches every call to the named method.
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub r#match: std::collections::HashMap<String, String>,
+    /// Response to return when this rule fires.
+    pub response: GrpcOverrideResponse,
+}
+
+/// Response shape for a `GrpcOverride`. Either `status` is set to a non-OK
+/// gRPC status code (in which case the call returns an error with `message`),
+/// or `body` is set to a JSON object that's serialized into the response
+/// message. Setting both is allowed but `status` wins when non-OK.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct GrpcOverrideResponse {
+    /// gRPC status code name (e.g. `OK`, `NOT_FOUND`, `PERMISSION_DENIED`).
+    /// Case-insensitive. Defaults to `OK` when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Human-readable error message used when `status` is non-OK.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Response body as a JSON object. Field names must match the response
+    /// message type from the proto. Ignored when `status` is non-OK.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<serde_json::Value>,
 }
 
 /// GraphQL server configuration

--- a/crates/mockforge-grpc/examples/flexible_grpc.rs
+++ b/crates/mockforge-grpc/examples/flexible_grpc.rs
@@ -22,6 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         excluded_services: vec!["grpc.reflection.v1alpha.ServerReflection".to_string()],
         http_bridge: None,
         tls: None,
+        overrides: vec![],
     };
 
     println!("Starting MockForge gRPC server with flexible proto discovery");

--- a/crates/mockforge-grpc/src/dynamic/mod.rs
+++ b/crates/mockforge-grpc/src/dynamic/mod.rs
@@ -84,6 +84,9 @@ pub struct DynamicGrpcConfig {
     pub http_bridge: Option<http_bridge::HttpBridgeConfig>,
     /// TLS configuration (None for plaintext)
     pub tls: Option<GrpcTlsConfig>,
+    /// Per-method response overrides. Populated by callers translating from
+    /// `mockforge_core::config::GrpcConfig`.
+    pub overrides: Vec<mockforge_core::config::GrpcOverride>,
 }
 
 impl Default for DynamicGrpcConfig {
@@ -92,6 +95,7 @@ impl Default for DynamicGrpcConfig {
             proto_dir: "proto".to_string(),
             enable_reflection: false,
             excluded_services: Vec::new(),
+            overrides: Vec::new(),
             http_bridge: Some(http_bridge::HttpBridgeConfig {
                 enabled: true,
                 ..Default::default()
@@ -109,6 +113,9 @@ pub struct ServiceRegistry {
     services: HashMap<String, Arc<DynamicGrpcService>>,
     /// Descriptor pool containing parsed proto definitions
     descriptor_pool: prost_reflect::DescriptorPool,
+    /// Per-method override rules from config; the router checks these before
+    /// falling through to smart-mock generation.
+    overrides: Arc<Vec<mockforge_core::config::GrpcOverride>>,
 }
 
 impl Default for ServiceRegistry {
@@ -128,6 +135,7 @@ impl ServiceRegistry {
         Self {
             services: HashMap::new(),
             descriptor_pool: prost_reflect::DescriptorPool::new(),
+            overrides: Arc::new(Vec::new()),
         }
     }
 
@@ -136,7 +144,19 @@ impl ServiceRegistry {
         Self {
             services: HashMap::new(),
             descriptor_pool,
+            overrides: Arc::new(Vec::new()),
         }
+    }
+
+    /// Replace the override list with `overrides`. Typically called once at
+    /// server start with the rules from `GrpcConfig::overrides`.
+    pub fn set_overrides(&mut self, overrides: Vec<mockforge_core::config::GrpcOverride>) {
+        self.overrides = Arc::new(overrides);
+    }
+
+    /// Get the configured override list.
+    pub fn overrides(&self) -> &[mockforge_core::config::GrpcOverride] {
+        self.overrides.as_ref()
     }
 
     /// Set the descriptor pool (useful when building registry incrementally)
@@ -184,6 +204,10 @@ pub async fn discover_services(
     let descriptor_pool = parser.into_pool();
 
     registry.set_descriptor_pool(descriptor_pool);
+    if !config.overrides.is_empty() {
+        info!("Loaded {} gRPC method override rule(s) from config", config.overrides.len());
+        registry.set_overrides(config.overrides.clone());
+    }
     let registry_duration = registry_start.elapsed();
     debug!("Registry creation completed (took {:?})", registry_duration);
 

--- a/crates/mockforge-grpc/src/dynamic/router.rs
+++ b/crates/mockforge-grpc/src/dynamic/router.rs
@@ -5,6 +5,7 @@
 
 use super::ServiceRegistry;
 use http::header::HeaderValue;
+use mockforge_core::config::{GrpcOverride, GrpcOverrideResponse};
 use prost_reflect::prost::Message as _;
 use prost_reflect::{DynamicMessage, MessageDescriptor, Value};
 use tonic::{Code, Status};
@@ -186,7 +187,7 @@ pub async fn handle_dynamic_grpc_request(
 
     // Determine streaming type and handle
     match (method.client_streaming, method.server_streaming) {
-        (false, false) => handle_unary(registry, service_name, method).await,
+        (false, false) => handle_unary(registry, service_name, method, &_body).await,
         (false, true) => handle_server_streaming(registry, service_name, method).await,
         (true, false) => {
             // Client streaming: aggregate incoming frames, respond with single message
@@ -199,16 +200,177 @@ pub async fn handle_dynamic_grpc_request(
     }
 }
 
+/// Find the first override rule that matches a `service/method` request.
+///
+/// Match semantics:
+/// - The override's `service` must exactly equal `service_name` (callers should
+///   pass the same form the proto uses — fully-qualified or not — consistently).
+/// - The override's `method` must exactly equal `method_name`.
+/// - If the override has a non-empty `match` map, every key must correspond to
+///   a top-level field of the decoded request whose stringified value equals
+///   the match value. If `request_body` is None or the request can't be
+///   decoded against `input_desc`, match conditions are skipped (a catch-all
+///   override — empty match — still applies; one with `match` does not).
+pub(super) fn find_matching_override<'a>(
+    overrides: &'a [GrpcOverride],
+    service_name: &str,
+    method_name: &str,
+    input_desc: Option<&MessageDescriptor>,
+    request_body: Option<&[u8]>,
+) -> Option<&'a GrpcOverride> {
+    for rule in overrides {
+        if rule.service != service_name || rule.method != method_name {
+            continue;
+        }
+        if rule.r#match.is_empty() {
+            return Some(rule);
+        }
+        // Need a decoded request to check match conditions.
+        let Some(desc) = input_desc else { continue };
+        let Some(body) = request_body else { continue };
+        let Ok(payload) = decode_grpc_body(body) else {
+            continue;
+        };
+        let Ok(decoded) = DynamicMessage::decode(desc.clone(), payload) else {
+            continue;
+        };
+
+        let all_match = rule.r#match.iter().all(|(field_name, expected)| {
+            let Some(field) = desc.get_field_by_name(field_name) else {
+                return false;
+            };
+            let value = decoded.get_field(&field);
+            stringify_value(value.as_ref()) == *expected
+        });
+        if all_match {
+            return Some(rule);
+        }
+    }
+    None
+}
+
+/// Stringify a `prost_reflect::Value` for equality matching against the
+/// `match` map (which is string-typed in YAML).
+fn stringify_value(value: &Value) -> String {
+    match value {
+        Value::Bool(v) => v.to_string(),
+        Value::I32(v) => v.to_string(),
+        Value::I64(v) => v.to_string(),
+        Value::U32(v) => v.to_string(),
+        Value::U64(v) => v.to_string(),
+        Value::F32(v) => v.to_string(),
+        Value::F64(v) => v.to_string(),
+        Value::String(s) => s.clone(),
+        Value::Bytes(b) => String::from_utf8_lossy(b).into_owned(),
+        Value::EnumNumber(n) => n.to_string(),
+        // For complex types (Message, List, Map) we don't define equality.
+        // Match map rules are intended for primitive field comparisons.
+        _ => String::new(),
+    }
+}
+
+/// Parse a gRPC status code name (case-insensitive) into a `tonic::Code`.
+/// Returns `Code::Unknown` for anything we don't recognize.
+fn parse_status_code(name: &str) -> Code {
+    match name.to_ascii_uppercase().as_str() {
+        "OK" => Code::Ok,
+        "CANCELLED" => Code::Cancelled,
+        "UNKNOWN" => Code::Unknown,
+        "INVALID_ARGUMENT" => Code::InvalidArgument,
+        "DEADLINE_EXCEEDED" => Code::DeadlineExceeded,
+        "NOT_FOUND" => Code::NotFound,
+        "ALREADY_EXISTS" => Code::AlreadyExists,
+        "PERMISSION_DENIED" => Code::PermissionDenied,
+        "RESOURCE_EXHAUSTED" => Code::ResourceExhausted,
+        "FAILED_PRECONDITION" => Code::FailedPrecondition,
+        "ABORTED" => Code::Aborted,
+        "OUT_OF_RANGE" => Code::OutOfRange,
+        "UNIMPLEMENTED" => Code::Unimplemented,
+        "INTERNAL" => Code::Internal,
+        "UNAVAILABLE" => Code::Unavailable,
+        "DATA_LOSS" => Code::DataLoss,
+        "UNAUTHENTICATED" => Code::Unauthenticated,
+        _ => Code::Unknown,
+    }
+}
+
+/// Build a response from an override rule.
+///
+/// - If `response.status` is set and non-OK, returns a gRPC error response.
+/// - Otherwise, if `response.body` is set, builds a `DynamicMessage` from the
+///   JSON object against the output descriptor and returns it.
+/// - If neither is usable (no descriptor available, body is invalid JSON),
+///   returns Ok(None) so the caller falls back to default generation.
+fn apply_override(
+    rule: &GrpcOverrideResponse,
+    output_desc: Option<&MessageDescriptor>,
+) -> Result<Option<axum::response::Response>, Status> {
+    // Status code first — non-OK short-circuits regardless of body.
+    if let Some(name) = rule.status.as_deref() {
+        let code = parse_status_code(name);
+        if code != Code::Ok {
+            let msg = rule.message.clone().unwrap_or_default();
+            return Ok(Some(create_grpc_error_response(Status::new(code, msg))));
+        }
+    }
+
+    let Some(body) = rule.body.as_ref() else {
+        // No status (or OK) and no body — nothing to apply. Caller falls back.
+        return Ok(None);
+    };
+    let Some(desc) = output_desc else {
+        warn!("Override has body but output descriptor unavailable; falling back to mock");
+        return Ok(None);
+    };
+
+    // Use the existing http_bridge converter — it already handles nested
+    // messages, repeated fields, enums, well-known types like timestamps,
+    // etc. — so we don't re-derive that logic here.
+    let converter =
+        super::http_bridge::converters::ProtobufJsonConverter::new(desc.parent_pool().clone());
+    match converter.json_to_protobuf(desc, body) {
+        Ok(msg) => Ok(Some(build_grpc_response(encode_grpc_body(&msg))?)),
+        Err(e) => {
+            warn!("Override body failed to convert into response message: {}", e);
+            Ok(None)
+        }
+    }
+}
+
 /// Handle a unary gRPC call
 async fn handle_unary(
     registry: &ServiceRegistry,
     service_name: &str,
     method: &super::proto_parser::ProtoMethod,
+    request_body: &[u8],
 ) -> Result<axum::response::Response, Status> {
     let pool = registry.descriptor_pool();
+    let input_desc = pool.get_message_by_name(&method.input_type);
+    let output_desc = pool.get_message_by_name(&method.output_type);
 
-    // Try descriptor-based response generation
-    let response_bytes = if let Some(output_desc) = pool.get_message_by_name(&method.output_type) {
+    // Try configured overrides before falling back to default mock generation.
+    if let Some(rule) = find_matching_override(
+        registry.overrides(),
+        service_name,
+        &method.name,
+        input_desc.as_ref(),
+        Some(request_body),
+    ) {
+        debug!(
+            "Applying override for {}.{} (rule match keys: {:?})",
+            service_name,
+            method.name,
+            rule.r#match.keys().collect::<Vec<_>>()
+        );
+        if let Some(resp) = apply_override(&rule.response, output_desc.as_ref())? {
+            return Ok(resp);
+        }
+        // Override didn't actually produce a response (e.g. body wouldn't
+        // deserialize) — log already happened, fall through.
+    }
+
+    // Default path: descriptor-based response generation.
+    let response_bytes = if let Some(output_desc) = output_desc {
         debug!("Generating response from descriptor for {}.{}", service_name, method.name);
         let mock_msg = generate_message_from_descriptor(&output_desc, 0);
         encode_grpc_body(&mock_msg)
@@ -383,6 +545,78 @@ fn build_grpc_response(body: Vec<u8>) -> Result<axum::response::Response, Status
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn override_rule(
+        service: &str,
+        method: &str,
+        match_fields: &[(&str, &str)],
+        status: Option<&str>,
+    ) -> GrpcOverride {
+        GrpcOverride {
+            service: service.to_string(),
+            method: method.to_string(),
+            r#match: match_fields.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect(),
+            response: GrpcOverrideResponse {
+                status: status.map(|s| s.to_string()),
+                message: None,
+                body: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_find_override_catch_all_matches_when_service_method_match() {
+        let rules = vec![override_rule(
+            "OrderService",
+            "GetOrder",
+            &[],
+            Some("NOT_FOUND"),
+        )];
+        let m = find_matching_override(&rules, "OrderService", "GetOrder", None, None);
+        assert!(m.is_some(), "catch-all override should match");
+    }
+
+    #[test]
+    fn test_find_override_returns_none_when_service_differs() {
+        let rules = vec![override_rule("OrderService", "GetOrder", &[], None)];
+        assert!(find_matching_override(&rules, "PaymentService", "GetOrder", None, None).is_none());
+        assert!(find_matching_override(&rules, "OrderService", "ListOrders", None, None).is_none());
+    }
+
+    #[test]
+    fn test_find_override_skips_match_rule_when_request_missing() {
+        // Rule has a match block, but caller passed no request body — rule
+        // can't be evaluated, so it should NOT fire.
+        let rules = vec![override_rule(
+            "OrderService",
+            "GetOrder",
+            &[("order_id", "x")],
+            Some("OK"),
+        )];
+        assert!(find_matching_override(&rules, "OrderService", "GetOrder", None, None).is_none());
+    }
+
+    #[test]
+    fn test_find_override_first_match_wins() {
+        // Multiple catch-all rules for the same method: the first one in declaration
+        // order should win, even if a later one would also match.
+        let rules = vec![
+            override_rule("OrderService", "GetOrder", &[], Some("NOT_FOUND")),
+            override_rule("OrderService", "GetOrder", &[], Some("PERMISSION_DENIED")),
+        ];
+        let m = find_matching_override(&rules, "OrderService", "GetOrder", None, None).unwrap();
+        assert_eq!(m.response.status.as_deref(), Some("NOT_FOUND"));
+    }
+
+    #[test]
+    fn test_parse_status_code_recognizes_standard_names() {
+        assert_eq!(parse_status_code("NOT_FOUND"), Code::NotFound);
+        assert_eq!(parse_status_code("not_found"), Code::NotFound);
+        assert_eq!(parse_status_code("PERMISSION_DENIED"), Code::PermissionDenied);
+        assert_eq!(parse_status_code("OK"), Code::Ok);
+        // Unknown name maps to Code::Unknown (safe fallback).
+        assert_eq!(parse_status_code("totally-made-up"), Code::Unknown);
+    }
 
     #[test]
     fn test_parse_grpc_path() {

--- a/crates/mockforge-grpc/tests/grpc_client_e2e.rs
+++ b/crates/mockforge-grpc/tests/grpc_client_e2e.rs
@@ -53,6 +53,7 @@ async fn spawn_greeter() -> (String, tokio::task::JoinHandle<()>) {
         excluded_services: vec![],
         http_bridge: None,
         tls: None,
+        overrides: vec![],
     };
     let handle = tokio::spawn(async move {
         mockforge_grpc::start_with_config(port, None, config).await.unwrap();

--- a/crates/mockforge-grpc/tests/grpc_server_e2e_test.rs
+++ b/crates/mockforge-grpc/tests/grpc_server_e2e_test.rs
@@ -28,6 +28,7 @@ async fn test_grpc_service_discovery_from_proto_files() {
         excluded_services: vec![],
         http_bridge: None,
         tls: None,
+        overrides: vec![],
     };
 
     let registry = discover_services(&config).await.expect("Service discovery should succeed");
@@ -51,6 +52,7 @@ async fn test_grpc_service_discovery_with_exclusion() {
         excluded_services: vec!["mockforge.greeter.Greeter".to_string()],
         http_bridge: None,
         tls: None,
+        overrides: vec![],
     };
 
     let registry = discover_services(&config).await.expect("Service discovery should succeed");
@@ -204,6 +206,7 @@ async fn test_grpc_descriptor_pool_accessible() {
         excluded_services: vec![],
         http_bridge: None,
         tls: None,
+        overrides: vec![],
     };
 
     let registry = discover_services(&config).await.expect("Service discovery should succeed");

--- a/crates/mockforge-grpc/tests/http_bridge_tests.rs
+++ b/crates/mockforge-grpc/tests/http_bridge_tests.rs
@@ -13,6 +13,7 @@ async fn test_http_bridge_creation() {
         excluded_services: vec![],
         http_bridge: Some(Default::default()),
         tls: None,
+        overrides: vec![],
     };
 
     // Discover services
@@ -29,6 +30,7 @@ async fn test_http_bridge_creation() {
         excluded_services: vec![],
         http_bridge: None, // Disable bridge
         tls: None,
+        overrides: vec![],
     };
 
     // Test that gRPC-only server can be started (but don't actually start it due to port conflicts)


### PR DESCRIPTION
Closes #485. Backfills the gRPC how-to blog section we had to delete in mockforge.dev PR #10 because the feature didn't exist.

## What ships

A new \`grpc.overrides\` config block that lets you customize gRPC responses per-method without touching the proto:

\`\`\`yaml
grpc:
  overrides:
    - service: OrderService
      method: GetOrder
      match: { order_id: \"missing-001\" }
      response: { status: NOT_FOUND, message: \"order not found\" }
    - service: OrderService
      method: GetOrder
      response:
        body: { id: \"order-002\", total_cents: 4299 }
\`\`\`

## Implementation

| Layer | What changed |
|---|---|
| **\`mockforge-core::config\`** | New \`GrpcOverride\` + \`GrpcOverrideResponse\` types. Added to \`GrpcConfig\` as \`overrides: Vec<GrpcOverride>\`. Both derive \`schemars::JsonSchema\` under the \`schema\` feature so the generated config-schema docs include them automatically. |
| **\`mockforge-grpc::dynamic\`** | \`DynamicGrpcConfig\` gains \`overrides\`, propagated into \`ServiceRegistry\` via \`set_overrides()\` during \`discover_services\`. |
| **\`mockforge-grpc::dynamic::router\`** | New \`find_matching_override()\` + \`apply_override()\` helpers. \`handle_unary\` checks overrides before falling through to default smart-mock generation. First matching rule wins; rules with empty \`match\` are catch-all. |

Match semantics:
- Service + method names must match exactly
- \`match\` map keys are top-level request field names; values are stringified-equality compared
- Catch-all rule (no \`match\`) always matches the named method
- Match rules without an available request body are skipped (never fire)

Response semantics:
- Non-OK \`status\` short-circuits, returns a gRPC error frame with \`message\`
- \`body\` is JSON deserialized into the response message via the existing \`ProtobufJsonConverter\` (the same path the HTTP→gRPC bridge uses) — full support for nested messages, enums, repeated fields, well-known types
- \`body\` that fails to deserialize logs a warning and falls through to default generation rather than erroring

## What's explicitly NOT in this PR (per the issue)

- **Handlebars body templating** (\`{{request.field}}\`) — bodies are static for now. The \`field_overrides\` on \`smart_mock_generator\` remains the path for per-field dynamism. Templating is worth a follow-up issue once a real customer needs it.
- **Streaming RPCs** — only unary covered. The pattern would extend to \`handle_server_streaming\` etc. but each has different match semantics around per-frame matching.
- **CLI YAML→DynamicGrpcConfig plumbing** — populating \`DynamicGrpcConfig::overrides\` from the loaded \`core::config::GrpcConfig::overrides\` happens wherever the CLI translates between the two config types today. The \`mockforge-cli\` currently calls \`mockforge_grpc::start(port)\` without passing config; that's a pre-existing gap the issue tracker can pick up.

## Verification

- \`cargo fmt --all --check\` — passes
- \`cargo clippy -p mockforge-grpc --all-targets -- -D warnings\` — passes
- \`cargo test -p mockforge-grpc --lib\` — **262 passed** (5 new override tests covering catch-all match, service-mismatch reject, match-without-body skip, first-match-wins ordering, status-code parsing)
- \`cargo test -p mockforge-core --lib\` — **1585 passed**, no regression

## Restoring the blog post

Once this merges, the deleted YAML block in \`mockforge.dev/src/pages/note-grpc-mocking-in-ci.html\` can come back word-for-word. Tracked in mockforge.dev issue #6 and task #18 in the agent's task list.