### PR TITLE
fix(ui,docker): allow esbuild/vue-demi build scripts under pnpm 11

### DIFF
--- a/crates/mockforge-ui/ui/package.json
+++ b/crates/mockforge-ui/ui/package.json
@@ -3,6 +3,12 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "vue-demi"
+    ]
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary

Docker build has been failing on every push to main for the last 3+ runs with `ERR_PNPM_IGNORED_BUILDS`. pnpm 11 introduced a managed-builds policy that blocks postinstall scripts unless they're listed in `pnpm.onlyBuiltDependencies`. esbuild (vite's bundler) and vue-demi (transitive) both have postinstalls that fetch native binaries / generate the legacy shim, so the build exits 1.

This adds the explicit allowlist.

## Why it matters

Discovered while verifying #468 end-to-end. The registry's `MOCKFORGE_DOCKER_IMAGE` secret was pinned to a May 4 Fly-internal-registry mirror (pre-#518) because no new image had been published to GHCR since the pnpm-11 policy landed. Once this fix merges and docker-build succeeds, the next `:latest` (or version tag) on GHCR can be set on the registry, and hosted-mocks will deploy with the resilience endpoints.

## Test plan

- [x] Local `pnpm install --frozen-lockfile` in `crates/mockforge-ui/ui` succeeds with the allowlist
- [ ] docker-build workflow goes green on this branch
- [ ] After merge: confirm GHCR shows new tags published