### PR TITLE
fix: workspace unused_qualifications cleanup, batch 4 — full workspace clean (#509)

### DIFF
--- a/crates/mockforge-amqp/src/broker.rs
+++ b/crates/mockforge-amqp/src/broker.rs
@@ -355,7 +355,7 @@ mod tests {
             let mut exchanges = broker.exchanges.write().await;
             exchanges.declare_exchange(
                 "test-exchange".to_string(),
-                crate::exchanges::ExchangeType::Direct,
+                ExchangeType::Direct,
                 true,
                 false,
             );
@@ -412,18 +412,8 @@ mod tests {
 
         {
             let mut exchanges = broker.exchanges.write().await;
-            exchanges.declare_exchange(
-                "exchange1".to_string(),
-                crate::exchanges::ExchangeType::Direct,
-                true,
-                false,
-            );
-            exchanges.declare_exchange(
-                "exchange2".to_string(),
-                crate::exchanges::ExchangeType::Fanout,
-                false,
-                true,
-            );
+            exchanges.declare_exchange("exchange1".to_string(), ExchangeType::Direct, true, false);
+            exchanges.declare_exchange("exchange2".to_string(), ExchangeType::Fanout, false, true);
         }
 
         let exchanges = broker.exchanges.read().await;
@@ -461,7 +451,7 @@ mod tests {
             let mut exchanges = broker1.exchanges.write().await;
             exchanges.declare_exchange(
                 "exchange-from-task1".to_string(),
-                crate::exchanges::ExchangeType::Direct,
+                ExchangeType::Direct,
                 true,
                 false,
             );

--- a/crates/mockforge-amqp/tests/integration.rs
+++ b/crates/mockforge-amqp/tests/integration.rs
@@ -163,7 +163,7 @@ async fn test_message_properties() {
         content_type: Some("application/json".to_string()),
         content_encoding: Some("utf-8".to_string()),
         headers: [("custom".to_string(), "value".to_string())].into(),
-        delivery_mode: mockforge_amqp::messages::DeliveryMode::Persistent,
+        delivery_mode: DeliveryMode::Persistent,
         priority: 5,
         correlation_id: Some("corr-123".to_string()),
         reply_to: Some("reply-queue".to_string()),

--- a/crates/mockforge-bench/src/conformance/executor.rs
+++ b/crates/mockforge-bench/src/conformance/executor.rs
@@ -1465,7 +1465,7 @@ custom_checks:
     method: POST
     expected_status: 201
 "#;
-        let parsed: super::CustomConformanceConfig =
+        let parsed: CustomConformanceConfig =
             serde_yaml::from_str(custom_yaml).expect("YAML parses");
         assert_eq!(parsed.custom_checks.len(), 2);
 
@@ -1497,7 +1497,7 @@ custom_checks:
     method: POST
     expected_status: 201
 "#;
-        let parsed: super::CustomConformanceConfig =
+        let parsed: CustomConformanceConfig =
             serde_yaml::from_str(custom_yaml).expect("YAML parses");
 
         let base = ConformanceConfig {
@@ -1520,7 +1520,7 @@ custom_checks:
 
     #[test]
     fn with_custom_checks_from_config_rejects_bad_filter_regex() {
-        let parsed: super::CustomConformanceConfig =
+        let parsed: CustomConformanceConfig =
             serde_yaml::from_str("custom_checks: []").expect("YAML parses");
         let base = ConformanceConfig {
             target_url: "http://localhost:3000".to_string(),
@@ -1760,9 +1760,9 @@ custom_checks:
             method: "GET".to_string(),
             expected_status: 200,
             body: None,
-            expected_headers: std::collections::HashMap::new(),
+            expected_headers: HashMap::new(),
             expected_body_fields: vec![],
-            headers: std::collections::HashMap::new(),
+            headers: HashMap::new(),
         };
 
         executor.add_custom_check(&custom);

--- a/crates/mockforge-bench/src/conformance/spec_driven.rs
+++ b/crates/mockforge-bench/src/conformance/spec_driven.rs
@@ -1315,7 +1315,7 @@ mod tests {
     #[test]
     fn test_annotate_post_with_json_body() {
         let mut op = Operation::default();
-        let mut body = openapiv3::RequestBody {
+        let mut body = RequestBody {
             required: true,
             ..Default::default()
         };

--- a/crates/mockforge-bench/src/spec_parser.rs
+++ b/crates/mockforge-bench/src/spec_parser.rs
@@ -312,7 +312,7 @@ mod tests {
         ];
 
         // Test excluding all DELETE operations
-        let spec = openapiv3::OpenAPI::default();
+        let spec = OpenAPI::default();
         let parser = SpecParser { spec };
         let result = parser.exclude_operations(operations.clone(), "DELETE").unwrap();
 
@@ -330,7 +330,7 @@ mod tests {
             create_test_operation("delete", "/posts/{id}", Some("deletePost")),
         ];
 
-        let spec = openapiv3::OpenAPI::default();
+        let spec = OpenAPI::default();
         let parser = SpecParser { spec };
 
         // Test excluding specific DELETE operation by path
@@ -352,7 +352,7 @@ mod tests {
             create_test_operation("put", "/users/{id}", Some("updateUser")),
         ];
 
-        let spec = openapiv3::OpenAPI::default();
+        let spec = OpenAPI::default();
         let parser = SpecParser { spec };
 
         // Test excluding DELETE and POST
@@ -370,7 +370,7 @@ mod tests {
             create_test_operation("delete", "/users/{id}", Some("deleteUser")),
         ];
 
-        let spec = openapiv3::OpenAPI::default();
+        let spec = OpenAPI::default();
         let parser = SpecParser { spec };
 
         // Empty string should return all operations
@@ -387,7 +387,7 @@ mod tests {
             create_test_operation("delete", "/posts/{id}", Some("deletePost")),
         ];
 
-        let spec = openapiv3::OpenAPI::default();
+        let spec = OpenAPI::default();
         let parser = SpecParser { spec };
 
         // Test excluding DELETE operations matching /users/*
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_get_base_path_with_full_url() {
-        let mut spec = openapiv3::OpenAPI::default();
+        let mut spec = OpenAPI::default();
         spec.servers.push(openapiv3::Server {
             url: "https://api.example.com/api/v1".to_string(),
             description: None,
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_get_base_path_with_relative_path() {
-        let mut spec = openapiv3::OpenAPI::default();
+        let mut spec = OpenAPI::default();
         spec.servers.push(openapiv3::Server {
             url: "/api/v2".to_string(),
             description: None,
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_get_base_path_no_path_in_url() {
-        let mut spec = openapiv3::OpenAPI::default();
+        let mut spec = OpenAPI::default();
         spec.servers.push(openapiv3::Server {
             url: "https://api.example.com".to_string(),
             description: None,
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_get_base_path_no_servers() {
-        let spec = openapiv3::OpenAPI::default();
+        let spec = OpenAPI::default();
         let parser = SpecParser { spec };
         let base_path = parser.get_base_path();
 
@@ -459,7 +459,7 @@ mod tests {
 
     #[test]
     fn test_get_base_path_trailing_slash_removed() {
-        let mut spec = openapiv3::OpenAPI::default();
+        let mut spec = OpenAPI::default();
         spec.servers.push(openapiv3::Server {
             url: "https://api.example.com/api/v1/".to_string(),
             description: None,

--- a/crates/mockforge-chaos/src/api.rs
+++ b/crates/mockforge-chaos/src/api.rs
@@ -2270,9 +2270,8 @@ mod tests {
         // coerce to the foundation trait object for storage in chaos.
         #[allow(deprecated)]
         let concrete = mockforge_core::intelligent_behavior::MockAI::new(mockai_config);
-        let mockai: Arc<
-            tokio::sync::RwLock<dyn mockforge_foundation::intelligent_behavior::MockAiBehavior>,
-        > = Arc::new(tokio::sync::RwLock::new(concrete));
+        let mockai: Arc<RwLock<dyn mockforge_foundation::intelligent_behavior::MockAiBehavior>> =
+            Arc::new(RwLock::new(concrete));
 
         let (_router, _config_arc, _latency_tracker, state) =
             create_chaos_api_router(config, Some(mockai.clone()));

--- a/crates/mockforge-core/src/config/protocol.rs
+++ b/crates/mockforge-core/src/config/protocol.rs
@@ -245,8 +245,8 @@ pub struct GrpcOverride {
     /// Optional request-field-equality match. Keys are top-level field names of
     /// the request message; values are stringified expected values. When
     /// omitted, the rule matches every call to the named method.
-    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-    pub r#match: std::collections::HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub r#match: HashMap<String, String>,
     /// Response to return when this rule fires.
     pub response: GrpcOverrideResponse,
 }
@@ -496,8 +496,8 @@ pub struct KafkaConfig {
     /// the beginning of a seeded topic sees these records at offset 0+.
     /// Topics referenced here are auto-created using `default_partitions`
     /// and `default_replication_factor`.
-    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-    pub seed_messages: std::collections::HashMap<String, Vec<KafkaSeedMessage>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub seed_messages: HashMap<String, Vec<KafkaSeedMessage>>,
     /// Fault-injection rules applied at the protocol-handler boundary.
     /// Each rule fires either deterministically (no `probability`) or
     /// stochastically (`probability: 0.0..=1.0`). Rules with `partition`
@@ -523,7 +523,7 @@ impl Default for KafkaConfig {
             default_replication_factor: 1,
             advertised_host: None,
             advertised_port: None,
-            seed_messages: std::collections::HashMap::new(),
+            seed_messages: HashMap::new(),
             faults: Vec::new(),
         }
     }
@@ -586,8 +586,8 @@ pub struct KafkaSeedMessage {
     /// but raw UTF-8 strings are fine for tests.
     pub value: String,
     /// Optional record headers. Same shape as on-the-wire Kafka headers.
-    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-    pub headers: std::collections::HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headers: HashMap<String, String>,
 }
 
 /// AMQP server configuration

--- a/crates/mockforge-ftp/src/fixtures.rs
+++ b/crates/mockforge-ftp/src/fixtures.rs
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn test_virtual_file_config_to_file_fixture_static() {
         let config = VirtualFileConfig {
-            path: std::path::PathBuf::from("/test.txt"),
+            path: PathBuf::from("/test.txt"),
             content: FileContentConfig::Static {
                 content: "Hello World".to_string(),
             },
@@ -188,14 +188,14 @@ mod tests {
         };
 
         let fixture = config.to_file_fixture();
-        assert_eq!(fixture.path, std::path::PathBuf::from("/test.txt"));
+        assert_eq!(fixture.path, PathBuf::from("/test.txt"));
         assert_eq!(fixture.metadata.permissions, "644");
     }
 
     #[test]
     fn test_virtual_file_config_to_file_fixture_template() {
         let config = VirtualFileConfig {
-            path: std::path::PathBuf::from("/template.txt"),
+            path: PathBuf::from("/template.txt"),
             content: FileContentConfig::Template {
                 template: "Hello {{name}}".to_string(),
             },
@@ -211,7 +211,7 @@ mod tests {
     #[test]
     fn test_virtual_file_config_to_file_fixture_generated() {
         let config = VirtualFileConfig {
-            path: std::path::PathBuf::from("/generated.bin"),
+            path: PathBuf::from("/generated.bin"),
             content: FileContentConfig::Generated {
                 size: 1024,
                 pattern: GenerationPattern::Random,
@@ -407,7 +407,7 @@ mod tests {
         let discard = UploadStorage::Discard;
         let memory = UploadStorage::Memory;
         let file = UploadStorage::File {
-            path: std::path::PathBuf::from("/tmp/uploads"),
+            path: PathBuf::from("/tmp/uploads"),
         };
 
         let _ = format!("{:?}", discard);

--- a/crates/mockforge-ftp/src/storage.rs
+++ b/crates/mockforge-ftp/src/storage.rs
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn test_mockforge_storage_new() {
-        let vfs = Arc::new(VirtualFileSystem::new(std::path::PathBuf::from("/")));
+        let vfs = Arc::new(VirtualFileSystem::new(PathBuf::from("/")));
         let spec_registry = Arc::new(FtpSpecRegistry::new());
         let storage = MockForgeStorage::new(vfs.clone(), spec_registry.clone());
 
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn test_mockforge_storage_clone() {
-        let vfs = Arc::new(VirtualFileSystem::new(std::path::PathBuf::from("/")));
+        let vfs = Arc::new(VirtualFileSystem::new(PathBuf::from("/")));
         let spec_registry = Arc::new(FtpSpecRegistry::new());
         let storage = MockForgeStorage::new(vfs.clone(), spec_registry.clone());
 
@@ -290,7 +290,7 @@ mod tests {
     #[test]
     fn test_mockforge_metadata_len_with_file() {
         let file = VirtualFile::new(
-            std::path::PathBuf::from("/test.txt"),
+            PathBuf::from("/test.txt"),
             FileContent::Static(b"test content".to_vec()),
             FileMetadata {
                 size: 1024,
@@ -330,7 +330,7 @@ mod tests {
     #[test]
     fn test_mockforge_metadata_is_file() {
         let file = VirtualFile::new(
-            std::path::PathBuf::from("/test.txt"),
+            PathBuf::from("/test.txt"),
             FileContent::Static(vec![]),
             FileMetadata::default(),
         );
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_mockforge_metadata_modified() {
         let file = VirtualFile::new(
-            std::path::PathBuf::from("/test.txt"),
+            PathBuf::from("/test.txt"),
             FileContent::Static(vec![]),
             FileMetadata::default(),
         );
@@ -405,7 +405,7 @@ mod tests {
     #[test]
     fn test_mockforge_metadata_clone() {
         let file = VirtualFile::new(
-            std::path::PathBuf::from("/test.txt"),
+            PathBuf::from("/test.txt"),
             FileContent::Static(vec![]),
             FileMetadata::default(),
         );

--- a/crates/mockforge-graphql/tests/graphql_tests.rs
+++ b/crates/mockforge-graphql/tests/graphql_tests.rs
@@ -35,7 +35,7 @@ async fn test_graphql_router_creation() {
 
     let router = result.unwrap();
     // Router should be created successfully
-    assert!(std::mem::size_of_val(&router) > 0);
+    assert!(size_of_val(&router) > 0);
 }
 
 #[tokio::test]

--- a/crates/mockforge-grpc/src/dynamic/http_bridge/handlers.rs
+++ b/crates/mockforge-grpc/src/dynamic/http_bridge/handlers.rs
@@ -521,37 +521,34 @@ mod tests {
     fn test_error_to_status_code() {
         assert_eq!(
             ErrorHandler::error_to_status_code("service not found"),
-            axum::http::StatusCode::NOT_FOUND
+            http::StatusCode::NOT_FOUND
         );
-        assert_eq!(
-            ErrorHandler::error_to_status_code("unauthorized"),
-            axum::http::StatusCode::FORBIDDEN
-        );
+        assert_eq!(ErrorHandler::error_to_status_code("unauthorized"), http::StatusCode::FORBIDDEN);
         assert_eq!(
             ErrorHandler::error_to_status_code("invalid request"),
-            axum::http::StatusCode::BAD_REQUEST
+            http::StatusCode::BAD_REQUEST
         );
         assert_eq!(
             ErrorHandler::error_to_status_code("internal error"),
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            http::StatusCode::INTERNAL_SERVER_ERROR
         );
 
         // Test additional error cases
         assert_eq!(
             ErrorHandler::error_to_status_code("Unknown service"),
-            axum::http::StatusCode::NOT_FOUND
+            http::StatusCode::NOT_FOUND
         );
         assert_eq!(
             ErrorHandler::error_to_status_code("forbidden access"),
-            axum::http::StatusCode::FORBIDDEN
+            http::StatusCode::FORBIDDEN
         );
         assert_eq!(
             ErrorHandler::error_to_status_code("malformed JSON"),
-            axum::http::StatusCode::BAD_REQUEST
+            http::StatusCode::BAD_REQUEST
         );
         assert_eq!(
             ErrorHandler::error_to_status_code("random error"),
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            http::StatusCode::INTERNAL_SERVER_ERROR
         );
     }
 
@@ -669,7 +666,7 @@ mod tests {
 
         // Verify it's an SSE response
         let sse_response = stream_response.into_response();
-        assert_eq!(sse_response.status(), axum::http::StatusCode::OK);
+        assert_eq!(sse_response.status(), http::StatusCode::OK);
 
         // Check content type
         let content_type = sse_response

--- a/crates/mockforge-grpc/src/dynamic/http_bridge/handlers.rs
+++ b/crates/mockforge-grpc/src/dynamic/http_bridge/handlers.rs
@@ -679,7 +679,7 @@ mod tests {
 
     #[test]
     fn test_bridge_response_serialization() {
-        let response = BridgeResponse::<serde_json::Value> {
+        let response = BridgeResponse::<Value> {
             success: true,
             data: Some(serde_json::json!({"result": "success"})),
             error: None,
@@ -699,8 +699,7 @@ mod tests {
         assert!(json_str.contains("service"));
         assert!(json_str.contains("method"));
 
-        let deserialized: BridgeResponse<serde_json::Value> =
-            serde_json::from_str(&json_str).unwrap();
+        let deserialized: BridgeResponse<Value> = serde_json::from_str(&json_str).unwrap();
         assert_eq!(deserialized.success, response.success);
         assert_eq!(deserialized.data, response.data);
         assert_eq!(deserialized.error, response.error);

--- a/crates/mockforge-http/src/file_server.rs
+++ b/crates/mockforge-http/src/file_server.rs
@@ -166,7 +166,7 @@ mod tests {
     fn test_file_serving_router_creation() {
         let router = file_serving_router();
         // Router should be created successfully
-        assert!(std::mem::size_of_val(&router) > 0);
+        assert!(size_of_val(&router) > 0);
     }
 
     #[tokio::test]

--- a/crates/mockforge-http/src/handlers/forecasting.rs
+++ b/crates/mockforge-http/src/handlers/forecasting.rs
@@ -399,11 +399,11 @@ pub async fn refresh_forecasts(
     use sqlx::Row;
     let mut incidents = Vec::new();
     for row in rows {
-        let id: uuid::Uuid = row.try_get("id").map_err(|e| {
+        let id: Uuid = row.try_get("id").map_err(|e| {
             tracing::error!("Failed to get id from row: {}", e);
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
-        let workspace_id: Option<uuid::Uuid> = row.try_get("workspace_id").ok();
+        let workspace_id: Option<Uuid> = row.try_get("workspace_id").ok();
         let endpoint: String = match row.try_get("endpoint") {
             Ok(e) => e,
             Err(_) => continue,

--- a/crates/mockforge-http/src/handlers/semantic_drift.rs
+++ b/crates/mockforge-http/src/handlers/semantic_drift.rs
@@ -47,8 +47,7 @@ fn map_row_to_semantic_incident(
     let after_semantic_state: serde_json::Value =
         row.try_get("after_semantic_state").unwrap_or_default();
     let details_json: serde_json::Value = row.try_get("details").unwrap_or_default();
-    let related_drift_incident_id: Option<uuid::Uuid> =
-        row.try_get("related_drift_incident_id").ok();
+    let related_drift_incident_id: Option<Uuid> = row.try_get("related_drift_incident_id").ok();
     let contract_diff_id: Option<String> = row.try_get("contract_diff_id").ok();
     let external_ticket_id: Option<String> = row.try_get("external_ticket_id").ok();
     let external_ticket_url: Option<String> = row.try_get("external_ticket_url").ok();

--- a/crates/mockforge-http/src/handlers/semantic_drift.rs
+++ b/crates/mockforge-http/src/handlers/semantic_drift.rs
@@ -32,8 +32,8 @@ fn map_row_to_semantic_incident(
     use mockforge_foundation::contract_diff_types::SemanticChangeType;
     use sqlx::Row;
 
-    let id: uuid::Uuid = row.try_get("id")?;
-    let workspace_id: Option<uuid::Uuid> = row.try_get("workspace_id").ok();
+    let id: Uuid = row.try_get("id")?;
+    let workspace_id: Option<Uuid> = row.try_get("workspace_id").ok();
     let endpoint: String = row.try_get("endpoint")?;
     let method: String = row.try_get("method")?;
     let semantic_change_type_str: String = row.try_get("semantic_change_type")?;

--- a/crates/mockforge-http/src/handlers/threat_modeling.rs
+++ b/crates/mockforge-http/src/handlers/threat_modeling.rs
@@ -39,7 +39,7 @@ fn map_row_to_threat_assessment(
     use sqlx::Row;
 
     // Parse basic fields
-    let workspace_id: Option<uuid::Uuid> = row.try_get("workspace_id")?;
+    let workspace_id: Option<Uuid> = row.try_get("workspace_id")?;
     let service_id: Option<String> = row.try_get("service_id")?;
     let service_name: Option<String> = row.try_get("service_name")?;
     let endpoint: Option<String> = row.try_get("endpoint")?;
@@ -437,7 +437,7 @@ pub async fn list_findings(
     use sqlx::Row;
     let mut findings = Vec::new();
     for row in rows {
-        let finding_id: uuid::Uuid = row.try_get("id").map_err(|e| {
+        let finding_id: Uuid = row.try_get("id").map_err(|e| {
             tracing::error!("Failed to get finding id from row: {}", e);
             StatusCode::INTERNAL_SERVER_ERROR
         })?;

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -2702,10 +2702,8 @@ pub async fn build_router_with_chains_and_multi_tenant(
                             req.extensions_mut().insert(state);
                         }
                         // Call the middleware function
-                        crate::middleware::behavioral_cloning::behavioral_cloning_middleware(
-                            req, next,
-                        )
-                        .await
+                        middleware::behavioral_cloning::behavioral_cloning_middleware(req, next)
+                            .await
                     }
                 },
             ));
@@ -3454,8 +3452,8 @@ fn test_http_server_state_multiple_routes() {
 fn test_http_server_state_with_rate_limiter() {
     use std::sync::Arc;
 
-    let config = crate::middleware::RateLimitConfig::default();
-    let rate_limiter = Arc::new(crate::middleware::GlobalRateLimiter::new(config));
+    let config = middleware::RateLimitConfig::default();
+    let rate_limiter = Arc::new(middleware::GlobalRateLimiter::new(config));
 
     let state = HttpServerState::new().with_rate_limiter(rate_limiter);
 

--- a/crates/mockforge-http/src/middleware/behavioral_cloning.rs
+++ b/crates/mockforge-http/src/middleware/behavioral_cloning.rs
@@ -5,7 +5,7 @@
 
 use axum::{
     body::Body,
-    http::{Request, Response, StatusCode},
+    http::{header, HeaderValue, Request, Response, StatusCode},
     middleware::Next,
 };
 use mockforge_intelligence::behavioral_cloning::ProbabilisticModel;
@@ -179,8 +179,8 @@ pub async fn behavioral_cloning_middleware(req: Request<Body>, next: Next) -> Re
 
                         // Set content-type header
                         response.headers_mut().insert(
-                            axum::http::header::CONTENT_TYPE,
-                            axum::http::HeaderValue::from_static("application/json"),
+                            header::CONTENT_TYPE,
+                            HeaderValue::from_static("application/json"),
                         );
 
                         debug!("Applied error pattern body from sample response");

--- a/crates/mockforge-http/src/op_middleware.rs
+++ b/crates/mockforge-http/src/op_middleware.rs
@@ -402,7 +402,7 @@ mod tests {
         let res = Response::builder()
             .status(StatusCode::OK)
             .header("content-type", "application/json")
-            .body(axum::body::Body::empty())
+            .body(Body::empty())
             .unwrap();
 
         let size = calculate_response_size(&res);
@@ -420,7 +420,7 @@ mod tests {
             .header("content-type", "application/json")
             .header("cache-control", "no-cache")
             .header("x-request-id", "123-456-789")
-            .body(axum::body::Body::empty())
+            .body(Body::empty())
             .unwrap();
 
         let size = calculate_response_size(&res);

--- a/crates/mockforge-http/src/verification.rs
+++ b/crates/mockforge-http/src/verification.rs
@@ -223,7 +223,7 @@ mod tests {
     async fn test_verification_router_creation() {
         let router = verification_router();
         // Router should be created without panicking
-        assert!(std::mem::size_of_val(&router) > 0);
+        assert!(size_of_val(&router) > 0);
     }
 
     #[tokio::test]
@@ -312,14 +312,14 @@ mod tests {
     fn test_verification_state_new() {
         let state = VerificationState::new();
         // State should be created successfully (size_of_val always >= 0 for usize)
-        let _ = std::mem::size_of_val(&state);
+        let _ = size_of_val(&state);
     }
 
     #[test]
     fn test_verification_state_default() {
         let state = VerificationState;
         // size_of_val always >= 0 for usize
-        let _ = std::mem::size_of_val(&state);
+        let _ = size_of_val(&state);
     }
 
     #[test]

--- a/crates/mockforge-http/tests/deceptive_deploy_test.rs
+++ b/crates/mockforge-http/tests/deceptive_deploy_test.rs
@@ -8,7 +8,7 @@
 
 use axum::{
     body::Body,
-    http::{Request, StatusCode},
+    http::{HeaderName, HeaderValue, Request, StatusCode},
     response::IntoResponse,
     routing::get,
     Router,
@@ -319,10 +319,9 @@ async fn test_production_headers_no_override() {
     // Handler that sets its own header
     async fn handler_with_header() -> impl IntoResponse {
         let mut response = (StatusCode::OK, "test").into_response();
-        response.headers_mut().insert(
-            axum::http::HeaderName::from_static("x-custom"),
-            axum::http::HeaderValue::from_static("handler-value"),
-        );
+        response
+            .headers_mut()
+            .insert(HeaderName::from_static("x-custom"), HeaderValue::from_static("handler-value"));
         response
     }
 

--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -2275,7 +2275,7 @@ mod tests {
         assert_eq!(parsed.topics[0].partitions[0].records[0].value, b"hello-produce");
 
         // Now round-trip through the broker.
-        let handler = crate::protocol::KafkaProtocolHandler::new();
+        let handler = KafkaProtocolHandler::new();
         let request = handler.parse_request(&msg).expect("parse header");
         assert_eq!(request.api_key, 0);
         assert_eq!(request.api_version, 9);

--- a/crates/mockforge-kafka/src/spec_registry.rs
+++ b/crates/mockforge-kafka/src/spec_registry.rs
@@ -697,10 +697,7 @@ mod tests {
 
         let response = registry.generate_mock_response(&request).unwrap();
 
-        assert!(matches!(
-            response.status,
-            mockforge_core::protocol_abstraction::ResponseStatus::KafkaStatus(0)
-        ));
+        assert!(matches!(response.status, ResponseStatus::KafkaStatus(0)));
         assert_eq!(response.content_type, "application/json");
         assert!(response.metadata.contains_key("topic"));
         assert!(response.metadata.contains_key("offset"));
@@ -755,10 +752,7 @@ mod tests {
 
         let response = registry.generate_mock_response(&request).unwrap();
 
-        assert!(matches!(
-            response.status,
-            mockforge_core::protocol_abstraction::ResponseStatus::KafkaStatus(0)
-        ));
+        assert!(matches!(response.status, ResponseStatus::KafkaStatus(0)));
         assert_eq!(response.content_type, "application/json");
         assert_eq!(response.metadata.get("topic").unwrap(), "test-topic");
         assert_eq!(response.metadata.get("partition").unwrap(), "0");

--- a/crates/mockforge-kafka/tests/fixture_triggers.rs
+++ b/crates/mockforge-kafka/tests/fixture_triggers.rs
@@ -323,8 +323,8 @@ impl TestOnlyBrokerExt for KafkaMockBroker {
         }
 
         // Silence unused imports when the trait is not instantiated.
-        let _ = std::mem::size_of::<DecodedRecord>();
-        let _ = std::mem::size_of::<PartitionProduceData>();
-        let _ = std::mem::size_of::<TopicProduceData>();
+        let _ = size_of::<DecodedRecord>();
+        let _ = size_of::<PartitionProduceData>();
+        let _ = size_of::<TopicProduceData>();
     }
 }

--- a/crates/mockforge-mqtt/src/lib.rs
+++ b/crates/mockforge-mqtt/src/lib.rs
@@ -143,10 +143,10 @@ mod tests {
     #[test]
     fn test_all_modules_accessible() {
         // Test that all modules are accessible
-        let _broker_module = broker::MqttConfig::default();
-        let _fixtures_module = fixtures::MqttFixtureRegistry::new();
-        let _spec_module = spec_registry::MqttSpecRegistry::new();
-        let _topics_module = topics::TopicTree::new();
+        let _broker_module = MqttConfig::default();
+        let _fixtures_module = MqttFixtureRegistry::new();
+        let _spec_module = MqttSpecRegistry::new();
+        let _topics_module = TopicTree::new();
         let _qos_module = qos::QoS::AtMostOnce;
     }
 

--- a/crates/mockforge-plugin-cli/src/commands/publish.rs
+++ b/crates/mockforge-plugin-cli/src/commands/publish.rs
@@ -605,9 +605,9 @@ mod tests {
         // Two SBOMs with identical semantics but different formatting.
         let a = tmp.path().join("a.json");
         let b = tmp.path().join("b.json");
-        std::fs::write(&a, br#"{"components":[{"name":"foo","version":"1.0"}]}"#).unwrap();
+        fs::write(&a, br#"{"components":[{"name":"foo","version":"1.0"}]}"#).unwrap();
         // Same content, reordered keys, pretty-printed whitespace.
-        std::fs::write(
+        fs::write(
             &b,
             br#"{
     "components": [
@@ -652,7 +652,7 @@ mod tests {
         key::generate_key(&key_path, false).await.unwrap();
 
         let sbom_path = temp_dir.path().join("sbom.json");
-        std::fs::write(&sbom_path, br#"{"components":[]}"#).unwrap();
+        fs::write(&sbom_path, br#"{"components":[]}"#).unwrap();
 
         let att = build_sbom_attestation(
             &pkg,
@@ -669,7 +669,7 @@ mod tests {
         use base64::Engine;
         use sha2::{Digest, Sha256};
         let signing = key::load_signing_key(&key_path).unwrap();
-        let checksum_bytes: [u8; 32] = Sha256::digest(std::fs::read(&pkg).unwrap()).into();
+        let checksum_bytes: [u8; 32] = Sha256::digest(fs::read(&pkg).unwrap()).into();
         let checksum_hex: String = checksum_bytes.iter().map(|b| format!("{:02x}", b)).collect();
         let msg = key::attestation_message(&checksum_hex, &att.sbom_canonical_bytes).unwrap();
         let sig_bytes =

--- a/crates/mockforge-plugin-core/src/plugins/react_client_generator.rs
+++ b/crates/mockforge-plugin-core/src/plugins/react_client_generator.rs
@@ -3343,7 +3343,7 @@ mod tests {
                 description: Some("Test API".to_string()),
             },
             servers: None,
-            paths: std::collections::HashMap::new(),
+            paths: HashMap::new(),
             components: None,
         };
 
@@ -3353,7 +3353,7 @@ mod tests {
             include_types: true,
             include_mocks: false,
             template_dir: None,
-            options: std::collections::HashMap::new(),
+            options: HashMap::new(),
         };
 
         let result = generator.generate_client(&spec, &config).await;

--- a/crates/mockforge-plugin-core/src/plugins/svelte_client_generator.rs
+++ b/crates/mockforge-plugin-core/src/plugins/svelte_client_generator.rs
@@ -3018,7 +3018,7 @@ mod tests {
                 description: Some("Test API".to_string()),
             },
             servers: None,
-            paths: std::collections::HashMap::new(),
+            paths: HashMap::new(),
             components: None,
         };
 
@@ -3028,7 +3028,7 @@ mod tests {
             include_types: true,
             include_mocks: false,
             template_dir: None,
-            options: std::collections::HashMap::new(),
+            options: HashMap::new(),
         };
 
         let result = generator.generate_client(&spec, &config).await;

--- a/crates/mockforge-plugin-core/src/plugins/vue_client_generator.rs
+++ b/crates/mockforge-plugin-core/src/plugins/vue_client_generator.rs
@@ -3355,7 +3355,7 @@ mod tests {
                 description: Some("Test API".to_string()),
             },
             servers: None,
-            paths: std::collections::HashMap::new(),
+            paths: HashMap::new(),
             components: None,
         };
 
@@ -3365,7 +3365,7 @@ mod tests {
             include_types: true,
             include_mocks: false,
             template_dir: None,
-            options: std::collections::HashMap::new(),
+            options: HashMap::new(),
         };
 
         let result = generator.generate_client(&spec, &config).await;

--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -107,7 +107,7 @@ impl Host {
         loader_config: PluginLoaderConfig,
         verifier: SignatureVerifier,
         blocklist: Blocklist,
-    ) -> (Self, HostActor, std::sync::Arc<mockforge_plugin_loader::InvocationMetricsBus>) {
+    ) -> (Self, HostActor, Arc<mockforge_plugin_loader::InvocationMetricsBus>) {
         let (cmd_tx, cmd_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let started_at = Arc::new(Instant::now());
 
@@ -635,8 +635,7 @@ mod tests {
                 crate::signing::TrustStore::new(),
                 crate::signing::SignatureMode::Optional,
             );
-            let (host, actor, _bus) =
-                Host::new(loader_config(), verifier, crate::blocklist::Blocklist::new());
+            let (host, actor, _bus) = Host::new(loader_config(), verifier, Blocklist::new());
             tokio::select! {
                 result = body(host) => result,
                 _ = actor => panic!("actor exited before test body finished"),
@@ -742,8 +741,7 @@ mod tests {
                 crate::signing::TrustStore::new(),
                 crate::signing::SignatureMode::Required,
             );
-            let (host, actor, _bus) =
-                Host::new(loader_config(), verifier, crate::blocklist::Blocklist::new());
+            let (host, actor, _bus) = Host::new(loader_config(), verifier, Blocklist::new());
             tokio::select! {
                 result = body(host) => result,
                 _ = actor => panic!("actor exited before test body finished"),
@@ -797,10 +795,7 @@ mod tests {
     /// Drive a Host wired to a Blocklist with the test plugin
     /// already revoked. Lets us verify the kill-switch refuses
     /// the load before any other check.
-    fn run_with_blocklist<F, T>(
-        blocklist: crate::blocklist::Blocklist,
-        body: impl FnOnce(Host) -> F,
-    ) -> T
+    fn run_with_blocklist<F, T>(blocklist: Blocklist, body: impl FnOnce(Host) -> F) -> T
     where
         F: std::future::Future<Output = T>,
     {

--- a/crates/mockforge-recorder/src/api.rs
+++ b/crates/mockforge-recorder/src/api.rs
@@ -951,7 +951,7 @@ mod tests {
         let router = create_api_router(recorder, None);
 
         // Router should be created successfully
-        assert!(std::mem::size_of_val(&router) > 0);
+        assert!(size_of_val(&router) > 0);
     }
 
     #[tokio::test]

--- a/crates/mockforge-recorder/src/protocols/graphql.rs
+++ b/crates/mockforge-recorder/src/protocols/graphql.rs
@@ -158,7 +158,7 @@ mod tests {
         let query = "query GetUser($id: ID!) { user(id: $id) { id name email } }";
         let variables = r#"{"id": "123"}"#;
 
-        let context = crate::models::RequestContext::new(Some("127.0.0.1"), None, None);
+        let context = RequestContext::new(Some("127.0.0.1"), None, None);
         let request_id = record_graphql_request(
             &recorder,
             "query",
@@ -197,7 +197,7 @@ mod tests {
         let mutation =
             "mutation CreateUser($input: UserInput!) { createUser(input: $input) { id name } }";
 
-        let context = crate::models::RequestContext::new(Some("127.0.0.1"), None, None);
+        let context = RequestContext::new(Some("127.0.0.1"), None, None);
         let request_id = record_graphql_request(
             &recorder,
             "mutation",

--- a/crates/mockforge-recorder/src/protocols/grpc.rs
+++ b/crates/mockforge-recorder/src/protocols/grpc.rs
@@ -100,7 +100,7 @@ mod tests {
         let metadata =
             HashMap::from([("content-type".to_string(), "application/grpc".to_string())]);
 
-        let context = crate::models::RequestContext::new(Some("127.0.0.1"), None, None);
+        let context = RequestContext::new(Some("127.0.0.1"), None, None);
         let request_id = record_grpc_request(
             &recorder,
             "helloworld.Greeter",

--- a/crates/mockforge-recorder/src/sync_drift.rs
+++ b/crates/mockforge-recorder/src/sync_drift.rs
@@ -413,7 +413,7 @@ mod tests {
         let evaluator = SyncDriftEvaluator::new(drift_engine, incident_manager, database);
 
         // Should create successfully
-        assert!(std::mem::size_of_val(&evaluator) > 0);
+        assert!(size_of_val(&evaluator) > 0);
     }
 
     #[tokio::test]

--- a/crates/mockforge-recorder/src/sync_snapshots.rs
+++ b/crates/mockforge-recorder/src/sync_snapshots.rs
@@ -150,8 +150,8 @@ mod tests {
     fn create_test_comparison_result(
         matches: bool,
         differences: Vec<crate::diff::Difference>,
-    ) -> crate::diff::ComparisonResult {
-        crate::diff::ComparisonResult {
+    ) -> ComparisonResult {
+        ComparisonResult {
             matches,
             status_match: matches,
             headers_match: matches,

--- a/crates/mockforge-recorder/src/sync_traffic.rs
+++ b/crates/mockforge-recorder/src/sync_traffic.rs
@@ -313,7 +313,7 @@ mod tests {
         let analyzer = TrafficAnalyzer::new(config);
 
         // Should create successfully
-        assert!(std::mem::size_of_val(&analyzer) > 0);
+        assert!(size_of_val(&analyzer) > 0);
     }
 
     #[tokio::test]
@@ -474,14 +474,14 @@ mod tests {
         let analyzer = TrafficAnalyzer::new(config);
 
         let changes = vec![
-            crate::sync::DetectedChange {
+            DetectedChange {
                 request_id: "req-1".to_string(),
                 method: "GET".to_string(),
                 path: "/api/users".to_string(),
                 comparison: create_test_comparison_result(false),
                 updated: false,
             },
-            crate::sync::DetectedChange {
+            DetectedChange {
                 request_id: "req-2".to_string(),
                 method: "POST".to_string(),
                 path: "/api/posts".to_string(),
@@ -503,14 +503,14 @@ mod tests {
         let analyzer = TrafficAnalyzer::new(config);
 
         let changes = vec![
-            crate::sync::DetectedChange {
+            DetectedChange {
                 request_id: "req-1".to_string(),
                 method: "GET".to_string(),
                 path: "/api/users".to_string(),
                 comparison: create_test_comparison_result(false),
                 updated: false,
             },
-            crate::sync::DetectedChange {
+            DetectedChange {
                 request_id: "req-2".to_string(),
                 method: "POST".to_string(),
                 path: "/api/posts".to_string(),
@@ -551,14 +551,14 @@ mod tests {
         let analyzer = TrafficAnalyzer::new(config);
 
         let changes = vec![
-            crate::sync::DetectedChange {
+            DetectedChange {
                 request_id: "req-1".to_string(),
                 method: "GET".to_string(),
                 path: "/api/users".to_string(),
                 comparison: create_test_comparison_result(false),
                 updated: false,
             },
-            crate::sync::DetectedChange {
+            DetectedChange {
                 request_id: "req-2".to_string(),
                 method: "POST".to_string(),
                 path: "/api/posts".to_string(),
@@ -598,7 +598,7 @@ mod tests {
         let config = create_test_traffic_config();
         let analyzer = TrafficAnalyzer::new(config);
 
-        let changes = vec![crate::sync::DetectedChange {
+        let changes = vec![DetectedChange {
             request_id: "req-1".to_string(),
             method: "GET".to_string(),
             path: "/api/users".to_string(),

--- a/crates/mockforge-registry-core/src/models/hosted_mock.rs
+++ b/crates/mockforge-registry-core/src/models/hosted_mock.rs
@@ -603,7 +603,7 @@ impl DeploymentMetrics {
         hosted_mock_id: Uuid,
     ) -> sqlx::Result<Self> {
         use chrono::Datelike;
-        let now = chrono::Utc::now().date_naive();
+        let now = Utc::now().date_naive();
         let period_start =
             chrono::NaiveDate::from_ymd_opt(now.year(), now.month(), 1).unwrap_or(now);
 

--- a/crates/mockforge-registry-core/src/models/subscription.rs
+++ b/crates/mockforge-registry-core/src/models/subscription.rs
@@ -240,7 +240,7 @@ pub struct UsageCounter {
 impl UsageCounter {
     /// Get or create usage counter for current month
     pub async fn get_or_create_current(pool: &sqlx::PgPool, org_id: Uuid) -> sqlx::Result<Self> {
-        let period_start = chrono::Utc::now().date_naive();
+        let period_start = Utc::now().date_naive();
         let period_start = NaiveDate::from_ymd_opt(period_start.year(), period_start.month(), 1)
             .unwrap_or(period_start);
 

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -1933,10 +1933,10 @@ impl RegistryStore for PgRegistryStore {
         .await?;
         let (inherited_org_id, revoked_at) = match row {
             Some(r) => r,
-            None => return Err(crate::error::StoreError::NotFound),
+            None => return Err(StoreError::NotFound),
         };
         if revoked_at.is_some() {
-            return Err(crate::error::StoreError::NotFound);
+            return Err(StoreError::NotFound);
         }
 
         let new_key: UserPublicKey = sqlx::query_as::<_, UserPublicKey>(

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -5207,7 +5207,7 @@ mod tests {
             .rotate_user_public_key(user_id, old.id, "ed25519", &b64(&[0x66u8; 32]), "another")
             .await
             .unwrap_err();
-        assert!(matches!(err, crate::error::StoreError::NotFound));
+        assert!(matches!(err, StoreError::NotFound));
     }
 
     /// End-to-end scenarios CRUD on SQLite. Seeds a user + org, creates

--- a/crates/mockforge-registry-server/src/email.rs
+++ b/crates/mockforge-registry-server/src/email.rs
@@ -68,7 +68,7 @@ impl EmailService {
     ///
     /// # Errors
     /// Returns an error if the HTTP client cannot be created
-    pub fn new(config: EmailConfig) -> anyhow::Result<Self> {
+    pub fn new(config: EmailConfig) -> Result<Self> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
             .build()
@@ -81,7 +81,7 @@ impl EmailService {
     ///
     /// # Errors
     /// Returns an error if the HTTP client cannot be created
-    pub fn from_env() -> anyhow::Result<Self> {
+    pub fn from_env() -> Result<Self> {
         let provider = std::env::var("EMAIL_PROVIDER").unwrap_or_else(|_| "disabled".to_string());
 
         let config = EmailConfig {

--- a/crates/mockforge-registry-server/src/handlers/auth.rs
+++ b/crates/mockforge-registry-server/src/handlers/auth.rs
@@ -1,7 +1,7 @@
 //! Authentication handlers
 
 use axum::{extract::State, Json};
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -490,7 +490,7 @@ pub struct MeResponse {
     pub email_notifications: bool,
     pub security_alerts: bool,
     pub preferences: serde_json::Value,
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
 }
 
 /// Get current user info (GET /api/v1/auth/me)

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -771,10 +771,7 @@ async fn handle_subscription_deleted(
 }
 
 /// Handle payment succeeded
-async fn handle_payment_succeeded(
-    pool: &sqlx::PgPool,
-    invoice: &stripe::Invoice,
-) -> Result<(), ApiError> {
+async fn handle_payment_succeeded(pool: &sqlx::PgPool, invoice: &Invoice) -> Result<(), ApiError> {
     let customer_id = match &invoice.customer {
         Some(stripe::Expandable::Id(id)) => id.to_string(),
         Some(stripe::Expandable::Object(customer)) => customer.id.to_string(),
@@ -803,10 +800,7 @@ async fn handle_payment_succeeded(
     Ok(())
 }
 
-async fn handle_payment_failed(
-    pool: &sqlx::PgPool,
-    invoice: &stripe::Invoice,
-) -> Result<(), ApiError> {
+async fn handle_payment_failed(pool: &sqlx::PgPool, invoice: &Invoice) -> Result<(), ApiError> {
     let customer_id = match &invoice.customer {
         Some(stripe::Expandable::Id(id)) => id.to_string(),
         Some(stripe::Expandable::Object(customer)) => customer.id.to_string(),

--- a/crates/mockforge-registry-server/src/handlers/flows.rs
+++ b/crates/mockforge-registry-server/src/handlers/flows.rs
@@ -267,12 +267,7 @@ pub async fn trigger_run(
     // run still queues with whatever metadata we have, so the runner
     // can record the failure with context.
     let version_config: Option<serde_json::Value> = match flow.current_version_id {
-        Some(vid) => match mockforge_registry_core::models::flow::FlowVersion::find_by_id(
-            state.db.pool(),
-            vid,
-        )
-        .await
-        {
+        Some(vid) => match FlowVersion::find_by_id(state.db.pool(), vid).await {
             Ok(Some(v)) => Some(v.config),
             Ok(None) => {
                 tracing::warn!(
@@ -390,7 +385,7 @@ async fn load_authorized_flow(
 
 fn deserialize_double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
 where
-    T: serde::Deserialize<'de>,
+    T: Deserialize<'de>,
     D: serde::Deserializer<'de>,
 {
     Option::<T>::deserialize(deserializer).map(Some)

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -1222,7 +1222,7 @@ fn build_runtime_logs_stream(app_name: String) -> impl Stream<Item = Result<Even
 /// so the wire format is the canonical contract.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RuntimeRequestEvent {
-    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub timestamp: DateTime<Utc>,
     pub method: String,
     pub path: String,
     pub status: u16,
@@ -1345,7 +1345,7 @@ pub async fn ingest_runtime_logs(
 pub struct CaptureIngestRequest {
     pub id: String,
     pub protocol: String,
-    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub timestamp: DateTime<Utc>,
     pub method: String,
     pub path: String,
     #[serde(default)]
@@ -1376,7 +1376,7 @@ pub struct CaptureIngestResponse {
     pub body: Option<String>,
     pub body_encoding: String,
     pub size_bytes: i64,
-    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub timestamp: DateTime<Utc>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1525,11 +1525,11 @@ pub async fn get_runtime_requests(
     let since = params
         .since
         .as_deref()
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-        .map(|d| d.with_timezone(&chrono::Utc));
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.with_timezone(&Utc));
 
     type RuntimeRequestRow = (
-        chrono::DateTime<chrono::Utc>,
+        DateTime<Utc>,
         String,
         String,
         i16,
@@ -1778,8 +1778,8 @@ pub async fn list_recorder_captures(
         let since = params
             .since
             .as_deref()
-            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-            .map(|d| d.with_timezone(&chrono::Utc));
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|d| d.with_timezone(&Utc));
         let captures = list_cloud_captures(pool, deployment_id, limit, since).await?;
         let body = serde_json::to_vec(&captures).map_err(|e| {
             ApiError::InvalidRequest(format!("Failed to serialize captures: {}", e))
@@ -1813,24 +1813,24 @@ async fn list_cloud_captures(
     pool: &sqlx::PgPool,
     deployment_id: Uuid,
     limit: i64,
-    since: Option<chrono::DateTime<chrono::Utc>>,
+    since: Option<DateTime<Utc>>,
 ) -> ApiResult<Vec<serde_json::Value>> {
     type Row = (
-        String,                        // capture_id
-        String,                        // protocol
-        chrono::DateTime<chrono::Utc>, // occurred_at
-        String,                        // method
-        String,                        // path
-        Option<String>,                // query_params
-        String,                        // request_headers
-        Option<String>,                // request_body
-        String,                        // request_body_encoding
-        Option<String>,                // client_ip
-        Option<String>,                // trace_id
-        Option<String>,                // span_id
-        Option<i64>,                   // duration_ms
-        Option<i32>,                   // status_code
-        Option<String>,                // tags
+        String,         // capture_id
+        String,         // protocol
+        DateTime<Utc>,  // occurred_at
+        String,         // method
+        String,         // path
+        Option<String>, // query_params
+        String,         // request_headers
+        Option<String>, // request_body
+        String,         // request_body_encoding
+        Option<String>, // client_ip
+        Option<String>, // trace_id
+        Option<String>, // span_id
+        Option<i64>,    // duration_ms
+        Option<i32>,    // status_code
+        Option<String>, // tags
     );
 
     let rows: Vec<Row> = if let Some(since) = since {
@@ -1951,7 +1951,7 @@ async fn fetch_cloud_capture(
     type Row = (
         String,
         String,
-        chrono::DateTime<chrono::Utc>,
+        DateTime<Utc>,
         String,
         String,
         Option<String>,
@@ -2320,7 +2320,7 @@ pub async fn get_deployment_metrics(
         match client.snapshot_for_app(&app_name).await {
             Ok(snap) => {
                 use chrono::Datelike;
-                let now = chrono::Utc::now().date_naive();
+                let now = Utc::now().date_naive();
                 let period_start =
                     chrono::NaiveDate::from_ymd_opt(now.year(), now.month(), 1).unwrap_or(now);
                 return Ok(Json(MetricsResponse {
@@ -2493,8 +2493,8 @@ pub struct DeploymentResponse {
     /// Persisted inside `config_json["upstream_url"]`; surfaced here so the
     /// UI can display and (eventually) edit it without reparsing config_json.
     pub upstream_url: Option<String>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 impl From<HostedMock> for DeploymentResponse {
@@ -2531,7 +2531,7 @@ pub struct LogResponse {
     pub level: String,
     pub message: String,
     pub metadata: serde_json::Value,
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
 }
 
 impl From<DeploymentLog> for LogResponse {

--- a/crates/mockforge-registry-server/src/handlers/oauth.rs
+++ b/crates/mockforge-registry-server/src/handlers/oauth.rs
@@ -73,7 +73,7 @@ pub async fn oauth_authorize(
     if let Some(redis) = &state.redis {
         // Store state token with provider info and timestamp for verification
         // Format: "provider:timestamp" (e.g., "github:1234567890")
-        let state_value = format!("{}:{}", provider.as_str(), chrono::Utc::now().timestamp());
+        let state_value = format!("{}:{}", provider.as_str(), Utc::now().timestamp());
         redis
             .set_with_expiry(&state_key, &state_value, 900) // 15 minutes expiration
             .await
@@ -212,7 +212,7 @@ pub async fn oauth_callback(
     // Send welcome email for new OAuth users (non-blocking). Gated on the
     // user's `email_notifications` preference — new accounts default to
     // opted-in so a brand-new signup still gets the welcome.
-    let is_new_user = user.created_at > chrono::Utc::now() - chrono::Duration::minutes(1);
+    let is_new_user = user.created_at > Utc::now() - Duration::minutes(1);
     if is_new_user && user.email_notifications {
         if let Ok(email_service) = crate::email::EmailService::from_env() {
             let welcome_email =

--- a/crates/mockforge-registry-server/src/handlers/otlp.rs
+++ b/crates/mockforge-registry-server/src/handlers/otlp.rs
@@ -440,15 +440,7 @@ pub async fn list_traces(
     // an ERROR status. Root-span name is pulled with a correlated
     // subquery — there's exactly one parent_span_id IS NULL span per
     // well-formed trace.
-    type Row = (
-        String,
-        i64,
-        chrono::DateTime<chrono::Utc>,
-        f64,
-        Option<String>,
-        Option<String>,
-        bool,
-    );
+    type Row = (String, i64, DateTime<Utc>, f64, Option<String>, Option<String>, bool);
 
     let rows: Vec<Row> = if let Some(since) = since {
         sqlx::query_as(

--- a/crates/mockforge-registry-server/src/handlers/public_keys.rs
+++ b/crates/mockforge-registry-server/src/handlers/public_keys.rs
@@ -180,7 +180,7 @@ pub async fn create_my_public_key(
     state
         .store
         .record_audit_event(
-            uuid::Uuid::nil(),
+            Uuid::nil(),
             Some(user_id),
             AuditEventType::PublisherKeyCreated,
             format!("Publisher key '{}' created", saved.label),
@@ -242,7 +242,7 @@ pub async fn revoke_my_public_key(
     state
         .store
         .record_audit_event(
-            uuid::Uuid::nil(),
+            Uuid::nil(),
             Some(user_id),
             AuditEventType::PublisherKeyRevoked,
             format!("Publisher key {} revoked", key_id),
@@ -322,7 +322,7 @@ pub async fn rotate_my_public_key(
     state
         .store
         .record_audit_event(
-            uuid::Uuid::nil(),
+            Uuid::nil(),
             Some(user_id),
             AuditEventType::PublisherKeyRotated,
             format!("Publisher key rotated from {} to {}", old_key_id, new_key.id),

--- a/crates/mockforge-registry-server/src/handlers/snapshots.rs
+++ b/crates/mockforge-registry-server/src/handlers/snapshots.rs
@@ -280,7 +280,7 @@ async fn build_workspace_manifest(
 
     let manifest = serde_json::json!({
         "schema_version": 1,
-        "captured_at": chrono::Utc::now(),
+        "captured_at": Utc::now(),
         "workspace_id": workspace_id,
         "partial": partial,
         "counts": {

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -419,7 +419,7 @@ pub async fn delete_sso_config(
 pub async fn get_saml_metadata(
     State(state): State<AppState>,
     Path(org_slug): Path<String>,
-) -> ApiResult<axum::response::Response> {
+) -> ApiResult<Response> {
     // Find organization by slug
     let org = state
         .store
@@ -462,7 +462,7 @@ pub async fn get_saml_metadata(
         slo_url
     );
 
-    axum::response::Response::builder()
+    Response::builder()
         .status(axum::http::StatusCode::OK)
         .header("Content-Type", "application/xml")
         .body(metadata.into())
@@ -614,8 +614,8 @@ pub async fn saml_acs(
     if let Some(assertion_id) = &user_info.assertion_id {
         let expires_at = user_info
             .not_on_or_after
-            .unwrap_or_else(|| chrono::Utc::now() + chrono::Duration::hours(1));
-        let issued_at = user_info.issued_at.unwrap_or_else(chrono::Utc::now);
+            .unwrap_or_else(|| Utc::now() + chrono::Duration::hours(1));
+        let issued_at = user_info.issued_at.unwrap_or_else(Utc::now);
 
         state
             .store
@@ -642,7 +642,7 @@ pub async fn saml_acs(
     }
 
     // Create SSO session
-    let session_expires = chrono::Utc::now() + chrono::Duration::hours(8); // 8 hour session
+    let session_expires = Utc::now() + chrono::Duration::hours(8); // 8 hour session
     let _session = SSOSession::create(
         pool,
         org.id,
@@ -759,7 +759,7 @@ struct SAMLUserInfo {
 /// Generate SAML AuthnRequest XML
 fn generate_saml_authn_request(entity_id: &str, acs_url: &str) -> String {
     let request_id = uuid::Uuid::new_v4().to_string();
-    let issue_instant = chrono::Utc::now().to_rfc3339();
+    let issue_instant = Utc::now().to_rfc3339();
 
     format!(
         r#"<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
@@ -833,20 +833,20 @@ async fn parse_saml_response(
     let not_before = extract_xml_value(xml_str, "NotBefore")
         .or_else(|| extract_xml_value(xml_str, "saml:NotBefore"))
         .or_else(|| extract_xml_value(xml_str, "saml2:NotBefore"))
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&chrono::Utc));
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
 
     let not_on_or_after = extract_xml_value(xml_str, "NotOnOrAfter")
         .or_else(|| extract_xml_value(xml_str, "saml:NotOnOrAfter"))
         .or_else(|| extract_xml_value(xml_str, "saml2:NotOnOrAfter"))
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&chrono::Utc));
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
 
     let issued_at = extract_xml_value(xml_str, "IssueInstant")
         .or_else(|| extract_xml_value(xml_str, "saml:IssueInstant"))
         .or_else(|| extract_xml_value(xml_str, "saml2:IssueInstant"))
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&chrono::Utc));
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
 
     // Extract attributes based on attribute mapping
     let mut attributes = serde_json::json!({});
@@ -1155,7 +1155,7 @@ fn parse_saml_logout_request(request_xml: &[u8]) -> Result<Option<String>, ApiEr
 /// Generate SAML logout response
 fn generate_saml_logout_response(slo_url: &str) -> String {
     let response_id = uuid::Uuid::new_v4().to_string();
-    let issue_instant = chrono::Utc::now().to_rfc3339();
+    let issue_instant = Utc::now().to_rfc3339();
 
     format!(
         r#"<samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
@@ -1226,7 +1226,7 @@ async fn find_or_create_user_from_saml(
 /// Validate SAML assertion timestamps (NotBefore/NotOnOrAfter)
 /// Prevents replay attacks by ensuring assertions are within valid time window
 fn validate_saml_timestamps(user_info: &SAMLUserInfo) -> Result<(), ApiError> {
-    let now = chrono::Utc::now();
+    let now = Utc::now();
 
     // Check NotBefore (assertion not valid before this time)
     if let Some(not_before) = user_info.not_before {

--- a/crates/mockforge-registry-server/src/handlers/test_suites.rs
+++ b/crates/mockforge-registry-server/src/handlers/test_suites.rs
@@ -161,7 +161,7 @@ pub async fn delete_suite(
 /// serde collapses both into `None`.
 fn deserialize_double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
 where
-    T: serde::Deserialize<'de>,
+    T: Deserialize<'de>,
     D: serde::Deserializer<'de>,
 {
     Option::<T>::deserialize(deserializer).map(Some)

--- a/crates/mockforge-registry-server/src/handlers/tunnels.rs
+++ b/crates/mockforge-registry-server/src/handlers/tunnels.rs
@@ -405,7 +405,7 @@ async fn load_authorized_tunnel(
 /// PATCH-semantics double-option deserializer (same pattern as test_suites).
 fn deserialize_double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
 where
-    T: serde::Deserialize<'de>,
+    T: Deserialize<'de>,
     D: serde::Deserializer<'de>,
 {
     Option::<T>::deserialize(deserializer).map(Some)

--- a/crates/mockforge-registry-server/src/handlers/workspace_import.rs
+++ b/crates/mockforge-registry-server/src/handlers/workspace_import.rs
@@ -283,8 +283,8 @@ pub async fn import_to_workspace(
     )?;
 
     // Optionally bucket routes into one folder per HTTP method.
-    let method_folder_cache: std::collections::HashMap<String, Uuid> = if create_folders {
-        let mut cache = std::collections::HashMap::new();
+    let method_folder_cache: HashMap<String, Uuid> = if create_folders {
+        let mut cache = HashMap::new();
         let mut unique_methods: Vec<String> =
             parsed.routes.iter().map(|r| r.method.to_uppercase()).collect();
         unique_methods.sort();
@@ -302,7 +302,7 @@ pub async fn import_to_workspace(
         }
         cache
     } else {
-        std::collections::HashMap::new()
+        HashMap::new()
     };
 
     let mut imported = 0usize;

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
 
     // Initialize pillar tracking with analytics database
     if let Some(ref analytics_db) = analytics_db {
-        let db_arc = std::sync::Arc::new(analytics_db.clone());
+        let db_arc = Arc::new(analytics_db.clone());
         pillar_tracking_init::init_pillar_tracking(Some(db_arc)).await;
     }
 
@@ -342,7 +342,7 @@ fn create_app(state: AppState, rate_limiter: RateLimiterState) -> Router {
         .with_state(state)
 }
 
-async fn metrics_handler() -> impl axum::response::IntoResponse {
+async fn metrics_handler() -> impl IntoResponse {
     use mockforge_observability::get_global_registry;
     use prometheus::{Encoder, TextEncoder};
 

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -614,7 +614,7 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         )
         .route(
             "/api/v1/monitored-services/{id}",
-            axum::routing::delete(handlers::contract_verification::delete_monitored_service),
+            delete(handlers::contract_verification::delete_monitored_service),
         )
         .route(
             "/api/v1/monitored-services/{id}/diffs",
@@ -649,7 +649,7 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         )
         .route(
             "/api/v1/verification-suites/{id}",
-            axum::routing::delete(handlers::contract_verification::delete_verification_suite),
+            delete(handlers::contract_verification::delete_verification_suite),
         )
         // Recorder + Behavioral cloning (cloud-enablement #6 / Phase 1).
         // Training worker / replay endpoint / per-capture cloud-shipping
@@ -665,7 +665,7 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         )
         .route(
             "/api/v1/capture-sessions/{id}",
-            axum::routing::delete(handlers::captures::delete_session),
+            delete(handlers::captures::delete_session),
         )
         .route(
             "/api/v1/workspaces/{workspace_id}/clone-models",

--- a/crates/mockforge-registry-server/tests/marketplace_e2e.rs
+++ b/crates/mockforge-registry-server/tests/marketplace_e2e.rs
@@ -654,6 +654,6 @@ async fn test_template_star_flow() {
     assert_eq!(got["stats"]["stars"], json!(0), "live stars should be 0");
 
     // Anonymous POST to star endpoint must be rejected.
-    let anon = reqwest::Client::new().post(&star_path).send().await.expect("anonymous request");
+    let anon = Client::new().post(&star_path).send().await.expect("anonymous request");
     assert_eq!(anon.status().as_u16(), 401, "anonymous star should be 401");
 }

--- a/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
+++ b/crates/mockforge-smtp/tests/smtp_deliver_e2e.rs
@@ -28,7 +28,7 @@ async fn free_port() -> u16 {
 async fn wait_for_port(port: u16, max: Duration) {
     let deadline = tokio::time::Instant::now() + max;
     loop {
-        if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+        if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
             return;
         }
         if tokio::time::Instant::now() >= deadline {

--- a/crates/mockforge-test-runner/src/executors/replay.rs
+++ b/crates/mockforge-test-runner/src/executors/replay.rs
@@ -264,7 +264,7 @@ async fn replay_one(
         }
     }
 
-    let started = std::time::Instant::now();
+    let started = Instant::now();
     let resp = match req.send().await {
         Ok(r) => r,
         Err(e) => {

--- a/crates/mockforge-test-runner/src/executors/test.rs
+++ b/crates/mockforge-test-runner/src/executors/test.rs
@@ -1072,7 +1072,7 @@ async fn run_real_bench(
         .unwrap_or_else(|_| reqwest::Client::new());
 
     let target = target_url.to_string();
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(duration_secs);
+    let deadline = Instant::now() + std::time::Duration::from_secs(duration_secs);
     let mut handles = Vec::with_capacity(concurrency as usize);
     for _ in 0..concurrency {
         let client = client.clone();
@@ -1081,8 +1081,8 @@ async fn run_real_bench(
             let mut latencies_ns: Vec<u128> = Vec::new();
             let mut ok = 0u64;
             let mut err = 0u64;
-            while std::time::Instant::now() < deadline {
-                let started = std::time::Instant::now();
+            while Instant::now() < deadline {
+                let started = Instant::now();
                 match client.get(&target).send().await {
                     Ok(resp) => {
                         if resp.status().is_success() {

--- a/crates/mockforge-tunnel/src/server.rs
+++ b/crates/mockforge-tunnel/src/server.rs
@@ -464,15 +464,17 @@ async fn forward_request(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    // Convert method
+    // Convert method. axum re-exports `http::Method`; reqwest uses the same
+    // underlying type, so we can construct via the in-scope `Method` without
+    // the redundant `reqwest::` prefix.
     let reqwest_method = match *method {
-        Method::GET => reqwest::Method::GET,
-        Method::POST => reqwest::Method::POST,
-        Method::PUT => reqwest::Method::PUT,
-        Method::DELETE => reqwest::Method::DELETE,
-        Method::PATCH => reqwest::Method::PATCH,
-        Method::HEAD => reqwest::Method::HEAD,
-        Method::OPTIONS => reqwest::Method::OPTIONS,
+        Method::GET => Method::GET,
+        Method::POST => Method::POST,
+        Method::PUT => Method::PUT,
+        Method::DELETE => Method::DELETE,
+        Method::PATCH => Method::PATCH,
+        Method::HEAD => Method::HEAD,
+        Method::OPTIONS => Method::OPTIONS,
         _ => {
             warn!("Unsupported method: {}", method);
             return Err(StatusCode::METHOD_NOT_ALLOWED);

--- a/crates/mockforge-ws/src/handlers.rs
+++ b/crates/mockforge-ws/src/handlers.rs
@@ -1165,7 +1165,7 @@ mod tests {
 
     #[test]
     fn test_handler_error_json_error() {
-        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
+        let json_err = serde_json::from_str::<Value>("invalid").unwrap_err();
         let err = HandlerError::JsonError(json_err);
         assert!(err.to_string().contains("JSON"));
     }

--- a/examples/plugins/response-graphql/src/lib.rs
+++ b/examples/plugins/response-graphql/src/lib.rs
@@ -536,7 +536,7 @@ mod tests {
         // Test GraphQL content type
         let mut headers = HeaderMap::new();
         headers.insert("content-type", HeaderValue::from_static("application/graphql"));
-        let request = mockforge_plugin_core::ResponseRequest {
+        let request = ResponseRequest {
             method: Method::POST,
             uri: "/graphql".to_string(),
             path: "/graphql".to_string(),
@@ -555,7 +555,7 @@ mod tests {
         // Test JSON content type
         let mut headers = HeaderMap::new();
         headers.insert("content-type", HeaderValue::from_static("application/json"));
-        let request = mockforge_plugin_core::ResponseRequest {
+        let request = ResponseRequest {
             method: Method::POST,
             uri: "/graphql".to_string(),
             path: "/graphql".to_string(),
@@ -588,7 +588,7 @@ mod tests {
         let context =
             PluginContext::new(PluginId::new("graphql-response"), PluginVersion::new(1, 0, 0));
 
-        let request = mockforge_plugin_core::ResponseRequest {
+        let request = ResponseRequest {
             method: Method::POST,
             uri: "/graphql".to_string(),
             path: "/graphql".to_string(),


### PR DESCRIPTION
**Closes #509. Final batch.** Workspace-wide audit now reports **zero** \`-Dunused_qualifications\` violations across all crates and targets. The backlog from #500 is fully drained.

Stacked on PR #508 so the audit can reach these crates.

## 17 files / 6 crates

| Pattern | Sites |
|---|---|
| \`std::mem::size_of_val/size_of\` → \`size_of_val\`/\`size_of\` (in prelude since Rust 1.80) | http/{file_server,verification}.rs, kafka/tests/fixture_triggers.rs, recorder/{api,sync_drift,sync_traffic}.rs |
| \`uuid::Uuid\` → \`Uuid\` | http/handlers/{semantic_drift,threat_modeling}.rs |
| \`crate::middleware::*\` → \`middleware::*\` (sibling module already in scope) | http/lib.rs (RateLimitConfig, GlobalRateLimiter, behavioral_cloning) |
| \`axum::body::Body::empty()\` → \`Body::empty()\` | http/op_middleware.rs |
| \`axum::http::HeaderName\` / \`HeaderValue\` → short forms (added to existing axum import) | http/tests/deceptive_deploy_test.rs |
| \`crate::models::RequestContext\` → \`RequestContext\` (already \`use crate::models::*\`) | recorder/protocols/{graphql,grpc}.rs |
| \`crate::diff::ComparisonResult\` → \`ComparisonResult\` (already imported) | recorder/sync_snapshots.rs |
| \`crate::sync::DetectedChange\` → \`DetectedChange\` (already imported) | recorder/sync_traffic.rs (7 sites) |
| \`broker::MqttConfig\`, \`fixtures::MqttFixtureRegistry\`, \`spec_registry::MqttSpecRegistry\`, \`topics::TopicTree\` → short forms (re-exported at crate root) | mqtt/lib.rs |
| \`serde_json::Value\` → \`Value\` (already imported) | grpc/dynamic/http_bridge/handlers.rs, ws/handlers.rs |

**Notable left alone**: \`qos::QoS\` in \`mqtt/lib.rs\`. \`QoS\` is re-exported at the crate root as \`ProtocolQoS\` (renamed), so the unqualified \`QoS\` doesn't resolve. Kept the qualified form.

## Promotion path

With the backlog clean, the next step is to move \`-Dunused_qualifications\` from \`scripts/lint-warning-ratchet-preview.sh\`'s RUSTFLAGS into the regular ratchet so new submitters can't re-introduce the pattern. One-line move, deferred to its own PR for visibility.

## Test plan

- [x] \`cargo fmt --all --check\` clean.
- [x] \`RUSTFLAGS=\"-Awarnings -Dunused_qualifications\" cargo check --workspace --all-targets --all-features\` reports **zero hits**.
- [x] Scoped clippy clean on the 6 affected crates.