### PR TITLE
feat(registry,ui): cloud resilience runtime proxy (#468 follow-up)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -28,6 +28,7 @@ abd = "abd"  # Part of git commit hashes (e.g., abd3306)
 existant = "existant"  # CSS variable name (--sidebar-non-existant) - consistently used in book CSS
 Configuracion = "Configuracion"  # Spanish translation for "Configuration" in i18n
 Requiere = "Requiere"  # Spanish translation for "Requires" in i18n
+PN = "PN"  # Part of "6PN" — Fly.io's IPv6 private network branding
 
 [files]
 extend-exclude = [

--- a/crates/mockforge-registry-server/src/deployment/orchestrator.rs
+++ b/crates/mockforge-registry-server/src/deployment/orchestrator.rs
@@ -254,6 +254,12 @@ impl DeploymentOrchestrator {
         env.insert("MOCKFORGE_ORG_ID".to_string(), deployment.org_id.to_string());
         env.insert("MOCKFORGE_CONFIG".to_string(), serde_json::to_string(&deployment.config_json)?);
         env.insert("PORT".to_string(), "3000".to_string());
+        // Admin server hosts `/api/resilience/*` (#468 Phase 2) and other
+        // internal endpoints the registry proxies over Fly 6PN. It binds on
+        // 0.0.0.0:9080 inside the container (Docker default for AdminConfig)
+        // and isn't published as a public Fly service, so it's reachable
+        // only on `{app}.internal:9080` from sibling apps in the same org.
+        env.insert("MOCKFORGE_ADMIN_ENABLED".to_string(), "true".to_string());
 
         if let Some(ref spec_url) = deployment.openapi_spec_url {
             env.insert("MOCKFORGE_OPENAPI_SPEC_URL".to_string(), spec_url.clone());
@@ -602,6 +608,9 @@ impl DeploymentOrchestrator {
         env.insert("MOCKFORGE_ORG_ID".to_string(), deployment.org_id.to_string());
         env.insert("MOCKFORGE_CONFIG".to_string(), serde_json::to_string(&deployment.config_json)?);
         env.insert("PORT".to_string(), "3000".to_string());
+        // Same admin-server enable rationale as `deploy_to_flyio` above —
+        // gives the resilience proxy something to reach over 6PN.
+        env.insert("MOCKFORGE_ADMIN_ENABLED".to_string(), "true".to_string());
 
         if let Some(ref spec_url) = deployment.openapi_spec_url {
             env.insert("MOCKFORGE_OPENAPI_SPEC_URL".to_string(), spec_url.clone());

--- a/crates/mockforge-registry-server/src/handlers/resilience.rs
+++ b/crates/mockforge-registry-server/src/handlers/resilience.rs
@@ -1,59 +1,81 @@
-//! Cloud resilience handlers (#468) — Phase 1 (cloud scaffold).
+//! Cloud resilience handlers (#468) — Phase 2 (runtime proxy).
 //!
-//! The local `ResiliencePage` reads circuit-breaker + bulkhead state from
-//! `/api/resilience/*`. The state managers
-//! (`mockforge_chaos::resilience::CircuitBreakerManager` / `BulkheadManager`)
-//! exist, but no part of `mockforge-cli serve`, the admin-UI binary, or the
-//! hosted-mock runtime daemon currently installs them as middleware in the
-//! request path. That gap is the actual #468 work; the runtime wire-up is
-//! tracked separately in the #468 description after the scope correction.
+//! Live circuit-breaker + bulkhead state from a hosted mock. The deployment
+//! itself runs `mockforge serve` with the resilience middleware installed
+//! (#518) and exposes `/api/resilience/*` on its admin port. We reach it
+//! over Fly.io's private network (`{fly-app}.internal:9080`).
 //!
-//! This Phase 1 ships the *cloud-side API surface* so:
-//!   - The UI can branch on `isCloudMode()` and call the registry instead
-//!     of the never-mounted local routes.
-//!   - The future runtime PR has a stable contract to wire its state into.
-//!   - The `resilience` nav item is unblocked from `cloudHiddenNavItemIds`.
+//! Phase 1 of #468 (PR #517) shipped a workspace-scoped envelope that
+//! always returned `runtime_state: "pending"`. Phase 2 (this PR) corrects
+//! the scope — resilience state is per-deployment, not per-workspace —
+//! and replaces the placeholder with a real reqwest-driven proxy.
 //!
-//! Endpoints return empty payloads with a top-level `runtime_state` field
-//! carrying `"pending"` so the UI can render an honest empty state instead
-//! of a generic spinner. Once the runtime ingest channel lands, this module
-//! reads from a `runtime_resilience_state` table (or equivalent) and
-//! flips `runtime_state` to `"live"`.
+//! ## Wire format
 //!
-//! Routes:
-//!   GET  /api/v1/workspaces/{workspace_id}/resilience/circuit-breakers
-//!   GET  /api/v1/workspaces/{workspace_id}/resilience/bulkheads
-//!   GET  /api/v1/workspaces/{workspace_id}/resilience/summary
-//!   POST /api/v1/workspaces/{workspace_id}/resilience/circuit-breakers/{endpoint}/reset
-//!   POST /api/v1/workspaces/{workspace_id}/resilience/bulkheads/{service}/reset
+//! Every GET returns `{ runtime_state, data }`. `runtime_state` is one of:
+//! * `"live"` — proxy succeeded; `data` is whatever the deployment reported.
+//! * `"unreachable"` — proxy failed (connection refused, timeout, non-2xx
+//!   upstream, etc.); `data` is empty. The UI shows a "deployment not
+//!   reachable" banner. Picked over `"pending"` because it covers every
+//!   non-live state with one label and is honest about *why* the page is
+//!   empty: the registry tried and the deployment did not answer.
+//!
+//! POST resets return `{ accepted, runtime_state, reason }`. `accepted=true`
+//! is only set on a 2xx from the upstream reset endpoint.
+//!
+//! ## Routes
+//!
+//! * `GET  /api/v1/hosted-mocks/{deployment_id}/resilience/circuit-breakers`
+//! * `GET  /api/v1/hosted-mocks/{deployment_id}/resilience/bulkheads`
+//! * `GET  /api/v1/hosted-mocks/{deployment_id}/resilience/summary`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/resilience/circuit-breakers/{endpoint}/reset`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/resilience/bulkheads/{service}/reset`
+
+use std::time::Duration;
 
 use axum::{
     extract::{Path, State},
     http::HeaderMap,
     Json,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::{
     error::{ApiError, ApiResult},
     middleware::{resolve_org_context, AuthUser},
-    models::CloudWorkspace,
+    models::HostedMock,
     AppState,
 };
 
-/// Cloud circuit-breaker state. Mirrors
-/// `mockforge_chaos::resilience_api::CircuitBreakerStateResponse` so the UI
-/// can swap services without changing its types.
-#[derive(Debug, Clone, Serialize)]
+/// Admin port the hosted mock exposes `/api/resilience/*` on. Matches the
+/// default in `mockforge-core::config::protocol::AdminConfig`. Fly machines
+/// expose ports bound to `0.0.0.0` on the private 6PN network, so the
+/// admin server is reachable from the registry pod even though no
+/// `[[services]]` entry publishes it.
+const ADMIN_PORT: u16 = 9080;
+
+/// Reqwest timeout for one proxy call. The dashboard polls every few
+/// seconds, so a slow call shouldn't block UX — fail fast and let the
+/// next poll retry.
+const PROXY_TIMEOUT: Duration = Duration::from_secs(3);
+
+// --- Wire types -----------------------------------------------------------
+//
+// These mirror `mockforge_chaos::resilience_api::*Response`. Duplicated here
+// (rather than `pub use`d) so the registry doesn't pull in the whole chaos
+// crate; the upstream shape changes rarely and Deserialize keeps us
+// resilient to additive fields.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CircuitBreakerStateResponse {
     pub endpoint: String,
     pub state: String,
     pub stats: CircuitStatsResponse,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CircuitStatsResponse {
     pub total_requests: u64,
     pub successful_requests: u64,
@@ -65,13 +87,13 @@ pub struct CircuitStatsResponse {
     pub failure_rate: f64,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BulkheadStateResponse {
     pub service: String,
     pub stats: BulkheadStatsResponse,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BulkheadStatsResponse {
     pub active_requests: u32,
     pub queued_requests: u32,
@@ -82,11 +104,6 @@ pub struct BulkheadStatsResponse {
 }
 
 /// Envelope wrapping each GET response with a `runtime_state` discriminator.
-///
-/// The UI checks this field to decide between "no breakers configured yet"
-/// (empty + state=`live`) and "runtime instrumentation not yet wired"
-/// (empty + state=`pending`). Once runtime ingest lands, the inner `data`
-/// list populates and `runtime_state` stays `live`.
 #[derive(Debug, Serialize)]
 pub struct ResilienceEnvelope<T: Serialize> {
     pub runtime_state: &'static str,
@@ -94,9 +111,16 @@ pub struct ResilienceEnvelope<T: Serialize> {
 }
 
 impl<T: Serialize> ResilienceEnvelope<T> {
-    fn pending() -> Self {
+    fn live(data: Vec<T>) -> Self {
         Self {
-            runtime_state: "pending",
+            runtime_state: "live",
+            data,
+        }
+    }
+
+    fn unreachable() -> Self {
+        Self {
+            runtime_state: "unreachable",
             data: Vec::new(),
         }
     }
@@ -107,112 +131,189 @@ impl<T: Serialize> ResilienceEnvelope<T> {
 pub async fn list_circuit_breakers(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
-    Path(workspace_id): Path<Uuid>,
+    Path(deployment_id): Path<Uuid>,
     headers: HeaderMap,
 ) -> ApiResult<Json<ResilienceEnvelope<CircuitBreakerStateResponse>>> {
-    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
-    // Runtime wire-up is pending; return empty + pending discriminator.
-    Ok(Json(ResilienceEnvelope::pending()))
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let base_url = admin_base_url(&deployment);
+    let url = format!("{base_url}/api/resilience/circuit-breakers");
+    Ok(Json(match proxy_get_vec::<CircuitBreakerStateResponse>(&url).await {
+        Ok(data) => ResilienceEnvelope::live(data),
+        Err(err) => {
+            tracing::warn!(%deployment_id, error = %err, "resilience proxy GET failed");
+            ResilienceEnvelope::unreachable()
+        }
+    }))
 }
 
 pub async fn list_bulkheads(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
-    Path(workspace_id): Path<Uuid>,
+    Path(deployment_id): Path<Uuid>,
     headers: HeaderMap,
 ) -> ApiResult<Json<ResilienceEnvelope<BulkheadStateResponse>>> {
-    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
-    Ok(Json(ResilienceEnvelope::pending()))
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let base_url = admin_base_url(&deployment);
+    let url = format!("{base_url}/api/resilience/bulkheads");
+    Ok(Json(match proxy_get_vec::<BulkheadStateResponse>(&url).await {
+        Ok(data) => ResilienceEnvelope::live(data),
+        Err(err) => {
+            tracing::warn!(%deployment_id, error = %err, "resilience proxy GET failed");
+            ResilienceEnvelope::unreachable()
+        }
+    }))
 }
 
 pub async fn get_summary(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
-    Path(workspace_id): Path<Uuid>,
+    Path(deployment_id): Path<Uuid>,
     headers: HeaderMap,
 ) -> ApiResult<Json<Value>> {
-    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
-    // Same shape as `mockforge_chaos::resilience_api::get_dashboard_summary`
-    // so the UI's summary cards render identically; `runtime_state` flags
-    // the data as scaffold rather than live.
-    Ok(Json(json!({
-        "runtime_state": "pending",
-        "circuit_breakers": {
-            "total": 0,
-            "open": 0,
-            "half_open": 0,
-            "closed": 0,
-        },
-        "bulkheads": {
-            "total": 0,
-            "active_requests": 0,
-            "queued_requests": 0,
-        },
-    })))
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let base_url = admin_base_url(&deployment);
+    let url = format!("{base_url}/api/resilience/dashboard/summary");
+    Ok(Json(match proxy_get_value(&url).await {
+        Ok(mut body) => {
+            // The hosted mock's summary endpoint returns the raw stats
+            // object without a runtime_state tag; tag it here so the UI's
+            // single discriminator path keeps working.
+            if let Value::Object(ref mut map) = body {
+                map.insert("runtime_state".into(), Value::String("live".into()));
+            }
+            body
+        }
+        Err(err) => {
+            tracing::warn!(%deployment_id, error = %err, "resilience proxy GET summary failed");
+            json!({
+                "runtime_state": "unreachable",
+                "circuit_breakers": { "total": 0, "open": 0, "half_open": 0, "closed": 0 },
+                "bulkheads": { "total": 0, "active_requests": 0, "queued_requests": 0 },
+            })
+        }
+    }))
 }
 
 // --- POST handlers --------------------------------------------------------
 
-/// Reset a circuit breaker. No-ops while the runtime ingest channel is
-/// pending; returns the same JSON envelope shape `{accepted, runtime_state,
-/// reason}` for both states so the UI doesn't need conditional parsing once
-/// the live runtime lands.
 pub async fn reset_circuit_breaker(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
-    Path((workspace_id, endpoint)): Path<(Uuid, String)>,
+    Path((deployment_id, endpoint)): Path<(Uuid, String)>,
     headers: HeaderMap,
 ) -> ApiResult<Json<Value>> {
-    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
-    tracing::info!(
-        %workspace_id,
-        endpoint = %endpoint,
-        "circuit-breaker reset requested while runtime wire-up is pending",
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let base_url = admin_base_url(&deployment);
+    // The hosted mock's endpoint segment is itself a path component that
+    // may contain `/`, so urlencode it.
+    let url = format!(
+        "{base_url}/api/resilience/circuit-breakers/{}/reset",
+        urlencoding::encode(&endpoint),
     );
-    Ok(Json(json!({
-        "accepted": false,
-        "runtime_state": "pending",
-        "reason": "Resilience runtime wire-up is pending; this reset is a no-op until it lands.",
-    })))
+    Ok(Json(match proxy_post_empty(&url).await {
+        Ok(()) => json!({ "accepted": true, "runtime_state": "live" }),
+        Err(err) => {
+            tracing::warn!(%deployment_id, %endpoint, error = %err, "resilience proxy POST reset failed");
+            json!({
+                "accepted": false,
+                "runtime_state": "unreachable",
+                "reason": err.to_string(),
+            })
+        }
+    }))
 }
 
 pub async fn reset_bulkhead(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
-    Path((workspace_id, service)): Path<(Uuid, String)>,
+    Path((deployment_id, service)): Path<(Uuid, String)>,
     headers: HeaderMap,
 ) -> ApiResult<Json<Value>> {
-    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
-    tracing::info!(
-        %workspace_id,
-        service = %service,
-        "bulkhead reset requested while runtime wire-up is pending",
-    );
-    Ok(Json(json!({
-        "accepted": false,
-        "runtime_state": "pending",
-        "reason": "Resilience runtime wire-up is pending; this reset is a no-op until it lands.",
-    })))
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let base_url = admin_base_url(&deployment);
+    let url =
+        format!("{base_url}/api/resilience/bulkheads/{}/reset", urlencoding::encode(&service),);
+    Ok(Json(match proxy_post_empty(&url).await {
+        Ok(()) => json!({ "accepted": true, "runtime_state": "live" }),
+        Err(err) => {
+            tracing::warn!(%deployment_id, %service, error = %err, "resilience proxy POST reset failed");
+            json!({
+                "accepted": false,
+                "runtime_state": "unreachable",
+                "reason": err.to_string(),
+            })
+        }
+    }))
 }
 
 // --- helpers --------------------------------------------------------------
 
-async fn authorize_workspace(
+/// Build the 6PN admin URL for a hosted mock. The deployment is a Fly app
+/// named via [`HostedMock::fly_app_name`]; Fly resolves `{name}.internal`
+/// to a private IPv6 reachable from the registry pod.
+fn admin_base_url(deployment: &HostedMock) -> String {
+    format!("http://{}.internal:{ADMIN_PORT}", deployment.fly_app_name())
+}
+
+/// GET a JSON list. 2xx + valid JSON → Ok; anything else → Err.
+async fn proxy_get_vec<T: for<'de> serde::Deserialize<'de>>(url: &str) -> reqwest::Result<Vec<T>> {
+    reqwest::Client::builder()
+        .timeout(PROXY_TIMEOUT)
+        .build()?
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Vec<T>>()
+        .await
+}
+
+/// GET an arbitrary JSON object (used for the summary endpoint, which has
+/// a fixed shape but the registry doesn't model it strongly).
+async fn proxy_get_value(url: &str) -> reqwest::Result<Value> {
+    reqwest::Client::builder()
+        .timeout(PROXY_TIMEOUT)
+        .build()?
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Value>()
+        .await
+}
+
+/// POST with no body, discard response. Used for reset endpoints; 2xx is
+/// the only signal we care about.
+async fn proxy_post_empty(url: &str) -> reqwest::Result<()> {
+    reqwest::Client::builder()
+        .timeout(PROXY_TIMEOUT)
+        .build()?
+        .post(url)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(())
+}
+
+/// Resolve `deployment_id` to a `HostedMock`, after confirming the caller's
+/// org matches. Returns the deployment so callers can build the admin URL
+/// without a second DB hit.
+async fn authorize_deployment(
     state: &AppState,
     user_id: Uuid,
     headers: &HeaderMap,
-    workspace_id: Uuid,
-) -> ApiResult<()> {
-    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+    deployment_id: Uuid,
+) -> ApiResult<HostedMock> {
+    let deployment = HostedMock::find_by_id(state.db.pool(), deployment_id)
         .await?
-        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+        .ok_or_else(|| ApiError::InvalidRequest("Deployment not found".into()))?;
     let ctx = resolve_org_context(state, user_id, headers, None)
         .await
         .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
-    if ctx.org_id != workspace.org_id {
-        return Err(ApiError::InvalidRequest("Workspace not found".into()));
+    if ctx.org_id != deployment.org_id {
+        return Err(ApiError::InvalidRequest("Deployment not found".into()));
     }
-    Ok(())
+    Ok(deployment)
 }
 
 #[cfg(test)]
@@ -220,20 +321,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn envelope_pending_is_empty() {
-        let env: ResilienceEnvelope<CircuitBreakerStateResponse> = ResilienceEnvelope::pending();
-        assert_eq!(env.runtime_state, "pending");
-        assert!(env.data.is_empty());
+    fn envelope_live_round_trips_data() {
+        let env = ResilienceEnvelope::live(vec![BulkheadStateResponse {
+            service: "http".into(),
+            stats: BulkheadStatsResponse {
+                active_requests: 3,
+                queued_requests: 0,
+                total_requests: 17,
+                rejected_requests: 0,
+                timeout_requests: 0,
+                utilization_percent: 3.0,
+            },
+        }]);
+        let body = serde_json::to_value(&env).unwrap();
+        assert_eq!(body["runtime_state"], "live");
+        assert_eq!(body["data"].as_array().unwrap().len(), 1);
+        assert_eq!(body["data"][0]["service"], "http");
+        assert_eq!(body["data"][0]["stats"]["active_requests"], 3);
     }
 
     #[test]
-    fn envelope_serialization_matches_contract() {
-        // The UI keys off `runtime_state` and `data`. Lock the JSON shape
-        // so a refactor doesn't silently break the client.
-        let env: ResilienceEnvelope<CircuitBreakerStateResponse> = ResilienceEnvelope::pending();
+    fn envelope_unreachable_is_empty() {
+        let env: ResilienceEnvelope<CircuitBreakerStateResponse> =
+            ResilienceEnvelope::unreachable();
         let body = serde_json::to_value(&env).unwrap();
-        assert_eq!(body["runtime_state"], "pending");
-        assert!(body["data"].is_array());
+        assert_eq!(body["runtime_state"], "unreachable");
         assert_eq!(body["data"].as_array().unwrap().len(), 0);
     }
 }

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -503,28 +503,30 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/snapshots/{id}/restore",
             post(handlers::snapshots::restore_snapshot),
         )
-        // Resilience scaffold routes (#468 / part of #459) — see
-        // handlers::resilience for the runtime-wire-up gap. Endpoints
-        // return empty payloads tagged `runtime_state: "pending"`; the
-        // UI renders that as an honest empty-state instead of a spinner.
+        // Resilience runtime proxy (#468 Phase 2 follow-up). Scoped to a
+        // hosted-mock deployment because circuit-breaker / bulkhead state
+        // lives in the running `mockforge serve` process. Handlers proxy
+        // over Fly 6PN to `{fly-app}.internal:9080/api/resilience/*` and
+        // return `runtime_state: "live"` or `"unreachable"`. Phase 1's
+        // workspace-scoped routes were the wrong scope; corrected here.
         .route(
-            "/api/v1/workspaces/{workspace_id}/resilience/circuit-breakers",
+            "/api/v1/hosted-mocks/{deployment_id}/resilience/circuit-breakers",
             get(handlers::resilience::list_circuit_breakers),
         )
         .route(
-            "/api/v1/workspaces/{workspace_id}/resilience/bulkheads",
+            "/api/v1/hosted-mocks/{deployment_id}/resilience/bulkheads",
             get(handlers::resilience::list_bulkheads),
         )
         .route(
-            "/api/v1/workspaces/{workspace_id}/resilience/summary",
+            "/api/v1/hosted-mocks/{deployment_id}/resilience/summary",
             get(handlers::resilience::get_summary),
         )
         .route(
-            "/api/v1/workspaces/{workspace_id}/resilience/circuit-breakers/{endpoint}/reset",
+            "/api/v1/hosted-mocks/{deployment_id}/resilience/circuit-breakers/{endpoint}/reset",
             post(handlers::resilience::reset_circuit_breaker),
         )
         .route(
-            "/api/v1/workspaces/{workspace_id}/resilience/bulkheads/{service}/reset",
+            "/api/v1/hosted-mocks/{deployment_id}/resilience/bulkheads/{service}/reset",
             post(handlers::resilience::reset_bulkhead),
         )
         // Flow routes (cloud-enablement task #9 / Phase 1).

--- a/crates/mockforge-ui/ui/src/pages/ResiliencePage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/ResiliencePage.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { isCloudMode } from '../utils/cloudMode';
-import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 import { cloudResilienceApi, type RuntimeState } from '../services/api/cloudResilience';
+
+interface DeploymentSummary {
+  id: string;
+  name: string;
+  status: string;
+}
 
 interface CircuitBreakerState {
   endpoint: string;
@@ -58,17 +63,52 @@ export const ResiliencePage: React.FC = () => {
   const [runtimeState, setRuntimeState] = useState<RuntimeState | null>(null);
 
   const cloudMode = isCloudMode();
-  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
-  const workspaceId = activeWorkspace?.id;
+  // In cloud mode the page scopes to a single hosted-mock deployment because
+  // resilience state lives in that deployment's running mockforge process.
+  // We pick the first active deployment by default; if the org has more
+  // than one, the dropdown lets the user switch.
+  const [deployments, setDeployments] = useState<DeploymentSummary[]>([]);
+  const [selectedDeploymentId, setSelectedDeploymentId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!cloudMode) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = localStorage.getItem('auth_token');
+        const response = await fetch('/api/v1/hosted-mocks', {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!response.ok) return;
+        const list = (await response.json()) as DeploymentSummary[];
+        if (cancelled) return;
+        const items = Array.isArray(list) ? list : [];
+        setDeployments(items);
+        // Auto-select the first active deployment so the page works without
+        // an extra click in the common one-deployment-per-org case.
+        if (!selectedDeploymentId) {
+          const active = items.find((d) => d.status === 'active') ?? items[0] ?? null;
+          if (active) setSelectedDeploymentId(active.id);
+        }
+      } catch (err) {
+        console.error('Failed to load deployments:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // selectedDeploymentId intentionally omitted: only run on mode change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cloudMode]);
 
   const fetchCircuitBreakers = async () => {
     try {
       if (cloudMode) {
-        if (!workspaceId) {
+        if (!selectedDeploymentId) {
           setCircuitBreakers([]);
           return;
         }
-        const env = await cloudResilienceApi.listCircuitBreakers(workspaceId);
+        const env = await cloudResilienceApi.listCircuitBreakers(selectedDeploymentId);
         setCircuitBreakers(env.data);
         setRuntimeState(env.runtime_state);
         return;
@@ -84,11 +124,11 @@ export const ResiliencePage: React.FC = () => {
   const fetchBulkheads = async () => {
     try {
       if (cloudMode) {
-        if (!workspaceId) {
+        if (!selectedDeploymentId) {
           setBulkheads([]);
           return;
         }
-        const env = await cloudResilienceApi.listBulkheads(workspaceId);
+        const env = await cloudResilienceApi.listBulkheads(selectedDeploymentId);
         setBulkheads(env.data);
         setRuntimeState(env.runtime_state);
         return;
@@ -104,11 +144,11 @@ export const ResiliencePage: React.FC = () => {
   const fetchSummary = async () => {
     try {
       if (cloudMode) {
-        if (!workspaceId) {
+        if (!selectedDeploymentId) {
           setSummary(null);
           return;
         }
-        const s = await cloudResilienceApi.getSummary(workspaceId);
+        const s = await cloudResilienceApi.getSummary(selectedDeploymentId);
         setSummary({
           circuit_breakers: s.circuit_breakers,
           bulkheads: { ...s.bulkheads },
@@ -127,8 +167,11 @@ export const ResiliencePage: React.FC = () => {
   const resetCircuitBreaker = async (endpoint: string) => {
     try {
       if (cloudMode) {
-        if (!workspaceId) return;
-        const result = await cloudResilienceApi.resetCircuitBreaker(workspaceId, endpoint);
+        if (!selectedDeploymentId) return;
+        const result = await cloudResilienceApi.resetCircuitBreaker(
+          selectedDeploymentId,
+          endpoint,
+        );
         if (!result.accepted) {
           console.info('Circuit breaker reset is a no-op:', result.reason);
         }
@@ -147,8 +190,8 @@ export const ResiliencePage: React.FC = () => {
   const resetBulkhead = async (service: string) => {
     try {
       if (cloudMode) {
-        if (!workspaceId) return;
-        const result = await cloudResilienceApi.resetBulkhead(workspaceId, service);
+        if (!selectedDeploymentId) return;
+        const result = await cloudResilienceApi.resetBulkhead(selectedDeploymentId, service);
         if (!result.accepted) {
           console.info('Bulkhead reset is a no-op:', result.reason);
         }
@@ -178,7 +221,8 @@ export const ResiliencePage: React.FC = () => {
     }, 3000);
 
     return () => clearInterval(interval);
-  }, [autoRefresh]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoRefresh, selectedDeploymentId]);
 
   const getStateColor = (state: string): string => {
     switch (state) {
@@ -201,24 +245,47 @@ export const ResiliencePage: React.FC = () => {
 
   return (
     <div className="p-6 space-y-6">
-      {/* Pending-runtime banner (#468 cloud scaffold). Stops users wondering
-          why their counts stay at zero. Hides once the runtime ingest lands
-          and the registry starts returning `runtime_state: 'live'`. */}
-      {cloudMode && runtimeState === 'pending' && (
+      {/* Deployment unreachable banner. The registry proxies live state from
+          the hosted-mock's admin port; when that proxy fails (deployment
+          stopped, not yet started, transient network), the page renders zeros
+          and we want to surface why instead of letting them look like real
+          live data. */}
+      {cloudMode && runtimeState === 'unreachable' && selectedDeploymentId && (
         <div className="bg-warning-50 border border-warning-200 dark:bg-warning-900/30 dark:border-warning-800 rounded-lg p-4">
           <p className="font-medium text-warning-700 dark:text-warning-300">
-            Resilience runtime not yet wired
+            Deployment not reachable
           </p>
           <p className="text-sm text-warning-700/80 dark:text-warning-300/80 mt-1">
-            Cloud-side API is live, but hosted-mock runners don&rsquo;t yet install
-            the circuit-breaker / bulkhead middleware. Counters stay at zero
-            until that follow-up ships; resets are accepted but no-op.
+            The registry could not reach this deployment&rsquo;s admin endpoint.
+            Resilience counters will populate once the deployment is running
+            and reachable on the private network.
           </p>
         </div>
       )}
-      {cloudMode && !workspaceId && (
+      {cloudMode && !selectedDeploymentId && (
         <div className="bg-card border border-border rounded-lg p-4 text-sm text-muted-foreground">
-          Select a workspace to view resilience state.
+          {deployments.length === 0
+            ? 'No hosted-mock deployments yet. Create one from the Hosted Mocks page to see resilience state here.'
+            : 'Select a deployment to view resilience state.'}
+        </div>
+      )}
+      {cloudMode && deployments.length > 1 && (
+        <div className="flex items-center space-x-2">
+          <label className="text-sm font-medium text-foreground" htmlFor="resilience-deployment">
+            Deployment:
+          </label>
+          <select
+            id="resilience-deployment"
+            value={selectedDeploymentId ?? ''}
+            onChange={(e) => setSelectedDeploymentId(e.target.value || null)}
+            className="rounded border border-border bg-card text-foreground text-sm px-2 py-1"
+          >
+            {deployments.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.name} ({d.status})
+              </option>
+            ))}
+          </select>
         </div>
       )}
 

--- a/crates/mockforge-ui/ui/src/services/api/cloudResilience.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudResilience.ts
@@ -1,23 +1,21 @@
 /**
- * Cloud resilience API client (#468 Phase 1 — cloud scaffold).
+ * Cloud resilience API client (#468).
  *
- * Backs the registry's `/api/v1/workspaces/{id}/resilience/*` routes.
+ * Backs the registry's `/api/v1/hosted-mocks/{deployment_id}/resilience/*`
+ * routes. The registry proxies over Fly 6PN to the running mockforge
+ * instance's admin port (`{fly-app}.internal:9080`) and tags the response
+ * with `runtime_state`.
  *
- * Phase 1 always returns `runtime_state: 'pending'` with empty lists because
- * the hosted-mock runtime doesn't yet install the circuit-breaker / bulkhead
- * middleware. The wire-up is the bulk of #468 and lives in a follow-up;
- * shipping the API surface now means `ResiliencePage` can stop calling the
- * never-mounted `/api/resilience/*` routes and instead render an honest
- * empty state.
- *
- * Reset endpoints return `{ accepted: false, runtime_state: 'pending',
- * reason }` so the page can surface a "no-op while pending" toast instead
- * of treating the reset as failed.
+ * `runtime_state` values:
+ * * `'live'` — proxy succeeded; `data` is the deployment's current state.
+ * * `'unreachable'` — registry could not reach the deployment (not yet
+ *   deployed, connection refused, timeout, etc.); `data` is empty. Show
+ *   an empty state with a "deployment not reachable" hint.
  */
 import { fetchJsonWithErrorBody } from './client';
 import { isCloudMode } from '../../utils/cloudMode';
 
-export type RuntimeState = 'pending' | 'live';
+export type RuntimeState = 'live' | 'unreachable';
 
 export interface ResilienceEnvelope<T> {
   runtime_state: RuntimeState;
@@ -71,46 +69,46 @@ class CloudResilienceApi {
   }
 
   async listCircuitBreakers(
-    workspaceId: string,
+    deploymentId: string,
   ): Promise<ResilienceEnvelope<CloudCircuitBreakerState>> {
     this.guard('listCircuitBreakers');
     return fetchJsonWithErrorBody(
-      `/api/v1/workspaces/${workspaceId}/resilience/circuit-breakers`,
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/resilience/circuit-breakers`,
     ) as Promise<ResilienceEnvelope<CloudCircuitBreakerState>>;
   }
 
-  async listBulkheads(workspaceId: string): Promise<ResilienceEnvelope<CloudBulkheadState>> {
+  async listBulkheads(deploymentId: string): Promise<ResilienceEnvelope<CloudBulkheadState>> {
     this.guard('listBulkheads');
     return fetchJsonWithErrorBody(
-      `/api/v1/workspaces/${workspaceId}/resilience/bulkheads`,
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/resilience/bulkheads`,
     ) as Promise<ResilienceEnvelope<CloudBulkheadState>>;
   }
 
-  async getSummary(workspaceId: string): Promise<CloudResilienceSummary> {
+  async getSummary(deploymentId: string): Promise<CloudResilienceSummary> {
     this.guard('getSummary');
     return fetchJsonWithErrorBody(
-      `/api/v1/workspaces/${workspaceId}/resilience/summary`,
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/resilience/summary`,
     ) as Promise<CloudResilienceSummary>;
   }
 
   async resetCircuitBreaker(
-    workspaceId: string,
+    deploymentId: string,
     endpoint: string,
   ): Promise<CloudResilienceResetResult> {
     this.guard('resetCircuitBreaker');
     return fetchJsonWithErrorBody(
-      `/api/v1/workspaces/${workspaceId}/resilience/circuit-breakers/${encodeURIComponent(endpoint)}/reset`,
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/resilience/circuit-breakers/${encodeURIComponent(endpoint)}/reset`,
       { method: 'POST' },
     ) as Promise<CloudResilienceResetResult>;
   }
 
   async resetBulkhead(
-    workspaceId: string,
+    deploymentId: string,
     service: string,
   ): Promise<CloudResilienceResetResult> {
     this.guard('resetBulkhead');
     return fetchJsonWithErrorBody(
-      `/api/v1/workspaces/${workspaceId}/resilience/bulkheads/${encodeURIComponent(service)}/reset`,
+      `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/resilience/bulkheads/${encodeURIComponent(service)}/reset`,
       { method: 'POST' },
     ) as Promise<CloudResilienceResetResult>;
   }


### PR DESCRIPTION
## Summary

Closes the runtime side of #468. Phase 1 (#517) shipped workspace-scoped resilience endpoints that always returned `runtime_state: pending` because no proxy to the running mockforge process existed yet. Phase 2 (#518) wired the middleware into the mockforge serve path. This PR is the last piece: a real proxy + a scope correction + the orchestrator change that makes the admin port reachable at all.

## Scope correction: workspace → deployment

The Phase 1 path was `/api/v1/workspaces/{workspace_id}/resilience/*`, but circuit-breaker / bulkhead state lives in a specific mockforge process — a deployment, not a workspace. A workspace can plausibly hold multiple deployments (dev/staging/prod), so the workspace-scoped path silently lost the question "which one?". Every other hosted-mock handler in the registry already uses `/api/v1/hosted-mocks/{deployment_id}/...` — resilience now matches.

## Server: handlers/resilience.rs

- `reqwest` proxy over Fly 6PN to `http://{HostedMock::fly_app_name}.internal:9080/api/resilience/*`. Verified `.internal` DNS resolves and TCP/HTTP works from inside the registry pod.
- `runtime_state` is now `"live" | "unreachable"`. Dropped `"pending"` — with a real proxy in place, every non-live state is some form of unreachable.
- 3-second proxy timeout. Fail fast and let the next poll retry.
- Reset POSTs proxy upstream; `accepted` reflects upstream 2xx only.

Authz mirrors the rest of `handlers/hosted_mocks.rs`.

## Orchestrator: enable admin server on hosted-mock deploys

The proxy reaches the deployment's admin port (9080). But the orchestrator never injected `MOCKFORGE_ADMIN_ENABLED` and the AdminConfig default is `enabled: false` — so the admin server didn't actually run in cloud deployments, and the proxy would have returned `unreachable` for every deployment that ever existed.

Both `deploy_to_flyio` and `redeploy_to_flyio` now set `MOCKFORGE_ADMIN_ENABLED=true`. The admin host is already `0.0.0.0` inside the container (Docker default), port 9080 is the default, and the Fly services list intentionally still doesn't publish 9080 publicly — it's reachable only on `{app}.internal:9080` from sibling apps.

## UI

- `cloudResilience.ts` takes `deploymentId` everywhere (was `workspaceId`).
- `ResiliencePage` fetches `/api/v1/hosted-mocks` and:
  - auto-selects the first active deployment so the one-deployment case works without an extra click,
  - shows a `<select>` only when the org has >1 deployment,
  - renders "no hosted-mock deployments yet" when the list is empty.
- The Phase 1 "runtime not yet wired" banner is replaced with a "deployment not reachable" banner.

## Drive-by

`.typos.toml`: allow `PN` so `6PN` (Fly's IPv6 private network branding) doesn't trip the typos hook.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-registry-server --lib handlers::resilience` — 2/2 envelope round-trip tests pass
- [x] `pnpm type-check` and `pnpm lint` in `mockforge-ui/ui` clean
- [x] Fly 6PN reachability verified manually (`curl mockforge-tunnel-relay.internal:8080/health` from inside the `mockforge-registry` pod returned `{"service":"mockforge-tunnel-server","status":"healthy"}`)
- [ ] End-to-end against a real hosted-mock — verify post-merge by deploying a temp test workspace and confirming `runtime_state: "live"` on the dashboard. No hosted-mock Fly apps exist yet in the personal org, so this is the first live-fire test of the full chain.

Closes the runtime side of #468.