### PR TITLE
fix(core): strip unnecessary std::collections:: qualification on HashMap (#500)

### DIFF
--- a/crates/mockforge-core/src/config/protocol.rs
+++ b/crates/mockforge-core/src/config/protocol.rs
@@ -245,8 +245,8 @@ pub struct GrpcOverride {
     /// Optional request-field-equality match. Keys are top-level field names of
     /// the request message; values are stringified expected values. When
     /// omitted, the rule matches every call to the named method.
-    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-    pub r#match: std::collections::HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub r#match: HashMap<String, String>,
     /// Response to return when this rule fires.
     pub response: GrpcOverrideResponse,
 }
@@ -496,8 +496,8 @@ pub struct KafkaConfig {
     /// the beginning of a seeded topic sees these records at offset 0+.
     /// Topics referenced here are auto-created using `default_partitions`
     /// and `default_replication_factor`.
-    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-    pub seed_messages: std::collections::HashMap<String, Vec<KafkaSeedMessage>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub seed_messages: HashMap<String, Vec<KafkaSeedMessage>>,
     /// Fault-injection rules applied at the protocol-handler boundary.
     /// Each rule fires either deterministically (no `probability`) or
     /// stochastically (`probability: 0.0..=1.0`). Rules with `partition`
@@ -523,7 +523,7 @@ impl Default for KafkaConfig {
             default_replication_factor: 1,
             advertised_host: None,
             advertised_port: None,
-            seed_messages: std::collections::HashMap::new(),
+            seed_messages: HashMap::new(),
             faults: Vec::new(),
         }
     }
@@ -586,8 +586,8 @@ pub struct KafkaSeedMessage {
     /// but raw UTF-8 strings are fine for tests.
     pub value: String,
     /// Optional record headers. Same shape as on-the-wire Kafka headers.
-    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-    pub headers: std::collections::HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headers: HashMap<String, String>,
 }
 
 /// AMQP server configuration


### PR DESCRIPTION
Closes #500.

## Summary

Warning Ratchet Preview surfaced these as hard errors once the runner-host \`.profile\` fix from #446 let the ratchet script actually run to completion (it had been short-circuiting on \`cargo: No such file\` since early May). \`unused_qualifications\` is already in the preview's \`RUSTFLAGS\` — these were just being masked.

Mechanical change: \`HashMap\` is already imported at \`crates/mockforge-core/src/config/protocol.rs:4\`, so all 7 fully-qualified usages collapse to the short form:

- Line 248 / 249: \`GrpcOverride.r#match\` (#485 gRPC overrides territory)
- Line 499 / 500 / 526: \`KafkaConfig.seed_messages\` + its \`Default\` impl (#486)
- Line 589 / 590: \`KafkaSeedMessage.headers\` (#486)

\`#[serde(skip_serializing_if = "...")]\` takes a string path which still resolves with the bare \`HashMap\` since the import is in scope at codegen time.

## Test plan

- [x] \`bash scripts/lint-warning-ratchet-preview.sh\` — **"Ratchet preview passed."** (this was the exact thing failing on PR #499 and surfacing the warnings).
- [x] \`cargo clippy -p mockforge-core --all-targets -- -D warnings\` clean.
- [x] \`cargo test -p mockforge-core --lib\` — **1585/1585 pass**.
- [x] \`cargo fmt --all --check\` clean.

## Scope

Only \`crates/mockforge-core/src/config/protocol.rs\` — the single file the ratchet flagged. A workspace-wide audit (\`rg "std::collections::HashMap" --type rust\`) for other crates with the same pattern is a separate follow-up so this PR stays surgical, per the issue's acceptance criteria.