### PR TITLE
chore(release): bump workspace to 0.3.136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [0.3.136] - 2026-05-15
+
+### Added
+
+- **[Registry][Security]** Usage-limit enforcement + `past_due` read-only mode — closes launch blocker #449 (#515)
+  - **429 spec body for quota exhaustion:** new `ApiError::UsageLimitExceeded { limit_type, current, max, period }` returns the `{"error":"usage_limit_exceeded","limit":"…","current":N,"max":M}` shape from the issue. Wired into both the hosted-mock proxy's inline `enforce_monthly_quota` and the previously-dead `org_rate_limit_middleware`, so the same response shape comes out of every path that ever has to reject for quota. Free-tier orgs no longer have an unbounded request budget; Pro/Team orgs trip 429 at their plan ceiling instead of silently consuming Team-tier volume on a Pro plan.
+  - **`past_due` read-only mode after 24h grace:** new `past_due_writes_blocked` middleware on the authenticated route stack. Once an org is in `past_due` past the 24h grace window (introduced in #507), write methods outside an explicit billing/auth/support/legal allowlist return 402 PaymentRequired. Reads + recovery paths (billing portal, support, legal) stay fully reachable so the customer can self-serve out of dunning. Closes the "customer keeps consuming compute through the 7–10 day Stripe retry window" leak.
+  - **402 on past_due deploys (criterion 8):** the deploy-time past_due gate now returns 402 PaymentRequired via a new `ApiError::PaymentRequired` variant, distinct from the old 400 InvalidRequest — billing-state failure is a distinct response class from a malformed request.
+  - **Integration coverage:** new `crates/mockforge-registry-server/tests/usage_limits_e2e.rs` exercises the free→429-with-spec-body path, past_due→402 on the deploy handler, past_due→402 on `POST /api/v1/workspaces` (proves the route-wide middleware works, not just the inline check), and confirms reads + billing endpoints stay reachable. Gated `#[ignore]` for DATABASE_URL availability; run via the registry's E2E job.
+  - This closes the last 3 of #449's 8 acceptance criteria; the deploy/workspace/member gates (#479), `requests_per_30d` hosted-mock proxy enforcement (#494), and 24h past_due grace window (#507) had already shipped in earlier patches.
+
+### Fixed
+
+- **[Reality]** Drained workspace-wide `unused_qualifications` regressions in `mockforge-http::counting_listener` (9 sites, from #520) and `mockforge-registry-server::handlers::resilience` (1 site, from #522) (#515, second commit)
+  - Both PRs ran the warning gate's scoped check (`mockforge-cli` + `mockforge-ui`) only, so the workspace-wide `unused_qualifications` ratchet (graduated workspace-wide in #500-#511) caught these on rebase rather than at merge time. Trivial removals of redundant `tower::`, `std::pin::`, `std::task::`, and `serde::` prefixes where the inner item is already in scope.
+
 ## [0.3.135] - 2026-05-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7652,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7869,7 +7869,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7900,7 +7900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8004,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8037,7 +8037,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8060,7 +8060,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8081,7 +8081,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8145,7 +8145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8267,7 +8267,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8285,7 +8285,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8378,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8403,7 +8403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8450,7 +8450,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8466,7 +8466,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8495,7 +8495,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8590,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8630,7 +8630,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8692,7 +8692,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8739,7 +8739,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8777,7 +8777,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8847,7 +8847,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8867,7 +8867,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8902,7 +8902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8939,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8967,7 +8967,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8997,7 +8997,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9024,7 +9024,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9048,14 +9048,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9082,7 +9082,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9133,7 +9133,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9156,7 +9156,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9187,7 +9187,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9274,7 +9274,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9285,7 +9285,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9302,7 +9302,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -14964,7 +14964,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.135"
+version = "0.3.136"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.135"
+version = "0.3.136"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Ship the registry usage-limit enforcement and `past_due` read-only middleware from #515 (closes #449 — final 3 of 8 acceptance criteria; the earlier 5 shipped in #479 / #494 / #507). Also rolls up the workspace-wide `unused_qualifications` cleanup from #515's second commit.

CHANGELOG has the full per-criterion breakdown.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo fmt --all --check` clean
- [x] Release verification will happen against the published binary after publish-crates.sh + tag, per the standard end-to-end release flow