### PR TITLE
feat(registry): enforce requests_per_30d on hosted-mock proxy (#449)

### DIFF
--- a/crates/mockforge-registry-server/src/deployment/router.rs
+++ b/crates/mockforge-registry-server/src/deployment/router.rs
@@ -12,8 +12,14 @@ use axum::{
 };
 use uuid::Uuid;
 
-use crate::models::HostedMock;
+use crate::middleware::org_rate_limit::increment_usage;
+use crate::models::{HostedMock, Organization, UsageCounter};
 use crate::AppState;
+
+/// Fallback monthly request limit when an org's `limits_json` has no
+/// `requests_per_30d` entry. Matches the Free plan default — conservative
+/// enough that legacy orgs without the field don't get unbounded traffic.
+const DEFAULT_REQUESTS_PER_30D: i64 = 10_000;
 
 /// Multitenant router that routes requests to deployed mock services
 pub struct MultitenantRouter;
@@ -56,6 +62,11 @@ impl MultitenantRouter {
             return Err(StatusCode::SERVICE_UNAVAILABLE);
         }
 
+        // Enforce the org's monthly `requests_per_30d` plan limit (#449).
+        // Returns 429 if the deployment's owning org has already burnt through
+        // its monthly request quota.
+        enforce_monthly_quota(&state, deployment.org_id).await?;
+
         // Get the target base URL (prefer internal_url for Fly.io internal routing)
         let base_url = deployment
             .internal_url
@@ -71,7 +82,9 @@ impl MultitenantRouter {
         // Build target URL
         let target_url = build_target_url(base_url, path_after_slug, uri.query());
 
-        proxy_request(method, headers, body, &target_url).await
+        let response = proxy_request(method, headers, body, &target_url).await?;
+        bump_proxy_usage(&state, deployment.org_id, &response);
+        Ok(response)
     }
 }
 
@@ -116,6 +129,9 @@ pub async fn custom_domain_fallback(
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
 
+    // Enforce the org's monthly `requests_per_30d` plan limit before forwarding.
+    enforce_monthly_quota(&state, deployment.org_id).await?;
+
     // Get the target base URL (prefer internal_url for Fly.io internal routing)
     let base_url = deployment
         .internal_url
@@ -125,7 +141,9 @@ pub async fn custom_domain_fallback(
 
     let target_url = build_target_url(base_url, uri.path(), uri.query());
 
-    proxy_request(method, headers, body, &target_url).await
+    let response = proxy_request(method, headers, body, &target_url).await?;
+    bump_proxy_usage(&state, deployment.org_id, &response);
+    Ok(response)
 }
 
 /// Build the full target URL from base, path, and optional query string
@@ -226,4 +244,144 @@ async fn proxy_request(
         tracing::error!("Failed to build proxy response: {}", e);
         StatusCode::INTERNAL_SERVER_ERROR
     })
+}
+
+/// Read `requests_per_30d` from `limits_json`, treating `-1` as "unlimited"
+/// and missing / wrong-type / non-positive values as the conservative Free-tier
+/// default. Splitting this out keeps the JSON-parsing rules unit-testable
+/// without needing a Postgres fixture.
+fn monthly_request_limit(limits_json: &serde_json::Value) -> Option<i64> {
+    match limits_json.get("requests_per_30d").and_then(|v| v.as_i64()) {
+        Some(-1) => None, // -1 = unlimited (matches the sentinel used on Team plan)
+        Some(n) if n > 0 => Some(n),
+        // 0 ("disabled"), wrong JSON type, or missing → fall back so we never
+        // accidentally open the gate.
+        _ => Some(DEFAULT_REQUESTS_PER_30D),
+    }
+}
+
+/// Enforce the owning org's `requests_per_30d` plan limit on a hosted-mock
+/// proxy request. Returns 429 if the org has already exhausted its monthly
+/// allotment.
+///
+/// Fail-open semantics on DB/Redis hiccups: a transient infra failure must
+/// not take the proxy offline. The body cap and per-second RPS check (added
+/// in #450) remain absolute safety floors regardless.
+async fn enforce_monthly_quota(state: &AppState, org_id: Uuid) -> Result<(), StatusCode> {
+    let org = match Organization::find_by_id(state.db.pool(), org_id).await {
+        Ok(Some(org)) => org,
+        Ok(None) => {
+            tracing::warn!("Org {} not found while enforcing monthly quota", org_id);
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::error!("DB error loading org {} for monthly quota check: {}", org_id, e);
+            return Ok(());
+        }
+    };
+
+    let Some(limit) = monthly_request_limit(&org.limits_json) else {
+        return Ok(()); // unlimited
+    };
+
+    let used = match UsageCounter::get_or_create_current(state.db.pool(), org_id).await {
+        Ok(counter) => counter.requests,
+        Err(e) => {
+            tracing::error!("Failed to read usage counter for org {}: {}", org_id, e);
+            return Ok(()); // fail open on DB read errors
+        }
+    };
+
+    if used >= limit {
+        tracing::info!("Monthly request quota exhausted for org {}: {}/{}", org_id, used, limit);
+        Err(StatusCode::TOO_MANY_REQUESTS)
+    } else {
+        Ok(())
+    }
+}
+
+/// Bump the org's monthly request counter after a successful proxy response.
+///
+/// Only counts 2xx — matches the convention in the auth-route rate-limit
+/// middleware so error responses don't burn quota for the customer. Spawned
+/// detached so the response isn't blocked on the counter write.
+///
+/// Synchronous fn (no `.await` here) so the caller can drop `&Response` before
+/// returning it — the upstream `axum::body::Body` is not `Sync`, and holding
+/// the reference across a suspension point would break the `Handler` Send
+/// bound on `route_request`.
+fn bump_proxy_usage(state: &AppState, org_id: Uuid, response: &Response) {
+    if !response.status().is_success() {
+        return;
+    }
+
+    let response_size = response
+        .headers()
+        .get("content-length")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or(256);
+
+    let pool = state.db.pool().clone();
+    let redis = state.redis.clone();
+    tokio::spawn(async move {
+        if let Err(e) = increment_usage(&pool, redis.as_ref(), org_id, response_size).await {
+            tracing::error!("Failed to increment proxy usage for org {}: {:?}", org_id, e);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn monthly_limit_pro_plan_default() {
+        assert_eq!(monthly_request_limit(&json!({ "requests_per_30d": 250_000 })), Some(250_000));
+    }
+
+    #[test]
+    fn monthly_limit_team_plan_default() {
+        assert_eq!(
+            monthly_request_limit(&json!({ "requests_per_30d": 1_000_000 })),
+            Some(1_000_000)
+        );
+    }
+
+    #[test]
+    fn monthly_limit_unlimited_sentinel() {
+        // -1 is the "unlimited" sentinel used elsewhere in limits_json
+        assert_eq!(monthly_request_limit(&json!({ "requests_per_30d": -1 })), None);
+    }
+
+    #[test]
+    fn monthly_limit_zero_falls_back_to_default() {
+        // 0 would mean "no requests allowed ever" — almost certainly a
+        // misconfiguration, fall back instead of bricking the proxy.
+        assert_eq!(
+            monthly_request_limit(&json!({ "requests_per_30d": 0 })),
+            Some(DEFAULT_REQUESTS_PER_30D)
+        );
+    }
+
+    #[test]
+    fn monthly_limit_missing_field_falls_back() {
+        assert_eq!(monthly_request_limit(&json!({})), Some(DEFAULT_REQUESTS_PER_30D));
+    }
+
+    #[test]
+    fn monthly_limit_null_json_falls_back() {
+        assert_eq!(monthly_request_limit(&serde_json::Value::Null), Some(DEFAULT_REQUESTS_PER_30D));
+    }
+
+    #[test]
+    fn monthly_limit_wrong_json_type_falls_back() {
+        // Defensive against limits_json corruption — string "250000" should
+        // not be parsed as an integer here, fall back to the default.
+        assert_eq!(
+            monthly_request_limit(&json!({ "requests_per_30d": "250000" })),
+            Some(DEFAULT_REQUESTS_PER_30D)
+        );
+    }
 }

--- a/crates/mockforge-registry-server/src/middleware/mod.rs
+++ b/crates/mockforge-registry-server/src/middleware/mod.rs
@@ -3,6 +3,7 @@
 pub mod api_token_auth;
 pub mod csrf;
 pub mod org_context;
+pub mod org_rate_limit;
 pub mod permission_check;
 // `permissions` module now lives in mockforge-registry-core. Re-exported
 // here so existing `crate::middleware::permissions::*` paths keep working.

--- a/crates/mockforge-registry-server/src/middleware/org_rate_limit.rs
+++ b/crates/mockforge-registry-server/src/middleware/org_rate_limit.rs
@@ -10,24 +10,29 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use chrono::Datelike;
 use serde_json::json;
 use uuid::Uuid;
 
 use crate::{
     middleware::resolve_org_context,
-    models::{Organization, Plan, UsageCounter},
-    redis::{current_month_period, org_usage_key, RedisPool},
+    models::{Organization, UsageCounter},
+    redis::{current_month_period, RedisPool},
     AppState,
 };
 
-/// Check if organization has exceeded plan limits
+/// Check if organization has exceeded plan limits.
+///
+/// `_redis` and `_user_id` are accepted as part of the public signature so
+/// the auth-route middleware can pass them in; current implementation reads
+/// the authoritative counter from Postgres, but a Redis fast-path is intended
+/// for a follow-up.
 pub async fn check_org_limits(
     pool: &sqlx::PgPool,
-    redis: Option<&RedisPool>,
+    _redis: Option<&RedisPool>,
     org: &Organization,
-    user_id: Uuid,
+    _user_id: Uuid,
 ) -> Result<(), RateLimitError> {
-    let plan = org.plan();
     let limits = &org.limits_json;
 
     // Get current month period
@@ -39,10 +44,7 @@ pub async fn check_org_limits(
         .map_err(|_| RateLimitError::Database)?;
 
     // Check request limit
-    let requests_limit = limits
-        .get("requests_per_30d")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(10000);
+    let requests_limit = limits.get("requests_per_30d").and_then(|v| v.as_i64()).unwrap_or(10000);
 
     if usage.requests >= requests_limit {
         return Err(RateLimitError::LimitExceeded {
@@ -54,10 +56,7 @@ pub async fn check_org_limits(
     }
 
     // Check storage limit
-    let storage_limit_gb = limits
-        .get("storage_gb")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(1);
+    let storage_limit_gb = limits.get("storage_gb").and_then(|v| v.as_i64()).unwrap_or(1);
     let storage_limit_bytes = storage_limit_gb * 1_000_000_000;
 
     if usage.storage_bytes >= storage_limit_bytes {
@@ -116,13 +115,11 @@ pub async fn increment_usage(
 pub async fn org_rate_limit_middleware(
     State(state): State<AppState>,
     headers: HeaderMap,
-    mut request: Request,
+    request: Request,
     next: Next,
 ) -> Result<Response, impl IntoResponse> {
     // Try to get user_id from auth middleware (set in extensions)
-    let user_id_str = request.extensions()
-        .get::<String>()
-        .cloned();
+    let user_id_str = request.extensions().get::<String>().cloned();
 
     // If no user_id, this might be a public endpoint - skip org rate limiting
     // (but still apply global rate limiting if configured)
@@ -139,13 +136,14 @@ pub async fn org_rate_limit_middleware(
     };
 
     // Resolve org context (pass request extensions for API token org_id lookup)
-    let org_ctx = match resolve_org_context(&state, user_id, &headers, Some(request.extensions())).await {
-        Ok(ctx) => ctx,
-        Err(_) => {
-            // No org context, skip org rate limiting
-            return Ok(next.run(request).await);
-        }
-    };
+    let org_ctx =
+        match resolve_org_context(&state, user_id, &headers, Some(request.extensions())).await {
+            Ok(ctx) => ctx,
+            Err(_) => {
+                // No org context, skip org rate limiting
+                return Ok(next.run(request).await);
+            }
+        };
 
     let pool = state.db.pool();
 
@@ -155,15 +153,10 @@ pub async fn org_rate_limit_middleware(
     }
 
     // Get usage info for rate limit headers
-    let usage = UsageCounter::get_or_create_current(pool, org_ctx.org_id)
-        .await
-        .ok();
+    let usage = UsageCounter::get_or_create_current(pool, org_ctx.org_id).await.ok();
 
     let limits = &org_ctx.org.limits_json;
-    let requests_limit = limits
-        .get("requests_per_30d")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(10000);
+    let requests_limit = limits.get("requests_per_30d").and_then(|v| v.as_i64()).unwrap_or(10000);
 
     let requests_remaining = usage
         .as_ref()
@@ -173,16 +166,15 @@ pub async fn org_rate_limit_middleware(
     // Calculate reset time (end of current month)
     let now = chrono::Utc::now();
     let next_month = if now.month() == 12 {
-        chrono::NaiveDate::from_ymd_opt((now.year() + 1) as i32, 1, 1)
+        chrono::NaiveDate::from_ymd_opt(now.year() + 1, 1, 1)
     } else {
-        chrono::NaiveDate::from_ymd_opt(now.year() as i32, (now.month() + 1) as u32, 1)
+        chrono::NaiveDate::from_ymd_opt(now.year(), now.month() + 1, 1)
     }
     .and_then(|d| d.and_hms_opt(0, 0, 0))
     .map(|dt| chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(dt, chrono::Utc));
 
-    let reset_timestamp = next_month
-        .map(|dt| dt.timestamp())
-        .unwrap_or_else(|| now.timestamp() + 2592000); // Fallback: 30 days from now
+    let reset_timestamp =
+        next_month.map(|dt| dt.timestamp()).unwrap_or_else(|| now.timestamp() + 2592000); // Fallback: 30 days from now
 
     // Capture request body size before it's consumed
     let request_body_bytes: i64 = request
@@ -267,7 +259,12 @@ fn rate_limit_error_response(error: RateLimitError) -> impl IntoResponse {
                 "message": "Failed to check rate limits"
             })),
         ),
-        RateLimitError::LimitExceeded { limit_type, limit, used, reset_period } => {
+        RateLimitError::LimitExceeded {
+            limit_type,
+            limit,
+            used,
+            reset_period,
+        } => {
             let limit_type_display = match limit_type.as_str() {
                 "requests" => "Monthly request limit",
                 "storage" => "Storage limit",


### PR DESCRIPTION
## Summary

Closes the last unblocked enforcement gap on #449 — wires the per-org monthly request quota into the hosted-mock wildcard proxy in \`crates/mockforge-registry-server\`. Follow-up to PR #479 (which handled workspace/collaborator/past_due gates) and complements PR #493 (which adds per-second RPS + body cap).

- **Quota check** on every proxied request: load owning org \`limits_json.requests_per_30d\`, compare against \`usage_counters.requests\`, return 429 when exhausted.
- **Counter bump** spawned on 2xx upstream responses only (matches the auth-route middleware convention; 4xx/5xx don't burn the customer's quota).
- \`-1\` is the "unlimited" sentinel (Team plan). \`0\` / missing / wrong-type fall back to the conservative \`DEFAULT_REQUESTS_PER_30D\` (10k, Free-tier default) so legacy \`limits_json\` rows can't open the gate.

### Drive-by fixes to \`middleware/org_rate_limit.rs\`

The module existed but was never declared in \`middleware/mod.rs\` — PR #479 noted "fully implemented but never wired". Wiring exposed pre-existing breakage:

- Add \`pub mod org_rate_limit;\` to \`middleware/mod.rs\`.
- Add missing \`chrono::Datelike\` import.
- Drop unused imports / locals and unnecessary self-casts flagged by clippy.
- Rename unused \`redis\` / \`user_id\` params with \`_\` prefix and document why they stay in the signature.

## What's still NOT done on #449 (intentional follow-ups)

- 24-hour \`past_due\` grace period — today PR #479 blocks immediately, which is stricter and safer.
- Read-only mode for \`past_due\` orgs — would audit many endpoints.
- Live integration tests against a Postgres+Stripe fixture — requires test-mode Stripe scaffolding (the e2e paid-flow work tracked in #451).
- AI gating on \`ai_tokens_per_month\` was already done via \`check_ai_quota\` in \`src/ai/quota.rs\` — no new code needed.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-registry-server --all-targets -- -D warnings\` clean
- [x] \`cargo test -p mockforge-registry-server --lib\` — 373/373 pass (7 new in \`deployment::router::tests\`)
- [ ] Manual smoke against staging: deploy a mock as Free user, send 10001 requests, confirm 429
- [ ] Follow-up: 24h past_due grace period
- [ ] Follow-up: read-only mode for past_due orgs
- [ ] Follow-up: e2e paid-flow integration test (#451)