### PR TITLE
ci: stop rustup-init from polluting ~/.profile (#510)

### DIFF
--- a/.github/actions/rust-toolchain/action.yml
+++ b/.github/actions/rust-toolchain/action.yml
@@ -1,0 +1,44 @@
+name: 'Install Rust toolchain (no profile pollution)'
+description: >
+  Drop-in wrapper for dtolnay/rust-toolchain that pre-seeds a rustup symlink
+  in $CARGO_HOME/bin before the upstream action runs. Without this, when our
+  workflows set CARGO_HOME=/tmp/cargo-mockforge-<run_id>, dtolnay sees an
+  empty $CARGO_HOME, invokes rustup-init, and rustup-init defaults to
+  appending `. "$CARGO_HOME/env"` to ~/.profile. After the tmp dir is wiped
+  the source line dangles, breaking shells that resolve cargo via .profile.
+  See SaaSy-Solutions/mockforge#510 for the full incident write-up.
+
+inputs:
+  toolchain:
+    description: 'Rust toolchain to install (passed through to dtolnay/rust-toolchain).'
+    required: false
+    default: 'stable'
+  components:
+    description: 'Comma-separated rustup components (clippy, rustfmt, ...). Passed through.'
+    required: false
+    default: ''
+  targets:
+    description: 'Comma-separated target triples to add. Passed through.'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Pre-seed rustup symlink in CARGO_HOME/bin (avoid rustup-init .profile write)
+      shell: bash
+      run: |
+        # Only matters on the self-hosted runner where /home/actions/.cargo/bin/rustup
+        # is preinstalled. On hosted runners $CARGO_HOME defaults to ~/.cargo and this
+        # is a no-op.
+        if [ -x /home/actions/.cargo/bin/rustup ] && [ -n "$CARGO_HOME" ] && [ ! -x "$CARGO_HOME/bin/rustup" ]; then
+          mkdir -p "$CARGO_HOME/bin"
+          ln -sf /home/actions/.cargo/bin/rustup "$CARGO_HOME/bin/rustup"
+        fi
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for baseline comparison
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/rust-toolchain
 
       - name: Cache cargo registry
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: ./.github/actions/rust-toolchain
       with:
         toolchain: ${{ matrix.rust }}
         components: rustfmt, clippy
@@ -151,7 +151,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: ./.github/actions/rust-toolchain
 
     - name: Install protoc (protobuf compiler)
       run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'
@@ -173,7 +173,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: ./.github/actions/rust-toolchain
 
     - name: Install protoc (protobuf compiler)
       run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'
@@ -192,7 +192,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: ./.github/actions/rust-toolchain
 
     - name: Install protoc (protobuf compiler)
       run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'
@@ -232,7 +232,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: ./.github/actions/rust-toolchain
       with:
         components: llvm-tools-preview
 
@@ -263,7 +263,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust toolchain (MSRV)
-      uses: dtolnay/rust-toolchain@stable
+      uses: ./.github/actions/rust-toolchain
       with:
         toolchain: "1.91"  # MSRV - matches highest requirement from dependencies (aws-sdk, async-graphql, time)
 
@@ -353,7 +353,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: ./.github/actions/rust-toolchain
       with:
         targets: ${{ matrix.target }}
 

--- a/.github/workflows/contract-diff.yml
+++ b/.github/workflows/contract-diff.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/rust-toolchain
 
       - name: Install protoc
         run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/rust-toolchain
         with:
           components: rustfmt, clippy
 
@@ -169,7 +169,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/rust-toolchain
 
       # See integration-tests job: heal any stale rustup default pin
       # left by another repo's workflow on this shared runner.

--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/rust-toolchain
 
       - name: Ensure rustup default = stable
         run: rustup default stable


### PR DESCRIPTION
**Closes #510.** Root-cause fix for the issue mockforge#446 worked around on the runner-host side. Per #510's Option A analysis.

## Problem

5 mockforge workflows set \`CARGO_HOME: /tmp/cargo-mockforge-\${{ github.run_id }}\` for parallel-runner isolation. The tmp dir is fresh per run, so when \`dtolnay/rust-toolchain@stable\` runs, it sees an empty \`\$CARGO_HOME\`, invokes \`rustup-init\` to install rustup there, and **rustup-init defaults to appending \`. "\$CARGO_HOME/env"\` to \`~/.profile\`**. After the tmp dir is wiped (per the host-shared cleanup script), the source line dangles. Login shells start printing "No such file or directory" 60+ times.

Original incident: PR #499's Warning Ratchet Preview failed with \`/home/actions/.cargo/bin/cargo: No such file or directory\`. The runner-host cleanup script (in saas-platform infra PR #476) sweeps stale lines every 30 min as a working symptom fix. This PR eliminates the cause.

## Fix

New composite action \`.github/actions/rust-toolchain\` wraps \`dtolnay/rust-toolchain\` with a pre-seed step that symlinks \`\$CARGO_HOME/bin/rustup\` to the persistent \`/home/actions/.cargo/bin/rustup\` (preinstalled on the runner, also used by PR #506's Security Audit verify-only check). dtolnay sees rustup is already installed and skips \`rustup-init\` entirely → no profile write.

The pre-seed step is guarded by \`if [ -x /home/actions/.cargo/bin/rustup ] && [ -n "\$CARGO_HOME" ]\`, so on GHA-hosted runners (where the persistent rustup path doesn't exist) it's a no-op. The 7 mockforge build-binaries matrix entries (ubuntu-latest, macos-latest, windows-latest) hit that no-op path.

## Migration

Replaced \`uses: dtolnay/rust-toolchain@stable\` with \`uses: ./.github/actions/rust-toolchain\` at **12 call sites across 5 workflows** that set CARGO_HOME=/tmp:

| Workflow | Call sites |
|---|---|
| ci.yml | 7 (test, warning-gate, warning-ratchet-preview, security-audit, coverage, msrv, build-binaries) |
| integration-tests.yml | 2 |
| benchmarks.yml | 1 |
| registry-e2e.yml | 1 |
| contract-diff.yml | 1 |

The composite forwards \`toolchain\`, \`components\`, \`targets\` inputs unchanged so call sites need no other change.

**Untouched workflows** (don't set CARGO_HOME=/tmp, so rustup-init never runs and there's no pollution to begin with): release.yml, load-testing.yml, mutation-testing.yml, chaos-testing.yml, docs-check.yml, fuzz.yml, jcs-fuzz.yml.

## After this lands

The runner-host Step 7 patch (saas-platform PR #476) stays in place as defense in depth — it costs nothing and catches anything that re-introduces the pattern from elsewhere on the shared host.

## Test plan

- [x] All 6 modified workflows parse cleanly as YAML (\`python3 -c \"import yaml; yaml.safe_load(open(f))\"\`).
- [x] Composite action's \`action.yml\` parses cleanly.
- [x] Diff is mechanical: same input names threaded through.
- [ ] CI itself will exercise this on the next push. The pre-seed step's stdout/stderr is empty when the symlink work happens (\`ln -sf\`), so observe the absence of new \`. "/tmp/cargo-mockforge-*/env"\` lines in \`/home/actions/.profile\` over the next several runs.