### PR TITLE
feat(chaos,cli): honour --circuit-breaker / --bulkhead CLI flags (#468 follow-up)

### DIFF
--- a/crates/mockforge-chaos/src/lib.rs
+++ b/crates/mockforge-chaos/src/lib.rs
@@ -208,7 +208,8 @@ pub use resilience::{
     RetryConfig as ResilienceRetryConfig, RetryPolicy,
 };
 pub use resilience_middleware::{
-    default_resilience_state, resilience_middleware, ResilienceMiddlewareState,
+    default_resilience_state, resilience_middleware, resilience_state_from_configs,
+    ResilienceMiddlewareState,
 };
 
 pub use resilience_api::{

--- a/crates/mockforge-chaos/src/resilience_middleware.rs
+++ b/crates/mockforge-chaos/src/resilience_middleware.rs
@@ -64,29 +64,38 @@ impl ResilienceMiddlewareState {
     }
 }
 
-/// Build the middleware state + matching dashboard state with default
-/// (disabled) configs and a fresh Prometheus registry. Both states share
-/// the same `Arc<...Manager>` instances, so `/api/resilience/*` reflects
-/// what the middleware records.
+/// Build the middleware state + matching dashboard state from explicit
+/// `CircuitBreakerConfig` / `BulkheadConfig` values. Both states share the
+/// same `Arc<...Manager>` instances backed by a fresh Prometheus registry,
+/// so `/api/resilience/*` reflects what the middleware records.
 ///
-/// Useful from binaries that don't want to depend on `prometheus` or
-/// `mockforge-chaos::config` directly — the `mockforge-cli` `serve`
-/// command uses this to wire #468 Phase 2 with one call.
-pub fn default_resilience_state(
+/// `None` for either config falls back to that type's `Default` (which has
+/// `enabled: false`), preserving the same behaviour `default_resilience_state`
+/// shipped with in #468 Phase 2.
+pub fn resilience_state_from_configs(
+    circuit_config: Option<crate::config::CircuitBreakerConfig>,
+    bulkhead_config: Option<crate::config::BulkheadConfig>,
 ) -> (ResilienceMiddlewareState, crate::resilience_api::ResilienceApiState) {
-    use crate::config::{BulkheadConfig, CircuitBreakerConfig};
     use prometheus::Registry;
 
     let registry = Arc::new(Registry::new());
     let circuit =
-        Arc::new(CircuitBreakerManager::new(CircuitBreakerConfig::default(), registry.clone()));
-    let bulkhead = Arc::new(BulkheadManager::new(BulkheadConfig::default(), registry));
+        Arc::new(CircuitBreakerManager::new(circuit_config.unwrap_or_default(), registry.clone()));
+    let bulkhead = Arc::new(BulkheadManager::new(bulkhead_config.unwrap_or_default(), registry));
     let mw_state = ResilienceMiddlewareState::new(circuit.clone(), bulkhead.clone());
     let api_state = crate::resilience_api::ResilienceApiState {
         circuit_breaker_manager: circuit,
         bulkhead_manager: bulkhead,
     };
     (mw_state, api_state)
+}
+
+/// Build the middleware state + matching dashboard state with default
+/// (disabled) configs. Thin wrapper around [`resilience_state_from_configs`]
+/// for callers that don't have CLI/YAML overrides to plumb through.
+pub fn default_resilience_state(
+) -> (ResilienceMiddlewareState, crate::resilience_api::ResilienceApiState) {
+    resilience_state_from_configs(None, None)
 }
 
 /// Axum middleware: gate request through circuit breaker + bulkhead.
@@ -286,6 +295,56 @@ mod tests {
         let s = ResilienceMiddlewareState::new(circuit, bulkhead);
         let app = app(s).await;
         assert_eq!(call(&app, "/ok").await, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn from_configs_threshold_drives_breaker_trip() {
+        // Hand the builder a 1-failure-threshold breaker and confirm it
+        // actually trips after one 5xx — proves the config passed through
+        // rather than being ignored / replaced with defaults.
+        let cb = CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 1,
+            success_threshold: 1,
+            timeout_ms: 60_000,
+            half_open_max_requests: 1,
+            failure_rate_threshold: 100.0,
+            min_requests_for_rate: 100,
+            rolling_window_ms: 10_000,
+        };
+        let (mw, _api) = resilience_state_from_configs(Some(cb), None);
+        let app = app(mw).await;
+        assert_eq!(call(&app, "/boom").await, StatusCode::INTERNAL_SERVER_ERROR);
+        // Threshold=1 means the next request hits an open breaker.
+        assert_eq!(call(&app, "/boom").await, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn from_configs_bulkhead_capacity_rejects() {
+        // 0-slot bulkhead via the new builder rejects unconditionally —
+        // proves the BulkheadConfig also threads through correctly.
+        let bh = BulkheadConfig {
+            enabled: true,
+            max_concurrent_requests: 0,
+            max_queue_size: 0,
+            queue_timeout_ms: 100,
+        };
+        let (mw, _api) = resilience_state_from_configs(None, Some(bh));
+        let app = app(mw).await;
+        assert_eq!(call(&app, "/ok").await, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn from_configs_with_none_matches_default_state() {
+        // Both None should be equivalent to `default_resilience_state` —
+        // no surprises in the boundary case.
+        let (mw, _api) = resilience_state_from_configs(None, None);
+        let app = app(mw).await;
+        // Disabled managers must let everything through unchanged.
+        assert_eq!(call(&app, "/ok").await, StatusCode::OK);
+        for _ in 0..5 {
+            assert_eq!(call(&app, "/boom").await, StatusCode::INTERNAL_SERVER_ERROR);
+        }
     }
 
     #[tokio::test]

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2471,6 +2471,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 verbose: args.verbose,
                 no_config: args.no_config,
                 no_rate_limit: args.no_rate_limit,
+                circuit_breaker: args.chaos_opts.circuit_breaker,
+                circuit_breaker_failure_threshold: args
+                    .chaos_opts
+                    .circuit_breaker_failure_threshold,
+                circuit_breaker_success_threshold: args
+                    .chaos_opts
+                    .circuit_breaker_success_threshold,
+                circuit_breaker_timeout_ms: args.chaos_opts.circuit_breaker_timeout_ms,
+                circuit_breaker_failure_rate: args.chaos_opts.circuit_breaker_failure_rate,
+                bulkhead: args.chaos_opts.bulkhead,
+                bulkhead_max_concurrent: args.chaos_opts.bulkhead_max_concurrent,
+                bulkhead_max_queue: args.chaos_opts.bulkhead_max_queue,
+                bulkhead_queue_timeout_ms: args.chaos_opts.bulkhead_queue_timeout_ms,
             })
             .await?;
         }

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -98,6 +98,17 @@ pub(crate) struct ServeArgs {
     pub(crate) no_config: bool,
     /// Disable the built-in HTTP rate limiter (sets `MOCKFORGE_RATE_LIMIT_ENABLED=false`).
     pub(crate) no_rate_limit: bool,
+    /// Enable the per-endpoint circuit breaker resilience pattern (#468 follow-up).
+    pub(crate) circuit_breaker: bool,
+    pub(crate) circuit_breaker_failure_threshold: u64,
+    pub(crate) circuit_breaker_success_threshold: u64,
+    pub(crate) circuit_breaker_timeout_ms: u64,
+    pub(crate) circuit_breaker_failure_rate: f64,
+    /// Enable the global bulkhead resilience pattern (#468 follow-up).
+    pub(crate) bulkhead: bool,
+    pub(crate) bulkhead_max_concurrent: u32,
+    pub(crate) bulkhead_max_queue: u32,
+    pub(crate) bulkhead_queue_timeout_ms: u64,
 }
 
 impl Default for ServeArgs {
@@ -169,6 +180,15 @@ impl Default for ServeArgs {
             verbose: false,
             no_config: false,
             no_rate_limit: false,
+            circuit_breaker: false,
+            circuit_breaker_failure_threshold: 5,
+            circuit_breaker_success_threshold: 2,
+            circuit_breaker_timeout_ms: 60_000,
+            circuit_breaker_failure_rate: 50.0,
+            bulkhead: false,
+            bulkhead_max_concurrent: 100,
+            bulkhead_max_queue: 10,
+            bulkhead_queue_timeout_ms: 5000,
         }
     }
 }
@@ -1709,6 +1729,31 @@ pub async fn handle_serve(
     )
     .await;
 
+    // CLI-flag overrides for the #468 resilience patterns. The YAML
+    // `ChaosEngConfig` doesn't carry `circuit_breaker` / `bulkhead` fields
+    // today, so CLI is the only way to turn these on. `None` falls back to
+    // the chaos crate's defaults (which keep `enabled: false`), so the
+    // middleware stays a no-op until the operator opts in.
+    let cli_circuit_breaker =
+        serve_args
+            .circuit_breaker
+            .then_some(mockforge_chaos::config::CircuitBreakerConfig {
+                enabled: true,
+                failure_threshold: serve_args.circuit_breaker_failure_threshold,
+                success_threshold: serve_args.circuit_breaker_success_threshold,
+                timeout_ms: serve_args.circuit_breaker_timeout_ms,
+                failure_rate_threshold: serve_args.circuit_breaker_failure_rate,
+                half_open_max_requests: 3,
+                min_requests_for_rate: 10,
+                rolling_window_ms: 10_000,
+            });
+    let cli_bulkhead = serve_args.bulkhead.then_some(mockforge_chaos::config::BulkheadConfig {
+        enabled: true,
+        max_concurrent_requests: serve_args.bulkhead_max_concurrent,
+        max_queue_size: serve_args.bulkhead_max_queue,
+        queue_timeout_ms: serve_args.bulkhead_queue_timeout_ms,
+    });
+
     // Integrate chaos engineering API router
     // Convert from ServerConfig's ChaosEngConfig to mockforge-chaos's ChaosConfig
     let chaos_config = if let Some(ref chaos_eng_config) = config.observability.chaos {
@@ -1743,13 +1788,19 @@ pub async fn handle_serve(
                     connection_timeout_ms: 30000,
                 }
             }),
-            circuit_breaker: None,
-            bulkhead: None,
+            circuit_breaker: cli_circuit_breaker.clone(),
+            bulkhead: cli_bulkhead.clone(),
         };
         chaos_cfg
     } else {
-        // Default chaos config if not configured
-        ChaosConfig::default()
+        // Default chaos config if not configured — still honour CLI flags
+        // for the resilience patterns so `--circuit-breaker` works without
+        // a chaos YAML.
+        ChaosConfig {
+            circuit_breaker: cli_circuit_breaker.clone(),
+            bulkhead: cli_bulkhead.clone(),
+            ..ChaosConfig::default()
+        }
     };
 
     // Create and merge chaos API router
@@ -1765,16 +1816,18 @@ pub async fn handle_serve(
     http_app = http_app.merge(chaos_router);
     println!("✅ Chaos Engineering API available at /api/chaos/*");
 
-    // Resilience middleware + dashboard state (#468 Phase 2).
+    // Resilience middleware + dashboard state (#468 Phase 2 + CLI follow-up).
     //
-    // The `CircuitBreakerConfig` / `BulkheadConfig` defaults both carry
-    // `enabled: false`, so installing the middleware here is essentially
-    // a no-op until someone turns the patterns on (CLI flags exist; full
-    // wiring is the follow-up). The Arcs we hand to the middleware are
-    // the *same* ones we pass to the admin server, so the
-    // `/api/resilience/*` dashboard reflects what this middleware
-    // records once it's active.
-    let (resilience_mw_state, resilience_api_state) = mockforge_chaos::default_resilience_state();
+    // We hand the same `Option<...Config>` values to both the chaos config
+    // (above) and the resilience state builder so `/api/chaos/*` and
+    // `/api/resilience/*` report identical settings. When both CLI flags
+    // are unset, the builder falls back to the disabled defaults and the
+    // middleware short-circuits per-request — effectively free.
+    let (resilience_mw_state, resilience_api_state) =
+        mockforge_chaos::resilience_state_from_configs(
+            cli_circuit_breaker.clone(),
+            cli_bulkhead.clone(),
+        );
 
     // Merge WebSocket router onto the HTTP app so `/ws` and `/ws/{*path}` are
     // reachable on the same port as HTTP. This is required for hosted mocks,


### PR DESCRIPTION
## Summary

PR #518 (#468 Phase 2) shipped the resilience middleware but
`mockforge_chaos::default_resilience_state()` only ever built it with the
disabled `CircuitBreakerConfig::default()` / `BulkheadConfig::default()`. The
existing `--circuit-breaker` / `--bulkhead` CLI flags (and their nine
thresholds/limits) were inert — turning them on did nothing.

This PR threads the CLI flags through. **Depends on #518 — stacked on its
branch and will rebase to `main` once #518 merges.**

## chaos

New `resilience_state_from_configs(circuit, bulkhead)` builder that takes
explicit `Option<...Config>` overrides. `default_resilience_state()` is now a
thin wrapper around `resilience_state_from_configs(None, None)` so #518's
existing callers stay untouched.

Three new tests cover the override path:

- `from_configs_threshold_drives_breaker_trip` — a 1-failure-threshold
  breaker actually trips after one 5xx, proving the config threads through.
- `from_configs_bulkhead_capacity_rejects` — a 0-slot bulkhead rejects
  unconditionally.
- `from_configs_with_none_matches_default_state` — boundary check that
  `None`/`None` is equivalent to the default builder.

## cli

`ServeArgs` gains nine fields mirroring the existing CLI flags
(`circuit_breaker`, `circuit_breaker_failure_threshold`,
`circuit_breaker_success_threshold`, `circuit_breaker_timeout_ms`,
`circuit_breaker_failure_rate`, `bulkhead`, `bulkhead_max_concurrent`,
`bulkhead_max_queue`, `bulkhead_queue_timeout_ms`). `main.rs` maps them from
`args.chaos_opts.*` so clap already validates ranges/defaults.

`handle_serve` builds two `Option<...Config>` values from the flags and:

- threads them into `ChaosConfig.circuit_breaker` / `.bulkhead` (so
  `/api/chaos/*` reports the same configuration the middleware uses), and
- passes them to `resilience_state_from_configs` (so `/api/resilience/*`
  reflects live behaviour).

When neither flag is set both values are `None` and behaviour is identical to
before — the middleware short-circuits per-request, no overhead.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-chaos -p mockforge-cli --all-targets -- -D warnings\` clean
- [x] \`cargo test -p mockforge-chaos --lib\` — 362 passed (9 in \`resilience_middleware\`, including the 3 new ones)
- [ ] Manual smoke (\`mockforge serve --circuit-breaker --circuit-breaker-failure-threshold 1 ...\` → trip with curl) — runner pressure; will validate post-merge

Follow-up to PR #518 (#468 Phase 2).