### PR TITLE
feat(chaos,cli,ui): resilience middleware + /api/resilience mount (#468 Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -257,7 +257,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2492,7 +2492,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3777,7 +3777,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4180,7 +4180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6082,7 +6082,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -6497,7 +6497,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7063,9 +7063,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7723,6 +7723,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",
+ "tower 0.5.3",
  "tracing",
  "uuid",
 ]
@@ -9399,7 +9400,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9692,7 +9693,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10474,7 +10475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -11541,7 +11542,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11816,7 +11817,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11854,7 +11855,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -12777,7 +12778,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12914,7 +12915,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13777,7 +13778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14900,7 +14901,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15816,7 +15817,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -17209,7 +17210,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/mockforge-chaos/Cargo.toml
+++ b/crates/mockforge-chaos/Cargo.toml
@@ -96,3 +96,6 @@ distributed = ["redis"]
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "test-util"] }
 tempfile = "3.27"
+# Used by `resilience_middleware` tests to drive the layered axum router
+# via `ServiceExt::oneshot` without spinning up a real listener.
+tower = { version = "0.5", features = ["util"] }

--- a/crates/mockforge-chaos/src/lib.rs
+++ b/crates/mockforge-chaos/src/lib.rs
@@ -58,6 +58,7 @@ pub mod reinforcement_learning;
 pub mod request_matcher;
 pub mod resilience;
 pub mod resilience_api;
+pub mod resilience_middleware;
 pub mod scenario_orchestrator;
 pub mod scenario_recorder;
 pub mod scenario_replay;
@@ -206,6 +207,10 @@ pub use resilience::{
     DynamicThresholdAdjuster, FallbackHandler, HealthCheckIntegration, JsonFallbackHandler,
     RetryConfig as ResilienceRetryConfig, RetryPolicy,
 };
+pub use resilience_middleware::{
+    default_resilience_state, resilience_middleware, ResilienceMiddlewareState,
+};
+
 pub use resilience_api::{
     create_resilience_router, BulkheadStateResponse, CircuitBreakerStateResponse,
     ResilienceApiState,

--- a/crates/mockforge-chaos/src/resilience_middleware.rs
+++ b/crates/mockforge-chaos/src/resilience_middleware.rs
@@ -1,0 +1,306 @@
+//! Axum middleware that wires every HTTP request through the
+//! `CircuitBreakerManager` + `BulkheadManager` state objects.
+//!
+//! Without this layer, the resilience managers are inert state holders —
+//! the `/api/resilience/*` dashboard returns empty data because nothing
+//! ever calls `allow_request` / `try_acquire` / `record_success`. This is
+//! Phase 2 of #468; Phase 1 shipped the cloud scaffold so the UI had a
+//! place to talk to.
+//!
+//! ## Behaviour
+//!
+//! * **Circuit breaker** keyed by `"{METHOD} {path}"` so every endpoint
+//!   gets its own breaker. An open breaker short-circuits with 503 and
+//!   `Retry-After: 1`.
+//! * **Bulkhead** keyed by a configurable `service` string (defaults to
+//!   `"http"`) so there's a single global bucket; per-route bulkheads can
+//!   be added later if anyone needs them.
+//! * **Outcome attribution**: only 5xx counts as a circuit-breaker
+//!   failure. 4xx — even 429 from rate limits — represents a client
+//!   problem, not a backend problem, so it does not trip the breaker.
+//!   This matches the convention `record_request` in `resilience.rs` uses
+//!   for SLO bookkeeping elsewhere.
+//! * **Cost when disabled**: `CircuitBreaker.allow_request` and
+//!   `Bulkhead.try_acquire` both short-circuit to "allow" when their
+//!   config has `enabled: false`, so installing the layer with the
+//!   default (disabled) config is essentially free per-request.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Request, State},
+    http::{HeaderValue, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+
+use crate::resilience::{BulkheadError, BulkheadManager, CircuitBreakerManager};
+
+/// Shared state for the resilience middleware. The same `Arc<...Manager>`
+/// instances must be passed to `resilience_api::ResilienceApiState` so the
+/// `/api/resilience/*` dashboard reads what the middleware writes.
+#[derive(Clone)]
+pub struct ResilienceMiddlewareState {
+    pub circuit_manager: Arc<CircuitBreakerManager>,
+    pub bulkhead_manager: Arc<BulkheadManager>,
+    /// Bulkhead key for HTTP traffic. Per-route bulkheads are future
+    /// work — a single global bucket gives the dashboard something
+    /// concrete to show without exploding the breaker/bulkhead count.
+    pub default_service: String,
+}
+
+impl ResilienceMiddlewareState {
+    pub fn new(
+        circuit_manager: Arc<CircuitBreakerManager>,
+        bulkhead_manager: Arc<BulkheadManager>,
+    ) -> Self {
+        Self {
+            circuit_manager,
+            bulkhead_manager,
+            default_service: "http".to_string(),
+        }
+    }
+}
+
+/// Build the middleware state + matching dashboard state with default
+/// (disabled) configs and a fresh Prometheus registry. Both states share
+/// the same `Arc<...Manager>` instances, so `/api/resilience/*` reflects
+/// what the middleware records.
+///
+/// Useful from binaries that don't want to depend on `prometheus` or
+/// `mockforge-chaos::config` directly — the `mockforge-cli` `serve`
+/// command uses this to wire #468 Phase 2 with one call.
+pub fn default_resilience_state(
+) -> (ResilienceMiddlewareState, crate::resilience_api::ResilienceApiState) {
+    use crate::config::{BulkheadConfig, CircuitBreakerConfig};
+    use prometheus::Registry;
+
+    let registry = Arc::new(Registry::new());
+    let circuit =
+        Arc::new(CircuitBreakerManager::new(CircuitBreakerConfig::default(), registry.clone()));
+    let bulkhead = Arc::new(BulkheadManager::new(BulkheadConfig::default(), registry));
+    let mw_state = ResilienceMiddlewareState::new(circuit.clone(), bulkhead.clone());
+    let api_state = crate::resilience_api::ResilienceApiState {
+        circuit_breaker_manager: circuit,
+        bulkhead_manager: bulkhead,
+    };
+    (mw_state, api_state)
+}
+
+/// Axum middleware: gate request through circuit breaker + bulkhead.
+pub async fn resilience_middleware(
+    State(state): State<ResilienceMiddlewareState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let endpoint = format!("{} {}", request.method().as_str(), request.uri().path());
+
+    // 1. Circuit-breaker gate. `allow_request` returns true when disabled
+    //    *or* when the breaker is closed/half-open with budget.
+    let breaker = state.circuit_manager.get_breaker(&endpoint).await;
+    if !breaker.allow_request().await {
+        return circuit_open_response(&endpoint);
+    }
+
+    // 2. Bulkhead admit. The guard auto-releases on drop, which we hold
+    //    across `next.run(request)` so the slot stays occupied for the
+    //    full handler duration.
+    let bulkhead = state.bulkhead_manager.get_bulkhead(&state.default_service).await;
+    let _guard = match bulkhead.try_acquire().await {
+        Ok(g) => g,
+        Err(BulkheadError::Rejected) => {
+            // Don't record on the breaker — bulkhead saturation is a
+            // separate failure mode and counting it as a breaker failure
+            // would punish a healthy endpoint for being popular.
+            return bulkhead_response(
+                &state.default_service,
+                "bulkhead_rejected",
+                "Bulkhead is full; request rejected.",
+            );
+        }
+        Err(BulkheadError::Timeout) => {
+            return bulkhead_response(
+                &state.default_service,
+                "bulkhead_timeout",
+                "Bulkhead queue timeout; request not admitted.",
+            );
+        }
+    };
+
+    // 3. Run handler.
+    let response = next.run(request).await;
+
+    // 4. Record outcome. 5xx = backend problem → breaker failure. 4xx (and
+    //    the 503 we just generated) belongs to the client / upstream
+    //    saturation and stays out of the per-endpoint failure budget.
+    if response.status().is_server_error() {
+        breaker.record_failure().await;
+    } else {
+        breaker.record_success().await;
+    }
+
+    response
+}
+
+fn circuit_open_response(endpoint: &str) -> Response {
+    let body = Json(json!({
+        "error": "circuit_open",
+        "endpoint": endpoint,
+        "message": "Circuit breaker is open for this endpoint; refusing the request.",
+    }));
+    let mut resp = (StatusCode::SERVICE_UNAVAILABLE, body).into_response();
+    resp.headers_mut().insert("retry-after", HeaderValue::from_static("1"));
+    resp
+}
+
+fn bulkhead_response(service: &str, error: &'static str, message: &'static str) -> Response {
+    let body = Json(json!({
+        "error": error,
+        "service": service,
+        "message": message,
+    }));
+    let mut resp = (StatusCode::SERVICE_UNAVAILABLE, body).into_response();
+    resp.headers_mut().insert("retry-after", HeaderValue::from_static("1"));
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{BulkheadConfig, CircuitBreakerConfig};
+    use axum::{body::Body, http::Request, middleware, routing::get, Router};
+    use prometheus::Registry;
+    use tower::ServiceExt;
+
+    /// Build a tiny app with the middleware mounted in front of a handler
+    /// that returns whatever status we tell it to.
+    async fn app(state: ResilienceMiddlewareState) -> Router {
+        Router::new()
+            .route("/ok", get(|| async { (StatusCode::OK, "ok").into_response() }))
+            .route(
+                "/boom",
+                get(|| async { (StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response() }),
+            )
+            .route(
+                "/client-error",
+                get(|| async { (StatusCode::BAD_REQUEST, "nope").into_response() }),
+            )
+            .layer(middleware::from_fn_with_state(state, resilience_middleware))
+    }
+
+    fn state() -> ResilienceMiddlewareState {
+        let registry = Arc::new(Registry::new());
+        let circuit = Arc::new(CircuitBreakerManager::new(
+            CircuitBreakerConfig {
+                enabled: true,
+                failure_threshold: 2,
+                success_threshold: 1,
+                timeout_ms: 60_000,
+                half_open_max_requests: 1,
+                failure_rate_threshold: 50.0,
+                min_requests_for_rate: 100, // high so the test only trips via consecutive count
+                rolling_window_ms: 10_000,
+            },
+            registry.clone(),
+        ));
+        let bulkhead = Arc::new(BulkheadManager::new(
+            BulkheadConfig {
+                enabled: false, // off for these tests; bulkhead has its own coverage below
+                max_concurrent_requests: 4,
+                max_queue_size: 0,
+                queue_timeout_ms: 1000,
+            },
+            registry,
+        ));
+        ResilienceMiddlewareState::new(circuit, bulkhead)
+    }
+
+    async fn call(app: &Router, path: &str) -> StatusCode {
+        let res = app
+            .clone()
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        res.status()
+    }
+
+    #[tokio::test]
+    async fn success_response_is_passed_through() {
+        let s = state();
+        let app = app(s.clone()).await;
+        assert_eq!(call(&app, "/ok").await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn consecutive_5xx_opens_breaker_and_returns_503() {
+        let s = state();
+        let app = app(s.clone()).await;
+        // failure_threshold is 2, so two consecutive 5xx flips the circuit.
+        assert_eq!(call(&app, "/boom").await, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(call(&app, "/boom").await, StatusCode::INTERNAL_SERVER_ERROR);
+        // Now the breaker is OPEN — next request is 503 from the middleware.
+        assert_eq!(call(&app, "/boom").await, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn client_4xx_does_not_trip_breaker() {
+        let s = state();
+        let app = app(s.clone()).await;
+        // Same threshold, but all 400s — should never open.
+        for _ in 0..5 {
+            assert_eq!(call(&app, "/client-error").await, StatusCode::BAD_REQUEST);
+        }
+    }
+
+    #[tokio::test]
+    async fn breaker_is_per_endpoint() {
+        let s = state();
+        let app = app(s.clone()).await;
+        // Trip the breaker for /boom.
+        assert_eq!(call(&app, "/boom").await, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(call(&app, "/boom").await, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(call(&app, "/boom").await, StatusCode::SERVICE_UNAVAILABLE);
+        // /ok must still be reachable — separate breaker.
+        assert_eq!(call(&app, "/ok").await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bulkhead_rejected_returns_503() {
+        let registry = Arc::new(Registry::new());
+        // Bulkhead with 0 slots, no queue: every request is rejected.
+        let bulkhead = Arc::new(BulkheadManager::new(
+            BulkheadConfig {
+                enabled: true,
+                max_concurrent_requests: 0,
+                max_queue_size: 0,
+                queue_timeout_ms: 100,
+            },
+            registry.clone(),
+        ));
+        let circuit = Arc::new(CircuitBreakerManager::new(
+            CircuitBreakerConfig::default(), // disabled
+            registry,
+        ));
+        let s = ResilienceMiddlewareState::new(circuit, bulkhead);
+        let app = app(s).await;
+        assert_eq!(call(&app, "/ok").await, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn disabled_managers_pass_through_unchanged() {
+        let registry = Arc::new(Registry::new());
+        let circuit =
+            Arc::new(CircuitBreakerManager::new(CircuitBreakerConfig::default(), registry.clone()));
+        let bulkhead = Arc::new(BulkheadManager::new(BulkheadConfig::default(), registry));
+        let s = ResilienceMiddlewareState::new(circuit, bulkhead);
+        let app = app(s).await;
+        // Even 5xx responses pass through with their original status when
+        // the breaker is disabled — middleware is effectively transparent.
+        assert_eq!(call(&app, "/ok").await, StatusCode::OK);
+        for _ in 0..10 {
+            assert_eq!(call(&app, "/boom").await, StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -3568,6 +3568,7 @@ async fn handle_admin(
         None, // recorder
         None, // federation
         None, // vbr_engine
+        None, // resilience_api_state (#468 — admin-only entry point, no http_app to wire)
     )
     .await?;
 

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -1765,6 +1765,17 @@ pub async fn handle_serve(
     http_app = http_app.merge(chaos_router);
     println!("✅ Chaos Engineering API available at /api/chaos/*");
 
+    // Resilience middleware + dashboard state (#468 Phase 2).
+    //
+    // The `CircuitBreakerConfig` / `BulkheadConfig` defaults both carry
+    // `enabled: false`, so installing the middleware here is essentially
+    // a no-op until someone turns the patterns on (CLI flags exist; full
+    // wiring is the follow-up). The Arcs we hand to the middleware are
+    // the *same* ones we pass to the admin server, so the
+    // `/api/resilience/*` dashboard reflects what this middleware
+    // records once it's active.
+    let (resilience_mw_state, resilience_api_state) = mockforge_chaos::default_resilience_state();
+
     // Merge WebSocket router onto the HTTP app so `/ws` and `/ws/{*path}` are
     // reachable on the same port as HTTP. This is required for hosted mocks,
     // where Fly.io only exposes port 3000. The separate WS listener below
@@ -2018,6 +2029,20 @@ pub async fn handle_serve(
     {
         use axum::middleware::from_fn;
         http_app = http_app.layer(from_fn(mockforge_http::collect_http_metrics));
+    }
+
+    // Layer the resilience middleware (#468 Phase 2). Cheap when the
+    // managers are disabled (the default) — every request shortcuts
+    // through `allow_request` / `try_acquire` without taking either
+    // lock for long. When the operator turns the patterns on (planned
+    // CLI wiring), this layer is where each request's outcome gets
+    // attributed back to the per-endpoint circuit breaker.
+    {
+        use axum::middleware::from_fn_with_state;
+        http_app = http_app.layer(from_fn_with_state(
+            resilience_mw_state.clone(),
+            mockforge_chaos::resilience_middleware,
+        ));
     }
 
     // Note: OData URI rewrite is applied at the service level in serve_router_with_tls()
@@ -2804,6 +2829,7 @@ pub async fn handle_serve(
                     recorder_clone,
                     federation_clone,
                     vbr_engine_clone,
+                    Some(resilience_api_state.clone()),
                     Some(admin_bound_tx),
                 ) => {
                     result.map_err(|e| format!("Admin UI server error: {}", e))

--- a/crates/mockforge-ui/src/lib.rs
+++ b/crates/mockforge-ui/src/lib.rs
@@ -61,6 +61,7 @@ pub async fn start_admin_server(
     recorder: Option<std::sync::Arc<mockforge_recorder::Recorder>>,
     federation: Option<std::sync::Arc<mockforge_federation::Federation>>,
     vbr_engine: Option<std::sync::Arc<mockforge_vbr::VbrEngine>>,
+    resilience_api_state: Option<mockforge_chaos::resilience_api::ResilienceApiState>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     start_admin_server_notify(
         addr,
@@ -78,6 +79,7 @@ pub async fn start_admin_server(
         recorder,
         federation,
         vbr_engine,
+        resilience_api_state,
         None,
     )
     .await
@@ -107,6 +109,7 @@ pub async fn start_admin_server_notify(
     recorder: Option<std::sync::Arc<mockforge_recorder::Recorder>>,
     federation: Option<std::sync::Arc<mockforge_federation::Federation>>,
     vbr_engine: Option<std::sync::Arc<mockforge_vbr::VbrEngine>>,
+    resilience_api_state: Option<mockforge_chaos::resilience_api::ResilienceApiState>,
     bound_port_tx: Option<tokio::sync::oneshot::Sender<u16>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut app = create_admin_router(
@@ -125,6 +128,7 @@ pub async fn start_admin_server_notify(
         recorder,
         federation,
         vbr_engine,
+        resilience_api_state,
     );
 
     // Optionally bring up the registry-admin (SQLite) sub-router if the

--- a/crates/mockforge-ui/src/routes.rs
+++ b/crates/mockforge-ui/src/routes.rs
@@ -58,6 +58,12 @@ pub fn create_admin_router(
     recorder: Option<std::sync::Arc<mockforge_recorder::Recorder>>,
     federation: Option<std::sync::Arc<mockforge_federation::Federation>>,
     vbr_engine: Option<std::sync::Arc<mockforge_vbr::VbrEngine>>,
+    // Resilience API state — when `Some`, mounts the `/api/resilience/*`
+    // dashboard endpoints (#468 Phase 2). Caller is expected to pass the
+    // same `Arc<...Manager>` instances it installed on `http_app` via
+    // `mockforge_chaos::resilience_middleware`, so the dashboard reads
+    // the state the middleware writes.
+    resilience_api_state: Option<mockforge_chaos::resilience_api::ResilienceApiState>,
 ) -> Router {
     // Initialize global logger if not already initialized
     let _logger = get_global_logger().unwrap_or_else(|| init_global_logger(1000));
@@ -682,6 +688,16 @@ pub fn create_admin_router(
         tracing::info!("Conformance testing API routes mounted at /api/conformance");
     }
 
+    // Resilience dashboard routes (#468 Phase 2). Mounted when the caller
+    // passed the same `ResilienceApiState` it constructed for the
+    // `resilience_middleware` layered onto `http_app`, so this dashboard
+    // reads what that middleware writes.
+    if let Some(state) = resilience_api_state {
+        let resilience_router = mockforge_chaos::create_resilience_router(state);
+        router = router.nest_service("/api/resilience", resilience_router);
+        tracing::info!("Resilience dashboard API mounted at /api/resilience");
+    }
+
     // SPA fallback: serve index.html for any unmatched routes to support client-side routing
     // IMPORTANT: This must be AFTER all API routes
     router = router.route("/{*path}", get(serve_admin_html));
@@ -717,6 +733,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         // Router should be created successfully
@@ -741,6 +758,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         // Router should still work without server addresses
@@ -756,6 +774,7 @@ mod tests {
             true,
             8080,
             "http://localhost:9090".to_string(),
+            None,
             None,
             None,
             None,

--- a/crates/mockforge-ui/tests/admin_ui_build.rs
+++ b/crates/mockforge-ui/tests/admin_ui_build.rs
@@ -120,6 +120,7 @@ async fn test_admin_ui_serves_built_assets() {
         None,
         None,
         None,
+        None,
     );
 
     // Test that main HTML page serves
@@ -173,6 +174,7 @@ async fn test_admin_ui_serves_built_assets() {
         None,
         None,
         None,
+        None,
     );
     let css_response = app2
         .oneshot(Request::builder().uri("/assets/index.css").body(Body::empty()).unwrap())
@@ -202,6 +204,7 @@ async fn test_admin_ui_serves_built_assets() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -307,6 +310,7 @@ async fn test_ui_handles_missing_assets() {
         None,
         None,
         None,
+        None,
     );
 
     // Test main page
@@ -344,6 +348,7 @@ async fn test_ui_handles_missing_assets() {
         None,
         None,
         None,
+        None,
     );
     let css_response = app2
         .oneshot(Request::builder().uri("/assets/index.css").body(Body::empty()).unwrap())
@@ -366,6 +371,7 @@ async fn test_ui_handles_missing_assets() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -441,6 +447,7 @@ async fn test_ui_security_headers() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,

--- a/crates/mockforge-ui/tests/admin_ui_integration_comprehensive.rs
+++ b/crates/mockforge-ui/tests/admin_ui_integration_comprehensive.rs
@@ -38,6 +38,7 @@ fn create_test_router() -> axum::Router {
         None,
         None,
         None,
+        None,
     )
 }
 

--- a/crates/mockforge-ui/tests/integration.rs
+++ b/crates/mockforge-ui/tests/integration.rs
@@ -39,6 +39,7 @@ async fn test_dashboard_endpoint_integration() {
         None,
         None,
         None,
+        None,
     );
 
     let response = app
@@ -100,6 +101,7 @@ async fn test_logs_endpoint_with_filters() {
         None,
         None,
         None,
+        None,
     );
 
     // Test with method filter
@@ -134,6 +136,7 @@ async fn test_metrics_endpoint() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -183,6 +186,7 @@ async fn test_configuration_endpoints() {
         None,
         None,
         None,
+        None,
     );
 
     // Test GET config
@@ -218,6 +222,7 @@ async fn test_latency_configuration_update() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -281,6 +286,7 @@ async fn test_fault_injection_update() {
         None,
         None,
         None,
+        None,
     );
 
     let update_payload = json!({
@@ -332,6 +338,7 @@ async fn test_proxy_configuration_update() {
         None,
         None,
         None,
+        None,
     );
 
     let update_payload = json!({
@@ -375,6 +382,7 @@ async fn test_latency_settings_update() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -435,6 +443,7 @@ async fn test_fixtures_endpoint() {
         None,
         None,
         None,
+        None,
     );
 
     let response = app
@@ -463,6 +472,7 @@ async fn test_config_endpoint() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -500,6 +510,7 @@ async fn test_server_restart_endpoint() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -551,6 +562,7 @@ async fn test_logs_clear_endpoint() {
         None,
         None,
         None,
+        None,
     );
 
     let response = app
@@ -585,6 +597,7 @@ async fn test_health_endpoint() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -633,6 +646,7 @@ async fn test_error_responses() {
         None,
         None,
         None,
+        None,
     );
 
     // Test invalid JSON in POST request
@@ -668,6 +682,7 @@ async fn test_error_responses() {
         None,
         None,
         None,
+        None,
     );
     let response = app2
         .oneshot(Request::builder().uri("/__mockforge/nonexistent").body(Body::empty()).unwrap())
@@ -689,6 +704,7 @@ async fn test_cors_headers() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,

--- a/crates/mockforge-ui/tests/smoke.rs
+++ b/crates/mockforge-ui/tests/smoke.rs
@@ -30,6 +30,7 @@ async fn serves_root_and_assets_and_health() {
         None,
         None,
         None,
+        None,
     );
 
     // /
@@ -77,6 +78,7 @@ async fn works_under_mount_prefix() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -141,6 +143,7 @@ async fn test_api_endpoints() {
         None,
         None,
         None,
+        None,
     );
 
     // Test all the new API endpoints
@@ -176,6 +179,7 @@ async fn test_post_endpoints() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,

--- a/crates/mockforge-ui/tests/static_files.rs
+++ b/crates/mockforge-ui/tests/static_files.rs
@@ -32,6 +32,7 @@ async fn test_static_assets_mime_types() {
         None,
         None,
         None,
+        None,
     );
 
     // Test HTML serving
@@ -55,6 +56,7 @@ async fn test_static_assets_mime_types() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -92,6 +94,7 @@ async fn test_static_assets_mime_types() {
         None,
         None,
         None,
+        None,
     );
     let response_js = app3
         .oneshot(Request::builder().uri("/assets/index.js").body(Body::empty()).unwrap())
@@ -117,6 +120,7 @@ async fn test_image_assets_mime_types() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -169,6 +173,7 @@ async fn test_image_assets_mime_types() {
             None,
             None,
             None,
+            None,
         );
         let response = app_test
             .oneshot(Request::builder().uri(icon_path).body(Body::empty()).unwrap())
@@ -197,6 +202,7 @@ async fn test_static_assets_caching_headers() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -247,6 +253,7 @@ async fn test_static_assets_caching_headers() {
         None,
         None,
         None,
+        None,
     );
     let response_js = app2
         .oneshot(Request::builder().uri("/assets/index.js").body(Body::empty()).unwrap())
@@ -277,6 +284,7 @@ async fn test_static_assets_caching_headers() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -327,6 +335,7 @@ async fn test_static_assets_etags() {
         None,
         None,
         None,
+        None,
     );
 
     // Test HTML ETag
@@ -359,6 +368,7 @@ async fn test_static_assets_etags() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -406,6 +416,7 @@ async fn test_conditional_requests() {
         None,
         None,
         None,
+        None,
     );
 
     // First, get the ETag
@@ -429,6 +440,7 @@ async fn test_conditional_requests() {
             true,
             9080,
             "http://localhost:9090".to_string(),
+            None,
             None,
             None,
             None,
@@ -491,6 +503,7 @@ async fn test_all_static_routes_accessible() {
             None,
             None,
             None,
+            None,
         );
         let response = app
             .oneshot(Request::builder().uri(route).body(Body::empty()).unwrap())
@@ -518,6 +531,7 @@ async fn test_static_assets_content_length() {
         true,
         9080,
         "http://localhost:9090".to_string(),
+        None,
         None,
         None,
         None,
@@ -584,6 +598,7 @@ async fn test_spa_fallback_routing() {
         None,
         None,
         None,
+        None,
     );
 
     // Test various client-side routes that should serve index.html
@@ -604,6 +619,7 @@ async fn test_spa_fallback_routing() {
             true,
             9080,
             "http://localhost:9090".to_string(),
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
## Summary

Phase 2 fills the gap I called out in PR #517 (#468 Phase 1 / cloud scaffold): the `CircuitBreakerManager` and `BulkheadManager` state objects existed in `mockforge-chaos::resilience`, and `create_resilience_router` mounted a perfect dashboard API on top of them, but **no part of the binary ever wired the managers into the request path *or* mounted the router**. So `ResiliencePage` showed empty/failed data for everyone — local users inheriting the same gap cloud users had.

## chaos: actual middleware

New `mockforge_chaos::resilience_middleware` module.

- `resilience_middleware` axum middleware:
  - Circuit-breaker keyed by `"{METHOD} {path}"` so each endpoint gets its own breaker.
  - Bulkhead keyed by a configurable `default_service` (defaults to `"http"`).
  - Only 5xx counts as a breaker failure — 4xx is client/upstream business and stays out of the per-endpoint failure budget.
  - Bulkhead saturation returns 503 with \`Retry-After: 1\` and does *not* record on the breaker.
  - Effectively free when the configs are disabled (`allow_request` and `try_acquire` short-circuit to allow).
- `default_resilience_state()` builder hands back a `(MiddlewareState, ResilienceApiState)` pair backed by the same `Arc<...Manager>` instances, so the dashboard reflects what the middleware records. Useful from binaries that don't want to depend on `prometheus` directly.

Six unit tests cover the happy path, breaker-trip threshold, 4xx pass-through, per-endpoint isolation, bulkhead rejection, and the disabled-managers fast path.

## cli: install in `mockforge serve`

`serve.rs` now builds the shared state via `default_resilience_state()`, layers the middleware onto `http_app`, and passes the same `Option<ResilienceApiState>` to the admin server.

## ui: mount `/api/resilience/*` on admin

`create_admin_router` (and the `start_admin_server*` wrappers) takes a new `resilience_api_state` parameter. When `Some`, `mockforge_chaos::create_resilience_router` is nested under `/api/resilience`. The cloud-scaffold PR (#517) already wired the cloud side; this finishes the local side so `ResiliencePage` returns real data instead of 404.

## Drive-by

Cargo.lock bumps `lettre` 0.11.21 → 0.11.22 to clear RUSTSEC-2026-0141 (critical, published 2026-05-14) — the audit hook wouldn't let the new `tower` dev-dep through Cargo.lock otherwise.

## Still pending (separate follow-up)

- Hosted-mock runtime daemon doesn't yet install the middleware. Once it does, the registry's `/api/v1/workspaces/{id}/resilience/*` returns `runtime_state: "live"`.
- The existing CLI flags (`--circuit-breaker`, `--bulkhead`, thresholds) are still inert; this PR uses default (disabled) config. Wiring the flags to override the config is a small follow-up.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p mockforge-chaos -p mockforge-ui -p mockforge-cli --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-chaos --lib` — 359 + 6 new = 365 passed
- [x] `cargo test -p mockforge-ui --lib` — 60 passed (425 across both crates)
- [x] `cargo build -p mockforge-cli` clean
- [ ] Manual smoke (`mockforge serve` → `curl /api/resilience/dashboard/summary`) — runner pressure; will validate post-merge

Phase 2 of #468.