### PR TITLE
feat(registry,ui): cloud-enable Virtual Backends — consistency lifecycle presets (#461)

### DIFF
--- a/crates/mockforge-registry-server/migrations/20250101000075_virtual_entities.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000075_virtual_entities.sql
@@ -1,0 +1,48 @@
+-- Virtual entities table (#461) — workspace-scoped persistent state for
+-- entities materialized when a lifecycle preset is applied to a persona.
+--
+-- The local mockforge-core engine keeps this in an in-process HashMap
+-- (`UnifiedState.entity_state`). Cloud needs durable per-workspace storage
+-- so the Virtual Backends UI shows the same shape users see locally.
+--
+-- Schema mirrors the fields the UI's `consistencyApi.listEntities()`
+-- consumes — `entity_type`, `entity_id`, `data`, `current_state`,
+-- `seen_in_protocols`. Time-driven transition execution lives elsewhere
+-- (or doesn't yet) — this table is the persisted state machine snapshot.
+
+CREATE TABLE IF NOT EXISTS virtual_entities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    -- Logical entity classification. Matches the lifecycle preset id
+    -- (e.g. 'subscription', 'order_fulfillment') when seeded by preset
+    -- application; free-form when populated by other writers later.
+    entity_type TEXT NOT NULL,
+    -- Stable key within (workspace_id, entity_type). For preset-applied
+    -- rows the apply handler defaults this to `{persona_id}:{entity_type}`
+    -- so re-applying is idempotent.
+    entity_id TEXT NOT NULL,
+    -- Optional persona binding — non-null for rows seeded by preset apply.
+    persona_id TEXT,
+    -- Current state name from the preset's state machine (e.g. 'active',
+    -- 'past_due'). Free-form text so future presets / custom state
+    -- machines don't need schema migrations.
+    current_state TEXT,
+    -- Provenance + arbitrary user metadata.
+    data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Which protocols have observed traffic against this entity (HTTP /
+    -- gRPC / etc.). Populated by future request-side writers; the apply
+    -- handler leaves this empty.
+    seen_in_protocols JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (workspace_id, entity_type, entity_id)
+);
+
+-- Workspace + type list view.
+CREATE INDEX IF NOT EXISTS idx_virtual_entities_workspace_type
+    ON virtual_entities(workspace_id, entity_type, updated_at DESC);
+
+-- Persona-scoped queries (e.g. "what's this persona's subscription state").
+CREATE INDEX IF NOT EXISTS idx_virtual_entities_persona
+    ON virtual_entities(workspace_id, persona_id)
+    WHERE persona_id IS NOT NULL;

--- a/crates/mockforge-registry-server/src/handlers/consistency.rs
+++ b/crates/mockforge-registry-server/src/handlers/consistency.rs
@@ -1,0 +1,374 @@
+//! Consistency / Virtual Backends handlers (#461) — Phase 1 surface.
+//!
+//! The Virtual Backends UI surfaces three concerns:
+//!   1. Lifecycle presets — predefined entity state machines (Subscription /
+//!      Loan / Order Fulfillment / User Engagement). Hardcoded the same as
+//!      `mockforge_data::persona_lifecycle::LifecyclePreset` so cloud users
+//!      see the same library local users do.
+//!   2. Virtual entities — workspace-scoped persisted rows that get written
+//!      when a preset is applied to a persona. Empty for new workspaces.
+//!   3. Snapshots — already cloud-enabled via `handlers::snapshots`, the UI
+//!      reuses `cloudSnapshotsApi` from the existing `cloud-snapshots` page.
+//!
+//! Phase 1 ships preset read endpoints + the entities list (empty for new
+//! workspaces) + an `apply` endpoint that materializes a virtual_entity row
+//! for the persona.
+//!
+//! Automatic state transitions (the local engine's job) are not part of
+//! cloud yet — the row reflects the applied initial state and stays there
+//! until the user manually advances it. That's enough to make the UI live
+//! for cloud users while we figure out where the transition driver belongs
+//! server-side.
+//!
+//! Routes:
+//!   GET    /api/v1/consistency/lifecycle-presets
+//!   GET    /api/v1/consistency/lifecycle-presets/{preset_id}
+//!   POST   /api/v1/workspaces/{workspace_id}/consistency/lifecycle-presets/apply
+//!   GET    /api/v1/workspaces/{workspace_id}/consistency/entities[?entity_type=&persona_id=]
+//!   GET    /api/v1/consistency/entities/{id}
+
+use axum::{
+    extract::{Path, Query, State},
+    http::HeaderMap,
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    models::CloudWorkspace,
+    AppState,
+};
+
+#[derive(Debug, Serialize)]
+pub struct LifecyclePreset {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub description: &'static str,
+    pub initial_state: &'static str,
+    pub states: Vec<&'static str>,
+    pub affected_endpoints: Vec<&'static str>,
+}
+
+const PRESETS: &[LifecyclePresetStatic] = &[
+    LifecyclePresetStatic {
+        id: "subscription",
+        name: "Subscription",
+        description: "Subscription lifecycle: NEW → ACTIVE → PAST_DUE → CANCELED",
+        initial_state: "new",
+        states: &["new", "active", "past_due", "canceled"],
+        affected_endpoints: &["billing", "support", "subscription"],
+    },
+    LifecyclePresetStatic {
+        id: "loan",
+        name: "Loan",
+        description: "Loan lifecycle: APPLICATION → APPROVED → ACTIVE → PAST_DUE → DEFAULTED",
+        initial_state: "application",
+        states: &["application", "approved", "active", "past_due", "defaulted"],
+        affected_endpoints: &["loan", "loans", "credit", "application"],
+    },
+    LifecyclePresetStatic {
+        id: "order_fulfillment",
+        name: "Order Fulfillment",
+        description:
+            "Order fulfillment lifecycle: PENDING → PROCESSING → SHIPPED → DELIVERED → COMPLETED",
+        initial_state: "pending",
+        states: &["pending", "processing", "shipped", "delivered", "completed"],
+        affected_endpoints: &["order", "orders", "fulfillment", "shipment", "delivery"],
+    },
+    LifecyclePresetStatic {
+        id: "user_engagement",
+        name: "User Engagement",
+        description: "User engagement lifecycle: NEW → ACTIVE → CHURN_RISK → CHURNED",
+        initial_state: "new",
+        states: &["new", "active", "churn_risk", "churned"],
+        affected_endpoints: &[
+            "profile",
+            "user",
+            "users",
+            "activity",
+            "engagement",
+            "notifications",
+        ],
+    },
+];
+
+/// Static-array variant — what we actually iterate. Public `LifecyclePreset`
+/// is the Serialize-friendly view we hand to the UI.
+struct LifecyclePresetStatic {
+    id: &'static str,
+    name: &'static str,
+    description: &'static str,
+    initial_state: &'static str,
+    states: &'static [&'static str],
+    affected_endpoints: &'static [&'static str],
+}
+
+impl LifecyclePresetStatic {
+    fn as_view(&self) -> LifecyclePreset {
+        LifecyclePreset {
+            id: self.id,
+            name: self.name,
+            description: self.description,
+            initial_state: self.initial_state,
+            states: self.states.to_vec(),
+            affected_endpoints: self.affected_endpoints.to_vec(),
+        }
+    }
+}
+
+fn lookup_preset(id: &str) -> Option<&'static LifecyclePresetStatic> {
+    let id_norm = id.to_lowercase().replace('-', "_");
+    PRESETS.iter().find(|p| p.id == id_norm)
+}
+
+// --- preset read endpoints ------------------------------------------------
+
+/// `GET /api/v1/consistency/lifecycle-presets`
+pub async fn list_lifecycle_presets() -> Json<Vec<LifecyclePreset>> {
+    Json(PRESETS.iter().map(LifecyclePresetStatic::as_view).collect())
+}
+
+/// `GET /api/v1/consistency/lifecycle-presets/{preset_id}`
+pub async fn get_lifecycle_preset(
+    Path(preset_id): Path<String>,
+) -> ApiResult<Json<LifecyclePreset>> {
+    let preset = lookup_preset(&preset_id).ok_or_else(|| {
+        ApiError::InvalidRequest(format!("Unknown lifecycle preset '{preset_id}'"))
+    })?;
+    Ok(Json(preset.as_view()))
+}
+
+// --- virtual entities -----------------------------------------------------
+
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+pub struct VirtualEntity {
+    pub id: Uuid,
+    pub workspace_id: Uuid,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub persona_id: Option<String>,
+    pub current_state: Option<String>,
+    pub data: serde_json::Value,
+    pub seen_in_protocols: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListEntitiesQuery {
+    #[serde(default)]
+    pub entity_type: Option<String>,
+    #[serde(default)]
+    pub persona_id: Option<String>,
+}
+
+/// `GET /api/v1/workspaces/{workspace_id}/consistency/entities`
+pub async fn list_workspace_entities(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(workspace_id): Path<Uuid>,
+    Query(query): Query<ListEntitiesQuery>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Vec<VirtualEntity>>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    let rows: Vec<VirtualEntity> = sqlx::query_as::<_, VirtualEntity>(
+        r#"
+        SELECT id, workspace_id, entity_type, entity_id, persona_id,
+               current_state, data, seen_in_protocols, created_at, updated_at
+        FROM virtual_entities
+        WHERE workspace_id = $1
+          AND ($2::text IS NULL OR entity_type = $2)
+          AND ($3::text IS NULL OR persona_id = $3)
+        ORDER BY updated_at DESC
+        LIMIT 500
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(query.entity_type)
+    .bind(query.persona_id)
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+    Ok(Json(rows))
+}
+
+/// `GET /api/v1/consistency/entities/{id}`
+pub async fn get_entity(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<VirtualEntity>> {
+    let row: Option<VirtualEntity> = sqlx::query_as::<_, VirtualEntity>(
+        r#"
+        SELECT id, workspace_id, entity_type, entity_id, persona_id,
+               current_state, data, seen_in_protocols, created_at, updated_at
+        FROM virtual_entities
+        WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .fetch_optional(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+    let entity = row.ok_or_else(|| ApiError::InvalidRequest("Entity not found".into()))?;
+    authorize_workspace(&state, user_id, &headers, entity.workspace_id).await?;
+    Ok(Json(entity))
+}
+
+// --- apply preset ---------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct ApplyPresetRequest {
+    /// Preset id (case-insensitive, `-` and `_` interchangeable).
+    pub preset: String,
+    /// Persona id the lifecycle is anchored to. Free-form string mirroring
+    /// the local engine's `persona_id`.
+    pub persona_id: String,
+    /// Logical entity type for the row. Defaults to the preset id when
+    /// omitted (e.g. applying `subscription` produces a row of type
+    /// `subscription`).
+    #[serde(default)]
+    pub entity_type: Option<String>,
+    /// Stable entity key. Defaults to `{persona_id}:{entity_type}` so
+    /// re-applying the same preset to the same persona is idempotent and
+    /// resets state instead of duplicating rows.
+    #[serde(default)]
+    pub entity_id: Option<String>,
+}
+
+/// `POST /api/v1/workspaces/{workspace_id}/consistency/lifecycle-presets/apply`
+///
+/// Materializes the preset's initial state as a `virtual_entities` row.
+/// Idempotent on `(workspace_id, entity_type, entity_id)` — re-applying
+/// resets `current_state` and bumps `updated_at`. The actual time-based
+/// transitions the local engine runs aren't modeled here; cloud-side
+/// transition driving is a follow-up once we decide where it belongs.
+pub async fn apply_lifecycle_preset(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(req): Json<ApplyPresetRequest>,
+) -> ApiResult<Json<VirtualEntity>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+
+    let preset = lookup_preset(&req.preset).ok_or_else(|| {
+        ApiError::InvalidRequest(format!(
+            "Unknown lifecycle preset '{}'. Try one of: {}",
+            req.preset,
+            PRESETS.iter().map(|p| p.id).collect::<Vec<_>>().join(", ")
+        ))
+    })?;
+
+    if req.persona_id.trim().is_empty() {
+        return Err(ApiError::InvalidRequest("persona_id must not be empty".into()));
+    }
+
+    let entity_type = req
+        .entity_type
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| preset.id.to_string());
+    let entity_id = req
+        .entity_id
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| format!("{}:{}", req.persona_id, entity_type));
+
+    let row: VirtualEntity = sqlx::query_as::<_, VirtualEntity>(
+        r#"
+        INSERT INTO virtual_entities
+            (workspace_id, entity_type, entity_id, persona_id, current_state,
+             data, seen_in_protocols)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        ON CONFLICT (workspace_id, entity_type, entity_id) DO UPDATE
+            SET persona_id    = EXCLUDED.persona_id,
+                current_state = EXCLUDED.current_state,
+                data          = EXCLUDED.data,
+                updated_at    = NOW()
+        RETURNING id, workspace_id, entity_type, entity_id, persona_id,
+                  current_state, data, seen_in_protocols, created_at, updated_at
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(&entity_type)
+    .bind(&entity_id)
+    .bind(&req.persona_id)
+    .bind(preset.initial_state)
+    .bind(serde_json::json!({
+        "preset_id": preset.id,
+        "preset_name": preset.name,
+        "applied_at": Utc::now(),
+    }))
+    .bind(serde_json::json!([]))
+    .fetch_one(state.db.pool())
+    .await
+    .map_err(ApiError::Database)?;
+
+    Ok(Json(row))
+}
+
+async fn authorize_workspace(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    workspace_id: Uuid,
+) -> ApiResult<()> {
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != workspace.org_id {
+        return Err(ApiError::InvalidRequest("Workspace not found".into()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_preset_case_and_separator_insensitive() {
+        assert!(lookup_preset("subscription").is_some());
+        assert!(lookup_preset("Subscription").is_some());
+        assert!(lookup_preset("SUBSCRIPTION").is_some());
+        assert!(lookup_preset("order_fulfillment").is_some());
+        assert!(lookup_preset("order-fulfillment").is_some());
+        assert!(lookup_preset("OrderFulfillment").is_none()); // case-changes only; we don't camel-split
+        assert!(lookup_preset("not_a_preset").is_none());
+    }
+
+    #[test]
+    fn all_four_presets_are_present() {
+        let names: Vec<&str> = PRESETS.iter().map(|p| p.id).collect();
+        assert_eq!(
+            names,
+            vec![
+                "subscription",
+                "loan",
+                "order_fulfillment",
+                "user_engagement"
+            ]
+        );
+    }
+
+    #[test]
+    fn presets_have_nonempty_state_machines() {
+        for p in PRESETS {
+            assert!(!p.states.is_empty(), "{} has no states", p.id);
+            assert!(
+                p.states.contains(&p.initial_state),
+                "{} initial_state {} not in states {:?}",
+                p.id,
+                p.initial_state,
+                p.states
+            );
+        }
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod cloud_plugin_attachments;
 pub mod cloud_plugins;
 pub mod cloud_services;
 pub mod cloud_workspaces;
+pub mod consistency;
 pub mod contract_verification;
 pub mod faq;
 pub mod federations;

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -527,6 +527,32 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/workspaces/{workspace_id}/resilience/bulkheads/{service}/reset",
             post(handlers::resilience::reset_bulkhead),
         )
+        // Consistency / Virtual Backends routes (#461 / part of #459).
+        // Lifecycle preset library is static (matches mockforge-data); the
+        // workspace-scoped apply + entity-list endpoints back the cloud
+        // VirtualBackendsPage. Time-driven state transitions are not modeled
+        // here — that's a future driver decision; cloud users see the
+        // applied initial state until they reapply.
+        .route(
+            "/api/v1/consistency/lifecycle-presets",
+            get(handlers::consistency::list_lifecycle_presets),
+        )
+        .route(
+            "/api/v1/consistency/lifecycle-presets/{preset_id}",
+            get(handlers::consistency::get_lifecycle_preset),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/consistency/lifecycle-presets/apply",
+            post(handlers::consistency::apply_lifecycle_preset),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/consistency/entities",
+            get(handlers::consistency::list_workspace_entities),
+        )
+        .route(
+            "/api/v1/consistency/entities/{id}",
+            get(handlers::consistency::get_entity),
+        )
         // Flow routes (cloud-enablement task #9 / Phase 1).
         // Unified resource for scenario/orchestration/state_machine/chain
         // editor surfaces. Run trigger reuses #4 test_runs (kind=...).

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -268,6 +268,12 @@ const cloudNavItemIds = new Set([
   // banner so users don't confuse "no breakers configured" with the
   // empty scaffold response.
   'resilience',
+  // Virtual Backends (#461) — entities tab dispatches to
+  // cloudConsistencyApi against /api/v1/workspaces/{id}/consistency/*.
+  // Lifecycle preset library is shared with local mode (static array
+  // server-side); cloud-mode snapshots tab links to the cloud-snapshots
+  // page instead of trying to host two snapshot UIs.
+  'virtual-backends',
   // Cloud incidents — org-wide dashboard wired through cloudIncidentsApi
   // (different feature from drift IncidentDashboard).
   'cloud-incidents',

--- a/crates/mockforge-ui/ui/src/pages/VirtualBackendsPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/VirtualBackendsPage.tsx
@@ -15,6 +15,9 @@ import {
 } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { consistencyApi, snapshotsApi } from '../services/api';
+import { cloudConsistencyApi } from '../services/api/cloudConsistency';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 
 type Tab = 'entities' | 'data' | 'snapshots' | 'settings';
 
@@ -34,14 +37,29 @@ export const VirtualBackendsPage: React.FC = () => {
     const [showCreateSnapshot, setShowCreateSnapshot] = useState(false);
     const queryClient = useQueryClient();
 
+    // Cloud-mode branching (#461). The entities tab swaps over to the
+    // registry's per-workspace consistency endpoints; the snapshots tab
+    // points at the dedicated `cloud-snapshots` page since cloud snapshots
+    // identify by UUID rather than name and warrant their own UI.
+    const cloudMode = isCloudMode();
+    const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+    const workspaceId = activeWorkspace?.id;
+
     // Fetch entities from consistency API
     const {
         data: entitiesData,
         isLoading: entitiesLoading,
         error: entitiesError,
     } = useQuery({
-        queryKey: ['virtual-backend', 'entities'],
-        queryFn: () => consistencyApi.listEntities(),
+        queryKey: ['virtual-backend', 'entities', cloudMode ? workspaceId ?? null : 'local'],
+        // In cloud mode we need an active workspace before we can hit the
+        // per-workspace endpoint; the `enabled` flag below short-circuits
+        // the query until one is selected.
+        queryFn: () =>
+            cloudMode
+                ? cloudConsistencyApi.listEntities(workspaceId!)
+                : consistencyApi.listEntities(),
+        enabled: !cloudMode || !!workspaceId,
     });
 
     // Fetch snapshots
@@ -214,7 +232,14 @@ export const VirtualBackendsPage: React.FC = () => {
 
             {/* Content */}
             <div className="flex-1 bg-card rounded-xl shadow-sm border border-border overflow-hidden">
-                {activeTab === 'entities' && (
+                {activeTab === 'entities' && cloudMode && !workspaceId ? (
+                    <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+                        <Database className="w-12 h-12 mb-3 opacity-20" />
+                        <p>Select a workspace to view virtual entities.</p>
+                    </div>
+                ) : null}
+
+                {activeTab === 'entities' && (!cloudMode || !!workspaceId) && (
                     <div className="p-0">
                         {entitiesLoading ? (
                             <div className="flex items-center justify-center py-16">
@@ -366,7 +391,25 @@ export const VirtualBackendsPage: React.FC = () => {
                     </div>
                 )}
 
-                {activeTab === 'snapshots' && (
+                {activeTab === 'snapshots' && cloudMode && (
+                    // Cloud snapshots identify by UUID (not name) and are
+                    // surfaced on the dedicated Cloud Snapshots page (#10).
+                    // Pointing both UIs at the same data would just duplicate
+                    // the controls — link out instead of half-wiring it here.
+                    <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+                        <History className="w-12 h-12 mb-3 opacity-30" />
+                        <p>Snapshots in cloud mode live on the dedicated page.</p>
+                        <a
+                            href="/cloud-snapshots"
+                            className="mt-3 inline-flex items-center px-3 py-2 bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg text-sm font-medium transition-colors"
+                        >
+                            <History className="w-4 h-4 mr-2" />
+                            Open Cloud Snapshots
+                        </a>
+                    </div>
+                )}
+
+                {activeTab === 'snapshots' && !cloudMode && (
                     <div className="p-6">
                         <div className="flex justify-between items-center mb-6">
                             <h3 className="text-lg font-medium text-foreground">Database Snapshots</h3>

--- a/crates/mockforge-ui/ui/src/services/api/cloudConsistency.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudConsistency.ts
@@ -1,0 +1,144 @@
+/**
+ * Cloud consistency / Virtual Backends API client (#461).
+ *
+ * Backs the registry-side `/api/v1/consistency/*` and
+ * `/api/v1/workspaces/{workspace_id}/consistency/*` routes added in
+ * `mockforge-registry-server::handlers::consistency`.
+ *
+ * The response shapes deliberately mirror what the local
+ * `consistencyApi` (services/api/consistency.ts) returns so the
+ * `VirtualBackendsPage` only needs to swap which service it calls
+ * — not refactor its data plumbing. Time-driven state transitions
+ * the local engine runs aren't part of cloud yet; entities show their
+ * applied initial state until manually re-applied.
+ */
+import { fetchJsonWithErrorBody } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
+
+/** Server-side `LifecyclePreset` shape (consistency.rs). */
+export interface CloudLifecyclePreset {
+  id: string;
+  name: string;
+  description: string;
+  initial_state: string;
+  states: string[];
+  affected_endpoints: string[];
+}
+
+/** Server-side `VirtualEntity` shape (consistency.rs). */
+export interface CloudVirtualEntity {
+  id: string;
+  workspace_id: string;
+  entity_type: string;
+  entity_id: string;
+  persona_id: string | null;
+  current_state: string | null;
+  data: Record<string, unknown>;
+  seen_in_protocols: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ApplyPresetRequest {
+  preset: string;
+  persona_id: string;
+  /** Defaults to the preset id when omitted. */
+  entity_type?: string;
+  /** Defaults to `{persona_id}:{entity_type}` for idempotency. */
+  entity_id?: string;
+}
+
+class CloudConsistencyApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud consistency ${method} only works in cloud mode.`);
+    }
+  }
+
+  async listLifecyclePresets(): Promise<CloudLifecyclePreset[]> {
+    this.guard('listLifecyclePresets');
+    return fetchJsonWithErrorBody(
+      '/api/v1/consistency/lifecycle-presets',
+    ) as Promise<CloudLifecyclePreset[]>;
+  }
+
+  async getLifecyclePreset(presetId: string): Promise<CloudLifecyclePreset> {
+    this.guard('getLifecyclePreset');
+    return fetchJsonWithErrorBody(
+      `/api/v1/consistency/lifecycle-presets/${encodeURIComponent(presetId)}`,
+    ) as Promise<CloudLifecyclePreset>;
+  }
+
+  async applyLifecyclePreset(
+    workspaceId: string,
+    body: ApplyPresetRequest,
+  ): Promise<CloudVirtualEntity> {
+    this.guard('applyLifecyclePreset');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/consistency/lifecycle-presets/apply`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    ) as Promise<CloudVirtualEntity>;
+  }
+
+  /**
+   * List entities for a workspace. Returns the data wrapped in the same
+   * `{workspace, entities, count}` envelope the local `consistencyApi`
+   * uses — keeps `VirtualBackendsPage` from needing two code paths just
+   * to unpack the response.
+   */
+  async listEntities(
+    workspaceId: string,
+    opts?: { entityType?: string; personaId?: string },
+  ): Promise<{
+    workspace: string;
+    entities: Array<{
+      entity_type: string;
+      entity_id: string;
+      data: Record<string, unknown>;
+      seen_in_protocols: string[];
+      created_at: string;
+      updated_at: string;
+      persona_id: string | null;
+    }>;
+    count: number;
+  }> {
+    this.guard('listEntities');
+    const qs = new URLSearchParams();
+    if (opts?.entityType) qs.set('entity_type', opts.entityType);
+    if (opts?.personaId) qs.set('persona_id', opts.personaId);
+    const suffix = qs.toString() ? `?${qs.toString()}` : '';
+    const rows = (await fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/consistency/entities${suffix}`,
+    )) as CloudVirtualEntity[];
+
+    // Adapt to the local-shape envelope. We drop the synthetic UUID/workspace_id
+    // fields because the page never reads them; persona_id/current_state stay
+    // on the row for any future use.
+    return {
+      workspace: workspaceId,
+      count: rows.length,
+      entities: rows.map((r) => ({
+        entity_type: r.entity_type,
+        entity_id: r.entity_id,
+        data: r.data,
+        seen_in_protocols: r.seen_in_protocols,
+        created_at: r.created_at,
+        updated_at: r.updated_at,
+        persona_id: r.persona_id,
+      })),
+    };
+  }
+
+  async getEntity(id: string): Promise<CloudVirtualEntity> {
+    this.guard('getEntity');
+    return fetchJsonWithErrorBody(
+      `/api/v1/consistency/entities/${encodeURIComponent(id)}`,
+    ) as Promise<CloudVirtualEntity>;
+  }
+}
+
+export const cloudConsistencyApi = new CloudConsistencyApi();


### PR DESCRIPTION
## Summary

Part of #459. The local `VirtualBackendsPage` was held back from cloud mode by `consistencyApi.listEntities()` having no cloud sibling. Snapshots were already cloud-enabled via the dedicated `cloud-snapshots` page.

## Server

- New migration `20250101000075_virtual_entities.sql` — workspace-scoped `virtual_entities` table mirroring the local `UnifiedState.entity_state` shape. Unique on `(workspace_id, entity_type, entity_id)` so re-applying a preset to the same persona is idempotent.
- New `handlers::consistency` module wiring five routes:
  - `GET /api/v1/consistency/lifecycle-presets`
  - `GET /api/v1/consistency/lifecycle-presets/{preset_id}`
  - `POST /api/v1/workspaces/{workspace_id}/consistency/lifecycle-presets/apply`
  - `GET /api/v1/workspaces/{workspace_id}/consistency/entities`
  - `GET /api/v1/consistency/entities/{id}`
- Workspace authz lifted from existing handlers — preset reads are global, entity/apply paths are workspace-scoped + org-matched.
- Time-driven state transitions stay out of scope; cloud entities show the applied initial state until manually re-applied. The driver decision is better tackled with the clock work (#466).

## UI

- New `services/api/cloudConsistency.ts` mirrors the cloud handler shapes and adapts `listEntities()` into the same `{workspace, entities, count}` envelope the local `consistencyApi` returns, so `VirtualBackendsPage` doesn't need two unpacking code paths.
- `VirtualBackendsPage` branches on `isCloudMode()`: entities/data tabs swap to `cloudConsistencyApi` against the active workspace, and the snapshots tab in cloud mode links out to the dedicated `cloud-snapshots` page rather than duplicating snapshot controls.
- Allowlisted `virtual-backends` in `cloudNavItemIds`.

## Out of scope (intentionally)

- Live entity replay against hosted-mocks
- Time-driven transitions of stored entities (no server-side driver yet)
- Cloud snapshots integration into VirtualBackendsPage itself — `cloud-snapshots` page covers that

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-registry-server --lib` — 393 passed
- [x] New unit tests in `handlers::consistency::tests`: 3 covering preset lookup case-insensitivity, preset library completeness, and state-machine integrity
- [x] `pnpm type-check` clean
- [x] `pnpm lint` — 0 errors in changed files (912 pre-existing warnings unchanged)
- [ ] Manual smoke against a running registry + database (not yet run; will exercise post-merge with the existing e2e harness)

Closes #461