### PR TITLE
fix(ui): mock cloudMode in TestingPage tests so they exercise the local view (#447)

### DIFF
--- a/crates/mockforge-ui/ui/src/pages/__tests__/TestingPage.test.tsx
+++ b/crates/mockforge-ui/ui/src/pages/__tests__/TestingPage.test.tsx
@@ -5,6 +5,21 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Force local mode. The shared test setup at src/test/setup.ts pins
+// `VITE_API_BASE_URL`, which the legacy detection in `cloudMode.ts`
+// reads as "cloud mode is on" — and `<TestingPage />` then short-circuits
+// to `<CloudSmokeView />` (the deployment picker, not the Smoke / Health
+// Check / Integration tabs these tests assert on). Mirrors the same
+// hoisted mock that the sibling `components/__tests__/testing/Testing.test.tsx`
+// uses. Cloud-branch coverage would belong in a dedicated suite that mocks
+// the deployment list + SSE event panel.
+const cloudModeMock = vi.hoisted(() => ({
+  isCloudMode: vi.fn(() => false),
+  getCloudApiBase: vi.fn(() => ''),
+}));
+vi.mock('../../utils/cloudMode', () => cloudModeMock);
+
 import { TestingPage } from '../TestingPage';
 import { dashboardApi, smokeTestsApi } from '../../services/api';
 import type { SmokeTestResult } from '../../types';
@@ -55,6 +70,9 @@ describe('TestingPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // vi.clearAllMocks resets the .mockReturnValue() set above; re-pin it
+    // so every test starts in local mode.
+    cloudModeMock.isCloudMode.mockReturnValue(false);
   });
 
   it('renders testing page header', () => {


### PR DESCRIPTION
## Summary

Resolves the \`pnpm test\` half of #447 ("chronic release.yml + UI test failures"). The 22 failing tests in \`crates/mockforge-ui/ui/src/pages/__tests__/TestingPage.test.tsx\` were all failing on the same root cause: the shared vitest setup (\`src/test/setup.ts:102\`) pins \`VITE_API_BASE_URL=http://localhost:3000/api\`, and the legacy detection in \`utils/cloudMode.ts\` treats a non-empty \`VITE_API_BASE_URL\` as "cloud mode on". That makes the \`TestingPage\` wrapper short-circuit to \`<CloudSmokeView />\` (deployment picker + latency-budget input) instead of \`<LocalTestingPage />\` (Smoke Tests / Health Check / Integration Tests tabs).

Every assertion in this file targets the LocalTestingPage view — looking for buttons named "Run Smoke Tests" or "Run Health Check" that only exist on the local view.

### Fix

Hoist a \`vi.mock\` for \`../../utils/cloudMode\` that returns \`isCloudMode: () => false\`, plus re-pin the return value in \`beforeEach\` since \`vi.clearAllMocks()\` resets it. This mirrors the same pattern that the sibling \`components/__tests__/testing/Testing.test.tsx\` has been using since #392 for the exact same reason — the comment in that file even documents this gotcha.

### Out of scope here

- **Cloud-branch coverage** (the \`CloudSmokeView\` deployment-picker flow) — that wants its own suite that mocks the deployment list + SSE event panel. Flagged in the inline comment.
- **\`release.yml\`** failures — the other half of #447 (CHANGELOG "validation release" papering, Fly.io auto-deploy gating on tests, removing \`#[ignore]\` from release-suite tests). Substantial separate work that needs the chronic-CI runner-host issue (#446) resolved first to verify cleanly. Will track in a follow-up issue / PR.

## Test plan

- [x] \`pnpm test --run src/pages/__tests__/TestingPage.test.tsx\` — 22/22 pass (was 0/22).
- [x] \`pnpm test\` (full UI suite) — 872/872 pass.
- [x] \`pnpm type-check\` clean.
- [x] \`pnpm lint\` — 0 errors (912 pre-existing warnings, none new).
- [ ] Follow-up issue: cloud-branch coverage for \`CloudSmokeView\`.
- [ ] Follow-up issue: \`release.yml\` test-gating + remove \`#[ignore]\` from release-suite tests (other half of #447).