### PR TITLE
feat(kafka): YAML-driven fault injection (#487)

### DIFF
--- a/crates/mockforge-core/src/config/protocol.rs
+++ b/crates/mockforge-core/src/config/protocol.rs
@@ -498,6 +498,13 @@ pub struct KafkaConfig {
     /// and `default_replication_factor`.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub seed_messages: std::collections::HashMap<String, Vec<KafkaSeedMessage>>,
+    /// Fault-injection rules applied at the protocol-handler boundary.
+    /// Each rule fires either deterministically (no `probability`) or
+    /// stochastically (`probability: 0.0..=1.0`). Rules with `partition`
+    /// set target a single partition; without it, every partition of the
+    /// named topic.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub faults: Vec<KafkaFault>,
 }
 
 impl Default for KafkaConfig {
@@ -517,8 +524,52 @@ impl Default for KafkaConfig {
             advertised_host: None,
             advertised_port: None,
             seed_messages: std::collections::HashMap::new(),
+            faults: Vec::new(),
         }
     }
+}
+
+/// Kafka fault-injection rule. See `KafkaConfig::faults`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct KafkaFault {
+    /// Topic name to target. Required.
+    pub topic: String,
+    /// Specific partition to target. When omitted, the rule fires for any
+    /// partition of the topic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partition: Option<i32>,
+    /// Which failure mode to inject.
+    pub kind: KafkaFaultKind,
+    /// Delay (in milliseconds) for `produce_throttle`. Ignored by other
+    /// kinds. Defaults to 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delay_ms: Option<u64>,
+    /// Stochastic firing probability in `0.0..=1.0`. `None` or `1.0` =
+    /// every request matching this rule fires the fault. `0.0` = never.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probability: Option<f64>,
+}
+
+/// Supported Kafka fault-injection kinds.
+///
+/// Each value matches a specific Kafka protocol error code the mock
+/// returns on the matching request type. Tests are deterministic when
+/// `probability` is None or 1.0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum KafkaFaultKind {
+    /// Delay produce response by `delay_ms` before allowing it through.
+    /// Exercises client retry-and-backoff paths.
+    ProduceThrottle,
+    /// Return NOT_LEADER_OR_FOLLOWER (error code 6) for matching produce
+    /// requests. Real clients re-fetch metadata and retry.
+    ProduceNotLeader,
+    /// Return OFFSET_OUT_OF_RANGE (error code 1) for matching fetch
+    /// requests. Real consumers handle this by resetting to the
+    /// configured `auto.offset.reset` policy.
+    OffsetOutOfRange,
 }
 
 /// A single message to inject into a topic's log at broker startup. See

--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -11,9 +11,67 @@ use crate::partitions::KafkaMessage;
 use crate::protocol::{KafkaProtocolHandler, KafkaRequest, KafkaRequestType, KafkaResponse};
 use crate::spec_registry::KafkaSpecRegistry;
 use crate::topics::Topic;
-use mockforge_core::config::KafkaConfig;
+use mockforge_core::config::{KafkaConfig, KafkaFault, KafkaFaultKind};
 use mockforge_core::Result;
 use std::sync::OnceLock;
+
+/// Outcome of evaluating a fault rule against a single (topic, partition).
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FaultOutcome {
+    /// No matching fault — let the request proceed normally.
+    None,
+    /// Sleep `ms` before processing the request. Used by `produce_throttle`.
+    Throttle { ms: u64 },
+    /// Replace the response with an error of `code`. Used by
+    /// `produce_not_leader` (6) and `offset_out_of_range` (1).
+    Error { code: i16 },
+}
+
+/// Decide what fault (if any) applies to a (topic, partition, kind) tuple.
+///
+/// Iterates rules in declaration order. The first rule whose topic +
+/// partition + kind all match (and whose probability roll passes) wins.
+/// Rules with no `partition` match every partition of the named topic.
+/// Stochastic firing uses `rand::random::<f64>()` so production traffic
+/// gets non-deterministic faults; tests should set `probability: 1.0` (or
+/// omit it) to fire deterministically.
+pub(crate) fn evaluate_fault(
+    faults: &[KafkaFault],
+    topic: &str,
+    partition: i32,
+    expected_kind: KafkaFaultKind,
+) -> FaultOutcome {
+    for rule in faults {
+        if rule.topic != topic {
+            continue;
+        }
+        if let Some(p) = rule.partition {
+            if p != partition {
+                continue;
+            }
+        }
+        if rule.kind != expected_kind {
+            continue;
+        }
+        let fires = match rule.probability {
+            None => true,
+            Some(p) if p >= 1.0 => true,
+            Some(p) if p <= 0.0 => false,
+            Some(p) => rand::random::<f64>() < p,
+        };
+        if !fires {
+            continue;
+        }
+        return match rule.kind {
+            KafkaFaultKind::ProduceThrottle => FaultOutcome::Throttle {
+                ms: rule.delay_ms.unwrap_or(0),
+            },
+            KafkaFaultKind::ProduceNotLeader => FaultOutcome::Error { code: 6 },
+            KafkaFaultKind::OffsetOutOfRange => FaultOutcome::Error { code: 1 },
+        };
+    }
+    FaultOutcome::None
+}
 
 /// Resolve the (host, port) the broker advertises in its
 /// MetadataResponse. When the orchestrator sets
@@ -571,6 +629,49 @@ impl KafkaMockBroker {
                     continue;
                 }
 
+                // Drop the topics guard before any fault-induced sleep so we
+                // don't block other partitions / requests holding the same
+                // lock. We re-acquire below for the actual produce.
+                drop(topics_guard);
+
+                // produce_not_leader fault — short-circuit with error code 6
+                // before any sleep or write.
+                if let FaultOutcome::Error { code } = evaluate_fault(
+                    &self.config.faults,
+                    &topic_data.name,
+                    part.partition_index,
+                    KafkaFaultKind::ProduceNotLeader,
+                ) {
+                    partition_results.push(PartitionProduceResult {
+                        partition_index: part.partition_index,
+                        error_code: code,
+                        base_offset: -1,
+                        log_append_time_ms: -1,
+                        log_start_offset: 0,
+                    });
+                    continue;
+                }
+
+                // produce_throttle fault — delay before the produce.
+                if let FaultOutcome::Throttle { ms } = evaluate_fault(
+                    &self.config.faults,
+                    &topic_data.name,
+                    part.partition_index,
+                    KafkaFaultKind::ProduceThrottle,
+                ) {
+                    if ms > 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+                    }
+                }
+
+                // Re-acquire the lock for the actual produce.
+                let mut topics_guard = self.topics.write().await;
+                let topic_entry = topics_guard.get_mut(&topic_data.name).ok_or_else(|| {
+                    mockforge_core::Error::internal(
+                        "topic disappeared between fault check and produce",
+                    )
+                })?;
+
                 let mut base_offset: i64 = -1;
                 for (i, rec) in part.records.into_iter().enumerate() {
                     let msg = KafkaMessage {
@@ -699,6 +800,25 @@ impl KafkaMockBroker {
                     });
                     continue;
                 };
+
+                // offset_out_of_range fault — synthesize the error before
+                // the real offset check, so a consumer reading from offset 0
+                // can still trip the fault.
+                if let FaultOutcome::Error { code } = evaluate_fault(
+                    &self.config.faults,
+                    &t.topic,
+                    p.partition_index,
+                    KafkaFaultKind::OffsetOutOfRange,
+                ) {
+                    partition_responses.push(FetchPartitionResponse {
+                        partition_index: p.partition_index,
+                        error_code: code,
+                        high_watermark: part.high_watermark,
+                        log_start_offset: part.log_start_offset,
+                        records: Vec::new(),
+                    });
+                    continue;
+                }
 
                 // Validate offset: fetch_offset > high_watermark is
                 // OFFSET_OUT_OF_RANGE; == high_watermark is a valid empty
@@ -1347,6 +1467,131 @@ fn get_api_key_from_request(request: &KafkaRequest) -> i16 {
 mod tests {
     use super::*;
     use mockforge_core::config::KafkaSeedMessage;
+
+    // ==================== Fault Injection Tests ====================
+
+    fn fault(
+        topic: &str,
+        partition: Option<i32>,
+        kind: KafkaFaultKind,
+        delay_ms: Option<u64>,
+    ) -> KafkaFault {
+        KafkaFault {
+            topic: topic.to_string(),
+            partition,
+            kind,
+            delay_ms,
+            probability: None,
+        }
+    }
+
+    #[test]
+    fn evaluate_fault_no_rules_returns_none() {
+        let outcome = evaluate_fault(&[], "orders.created", 0, KafkaFaultKind::ProduceThrottle);
+        assert!(matches!(outcome, FaultOutcome::None));
+    }
+
+    #[test]
+    fn evaluate_fault_matches_topic_and_kind() {
+        let rules = vec![fault(
+            "orders.created",
+            None,
+            KafkaFaultKind::ProduceThrottle,
+            Some(500),
+        )];
+        let outcome = evaluate_fault(&rules, "orders.created", 0, KafkaFaultKind::ProduceThrottle);
+        assert!(matches!(outcome, FaultOutcome::Throttle { ms: 500 }));
+    }
+
+    #[test]
+    fn evaluate_fault_topic_mismatch_skips() {
+        let rules = vec![fault(
+            "orders.created",
+            None,
+            KafkaFaultKind::ProduceThrottle,
+            None,
+        )];
+        let outcome = evaluate_fault(&rules, "orders.shipped", 0, KafkaFaultKind::ProduceThrottle);
+        assert!(matches!(outcome, FaultOutcome::None));
+    }
+
+    #[test]
+    fn evaluate_fault_partition_filter() {
+        let rules = vec![fault(
+            "orders.created",
+            Some(1),
+            KafkaFaultKind::ProduceThrottle,
+            Some(1000),
+        )];
+        // Partition 1 — matches
+        assert!(matches!(
+            evaluate_fault(&rules, "orders.created", 1, KafkaFaultKind::ProduceThrottle),
+            FaultOutcome::Throttle { .. }
+        ));
+        // Partition 0 — doesn't match
+        assert!(matches!(
+            evaluate_fault(&rules, "orders.created", 0, KafkaFaultKind::ProduceThrottle),
+            FaultOutcome::None
+        ));
+    }
+
+    #[test]
+    fn evaluate_fault_kind_mismatch_skips() {
+        let rules = vec![fault(
+            "orders.created",
+            None,
+            KafkaFaultKind::ProduceThrottle,
+            None,
+        )];
+        let outcome = evaluate_fault(&rules, "orders.created", 0, KafkaFaultKind::OffsetOutOfRange);
+        assert!(matches!(outcome, FaultOutcome::None));
+    }
+
+    #[test]
+    fn evaluate_fault_probability_zero_never_fires() {
+        let mut rule = fault("t", None, KafkaFaultKind::OffsetOutOfRange, None);
+        rule.probability = Some(0.0);
+        for _ in 0..20 {
+            assert!(matches!(
+                evaluate_fault(&[rule.clone()], "t", 0, KafkaFaultKind::OffsetOutOfRange),
+                FaultOutcome::None
+            ));
+        }
+    }
+
+    #[test]
+    fn evaluate_fault_probability_one_always_fires() {
+        let mut rule = fault("t", None, KafkaFaultKind::OffsetOutOfRange, None);
+        rule.probability = Some(1.0);
+        for _ in 0..20 {
+            assert!(matches!(
+                evaluate_fault(&[rule.clone()], "t", 0, KafkaFaultKind::OffsetOutOfRange),
+                FaultOutcome::Error { code: 1 }
+            ));
+        }
+    }
+
+    #[test]
+    fn evaluate_fault_first_match_wins() {
+        // Two rules on the same topic+kind. The first one (higher
+        // throttle) should win even though a later catch-all is shorter.
+        let rules = vec![
+            fault("t", Some(0), KafkaFaultKind::ProduceThrottle, Some(2000)),
+            fault("t", None, KafkaFaultKind::ProduceThrottle, Some(100)),
+        ];
+        let outcome = evaluate_fault(&rules, "t", 0, KafkaFaultKind::ProduceThrottle);
+        match outcome {
+            FaultOutcome::Throttle { ms } => assert_eq!(ms, 2000),
+            _ => panic!("expected throttle, got {:?}", outcome),
+        }
+    }
+
+    #[test]
+    fn evaluate_fault_produce_not_leader_returns_code_6() {
+        let rules = vec![fault("t", None, KafkaFaultKind::ProduceNotLeader, None)];
+        let outcome = evaluate_fault(&rules, "t", 0, KafkaFaultKind::ProduceNotLeader);
+        assert!(matches!(outcome, FaultOutcome::Error { code: 6 }));
+    }
 
     // ==================== Seed Message Tests ====================
 


### PR DESCRIPTION
Closes #487. Stacks on #486 (Kafka seed messages). Backfills the "Failure-injection: where mock brokers earn their keep" section from the deleted Kafka how-to.

## What ships

A new \`kafka.faults\` config block targeting specific failure modes deterministically — exactly the value-prop of a mock broker over testcontainers:

\`\`\`yaml
kafka:
  faults:
    - topic: orders.created
      partition: 1
      kind: produce_throttle
      delay_ms: 2000
    - topic: orders.shipped
      kind: offset_out_of_range
      probability: 0.05
    - topic: critical-pipeline
      kind: produce_not_leader
\`\`\`

## Supported fault kinds

| Kind | Behavior | Kafka error code | Real-client impact |
|---|---|---|---|
| \`produce_throttle\` | Sleeps \`delay_ms\` before processing the produce. | n/a (success after delay) | Exercises retry-and-backoff + acks=all timing |
| \`produce_not_leader\` | Returns NOT_LEADER_OR_FOLLOWER. | 6 | Client re-fetches metadata and retries |
| \`offset_out_of_range\` | Returns OFFSET_OUT_OF_RANGE on fetch, regardless of actual offset. | 1 | Consumer hits \`auto.offset.reset\` policy |

## Implementation

| Layer | Change |
|---|---|
| **\`mockforge-core::config\`** | New \`KafkaFault\` + \`KafkaFaultKind\` (snake_case-serialized enum). Added \`faults: Vec<KafkaFault>\` to \`KafkaConfig\`. Both derive \`schemars::JsonSchema\` under \`schema\` feature. |
| **\`mockforge-kafka::broker\`** | New \`evaluate_fault()\` helper + \`FaultOutcome\` enum. Produce handler checks \`ProduceNotLeader\` (short-circuit) then \`ProduceThrottle\` (sleep) before the write. Fetch handler checks \`OffsetOutOfRange\` before the real offset check, so even a consumer at offset 0 trips the fault. |

Match semantics:
- \`topic\` exact match required; \`partition\` optional (omitted = any partition)
- Rules iterate in declaration order; first match wins
- Probability: \`None\` or \`1.0\` = always fires (deterministic, test-friendly); \`0.0\` = never; in-between rolls \`rand::random::<f64>()\`
- Topic/kind/partition mismatch falls through to the next rule

Locking note: produce-side throttle drops the topics write-lock during the sleep so it can't deadlock against other partitions or fetch requests. Re-acquires on the other side.

## What's NOT in this PR (per the issue)

- **\`fetch_corrupt_record\` and \`tcp_reset\` fault kinds** — both require deeper handler refactoring (record-batch CRC manipulation, connection-level drop). Worth a follow-up.
- **Per-fault metric counters** — the issue spec mentioned bumping a counter per fault site; current PR has tracing logs but no \`/metrics\` integration. Pattern from \`mockforge-chaos\` (HTTP) maps directly; deferred.
- **CLI YAML→config plumbing** — populating \`KafkaConfig::faults\` from loaded YAML in the CLI's serve path is downstream of this.

## Verification

- \`cargo fmt --all --check\` — passes
- \`cargo clippy -p mockforge-kafka --all-targets -- -D warnings\` — passes
- \`cargo test -p mockforge-kafka --lib\` — **307 passed** (9 new fault-evaluation tests covering: empty rules, topic match, topic mismatch, partition filter, kind mismatch, probability=0 never-fires, probability=1 always-fires, first-match-wins ordering, produce_not_leader returns code 6)
- \`cargo test -p mockforge-core --lib\` — **1585 passed**, no regression

## Restoring the blog post

Once this lands, the deleted "Failure-injection: where mock brokers earn their keep" section in \`mockforge.dev/src/pages/note-mocking-kafka-without-broker.html\` can come back. Tracked in mockforge.dev issue #7 and task #18.

## Stacking

This branch was built on top of \`feat/kafka-seed-messages\` (#486 / PR #490). Once #490 lands, this PR's diff will show only the fault-injection additions.