### PR TITLE
feat(http,bench,ui,tui): server-side connection lifecycle gauges + bench connection counts (#79 round 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.3.134] - 2026-05-14
+
+### Added
+
+- **[Reality]** Server-side HTTP connection lifecycle gauges (#79 round 6, Srikanth's "how many connections are opened at a time")
+  - `CountingMakeService` (in `mockforge-http`) now wraps each per-connection service in a `TrackedService` whose `Drop` impl records the close. The pair of `record_accept` / `record_close` increments give an exact live `connections_open` gauge plus cumulative `connections_total_opened` / `connections_total_closed` counters in `mockforge_foundation::rate_counters`.
+  - Works for both plain HTTP (`axum::serve`) and HTTPS (`axum_server::bind_rustls`) paths — only successfully accepted connections (post-TLS-handshake for HTTPS) are counted. A `record_close` always fires per `record_accept`, even for make-service errors, so the gauge stays balanced.
+  - When `MOCKFORGE_HTTP_LOG_CONN=1` is set, each connection close emits an INFO log line under target `mockforge_http::conn_diag` with `duration_ms` and `requests` (number served before close). Combined with the existing per-request `http_conn_diag` line, this tells you with certainty whether MockForge closed the socket after 1 request (versus the peer closing) — the exact missing piece for diagnosing Srikanth's FIN-from-server PCAP.
+  - Exposed in the admin/UI `SystemInfo` response: `connections_open`, `connections_total_opened`, `connections_total_closed`, `peak_connections_open`. Surfaced in the TUI dashboard's stats panel as `Conns Open: N (peak M)  Opened: X  Closed: Y` — a live multiplexing / churn indicator.
+- **[Reality]** Bench client summary always shows connection-open counts when k6 made TCP sockets (#79 round 6, Srikanth's "open connection on the client")
+  - Previously the `Connections opened`, `TCP connect avg/max`, and `TLS handshake avg/max` lines only printed in `--cps` mode. Now they print whenever `http_req_connecting.count > 0`, so non-`--cps` runs can also see distinct connections opened vs request count — i.e. whether the client actually pooled connections.
+  - New `Peak concurrent VUs` line surfaces `vus_max` as the upper bound on simultaneously-open client connections, paired with the server-side `Conns Open` gauge for cross-checking.
+
 ## [0.3.133] - 2026-05-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7652,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7869,7 +7869,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7900,7 +7900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8004,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8037,7 +8037,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8060,7 +8060,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8081,7 +8081,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8145,7 +8145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8267,7 +8267,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8285,7 +8285,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8378,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8403,7 +8403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8450,7 +8450,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8466,7 +8466,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8495,7 +8495,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8590,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8630,7 +8630,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8692,7 +8692,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8739,7 +8739,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8777,7 +8777,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8847,7 +8847,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8867,7 +8867,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8902,7 +8902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8939,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8967,7 +8967,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8997,7 +8997,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9024,7 +9024,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9048,14 +9048,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9082,7 +9082,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9133,7 +9133,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9156,7 +9156,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9187,7 +9187,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9274,7 +9274,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9285,7 +9285,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9302,7 +9302,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -14964,7 +14964,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.133"
+version = "0.3.134"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.133"
+version = "0.3.134"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/mockforge-bench/src/reporter.rs
+++ b/crates/mockforge-bench/src/reporter.rs
@@ -20,6 +20,13 @@ impl TerminalReporter {
     }
 
     /// Like [`print_summary`] but lets the caller opt into the `--cps` view.
+    ///
+    /// Issue #79 round 6 — the connection-count lines now render unconditionally
+    /// whenever k6 reported `http_req_connecting` samples (i.e. it actually
+    /// opened TCP sockets), so non-`--cps` runs also surface client-side
+    /// connection counts. Without `--cps` k6 reuses sockets, so the count
+    /// equals "distinct connections opened", which is what Srikanth wanted
+    /// alongside RPS.
     pub fn print_summary_with_mode(results: &K6Results, duration_secs: u64, cps_mode: bool) {
         println!("\n{}", "=".repeat(60).bright_green());
         println!("{}", "Load Test Complete! ✓".bright_green().bold());
@@ -72,18 +79,52 @@ impl TerminalReporter {
             };
             println!("  CPS:                  {} conn/s (--cps)", format!("{:.1}", cps).cyan());
             println!("  Total Connections:    {}", results.total_requests.to_string().cyan());
-            if results.tcp_connect_samples > 0 {
+        }
+
+        // Issue #79 round 6 — Always surface client-side connection counts
+        // when k6 actually opened sockets. Helpful even without `--cps`
+        // because it lets you compare "k6 opened N connections" against
+        // the server's `connections_total_opened` and detect whether
+        // your proxy is keeping the upstream pool warm. `tcp_connect_samples`
+        // is k6's `http_req_connecting.count`, which is the number of
+        // request iterations that had to wait for a new TCP socket — i.e.
+        // a fresh connection.
+        if results.tcp_connect_samples > 0 {
+            if !cps_mode {
+                // Surface the count in non-CPS mode too — Srikanth's "open
+                // connection on the client" ask.
                 println!(
-                    "  TCP connect:          avg {:.2}ms, max {:.2}ms",
-                    results.tcp_connect_avg_ms, results.tcp_connect_max_ms,
+                    "  Connections opened:   {} ({} conn/s avg)",
+                    results.tcp_connect_samples.to_string().cyan(),
+                    format!(
+                        "{:.1}",
+                        results.tcp_connect_samples as f64 / duration_secs.max(1) as f64
+                    )
+                    .cyan(),
                 );
             }
-            if results.tls_handshake_samples > 0 {
-                println!(
-                    "  TLS handshake:        avg {:.2}ms, max {:.2}ms",
-                    results.tls_handshake_avg_ms, results.tls_handshake_max_ms,
-                );
-            }
+            println!(
+                "  TCP connect:          avg {:.2}ms, max {:.2}ms",
+                results.tcp_connect_avg_ms, results.tcp_connect_max_ms,
+            );
+        }
+        if results.tls_handshake_samples > 0 {
+            println!(
+                "  TLS handshake:        avg {:.2}ms, max {:.2}ms",
+                results.tls_handshake_avg_ms, results.tls_handshake_max_ms,
+            );
+        }
+        // Peak concurrent VUs — the upper bound on simultaneously-open
+        // connections from the client. For HTTP/1.1 each VU holds at
+        // most one socket; for HTTP/2 with multiplexing this is the
+        // bound on streams, not sockets. Surface it as an open-connection
+        // ceiling so users can sanity-check against the server's
+        // `connections_open` gauge.
+        if results.vus_max > 0 && (cps_mode || results.tcp_connect_samples > 0) {
+            println!(
+                "  Peak concurrent VUs:  {} (max open conns from client side)",
+                results.vus_max.to_string().cyan(),
+            );
         }
 
         // Issue #79 — server-injected chaos signals (latency / jitter / faults)

--- a/crates/mockforge-foundation/src/rate_counters.rs
+++ b/crates/mockforge-foundation/src/rate_counters.rs
@@ -17,6 +17,16 @@
 //! The "successful API transaction" definition for TPS is `200..=399`,
 //! matching how load-testing tools (k6, JMeter, etc.) classify a successful
 //! request — anything that wasn't a 4xx/5xx error.
+//!
+//! Connection-lifecycle counters (added in 0.3.134 / issue #79 round 6 —
+//! Srikanth's "how many open at any time" ask):
+//!
+//! * `HTTP_CONNECTIONS_OPEN` — currently open (incremented on accept,
+//!   decremented on connection drop). The dashboard sampler reads this
+//!   for the live "Active Connections" gauge in the TUI / admin UI.
+//! * `HTTP_CONNECTIONS_CLOSED_TOTAL` — lifetime closed. `accepts - closed`
+//!   equals open at any sampling instant; we keep both so a single load
+//!   can read either without doing subtraction.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -29,6 +39,13 @@ pub static OK_RESPONSES_TOTAL: AtomicU64 = AtomicU64::new(0);
 /// Total accepted TCP connections (plain HTTP path only — see module docs).
 pub static HTTP_ACCEPTS_TOTAL: AtomicU64 = AtomicU64::new(0);
 
+/// Currently-open HTTP connections (incremented on accept, decremented on
+/// connection drop). Issue #79 round 6.
+pub static HTTP_CONNECTIONS_OPEN: AtomicU64 = AtomicU64::new(0);
+
+/// Lifetime closed HTTP connections. Issue #79 round 6.
+pub static HTTP_CONNECTIONS_CLOSED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
 /// Bump the response counters according to the response's status code.
 #[inline]
 pub fn record_response(status_code: u16) {
@@ -40,10 +57,26 @@ pub fn record_response(status_code: u16) {
     }
 }
 
-/// Bump the TCP-accept counter. Call once per accepted connection.
+/// Bump the TCP-accept counter AND the currently-open gauge. Call once per
+/// accepted connection — paired with [`record_close`] when the connection
+/// terminates.
 #[inline]
 pub fn record_accept() {
     HTTP_ACCEPTS_TOTAL.fetch_add(1, Ordering::Relaxed);
+    HTTP_CONNECTIONS_OPEN.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Decrement the currently-open gauge and bump the lifetime-closed counter.
+/// Call once when a previously-accepted connection terminates.
+#[inline]
+pub fn record_close() {
+    // Saturating decrement — a stray `record_close` without a matching
+    // `record_accept` should not wrap around to `u64::MAX`.
+    let prev = HTTP_CONNECTIONS_OPEN.load(Ordering::Relaxed);
+    if prev > 0 {
+        HTTP_CONNECTIONS_OPEN.fetch_sub(1, Ordering::Relaxed);
+    }
+    HTTP_CONNECTIONS_CLOSED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Point-in-time snapshot of the rate counters.
@@ -52,6 +85,10 @@ pub struct CounterSnapshot {
     pub successful: u64,
     pub ok: u64,
     pub accepts: u64,
+    /// Currently-open HTTP connections.
+    pub connections_open: u64,
+    /// Lifetime closed HTTP connections.
+    pub connections_closed: u64,
 }
 
 /// Read all counters atomically (each load is independent — a snapshot
@@ -61,6 +98,8 @@ pub fn snapshot() -> CounterSnapshot {
         successful: SUCCESSFUL_RESPONSES_TOTAL.load(Ordering::Relaxed),
         ok: OK_RESPONSES_TOTAL.load(Ordering::Relaxed),
         accepts: HTTP_ACCEPTS_TOTAL.load(Ordering::Relaxed),
+        connections_open: HTTP_CONNECTIONS_OPEN.load(Ordering::Relaxed),
+        connections_closed: HTTP_CONNECTIONS_CLOSED_TOTAL.load(Ordering::Relaxed),
     }
 }
 
@@ -76,6 +115,8 @@ mod tests {
         SUCCESSFUL_RESPONSES_TOTAL.store(0, Ordering::Relaxed);
         OK_RESPONSES_TOTAL.store(0, Ordering::Relaxed);
         HTTP_ACCEPTS_TOTAL.store(0, Ordering::Relaxed);
+        HTTP_CONNECTIONS_OPEN.store(0, Ordering::Relaxed);
+        HTTP_CONNECTIONS_CLOSED_TOTAL.store(0, Ordering::Relaxed);
     }
 
     #[test]
@@ -125,6 +166,44 @@ mod tests {
         assert_eq!(s.successful, 2);
         assert_eq!(s.ok, 2);
         assert_eq!(s.accepts, 1);
+    }
+
+    #[test]
+    fn record_accept_bumps_open_gauge() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+        record_accept();
+        record_accept();
+        let s = snapshot();
+        assert_eq!(s.accepts, 2, "lifetime accepts");
+        assert_eq!(s.connections_open, 2, "currently open");
+        assert_eq!(s.connections_closed, 0);
+    }
+
+    #[test]
+    fn record_close_decrements_open_and_bumps_closed() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+        record_accept();
+        record_accept();
+        record_close();
+        let s = snapshot();
+        assert_eq!(s.accepts, 2);
+        assert_eq!(s.connections_open, 1, "one still open");
+        assert_eq!(s.connections_closed, 1);
+    }
+
+    #[test]
+    fn record_close_without_matching_accept_does_not_underflow() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+        // Defensive: a stray close (e.g. across reset boundaries during shutdown)
+        // must not underflow to u64::MAX.
+        record_close();
+        record_close();
+        let s = snapshot();
+        assert_eq!(s.connections_open, 0, "saturating decrement");
+        assert_eq!(s.connections_closed, 2, "closed still tallied");
     }
 
     #[test]

--- a/crates/mockforge-http/src/counting_listener.rs
+++ b/crates/mockforge-http/src/counting_listener.rs
@@ -1,23 +1,55 @@
-//! Connection-accept counter for HTTP serve paths.
+//! Connection lifecycle counter for HTTP serve paths.
 //!
 //! Wraps a Tower service (in `axum::serve` / `axum_server::Server::serve`
-//! parlance, the "make-service") so that the per-connection
-//! `make_service.call(target)` increments the global `record_accept()`
-//! counter. The dashboard sampler reads the counter every 10s to derive
-//! a connections-per-second rate.
+//! parlance, the "make-service") so that:
 //!
-//! Counting at the make-service layer (not the TCP listener layer) works
+//! * Each `make_service.call(target)` bumps the global `record_accept()`
+//!   counter (which increments both `HTTP_ACCEPTS_TOTAL` and the
+//!   currently-open gauge).
+//! * The returned per-connection service is wrapped in a [`TrackedService`]
+//!   whose `Drop` impl calls `record_close()` (decrementing the open gauge
+//!   and bumping `HTTP_CONNECTIONS_CLOSED_TOTAL`).
+//!
+//! The dashboard sampler reads the counters every 10s to derive a
+//! connections-per-second rate, and the TUI / admin UI reads the
+//! `connections_open` gauge for the live "Active Connections" widget
+//! (issue #79 round 6, Srikanth's "open/closed/total" ask).
+//!
+//! Tracking at the make-service layer (not the TCP listener layer) works
 //! for **both**:
 //! - plain HTTP via `axum::serve(listener, make_svc)`
 //! - HTTPS via `axum_server::Server::bind_rustls(...).serve(make_svc)`
 //!
 //! For HTTPS, the counter only ticks once the TLS handshake completes —
 //! failed handshakes aren't counted, which is the correct semantic for
-//! "successful connection".
+//! "successful connection". Likewise, `record_close` fires when hyper
+//! drops the per-connection service — i.e. *after* the connection is
+//! torn down from MockForge's side, regardless of which end initiated
+//! the FIN. The `MOCKFORGE_HTTP_LOG_CONN` env var (see
+//! `middleware::conn_diagnostics`) turns on a per-close INFO log line
+//! that includes the connection's duration and the number of requests
+//! it served — useful for distinguishing "MockForge closed after one
+//! request" from "the peer closed after one request" in
+//! single-request-per-connection PCAPs (issue #79 round 5/6).
+//!
+//! ### Why `Arc<ConnectionGuard>`?
+//!
+//! axum's `serve` bound requires the per-connection service to be
+//! `Clone`. If hyper clones the wrapped service (e.g. for an upgrade
+//! handshake), naïvely owning the guard inline would record-close
+//! once per clone instead of once per connection. Sharing a single
+//! guard behind an `Arc` makes the close fire exactly once: when the
+//! last clone is dropped.
 
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Instant;
 
-/// Tower service that bumps the global accept counter on each `call()`.
+/// Tower service that bumps the global accept counter on each `call()`,
+/// then wraps the inner service in a [`TrackedService`] so the open-gauge
+/// decrement and the optional close-log fire when the connection ends.
 ///
 /// `Service<T>` for any `T` — works as an axum make-service regardless
 /// of the connection target type (`SocketAddr`, `ChaosClientAddr`, etc.).
@@ -27,8 +59,10 @@ pub struct CountingMakeService<M> {
 }
 
 impl<M> CountingMakeService<M> {
-    /// Wrap a make-service. Each `call(target)` will bump the global
-    /// accept counter before delegating.
+    /// Wrap a make-service. Each `call(target)` bumps the global accept
+    /// counter (and the currently-open gauge) before delegating, and the
+    /// returned per-connection service is wrapped so the open-gauge
+    /// decrement fires when the connection terminates.
     pub fn new(inner: M) -> Self {
         Self { inner }
     }
@@ -37,32 +71,164 @@ impl<M> CountingMakeService<M> {
 impl<M, T> tower::Service<T> for CountingMakeService<M>
 where
     M: tower::Service<T>,
+    M::Future: Send + 'static,
+    M::Response: 'static,
 {
-    type Response = M::Response;
+    type Response = TrackedService<M::Response>;
     type Error = M::Error;
-    type Future = M::Future;
+    type Future =
+        Pin<Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, target: T) -> Self::Future {
+        // Bump accept + open-gauge BEFORE the make-service runs so even an
+        // immediate make-service failure (no Service produced) still keeps
+        // the gauge balanced via the error branch below.
         mockforge_foundation::rate_counters::record_accept();
-        self.inner.call(target)
+        let fut = self.inner.call(target);
+        Box::pin(async move {
+            match fut.await {
+                Ok(inner) => Ok(TrackedService::new(inner)),
+                Err(err) => {
+                    // No TrackedService exists to close on drop — balance
+                    // the gauge here.
+                    mockforge_foundation::rate_counters::record_close();
+                    Err(err)
+                }
+            }
+        })
     }
 }
 
+/// Per-connection service wrapper. The connection's lifetime is owned by
+/// the inner `Arc<ConnectionGuard>` — when every clone of this service is
+/// dropped, the guard's refcount hits zero and `record_close()` fires
+/// exactly once (with optional INFO log of duration + requests served).
+pub struct TrackedService<S> {
+    inner: S,
+    guard: Arc<ConnectionGuard>,
+}
+
+impl<S> TrackedService<S> {
+    fn new(inner: S) -> Self {
+        Self {
+            inner,
+            guard: Arc::new(ConnectionGuard::new()),
+        }
+    }
+}
+
+impl<S: Clone> Clone for TrackedService<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            // Share the guard — the close fires when the LAST clone drops.
+            guard: self.guard.clone(),
+        }
+    }
+}
+
+impl<S, R> tower::Service<R> for TrackedService<S>
+where
+    S: tower::Service<R>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        self.guard.bump_request();
+        self.inner.call(req)
+    }
+}
+
+/// RAII guard for a single accepted connection. Drop calls `record_close`
+/// and (when `MOCKFORGE_HTTP_LOG_CONN=1`) logs the connection's duration
+/// and request count.
+struct ConnectionGuard {
+    opened_at: Instant,
+    requests: AtomicU64,
+}
+
+impl ConnectionGuard {
+    fn new() -> Self {
+        Self {
+            opened_at: Instant::now(),
+            requests: AtomicU64::new(0),
+        }
+    }
+
+    fn bump_request(&self) {
+        self.requests.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        let duration = self.opened_at.elapsed();
+        let requests = self.requests.load(Ordering::Relaxed);
+        mockforge_foundation::rate_counters::record_close();
+        if is_conn_log_enabled() {
+            tracing::info!(
+                target: "mockforge_http::conn_diag",
+                duration_ms = duration.as_millis() as u64,
+                requests = requests,
+                "http_conn_closed",
+            );
+        }
+    }
+}
+
+/// Inline copy of the env-flag check used by the diagnostics middleware,
+/// kept here to avoid a cyclic dependency between this module and
+/// `middleware::conn_diagnostics` (which lives at a higher layer).
+fn is_conn_log_enabled() -> bool {
+    std::env::var("MOCKFORGE_HTTP_LOG_CONN")
+        .ok()
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
+// Tests hold the serializing `TEST_LOCK` (a `std::sync::Mutex`) across
+// `await` points by design — the lock has no purpose during the test
+// body other than excluding other tests from touching the global
+// counters at the same time. Clippy's `await_holding_lock` is a real
+// concern in production async code, but here we run on
+// `current_thread` runtimes so the guard never crosses threads and
+// there's no deadlock surface; suppress at the module level.
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
     use mockforge_foundation::rate_counters;
     use std::convert::Infallible;
-    use std::sync::atomic::Ordering;
+    use std::sync::Mutex;
     use tower::{service_fn, Service, ServiceExt};
+
+    // Global counters are shared across all tests in this process. Serialize
+    // every test that asserts on the gauge so parallel runs (the default
+    // `cargo test` mode) don't see each other's increments.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn reset_counters() {
+        rate_counters::SUCCESSFUL_RESPONSES_TOTAL.store(0, Ordering::Relaxed);
+        rate_counters::OK_RESPONSES_TOTAL.store(0, Ordering::Relaxed);
+        rate_counters::HTTP_ACCEPTS_TOTAL.store(0, Ordering::Relaxed);
+        rate_counters::HTTP_CONNECTIONS_OPEN.store(0, Ordering::Relaxed);
+        rate_counters::HTTP_CONNECTIONS_CLOSED_TOTAL.store(0, Ordering::Relaxed);
+    }
 
     #[tokio::test]
     async fn counting_make_service_bumps_accept_counter() {
-        let before = rate_counters::HTTP_ACCEPTS_TOTAL.load(Ordering::Relaxed);
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
 
         let inner = service_fn(|_addr: std::net::SocketAddr| async {
             Ok::<_, Infallible>(service_fn(|_req: ()| async { Ok::<_, Infallible>(()) }))
@@ -70,10 +236,119 @@ mod tests {
         let mut counted = CountingMakeService::new(inner);
         let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-        let _service = counted.ready().await.unwrap().call(addr).await.unwrap();
-        let _service = counted.ready().await.unwrap().call(addr).await.unwrap();
+        let _service_a = counted.ready().await.unwrap().call(addr).await.unwrap();
+        let _service_b = counted.ready().await.unwrap().call(addr).await.unwrap();
 
-        let after = rate_counters::HTTP_ACCEPTS_TOTAL.load(Ordering::Relaxed);
-        assert_eq!(after, before + 2, "each make-service call bumps the counter");
+        let snap = rate_counters::snapshot();
+        assert_eq!(snap.accepts, 2, "each make-service call bumps the accept counter");
+        assert_eq!(snap.connections_open, 2, "both services held => 2 open");
+    }
+
+    #[tokio::test]
+    async fn dropping_tracked_service_records_close() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+
+        let inner = service_fn(|_addr: std::net::SocketAddr| async {
+            Ok::<_, Infallible>(service_fn(|_req: ()| async { Ok::<_, Infallible>(()) }))
+        });
+        let mut counted = CountingMakeService::new(inner);
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+        let service = counted.ready().await.unwrap().call(addr).await.unwrap();
+        assert_eq!(rate_counters::snapshot().connections_open, 1);
+
+        drop(service);
+        let snap = rate_counters::snapshot();
+        assert_eq!(snap.connections_open, 0, "drop decrements open gauge");
+        assert_eq!(snap.connections_closed, 1, "drop bumps closed counter");
+        assert_eq!(snap.accepts, 1, "accepts unchanged on drop");
+    }
+
+    #[tokio::test]
+    async fn cloned_service_only_records_close_once_when_all_clones_drop() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+
+        // Wrap a Cloneable inner service so TrackedService can be cloned.
+        #[derive(Clone)]
+        struct EchoSvc;
+        impl tower::Service<u32> for EchoSvc {
+            type Response = u32;
+            type Error = Infallible;
+            type Future = std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<u32, Infallible>> + Send>,
+            >;
+            fn poll_ready(
+                &mut self,
+                _cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Result<(), Infallible>> {
+                std::task::Poll::Ready(Ok(()))
+            }
+            fn call(&mut self, req: u32) -> Self::Future {
+                Box::pin(async move { Ok(req) })
+            }
+        }
+
+        let inner =
+            service_fn(|_addr: std::net::SocketAddr| async { Ok::<_, Infallible>(EchoSvc) });
+        let mut counted = CountingMakeService::new(inner);
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let service = counted.ready().await.unwrap().call(addr).await.unwrap();
+
+        let clone_a = service.clone();
+        let clone_b = service.clone();
+        // Three live references to the same guard — gauge stayed at 1.
+        assert_eq!(rate_counters::snapshot().connections_open, 1);
+
+        drop(service);
+        drop(clone_a);
+        // Still one reference alive (clone_b) — close has not fired.
+        assert_eq!(rate_counters::snapshot().connections_open, 1);
+        assert_eq!(rate_counters::snapshot().connections_closed, 0);
+
+        drop(clone_b);
+        let snap = rate_counters::snapshot();
+        assert_eq!(snap.connections_open, 0);
+        assert_eq!(snap.connections_closed, 1, "close fires exactly once");
+    }
+
+    #[tokio::test]
+    async fn make_service_error_balances_open_gauge() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_counters();
+
+        // Concrete dummy Service that satisfies CountingMakeService's
+        // bounds — never actually invoked because the make-service
+        // returns Err first.
+        #[derive(Clone)]
+        struct NeverSvc;
+        impl tower::Service<()> for NeverSvc {
+            type Response = ();
+            type Error = Infallible;
+            type Future = std::future::Ready<Result<(), Infallible>>;
+            fn poll_ready(
+                &mut self,
+                _cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Result<(), Infallible>> {
+                std::task::Poll::Ready(Ok(()))
+            }
+            fn call(&mut self, _req: ()) -> Self::Future {
+                std::future::ready(Ok(()))
+            }
+        }
+
+        let inner = service_fn(|_addr: std::net::SocketAddr| async {
+            Err::<NeverSvc, _>(std::io::Error::other("boom"))
+        });
+        let mut counted = CountingMakeService::new(inner);
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let result = counted.ready().await.unwrap().call(addr).await;
+        assert!(result.is_err(), "inner make-service errored");
+
+        let snap = rate_counters::snapshot();
+        assert_eq!(snap.accepts, 1, "accept still counted");
+        assert_eq!(snap.connections_open, 0, "open gauge balanced after error");
+        assert_eq!(snap.connections_closed, 1, "close recorded for the failed make-service");
     }
 }

--- a/crates/mockforge-tui/src/api/models.rs
+++ b/crates/mockforge-tui/src/api/models.rs
@@ -150,6 +150,19 @@ pub struct SystemInfo {
     pub cps: f64,
     #[serde(default)]
     pub peak_cps: f64,
+    /// Currently-open HTTP connections (live gauge). Issue #79 round 6 —
+    /// Srikanth's "how many open at a time" ask.
+    #[serde(default)]
+    pub connections_open: u64,
+    /// Lifetime accepted HTTP connections (cumulative).
+    #[serde(default)]
+    pub connections_total_opened: u64,
+    /// Lifetime closed HTTP connections (cumulative).
+    #[serde(default)]
+    pub connections_total_closed: u64,
+    /// Peak `connections_open` observed since `peaks_since`.
+    #[serde(default)]
+    pub peak_connections_open: u64,
 }
 
 // ── Request logs ─────────────────────────────────────────────────────

--- a/crates/mockforge-tui/src/screens/dashboard.rs
+++ b/crates/mockforge-tui/src/screens/dashboard.rs
@@ -256,9 +256,9 @@ impl DashboardScreen {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        // Reserve 4 lines for the text stats (Total/ErrRate, Avg RT, TPS/RPS,
-        // CPS); rest goes to the sparkline.
-        let chunks = Layout::vertical([Constraint::Length(4), Constraint::Min(2)]).split(inner);
+        // Reserve 5 lines for the text stats (Total/ErrRate, Avg RT, TPS/RPS,
+        // CPS, Connections); rest goes to the sparkline.
+        let chunks = Layout::vertical([Constraint::Length(5), Constraint::Min(2)]).split(inner);
 
         // Stats summary
         let total = data.metrics.total_requests;
@@ -271,6 +271,12 @@ impl DashboardScreen {
         let peak_rps_200 = data.system.peak_rps_200.max(rps_200);
         let cps = data.system.cps;
         let peak_cps = data.system.peak_cps.max(cps);
+        // Issue #79 round 6 — connection lifecycle gauges. `open` is live;
+        // `opened` / `closed` are cumulative since process start.
+        let conn_open = data.system.connections_open;
+        let peak_conn_open = data.system.peak_connections_open.max(conn_open);
+        let conn_opened = data.system.connections_total_opened;
+        let conn_closed = data.system.connections_total_closed;
 
         let stats = vec![
             Line::from(vec![
@@ -306,6 +312,20 @@ impl DashboardScreen {
                 Span::styled(" CPS: ", Theme::dim()),
                 Span::styled(format!("{cps:.1}"), Style::default().fg(Theme::FG)),
                 Span::styled(format!(" (peak {peak_cps:.1})"), Theme::dim()),
+            ]),
+            // Connection lifecycle line — answers Srikanth's "how many
+            // connections are opened at a time" ask. Open is the live
+            // gauge; Opened/Closed are the cumulative tallies that the
+            // bench client's "Connections opened" line should match for
+            // a well-behaved test.
+            Line::from(vec![
+                Span::styled(" Conns Open: ", Theme::dim()),
+                Span::styled(format!("{conn_open}"), Style::default().fg(Theme::FG)),
+                Span::styled(format!(" (peak {peak_conn_open})"), Theme::dim()),
+                Span::styled("  Opened: ", Theme::dim()),
+                Span::styled(format_number(conn_opened), Style::default().fg(Theme::FG)),
+                Span::styled("  Closed: ", Theme::dim()),
+                Span::styled(format_number(conn_closed), Style::default().fg(Theme::FG)),
             ]),
         ];
         frame.render_widget(Paragraph::new(stats), chunks[0]);

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -144,6 +144,20 @@ pub struct SystemMetrics {
     pub cps: f64,
     /// Peak `cps` observed since `peaks_since`.
     pub peak_cps: f64,
+    /// Currently-open HTTP connections (live gauge, sampled once per tick).
+    /// Issue #79 round 6 — Srikanth's "how many connections are opened at
+    /// a time" ask. Tracked via [`mockforge_foundation::rate_counters::
+    /// HTTP_CONNECTIONS_OPEN`].
+    pub connections_open: u64,
+    /// Lifetime accepted HTTP connections (cumulative, not a rate).
+    pub connections_total_opened: u64,
+    /// Lifetime closed HTTP connections (cumulative).
+    pub connections_total_closed: u64,
+    /// Peak `connections_open` observed since `peaks_since` — useful for
+    /// confirming whether the server actually held many connections open
+    /// concurrently (multiplexing) or churned through one-shots (a sign
+    /// the proxy isn't keeping the upstream pool warm).
+    pub peak_connections_open: u64,
 }
 
 /// Time series data point
@@ -433,6 +447,13 @@ impl AdminState {
                 let rps_200 = cur_snapshot.ok.saturating_sub(prev_snapshot.ok) as f64 / dt_secs;
                 let cps =
                     cur_snapshot.accepts.saturating_sub(prev_snapshot.accepts) as f64 / dt_secs;
+                // Connection lifecycle gauges (#79 round 6). `connections_open`
+                // is a live gauge — read straight from the counter snapshot
+                // rather than a delta — and `total_opened` / `total_closed`
+                // are cumulative.
+                let conn_open = cur_snapshot.connections_open;
+                let conn_opened = cur_snapshot.accepts;
+                let conn_closed = cur_snapshot.connections_closed;
                 prev_snapshot = cur_snapshot;
                 prev_sample_at = now;
 
@@ -453,6 +474,7 @@ impl AdminState {
                     .update_system_metrics(memory_mb_u64, cpu_usage as f64, active_threads)
                     .await;
                 state_clone.update_rate_metrics(tps, rps_200, cps).await;
+                state_clone.update_connection_metrics(conn_open, conn_opened, conn_closed).await;
 
                 if let Some(file) = metrics_log.as_mut() {
                     let m = state_clone.metrics.read().await;
@@ -546,6 +568,10 @@ impl AdminState {
                 peak_rps_200: 0.0,
                 cps: 0.0,
                 peak_cps: 0.0,
+                connections_open: 0,
+                connections_total_opened: 0,
+                connections_total_closed: 0,
+                peak_connections_open: 0,
             })),
             config: Arc::new(RwLock::new(ConfigurationState {
                 latency_profile: LatencyProfile {
@@ -754,6 +780,7 @@ impl AdminState {
         sm.peak_tps = sm.tps;
         sm.peak_rps_200 = sm.rps_200;
         sm.peak_cps = sm.cps;
+        sm.peak_connections_open = sm.connections_open;
         sm.peaks_since = Utc::now();
     }
 
@@ -772,6 +799,19 @@ impl AdminState {
         }
         if cps > sm.peak_cps {
             sm.peak_cps = cps;
+        }
+    }
+
+    /// Update connection-lifecycle metrics. `open` is the live gauge,
+    /// `total_opened` and `total_closed` are cumulative counters.
+    /// Issue #79 round 6 — Srikanth's "show open/closed/total" ask.
+    pub async fn update_connection_metrics(&self, open: u64, total_opened: u64, total_closed: u64) {
+        let mut sm = self.system_metrics.write().await;
+        sm.connections_open = open;
+        sm.connections_total_opened = total_opened;
+        sm.connections_total_closed = total_closed;
+        if open > sm.peak_connections_open {
+            sm.peak_connections_open = open;
         }
     }
 
@@ -1155,6 +1195,10 @@ pub async fn get_dashboard(State(state): State<AdminState>) -> Json<ApiResponse<
         peak_rps_200: system_metrics.peak_rps_200,
         cps: system_metrics.cps,
         peak_cps: system_metrics.peak_cps,
+        connections_open: system_metrics.connections_open,
+        connections_total_opened: system_metrics.connections_total_opened,
+        connections_total_closed: system_metrics.connections_total_closed,
+        peak_connections_open: system_metrics.peak_connections_open,
     };
 
     let servers = vec![
@@ -5020,6 +5064,10 @@ mod tests {
             peak_rps_200: 0.0,
             cps: 0.0,
             peak_cps: 0.0,
+            connections_open: 0,
+            connections_total_opened: 0,
+            connections_total_closed: 0,
+            peak_connections_open: 0,
         };
 
         assert_eq!(metrics.active_threads, 10);

--- a/crates/mockforge-ui/src/models.rs
+++ b/crates/mockforge-ui/src/models.rs
@@ -121,6 +121,22 @@ pub struct SystemInfo {
     /// Peak `cps` observed since `peaks_since`.
     #[serde(default)]
     pub peak_cps: f64,
+    /// Currently-open HTTP connections (live gauge). Issue #79 round 6 —
+    /// Srikanth's "how many open at a time" ask. Tracked by the
+    /// `CountingMakeService` wrapper in `mockforge-http`; reflects
+    /// connections that completed accept (and, for HTTPS, the TLS
+    /// handshake) and that hyper still owns.
+    #[serde(default)]
+    pub connections_open: u64,
+    /// Lifetime accepted HTTP connections (cumulative).
+    #[serde(default)]
+    pub connections_total_opened: u64,
+    /// Lifetime closed HTTP connections (cumulative).
+    #[serde(default)]
+    pub connections_total_closed: u64,
+    /// Peak `connections_open` observed since `peaks_since`.
+    #[serde(default)]
+    pub peak_connections_open: u64,
 }
 
 /// Latency profile configuration
@@ -1254,6 +1270,10 @@ mod tests {
             peak_rps_200: 0.0,
             cps: 0.0,
             peak_cps: 0.0,
+            connections_open: 0,
+            connections_total_opened: 0,
+            connections_total_closed: 0,
+            peak_connections_open: 0,
         };
 
         assert_eq!(info.version, "0.3.8");


### PR DESCRIPTION
## Summary

- Adds `connections_open` (live), `connections_total_opened`, `connections_total_closed` gauges to `mockforge_foundation::rate_counters`; both plain HTTP and HTTPS serve paths bump them via the existing `CountingMakeService`.
- `MOCKFORGE_HTTP_LOG_CONN=1` now also emits a paired `http_conn_closed` INFO log per connection with `duration_ms` + `requests`, closing the round-5 diagnostic gap (we can now distinguish "MockForge closed" from "peer closed" in Srikanth's FIN-from-server PCAP).
- TUI dashboard surfaces the new gauges; bench reporter unconditionally prints client-side connection counts + peak concurrent VUs.

## Test plan

- [x] `cargo test -p mockforge-foundation -p mockforge-http -p mockforge-bench -p mockforge-ui -p mockforge-tui --lib` passes (incl. 4 new counting_listener tests covering accept/close, drop ordering, Arc-shared guard, and make-service-error balancing)
- [x] `cargo clippy ... -- -D warnings` passes for all affected crates
- [x] `cargo fmt --all --check` passes
- [x] Local smoke test: started `mockforge serve` with `MOCKFORGE_HTTP_LOG_CONN=1`, sent 3 keep-alive GETs + a `Connection: close` GET + a POST. Verified one `http_conn_closed duration_ms=N requests=3` for the keep-alive socket and `requests=1` for the single-shot ones.

Closes #79 (fingers crossed).