### PR TITLE
fix(ci): make cargo_audit.py robust to step-boundary PATH races (#447)

### DIFF
--- a/scripts/precommit/cargo_audit.py
+++ b/scripts/precommit/cargo_audit.py
@@ -9,6 +9,8 @@ to this script are appended to the cargo-audit invocation unchanged.
 """
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -29,9 +31,44 @@ def load_ignored_ids(config_path: Path) -> list[str]:
     return ids
 
 
+def resolve_cargo() -> str:
+    """Locate the cargo binary.
+
+    The Security Audit CI job sets `CARGO_HOME=/tmp/cargo-mockforge-<run_id>`
+    and `dtolnay/rust-toolchain` adds `$CARGO_HOME/bin` to `GITHUB_PATH`.
+    That propagates fine for bash steps, but the wrapper here has been
+    observed to fail with `FileNotFoundError: 'cargo'` on the self-hosted
+    runner anyway (#447 / PR #497 Security Audit) — most likely a
+    step-boundary PATH-propagation race where `subprocess.call(["cargo",
+    ...])` sees a PATH that does not include the toolchain dir even though
+    the previous bash step found cargo fine.
+
+    Falling back to the conventional rustup-managed locations
+    (`$CARGO_HOME/bin`, `~/.cargo/bin`) keeps the wrapper working when
+    `shutil.which` returns `None`. We only return absolute paths to a
+    binary that actually exists and is executable — preserving the
+    original ENOENT failure mode for true "no rust toolchain installed"
+    environments instead of masking those.
+    """
+    found = shutil.which("cargo")
+    if found:
+        return found
+    candidates = [
+        os.environ.get("CARGO_HOME"),
+        os.path.expanduser("~/.cargo"),
+    ]
+    for base in candidates:
+        if not base:
+            continue
+        candidate = os.path.join(base, "bin", "cargo")
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return "cargo"
+
+
 def main() -> int:
     ids = load_ignored_ids(Path("audit.toml"))
-    cmd = ["cargo", "audit"]
+    cmd = [resolve_cargo(), "audit"]
     for adv_id in ids:
         cmd.extend(["--ignore", adv_id])
     cmd.extend(sys.argv[1:])


### PR DESCRIPTION
## Summary

PR #497's Security Audit job failed at \`python3 scripts/precommit/cargo_audit.py\` with \`FileNotFoundError: [Errno 2] No such file or directory: 'cargo'\` (job [75643108260](https://github.com/SaaSy-Solutions/mockforge/actions/runs/25755608785/job/75643108260)) even though the immediately-preceding \`cargo install cargo-audit --locked\` step in the same job succeeded — so cargo was on the bash PATH at minute 5 but not on Python's \`subprocess.call\` PATH 200ms later.

PR #494's identical Security Audit on the prior day passed, so this is intermittent — most likely a step-boundary PATH-propagation race where the runner re-evaluates \`GITHUB_PATH\` between steps and drops the toolchain dir set by \`dtolnay/rust-toolchain\` (which exports \`echo "\$CARGO_HOME/bin" >> \$GITHUB_PATH\`).

The original \`/home/actions/.cargo/bin/cargo: No such file\` failure mode from #446 is unrelated — that one is now fixed at the runner-host level and \`Warning Ratchet Preview\` passes green on all my open PRs (#493–#497).

## Fix

Small \`resolve_cargo()\` helper in the wrapper:

1. \`shutil.which("cargo")\` first — preserves the current PATH-lookup behavior as the default.
2. Falls back to \`\$CARGO_HOME/bin/cargo\` if set and executable.
3. Falls back to \`~/.cargo/bin/cargo\` if set and executable.
4. Returns the literal \`"cargo"\` if nothing matched — preserves the original ENOENT failure mode so we don't mask "Rust isn't installed at all" in clean environments.

No behavior change when \`shutil.which\` already finds cargo. Only matters in the race window where bash PATH was correct but Python's inherited PATH wasn't.

## Test plan

- [x] \`python3 -m py_compile scripts/precommit/cargo_audit.py\` — syntax OK.
- [x] Smoke-tested \`resolve_cargo()\` locally — \`shutil.which\` returns \`/usr/bin/cargo\` as expected; fallback paths checked for existence + executability.
- [ ] CI: re-runs Security Audit with the patched wrapper.
- [ ] Once merged: rebase PR #497 to pull the fix and re-trigger Security Audit there.