### PR TITLE
ci: speed up Security Audit ~10x (preinstall tools + drop no-op clippy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,17 @@ jobs:
 
     - name: Install protoc (protobuf compiler)
       run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'
-    - name: Install security tools
+    - name: Verify security tools present on self-hosted runner
+      # `cargo install` rebuilds these from source on every run (~5 min total),
+      # which dominated Security Audit wall-clock. Both tools change rarely;
+      # we preinstall them on the runner and verify here with the same
+      # pattern used for protoc above. To upgrade: SSH the runner and run
+      # `sudo -u actions cargo install <tool> --locked --force`.
       run: |
-        cargo install cargo-audit --locked
-        cargo install cargo-deny --locked
+        command -v cargo-audit > /dev/null || { echo "::error::cargo-audit missing on self-hosted runner. Run on the runner host: sudo -u actions cargo install cargo-audit --locked"; exit 1; }
+        command -v cargo-deny > /dev/null || { echo "::error::cargo-deny missing on self-hosted runner. Run on the runner host: sudo -u actions cargo install cargo-deny --locked"; exit 1; }
+        cargo-audit --version
+        cargo-deny --version
 
     - name: Run RustSec advisory scan
       # Delegate to scripts/precommit/cargo_audit.py so audit.toml is the
@@ -211,8 +218,12 @@ jobs:
     - name: Run license and source compliance check
       run: cargo deny check licenses sources bans
 
-    - name: Run security-focused Clippy checks
-      run: cargo clippy --workspace --exclude mockforge-desktop --all-targets --all-features -- -W clippy::suspicious -W clippy::security -D warnings || true
+    # The previous `cargo clippy --workspace --all-features ... || true` step
+    # used to live here. It ran for 3-5 minutes per CI run but always exited
+    # 0 because of the trailing `|| true`, so it never blocked anything and
+    # nobody acted on its output. Regular workspace clippy (in the `Test
+    # (stable)` job) already covers the same surface. Removed — see
+    # `[[reference_security_audit_perf]]`.
 
     - name: Check for unsafe code blocks
       run: |


### PR DESCRIPTION
## Why

\`Security Audit\` is the only required check in branch protection on \`main\`, so every PR auto-merge waits on it. Recent runs measured at **8-12 minutes wall-clock** (PR #494: 8 min, PR #493: 12 min). The actual security signal is ~40 seconds; the rest is overhead.

## What this changes

### 1. Stop \`cargo install\`-ing the tools every run

Today:

\`\`\`yaml
- name: Install security tools
  run: |
    cargo install cargo-audit --locked     # ~2 min source build, every run
    cargo install cargo-deny --locked      # ~3-5 min source build, every run
\`\`\`

After:

\`\`\`yaml
- name: Verify security tools present on self-hosted runner
  run: |
    command -v cargo-audit > /dev/null || { echo "::error::..."; exit 1; }
    command -v cargo-deny > /dev/null || { echo "::error::..."; exit 1; }
    cargo-audit --version
    cargo-deny --version
\`\`\`

Same pattern as the \`dpkg -s\` system-deps check immediately above (added by #478). If the binary is missing the job exits with an actionable message telling the runner operator how to install it.

**Runner-side prerequisite (already applied)**: \`cargo-deny 0.19.6\` now installed at \`/home/actions/.cargo/bin/cargo-deny\` on \`saasy-ci-runner-01\` alongside the existing \`cargo-audit 0.22.1\`. To upgrade either tool: SSH the runner and \`sudo -u actions cargo install <tool> --locked --force\`.

### 2. Remove the no-op clippy step

Today:

\`\`\`yaml
- name: Run security-focused Clippy checks
  run: cargo clippy --workspace --exclude mockforge-desktop --all-targets --all-features -- -W clippy::suspicious -W clippy::security -D warnings || true
\`\`\`

That step runs full workspace clippy with all features for **3-5 minutes** per run, but the trailing \`|| true\` means it **always exits 0**. So it has been eating CI time without ever blocking a merge or producing actionable signal. The regular workspace clippy in the \`Test (stable)\` job covers the same surface.

Replaced with a brief comment explaining why it was removed, in case someone wonders.

## Expected wall-clock impact

| Phase | Before | After |
|---|---|---|
| Toolchain install + protoc check | ~10 s | ~10 s |
| \`cargo install cargo-audit\` / \`cargo install cargo-deny\` | **~5 min** | ~1 s (verify-only) |
| \`cargo audit\` (the actual scan) | ~10 s | ~10 s |
| \`cargo deny check\` | ~30 s | ~30 s |
| \`cargo clippy --workspace --all-features\` | **~3-5 min** | (removed) |
| Find unsafe blocks | ~1 s | ~1 s |
| **Total** | **8-12 min** | **~1 min** |

## Test plan

- [x] YAML parses: \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"\`
- [x] \`cargo-audit\` + \`cargo-deny\` confirmed installed on runner at \`/home/actions/.cargo/bin/\` (cargo-audit 0.22.1, cargo-deny 0.19.6).
- [ ] CI will exercise the verify step on the next push. If either tool goes missing in the future, the job errors with the install hint instead of silently re-installing.