### PR TITLE
ci(release): gate Fly deploy + crates publish + helm on release tests (#447)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,9 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # Same gating rationale as deploy-registry: publishing to crates.io
+    # with broken tests yanks our reputation, not just our deploy.
+    needs: release
     if: '!contains(github.ref_name, ''rc'') && !contains(github.ref_name, ''alpha'') && !contains(github.ref_name, ''beta'')'
     steps:
     - name: Checkout repository
@@ -154,6 +157,12 @@ jobs:
   deploy-registry:
     name: Deploy Registry Server to Fly.io
     runs-on: ubuntu-latest
+    # Block Fly auto-deploy on the `release` job (which runs `cargo test
+    # --workspace --release` + builds the binary). Without this, a tag push
+    # would deploy whatever the build pipeline produced even if tests had
+    # failed — exactly the scenario #447 calls out. If you want to ship a
+    # deploy without tests, re-trigger this job manually after the test fix.
+    needs: release
     if: '!contains(github.ref_name, ''rc'') && !contains(github.ref_name, ''alpha'') && !contains(github.ref_name, ''beta'')'
     steps:
     - name: Checkout repository
@@ -170,6 +179,8 @@ jobs:
   helm:
     name: Package and Publish Helm Chart
     runs-on: ubuntu-latest
+    # Same gating rationale as deploy-registry + publish.
+    needs: release
     if: '!contains(github.ref_name, ''rc'') && !contains(github.ref_name, ''alpha'') && !contains(github.ref_name, ''beta'')'
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Addresses [#447](https://github.com/SaaSy-Solutions/mockforge/issues/447)'s last open acceptance criterion: **"Gate Fly auto-deploy on release.yml's test job (not just build)"**.

`release.yml` currently has four jobs (`release`, `publish`, `deploy-registry`, `helm`) that all fan out in parallel from a tag push. The `release` job runs `cargo test --workspace --release` + builds binaries, but the other three have no `needs:` on it — so a tag with red tests ships to crates.io / Fly / Helm anyway.

Add `needs: release` to all three downstream jobs.

## Why all three (not just deploy-registry)

The issue's explicit ask is Fly, but the same shape of risk applies to crates.io and the Helm chart — publishing broken code is just as bad as deploying it. Conservative move: gate all three. The cost is a few minutes' latency on the deploy pipeline (release tests typically finish in ~5–10 min on the self-hosted runner). If you ever need to ship past a flaky test you've manually validated, re-trigger the gated job from the Actions UI — a deliberate human decision rather than a silent ship.

## Diagnostic context — the rest of #447 is stale

| #447 claim | Reality |
|---|---|
| "release.yml has been red on every release tag for months" | 9 of last 10 tags (v0.3.125–v0.3.136) green. v0.3.132 was a one-off Fly deploy hiccup, not a test failure. |
| "pnpm test failing in ci.yml" | UI Tests pass on main — verified across the last 5 ci.yml runs (last failure was a cancellation by superseding push, not an actual failure). |
| "Stop using `#[ignore]` as the answer" | The 80 `#[ignore]` test usages in the registry crate are legit "requires running registry server" gates (verified in `marketplace_e2e.rs` and `paid_flow_e2e.rs`) — not failure-masking. They're run by `registry-e2e.yml` with `--ignored`. |
| "Validation release 0.3.122–0.3.124 papered over symptoms" | Historical; those landed before the runner-host fixes for the rustup-init race + rust-cache staleness that drove the chronic failures. |

So this PR closes the one real action item; the rest of #447 was diagnostic and is now obsolete.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"` clean
- [x] `git diff` shows 11 lines added, 0 changed (additive `needs:` lines + comments only)
- [ ] Post-merge: next tag (v0.3.137 or later) shows `publish`, `deploy-registry`, `helm` waiting for `release` to finish before starting in the Actions UI