### PR TITLE
chore(release): bump workspace to 0.3.135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [0.3.135] - 2026-05-15
+
+### Added
+
+- **[Cloud][Reality]** Cloud-mode Resilience dashboard — end-to-end live state from hosted-mock deployments (#468)
+  - **Phase 1 (#517) — cloud scaffold:** registry exposes `/api/v1/hosted-mocks/{deployment_id}/resilience/{circuit-breakers, bulkheads, summary}` and POST reset endpoints. UI's `ResiliencePage` branches on `isCloudMode()` and calls the registry instead of the never-mounted local `/api/resilience/*` routes. Originally workspace-scoped; #522 corrected the scope (see below) — circuit-breaker / bulkhead state lives in a specific mockforge process so it must be deployment-scoped.
+  - **Phase 2 (#518) — middleware in the runtime:** new `mockforge_chaos::resilience_middleware` axum layer wires every HTTP request through the existing `CircuitBreakerManager` + `BulkheadManager`. Per-endpoint circuit breaker keyed by `"{METHOD} {path}"`; bulkhead keyed on a configurable service string (defaults to `"http"`); only 5xx counts as a breaker failure (4xx stays out of the per-endpoint failure budget). Bulkhead saturation returns 503 + `Retry-After: 1` without recording on the breaker. `mockforge serve` now layers the middleware on the HTTP app and mounts `mockforge_chaos::create_resilience_router` on the admin port; `default_resilience_state()` returns a `(MiddlewareState, ResilienceApiState)` pair backed by the same `Arc<...Manager>` instances so the dashboard reflects what the middleware records.
+  - **CLI flags wired (#519):** existing `--circuit-breaker` / `--bulkhead` flags (and the nine threshold/limit knobs that come with them) actually turn the middleware on. New `resilience_state_from_configs(circuit, bulkhead)` builder takes `Option<CircuitBreakerConfig>` / `Option<BulkheadConfig>` overrides; `serve.rs` threads the CLI values into both `ChaosConfig` (so `/api/chaos/*` reports identical settings) and the resilience state. When both flags are unset, behaviour is identical to before — middleware short-circuits per-request, effectively free.
+  - **Phase 3 (#522) — runtime proxy + admin enable:** registry now `reqwest`-proxies `/api/v1/hosted-mocks/{deployment_id}/resilience/*` over Fly 6PN to `http://{HostedMock::fly_app_name}.internal:9080/api/resilience/*` (3-second timeout, fail-fast). `runtime_state` is now `"live" | "unreachable"` — dropped `"pending"` because every non-live state is some form of unreachable with a real proxy in place. **The orchestrator now injects `MOCKFORGE_ADMIN_ENABLED=true` on every Fly deploy** (both `deploy_to_flyio` and `redeploy_to_flyio`); without that, the admin server wouldn't start in cloud and the proxy would have returned `unreachable` for every deployment that ever existed. UI gains a deployment selector: auto-selects the first active deployment in the org, shows a `<select>` only when >1 exists, renders a helpful empty state when none.
+- **[Cloud]** Cloud-mode Virtual Backends — consistency lifecycle presets (#516, #461)
+  - Registry endpoints for managing virtual-backend lifecycle (provisioning, eventual consistency, primary/secondary fan-out) with cloud-side persistence and audit. UI lifecycle picker now drives cloud-mode workspaces without falling back to the local-only surface.
+
+### Fixed
+
+- **[Security]** `lettre` 0.11.21 → 0.11.22 to clear RUSTSEC-2026-0141 (critical, published 2026-05-14) (#521)
+  - Patch-level bump in Cargo.lock; no API surface change.
+  - Drive-by clippy cleanup in `mockforge-registry` to unblock the warning ratchet on the lettre commit.
+
 ## [0.3.134] - 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7652,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7869,7 +7869,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7900,7 +7900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8004,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8037,7 +8037,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8060,7 +8060,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8081,7 +8081,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8145,7 +8145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8267,7 +8267,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8285,7 +8285,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8378,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8403,7 +8403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8450,7 +8450,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8466,7 +8466,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8495,7 +8495,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8590,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8630,7 +8630,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8692,7 +8692,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8739,7 +8739,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8777,7 +8777,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8847,7 +8847,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8867,7 +8867,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8902,7 +8902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8939,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8967,7 +8967,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8997,7 +8997,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9024,7 +9024,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9048,14 +9048,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9082,7 +9082,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9133,7 +9133,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9156,7 +9156,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9187,7 +9187,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9274,7 +9274,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9285,7 +9285,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9302,7 +9302,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -14964,7 +14964,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.134"
+version = "0.3.135"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.134"
+version = "0.3.135"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Release v0.3.135. CHANGELOG covers everything since v0.3.134:

- **#468 chain (Phase 1-3)** — cloud-mode Resilience dashboard end-to-end
  - #517 cloud scaffold (registry endpoints + UI client)
  - #518 middleware in `mockforge serve` + admin-side router mount
  - #519 CLI flags actually drive the middleware
  - #522 registry-side `reqwest` proxy over Fly 6PN + orchestrator now sets `MOCKFORGE_ADMIN_ENABLED=true` so the proxy can reach the admin port at all
- **#516 / #461** — Cloud-mode Virtual Backends consistency lifecycle presets
- **#521** — `lettre` 0.11.21 → 0.11.22 (RUSTSEC-2026-0141, critical)

## Why

#522 just merged; once this release tags, `release.yml` `deploy-registry` redeploys `mockforge-registry` on Fly with the new proxy + orchestrator. After that, deploying any hosted-mock will give `runtime_state: "live"` on the Resilience dashboard — the first time #468 actually works end-to-end in cloud.

## Test plan

- [x] `cargo fmt` / clippy / typos / audit pre-commit hooks all pass on this branch
- [ ] After merge: tag `v0.3.135` on the squashed merge commit, push tag, watch `release.yml` deploy the registry
- [ ] Provision a test hosted-mock, confirm `runtime_state: "live"` on `/api/v1/hosted-mocks/{id}/resilience/circuit-breakers`