### PR TITLE
feat(registry,ui): cloud scaffold for Resilience dashboard (#468 Phase 1)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -38,6 +38,7 @@ pub mod plugins;
 pub mod projects;
 pub mod public_keys;
 pub mod request_verification;
+pub mod resilience;
 pub mod reviews;
 pub mod routing_rules;
 pub mod runtime_logs;

--- a/crates/mockforge-registry-server/src/handlers/resilience.rs
+++ b/crates/mockforge-registry-server/src/handlers/resilience.rs
@@ -1,0 +1,239 @@
+//! Cloud resilience handlers (#468) — Phase 1 (cloud scaffold).
+//!
+//! The local `ResiliencePage` reads circuit-breaker + bulkhead state from
+//! `/api/resilience/*`. The state managers
+//! (`mockforge_chaos::resilience::CircuitBreakerManager` / `BulkheadManager`)
+//! exist, but no part of `mockforge-cli serve`, the admin-UI binary, or the
+//! hosted-mock runtime daemon currently installs them as middleware in the
+//! request path. That gap is the actual #468 work; the runtime wire-up is
+//! tracked separately in the #468 description after the scope correction.
+//!
+//! This Phase 1 ships the *cloud-side API surface* so:
+//!   - The UI can branch on `isCloudMode()` and call the registry instead
+//!     of the never-mounted local routes.
+//!   - The future runtime PR has a stable contract to wire its state into.
+//!   - The `resilience` nav item is unblocked from `cloudHiddenNavItemIds`.
+//!
+//! Endpoints return empty payloads with a top-level `runtime_state` field
+//! carrying `"pending"` so the UI can render an honest empty state instead
+//! of a generic spinner. Once the runtime ingest channel lands, this module
+//! reads from a `runtime_resilience_state` table (or equivalent) and
+//! flips `runtime_state` to `"live"`.
+//!
+//! Routes:
+//!   GET  /api/v1/workspaces/{workspace_id}/resilience/circuit-breakers
+//!   GET  /api/v1/workspaces/{workspace_id}/resilience/bulkheads
+//!   GET  /api/v1/workspaces/{workspace_id}/resilience/summary
+//!   POST /api/v1/workspaces/{workspace_id}/resilience/circuit-breakers/{endpoint}/reset
+//!   POST /api/v1/workspaces/{workspace_id}/resilience/bulkheads/{service}/reset
+
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
+use serde::Serialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    models::CloudWorkspace,
+    AppState,
+};
+
+/// Cloud circuit-breaker state. Mirrors
+/// `mockforge_chaos::resilience_api::CircuitBreakerStateResponse` so the UI
+/// can swap services without changing its types.
+#[derive(Debug, Clone, Serialize)]
+pub struct CircuitBreakerStateResponse {
+    pub endpoint: String,
+    pub state: String,
+    pub stats: CircuitStatsResponse,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CircuitStatsResponse {
+    pub total_requests: u64,
+    pub successful_requests: u64,
+    pub failed_requests: u64,
+    pub rejected_requests: u64,
+    pub consecutive_failures: u64,
+    pub consecutive_successes: u64,
+    pub success_rate: f64,
+    pub failure_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BulkheadStateResponse {
+    pub service: String,
+    pub stats: BulkheadStatsResponse,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BulkheadStatsResponse {
+    pub active_requests: u32,
+    pub queued_requests: u32,
+    pub total_requests: u64,
+    pub rejected_requests: u64,
+    pub timeout_requests: u64,
+    pub utilization_percent: f64,
+}
+
+/// Envelope wrapping each GET response with a `runtime_state` discriminator.
+///
+/// The UI checks this field to decide between "no breakers configured yet"
+/// (empty + state=`live`) and "runtime instrumentation not yet wired"
+/// (empty + state=`pending`). Once runtime ingest lands, the inner `data`
+/// list populates and `runtime_state` stays `live`.
+#[derive(Debug, Serialize)]
+pub struct ResilienceEnvelope<T: Serialize> {
+    pub runtime_state: &'static str,
+    pub data: Vec<T>,
+}
+
+impl<T: Serialize> ResilienceEnvelope<T> {
+    fn pending() -> Self {
+        Self {
+            runtime_state: "pending",
+            data: Vec::new(),
+        }
+    }
+}
+
+// --- GET handlers ---------------------------------------------------------
+
+pub async fn list_circuit_breakers(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<ResilienceEnvelope<CircuitBreakerStateResponse>>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    // Runtime wire-up is pending; return empty + pending discriminator.
+    Ok(Json(ResilienceEnvelope::pending()))
+}
+
+pub async fn list_bulkheads(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<ResilienceEnvelope<BulkheadStateResponse>>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    Ok(Json(ResilienceEnvelope::pending()))
+}
+
+pub async fn get_summary(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Value>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    // Same shape as `mockforge_chaos::resilience_api::get_dashboard_summary`
+    // so the UI's summary cards render identically; `runtime_state` flags
+    // the data as scaffold rather than live.
+    Ok(Json(json!({
+        "runtime_state": "pending",
+        "circuit_breakers": {
+            "total": 0,
+            "open": 0,
+            "half_open": 0,
+            "closed": 0,
+        },
+        "bulkheads": {
+            "total": 0,
+            "active_requests": 0,
+            "queued_requests": 0,
+        },
+    })))
+}
+
+// --- POST handlers --------------------------------------------------------
+
+/// Reset a circuit breaker. No-ops while the runtime ingest channel is
+/// pending; returns the same JSON envelope shape `{accepted, runtime_state,
+/// reason}` for both states so the UI doesn't need conditional parsing once
+/// the live runtime lands.
+pub async fn reset_circuit_breaker(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path((workspace_id, endpoint)): Path<(Uuid, String)>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Value>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    tracing::info!(
+        %workspace_id,
+        endpoint = %endpoint,
+        "circuit-breaker reset requested while runtime wire-up is pending",
+    );
+    Ok(Json(json!({
+        "accepted": false,
+        "runtime_state": "pending",
+        "reason": "Resilience runtime wire-up is pending; this reset is a no-op until it lands.",
+    })))
+}
+
+pub async fn reset_bulkhead(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path((workspace_id, service)): Path<(Uuid, String)>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Value>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    tracing::info!(
+        %workspace_id,
+        service = %service,
+        "bulkhead reset requested while runtime wire-up is pending",
+    );
+    Ok(Json(json!({
+        "accepted": false,
+        "runtime_state": "pending",
+        "reason": "Resilience runtime wire-up is pending; this reset is a no-op until it lands.",
+    })))
+}
+
+// --- helpers --------------------------------------------------------------
+
+async fn authorize_workspace(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    workspace_id: Uuid,
+) -> ApiResult<()> {
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != workspace.org_id {
+        return Err(ApiError::InvalidRequest("Workspace not found".into()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_pending_is_empty() {
+        let env: ResilienceEnvelope<CircuitBreakerStateResponse> = ResilienceEnvelope::pending();
+        assert_eq!(env.runtime_state, "pending");
+        assert!(env.data.is_empty());
+    }
+
+    #[test]
+    fn envelope_serialization_matches_contract() {
+        // The UI keys off `runtime_state` and `data`. Lock the JSON shape
+        // so a refactor doesn't silently break the client.
+        let env: ResilienceEnvelope<CircuitBreakerStateResponse> = ResilienceEnvelope::pending();
+        let body = serde_json::to_value(&env).unwrap();
+        assert_eq!(body["runtime_state"], "pending");
+        assert!(body["data"].is_array());
+        assert_eq!(body["data"].as_array().unwrap().len(), 0);
+    }
+}

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -503,6 +503,30 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/snapshots/{id}/restore",
             post(handlers::snapshots::restore_snapshot),
         )
+        // Resilience scaffold routes (#468 / part of #459) — see
+        // handlers::resilience for the runtime-wire-up gap. Endpoints
+        // return empty payloads tagged `runtime_state: "pending"`; the
+        // UI renders that as an honest empty-state instead of a spinner.
+        .route(
+            "/api/v1/workspaces/{workspace_id}/resilience/circuit-breakers",
+            get(handlers::resilience::list_circuit_breakers),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/resilience/bulkheads",
+            get(handlers::resilience::list_bulkheads),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/resilience/summary",
+            get(handlers::resilience::get_summary),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/resilience/circuit-breakers/{endpoint}/reset",
+            post(handlers::resilience::reset_circuit_breaker),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/resilience/bulkheads/{service}/reset",
+            post(handlers::resilience::reset_bulkhead),
+        )
         // Flow routes (cloud-enablement task #9 / Phase 1).
         // Unified resource for scenario/orchestration/state_machine/chain
         // editor surfaces. Run trigger reuses #4 test_runs (kind=...).

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -261,6 +261,13 @@ const cloudNavItemIds = new Set([
   // Cloud snapshots — synchronous capture / diff / restore for the
   // active workspace via cloudSnapshotsApi.
   'cloud-snapshots',
+  // Resilience dashboard (#468 cloud scaffold) — circuit-breaker /
+  // bulkhead state via cloudResilienceApi. Phase 1 returns
+  // `runtime_state: 'pending'` because the hosted-mock runtime hasn't
+  // wired the middleware yet; the page shows an explicit pending
+  // banner so users don't confuse "no breakers configured" with the
+  // empty scaffold response.
+  'resilience',
   // Cloud incidents — org-wide dashboard wired through cloudIncidentsApi
   // (different feature from drift IncidentDashboard).
   'cloud-incidents',

--- a/crates/mockforge-ui/ui/src/pages/ResiliencePage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ResiliencePage.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useWebSocket } from '../hooks/useWebSocket';
+import { isCloudMode } from '../utils/cloudMode';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
+import { cloudResilienceApi, type RuntimeState } from '../services/api/cloudResilience';
 
 interface CircuitBreakerState {
   endpoint: string;
@@ -48,9 +51,28 @@ export const ResiliencePage: React.FC = () => {
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
   const [selectedTab, setSelectedTab] = useState<'circuit-breakers' | 'bulkheads'>('circuit-breakers');
   const [autoRefresh, setAutoRefresh] = useState(true);
+  // `runtime_state: 'pending'` from the cloud scaffold (#468) means the
+  // runtime hasn't wired up middleware yet; we want to swap the auto-refresh
+  // banner for an honest "pending" notice rather than showing zeros that
+  // look like live data.
+  const [runtimeState, setRuntimeState] = useState<RuntimeState | null>(null);
+
+  const cloudMode = isCloudMode();
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const workspaceId = activeWorkspace?.id;
 
   const fetchCircuitBreakers = async () => {
     try {
+      if (cloudMode) {
+        if (!workspaceId) {
+          setCircuitBreakers([]);
+          return;
+        }
+        const env = await cloudResilienceApi.listCircuitBreakers(workspaceId);
+        setCircuitBreakers(env.data);
+        setRuntimeState(env.runtime_state);
+        return;
+      }
       const response = await fetch('/api/resilience/circuit-breakers');
       const data = await response.json();
       setCircuitBreakers(Array.isArray(data) ? data : []);
@@ -61,6 +83,16 @@ export const ResiliencePage: React.FC = () => {
 
   const fetchBulkheads = async () => {
     try {
+      if (cloudMode) {
+        if (!workspaceId) {
+          setBulkheads([]);
+          return;
+        }
+        const env = await cloudResilienceApi.listBulkheads(workspaceId);
+        setBulkheads(env.data);
+        setRuntimeState(env.runtime_state);
+        return;
+      }
       const response = await fetch('/api/resilience/bulkheads');
       const data = await response.json();
       setBulkheads(Array.isArray(data) ? data : []);
@@ -71,6 +103,19 @@ export const ResiliencePage: React.FC = () => {
 
   const fetchSummary = async () => {
     try {
+      if (cloudMode) {
+        if (!workspaceId) {
+          setSummary(null);
+          return;
+        }
+        const s = await cloudResilienceApi.getSummary(workspaceId);
+        setSummary({
+          circuit_breakers: s.circuit_breakers,
+          bulkheads: { ...s.bulkheads },
+        });
+        setRuntimeState(s.runtime_state);
+        return;
+      }
       const response = await fetch('/api/resilience/dashboard/summary');
       const data = await response.json();
       setSummary(data && typeof data === 'object' && !Array.isArray(data) ? data : null);
@@ -81,6 +126,15 @@ export const ResiliencePage: React.FC = () => {
 
   const resetCircuitBreaker = async (endpoint: string) => {
     try {
+      if (cloudMode) {
+        if (!workspaceId) return;
+        const result = await cloudResilienceApi.resetCircuitBreaker(workspaceId, endpoint);
+        if (!result.accepted) {
+          console.info('Circuit breaker reset is a no-op:', result.reason);
+        }
+        fetchCircuitBreakers();
+        return;
+      }
       await fetch(`/api/resilience/circuit-breakers/${encodeURIComponent(endpoint)}/reset`, {
         method: 'POST',
       });
@@ -92,6 +146,15 @@ export const ResiliencePage: React.FC = () => {
 
   const resetBulkhead = async (service: string) => {
     try {
+      if (cloudMode) {
+        if (!workspaceId) return;
+        const result = await cloudResilienceApi.resetBulkhead(workspaceId, service);
+        if (!result.accepted) {
+          console.info('Bulkhead reset is a no-op:', result.reason);
+        }
+        fetchBulkheads();
+        return;
+      }
       await fetch(`/api/resilience/bulkheads/${encodeURIComponent(service)}/reset`, {
         method: 'POST',
       });
@@ -138,6 +201,27 @@ export const ResiliencePage: React.FC = () => {
 
   return (
     <div className="p-6 space-y-6">
+      {/* Pending-runtime banner (#468 cloud scaffold). Stops users wondering
+          why their counts stay at zero. Hides once the runtime ingest lands
+          and the registry starts returning `runtime_state: 'live'`. */}
+      {cloudMode && runtimeState === 'pending' && (
+        <div className="bg-warning-50 border border-warning-200 dark:bg-warning-900/30 dark:border-warning-800 rounded-lg p-4">
+          <p className="font-medium text-warning-700 dark:text-warning-300">
+            Resilience runtime not yet wired
+          </p>
+          <p className="text-sm text-warning-700/80 dark:text-warning-300/80 mt-1">
+            Cloud-side API is live, but hosted-mock runners don&rsquo;t yet install
+            the circuit-breaker / bulkhead middleware. Counters stay at zero
+            until that follow-up ships; resets are accepted but no-op.
+          </p>
+        </div>
+      )}
+      {cloudMode && !workspaceId && (
+        <div className="bg-card border border-border rounded-lg p-4 text-sm text-muted-foreground">
+          Select a workspace to view resilience state.
+        </div>
+      )}
+
       {/* Header */}
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-foreground">Resilience Dashboard</h1>

--- a/crates/mockforge-ui/ui/src/services/api/cloudResilience.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudResilience.ts
@@ -1,0 +1,119 @@
+/**
+ * Cloud resilience API client (#468 Phase 1 — cloud scaffold).
+ *
+ * Backs the registry's `/api/v1/workspaces/{id}/resilience/*` routes.
+ *
+ * Phase 1 always returns `runtime_state: 'pending'` with empty lists because
+ * the hosted-mock runtime doesn't yet install the circuit-breaker / bulkhead
+ * middleware. The wire-up is the bulk of #468 and lives in a follow-up;
+ * shipping the API surface now means `ResiliencePage` can stop calling the
+ * never-mounted `/api/resilience/*` routes and instead render an honest
+ * empty state.
+ *
+ * Reset endpoints return `{ accepted: false, runtime_state: 'pending',
+ * reason }` so the page can surface a "no-op while pending" toast instead
+ * of treating the reset as failed.
+ */
+import { fetchJsonWithErrorBody } from './client';
+import { isCloudMode } from '../../utils/cloudMode';
+
+export type RuntimeState = 'pending' | 'live';
+
+export interface ResilienceEnvelope<T> {
+  runtime_state: RuntimeState;
+  data: T[];
+}
+
+export interface CloudCircuitBreakerState {
+  endpoint: string;
+  state: string;
+  stats: {
+    total_requests: number;
+    successful_requests: number;
+    failed_requests: number;
+    rejected_requests: number;
+    consecutive_failures: number;
+    consecutive_successes: number;
+    success_rate: number;
+    failure_rate: number;
+  };
+}
+
+export interface CloudBulkheadState {
+  service: string;
+  stats: {
+    active_requests: number;
+    queued_requests: number;
+    total_requests: number;
+    rejected_requests: number;
+    timeout_requests: number;
+    utilization_percent: number;
+  };
+}
+
+export interface CloudResilienceSummary {
+  runtime_state: RuntimeState;
+  circuit_breakers: { total: number; open: number; half_open: number; closed: number };
+  bulkheads: { total: number; active_requests: number; queued_requests: number };
+}
+
+export interface CloudResilienceResetResult {
+  accepted: boolean;
+  runtime_state: RuntimeState;
+  reason?: string;
+}
+
+class CloudResilienceApi {
+  private guard(method: string): void {
+    if (!isCloudMode()) {
+      throw new Error(`Cloud resilience ${method} only works in cloud mode.`);
+    }
+  }
+
+  async listCircuitBreakers(
+    workspaceId: string,
+  ): Promise<ResilienceEnvelope<CloudCircuitBreakerState>> {
+    this.guard('listCircuitBreakers');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/resilience/circuit-breakers`,
+    ) as Promise<ResilienceEnvelope<CloudCircuitBreakerState>>;
+  }
+
+  async listBulkheads(workspaceId: string): Promise<ResilienceEnvelope<CloudBulkheadState>> {
+    this.guard('listBulkheads');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/resilience/bulkheads`,
+    ) as Promise<ResilienceEnvelope<CloudBulkheadState>>;
+  }
+
+  async getSummary(workspaceId: string): Promise<CloudResilienceSummary> {
+    this.guard('getSummary');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/resilience/summary`,
+    ) as Promise<CloudResilienceSummary>;
+  }
+
+  async resetCircuitBreaker(
+    workspaceId: string,
+    endpoint: string,
+  ): Promise<CloudResilienceResetResult> {
+    this.guard('resetCircuitBreaker');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/resilience/circuit-breakers/${encodeURIComponent(endpoint)}/reset`,
+      { method: 'POST' },
+    ) as Promise<CloudResilienceResetResult>;
+  }
+
+  async resetBulkhead(
+    workspaceId: string,
+    service: string,
+  ): Promise<CloudResilienceResetResult> {
+    this.guard('resetBulkhead');
+    return fetchJsonWithErrorBody(
+      `/api/v1/workspaces/${workspaceId}/resilience/bulkheads/${encodeURIComponent(service)}/reset`,
+      { method: 'POST' },
+    ) as Promise<CloudResilienceResetResult>;
+  }
+}
+
+export const cloudResilienceApi = new CloudResilienceApi();


### PR DESCRIPTION
## Summary

Part of #459. Phase 1 ships the cloud-side API surface so `ResiliencePage` can branch on `isCloudMode()` and stop pointing at the never-mounted `/api/resilience/*` routes; the runtime wire-up is a follow-up tracked on the same issue.

## Scope correction

The original #468 framing assumed the resilience middleware existed in `mockforge-core` / `mockforge-http` and just needed to be turned on in the hosted-mock runner. Walking the code: the state managers (`mockforge_chaos::resilience::CircuitBreakerManager` / `BulkheadManager`) exist and `mockforge_chaos::resilience_api::create_resilience_router` exists, but **nothing in `mockforge-cli serve`, the admin-UI binary, or the hosted-mock runtime daemon installs the managers as middleware *or* mounts the router**. So `/api/resilience/*` returns 404 even in local mode — the page has been broken for everyone.

Implementing actual middleware is its own concern (intercepting request/response, attributing per-endpoint failures, dispatching to bulkhead admit/release). Scoping that into a single PR with the cloud-enablement was too much risk. Phase 1 here unblocks the UI; Phase 2 wires the runtime.

## Server

- New `handlers::resilience` with five routes:
  - `GET  /api/v1/workspaces/{id}/resilience/circuit-breakers`
  - `GET  /api/v1/workspaces/{id}/resilience/bulkheads`
  - `GET  /api/v1/workspaces/{id}/resilience/summary`
  - `POST /api/v1/workspaces/{id}/resilience/circuit-breakers/{endpoint}/reset`
  - `POST /api/v1/workspaces/{id}/resilience/bulkheads/{service}/reset`
- GETs return a `{runtime_state, data}` envelope with `runtime_state: 'pending'` and empty data; resets return `{accepted: false, runtime_state: 'pending', reason}`. The discriminator lets the UI show an honest pending banner instead of zeros that look like live data, and gives the future runtime PR a stable place to flip the flag to `'live'` without changing the response shape.
- Workspace authz lifted from `handlers::consistency` (org-matched).

## UI

- New `services/api/cloudResilience.ts` mirrors the cloud handler shapes.
- `ResiliencePage` branches on `isCloudMode()`: fetches go through the cloud client, reset clicks log the no-op reason, and a banner makes the runtime gap explicit.
- Allowlisted `resilience` in `cloudNavItemIds`.

## Follow-up (Phase 2, separate PR)

- Install circuit-breaker + bulkhead middleware in the hosted-mock runner. Wire per-request attribution.
- Push runtime state to the registry via the existing log/capture ingest channel (deployment-scoped JWT).
- Flip `runtime_state` to `'live'` and populate `data` from the pushed state.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-registry-server --lib` — 392 passed
- [x] New unit tests in `handlers::resilience::tests` covering envelope pending shape and JSON contract
- [x] `pnpm type-check` clean
- [x] `pnpm lint` — no new errors/warnings in changed files
- [ ] Manual smoke against a running registry (not yet run; will exercise post-merge)

Phase 1 of #468.