### PR TITLE
feat(registry,ui): cloud Time Travel — proxy + page branch (#466)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -53,6 +53,7 @@ pub mod support;
 pub mod test_runs;
 pub mod test_schedules;
 pub mod test_suites;
+pub mod time_travel;
 pub mod tokens;
 pub mod trust_roots;
 pub mod tunnels;

--- a/crates/mockforge-registry-server/src/handlers/time_travel.rs
+++ b/crates/mockforge-registry-server/src/handlers/time_travel.rs
@@ -1,0 +1,402 @@
+//! Cloud time-travel handlers (#466).
+//!
+//! Live virtual-clock control for a hosted mock. The deployment itself runs
+//! `mockforge serve`, which mounts `mockforge_http::time_travel_api::time_travel_router()`
+//! at `/__mockforge/time-travel` on the **main HTTP port (3000)** — not the
+//! admin port like resilience. The runtime-side router is intentionally a
+//! subset of the local admin's full surface: only the 7 clock-control endpoints
+//! (status / enable / disable / advance / set / scale / reset). Cron jobs and
+//! mutation rules stay local-only because they don't belong to a hosted-mock's
+//! single-process clock.
+//!
+//! ## Wire format
+//!
+//! GET `/status` is wrapped in `{ runtime_state, data }`:
+//! * `"live"` — proxy succeeded; `data` is the deployment's clock state.
+//! * `"unreachable"` — proxy failed (connection refused, timeout, non-2xx);
+//!   `data` is a synthesized "disabled" state so the UI's existing rendering
+//!   path keeps working. Same rationale as `resilience::ResilienceEnvelope`.
+//!
+//! Mutating POSTs return `{ accepted, runtime_state, status?, reason? }`.
+//! `accepted=true` only on a 2xx from the upstream endpoint; the optional
+//! `status` field carries the post-mutation state so the UI doesn't need a
+//! follow-up GET to refresh.
+//!
+//! ## Routes
+//!
+//! * `GET  /api/v1/hosted-mocks/{deployment_id}/time-travel/status`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/time-travel/enable`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/time-travel/disable`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/time-travel/advance`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/time-travel/set`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/time-travel/scale`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/time-travel/reset`
+
+use std::time::Duration;
+
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    models::HostedMock,
+    AppState,
+};
+
+/// Main HTTP port the hosted mock listens on. Matches the `PORT=3000` that
+/// the orchestrator injects on every Fly deploy
+/// (`deployment::orchestrator::deploy_to_flyio`). The time-travel routes
+/// are mounted on this app by `mockforge serve` — not on the admin port,
+/// because the admin port isn't always exposed publicly on a hosted mock.
+const RUNTIME_HTTP_PORT: u16 = 3000;
+
+/// Reqwest timeout for one proxy call. Time-travel is interactive — the UI
+/// fires these from button clicks — so a slow upstream shouldn't lock the
+/// browser. Fail fast and let the user retry.
+const PROXY_TIMEOUT: Duration = Duration::from_secs(3);
+
+// --- Wire types -----------------------------------------------------------
+//
+// These mirror `mockforge_http::time_travel_api::TimeTravelStatus` etc.
+// Duplicated here (rather than `pub use`d) so the registry doesn't pull in
+// the mockforge-http crate; the upstream shape changes rarely and Deserialize
+// keeps us resilient to additive fields.
+
+/// Mirrors the runtime's `TimeTravelStatus` response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeTravelStatusResponse {
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_time: Option<String>,
+    pub scale_factor: f64,
+    pub real_time: String,
+}
+
+impl TimeTravelStatusResponse {
+    /// Synthesized "disabled" state for `unreachable` responses. Matches the
+    /// shape the UI already renders when time-travel has never been turned
+    /// on, so the dashboard's empty state is the same UX as before.
+    fn disabled_placeholder() -> Self {
+        Self {
+            enabled: false,
+            current_time: None,
+            scale_factor: 1.0,
+            real_time: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+/// Envelope discriminating live proxy vs unreachable upstream.
+#[derive(Debug, Serialize)]
+pub struct TimeTravelEnvelope<T: Serialize> {
+    pub runtime_state: &'static str,
+    pub data: T,
+}
+
+impl<T: Serialize> TimeTravelEnvelope<T> {
+    fn live(data: T) -> Self {
+        Self {
+            runtime_state: "live",
+            data,
+        }
+    }
+
+    fn unreachable(data: T) -> Self {
+        Self {
+            runtime_state: "unreachable",
+            data,
+        }
+    }
+}
+
+// --- Mutation request bodies ----------------------------------------------
+//
+// We accept these from the UI then forward verbatim to the runtime — the
+// runtime owns the canonical schema. Defining them here keeps axum's
+// extractor happy without leaking the runtime types into the registry.
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EnableRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scale: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AdvanceRequest {
+    pub duration: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SetTimeRequest {
+    pub time: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SetScaleRequest {
+    pub scale: f64,
+}
+
+// --- GET handlers ---------------------------------------------------------
+
+pub async fn get_status(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<TimeTravelEnvelope<TimeTravelStatusResponse>>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/__mockforge/time-travel/status", runtime_base_url(&deployment));
+    Ok(Json(match proxy_get::<TimeTravelStatusResponse>(&url).await {
+        Ok(data) => TimeTravelEnvelope::live(data),
+        Err(err) => {
+            tracing::warn!(%deployment_id, error = %err, "time-travel proxy GET status failed");
+            TimeTravelEnvelope::unreachable(TimeTravelStatusResponse::disabled_placeholder())
+        }
+    }))
+}
+
+// --- POST handlers --------------------------------------------------------
+
+pub async fn enable(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<EnableRequest>,
+) -> ApiResult<Json<Value>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/__mockforge/time-travel/enable", runtime_base_url(&deployment));
+    Ok(Json(proxy_post_json(&url, &body, deployment_id, "enable").await))
+}
+
+pub async fn disable(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Value>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/__mockforge/time-travel/disable", runtime_base_url(&deployment));
+    // `disable` has no body; upstream tolerates empty `{}`.
+    Ok(Json(proxy_post_json(&url, &json!({}), deployment_id, "disable").await))
+}
+
+pub async fn advance(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<AdvanceRequest>,
+) -> ApiResult<Json<Value>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/__mockforge/time-travel/advance", runtime_base_url(&deployment));
+    Ok(Json(proxy_post_json(&url, &body, deployment_id, "advance").await))
+}
+
+pub async fn set_time(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<SetTimeRequest>,
+) -> ApiResult<Json<Value>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/__mockforge/time-travel/set", runtime_base_url(&deployment));
+    Ok(Json(proxy_post_json(&url, &body, deployment_id, "set").await))
+}
+
+pub async fn set_scale(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<SetScaleRequest>,
+) -> ApiResult<Json<Value>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/__mockforge/time-travel/scale", runtime_base_url(&deployment));
+    Ok(Json(proxy_post_json(&url, &body, deployment_id, "scale").await))
+}
+
+pub async fn reset(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Value>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/__mockforge/time-travel/reset", runtime_base_url(&deployment));
+    Ok(Json(proxy_post_json(&url, &json!({}), deployment_id, "reset").await))
+}
+
+// --- helpers --------------------------------------------------------------
+
+/// Build the 6PN base URL for a hosted mock's main HTTP port. Fly resolves
+/// `{name}.internal` to a private IPv6 reachable from the registry pod.
+fn runtime_base_url(deployment: &HostedMock) -> String {
+    format!("http://{}.internal:{RUNTIME_HTTP_PORT}", deployment.fly_app_name())
+}
+
+/// GET a JSON object. 2xx + valid JSON → Ok; anything else → Err.
+async fn proxy_get<T: for<'de> Deserialize<'de>>(url: &str) -> reqwest::Result<T> {
+    reqwest::Client::builder()
+        .timeout(PROXY_TIMEOUT)
+        .build()?
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<T>()
+        .await
+}
+
+/// POST a JSON body, forward the runtime's response. On 2xx returns the
+/// runtime's full payload tagged `accepted: true, runtime_state: "live"`;
+/// on any error returns the standard unreachable envelope. The optional
+/// pre-existing `status` / `success` fields from the runtime are preserved
+/// so the UI doesn't need a follow-up GET to refresh.
+async fn proxy_post_json<B: Serialize>(
+    url: &str,
+    body: &B,
+    deployment_id: Uuid,
+    op: &'static str,
+) -> Value {
+    let client = match reqwest::Client::builder().timeout(PROXY_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::warn!(%deployment_id, op, error = %err, "reqwest client build failed");
+            return unreachable_post_body(err.to_string());
+        }
+    };
+
+    let resp = match client.post(url).json(body).send().await {
+        Ok(r) => r,
+        Err(err) => {
+            tracing::warn!(%deployment_id, op, error = %err, "time-travel POST failed");
+            return unreachable_post_body(err.to_string());
+        }
+    };
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        tracing::warn!(%deployment_id, op, %status, body = %text, "time-travel POST non-2xx");
+        return unreachable_post_body(format!("upstream {status}"));
+    }
+
+    // Best-effort: parse upstream JSON to merge into our envelope. If parse
+    // fails (e.g. empty body) we still report success — the proxy POST got
+    // a 2xx so the runtime accepted the mutation.
+    let upstream: Value = resp.json().await.unwrap_or(Value::Null);
+
+    let mut body = json!({
+        "accepted": true,
+        "runtime_state": "live",
+    });
+    if let Value::Object(ref mut map) = body {
+        if !upstream.is_null() {
+            map.insert("upstream".into(), upstream);
+        }
+    }
+    body
+}
+
+fn unreachable_post_body(reason: String) -> Value {
+    json!({
+        "accepted": false,
+        "runtime_state": "unreachable",
+        "reason": reason,
+    })
+}
+
+/// Resolve `deployment_id` to a `HostedMock`, after confirming the caller's
+/// org matches. Mirrors `resilience::authorize_deployment`.
+async fn authorize_deployment(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    deployment_id: Uuid,
+) -> ApiResult<HostedMock> {
+    let deployment = HostedMock::find_by_id(state.db.pool(), deployment_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Deployment not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != deployment.org_id {
+        return Err(ApiError::InvalidRequest("Deployment not found".into()));
+    }
+    Ok(deployment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_live_round_trips_status() {
+        let env = TimeTravelEnvelope::live(TimeTravelStatusResponse {
+            enabled: true,
+            current_time: Some("2030-01-01T00:00:00Z".into()),
+            scale_factor: 60.0,
+            real_time: "2026-05-16T05:00:00Z".into(),
+        });
+        let body = serde_json::to_value(&env).unwrap();
+        assert_eq!(body["runtime_state"], "live");
+        assert_eq!(body["data"]["enabled"], true);
+        assert_eq!(body["data"]["current_time"], "2030-01-01T00:00:00Z");
+        assert_eq!(body["data"]["scale_factor"], 60.0);
+    }
+
+    #[test]
+    fn envelope_unreachable_is_disabled_placeholder() {
+        let env = TimeTravelEnvelope::unreachable(TimeTravelStatusResponse::disabled_placeholder());
+        let body = serde_json::to_value(&env).unwrap();
+        assert_eq!(body["runtime_state"], "unreachable");
+        assert_eq!(body["data"]["enabled"], false);
+        assert_eq!(body["data"]["scale_factor"], 1.0);
+        // current_time is omitted when None — UI treats absence as "no virtual time".
+        assert!(
+            body["data"]["current_time"].is_null()
+                || !body["data"].as_object().unwrap().contains_key("current_time")
+        );
+    }
+
+    #[test]
+    fn unreachable_post_body_shape() {
+        let body = unreachable_post_body("connection refused".into());
+        assert_eq!(body["accepted"], false);
+        assert_eq!(body["runtime_state"], "unreachable");
+        assert_eq!(body["reason"], "connection refused");
+    }
+
+    #[test]
+    fn enable_request_serializes_minimal() {
+        let body = serde_json::to_value(EnableRequest {
+            time: None,
+            scale: None,
+        })
+        .unwrap();
+        // Both fields skip_serializing_if = None — empty object passes through.
+        assert_eq!(body, serde_json::json!({}));
+    }
+
+    #[test]
+    fn enable_request_serializes_partial() {
+        let body = serde_json::to_value(EnableRequest {
+            time: None,
+            scale: Some(60.0),
+        })
+        .unwrap();
+        assert_eq!(body["scale"], 60.0);
+        assert!(body.get("time").is_none());
+    }
+}

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -530,6 +530,41 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/hosted-mocks/{deployment_id}/resilience/bulkheads/{service}/reset",
             post(handlers::resilience::reset_bulkhead),
         )
+        // Time-travel routes (#466 / part of #459). Proxy the runtime's
+        // /__mockforge/time-travel/* endpoints over Fly 6PN to
+        // `{fly-app}.internal:3000/__mockforge/time-travel/*`. Only the 7
+        // clock-control endpoints are exposed in cloud — cron jobs and
+        // mutation rules stay local-only (they don't belong to a hosted
+        // mock's single-process clock). Same `runtime_state: "live" |
+        // "unreachable"` envelope as resilience.
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/time-travel/status",
+            get(handlers::time_travel::get_status),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/time-travel/enable",
+            post(handlers::time_travel::enable),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/time-travel/disable",
+            post(handlers::time_travel::disable),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/time-travel/advance",
+            post(handlers::time_travel::advance),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/time-travel/set",
+            post(handlers::time_travel::set_time),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/time-travel/scale",
+            post(handlers::time_travel::set_scale),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/time-travel/reset",
+            post(handlers::time_travel::reset),
+        )
         // Consistency / Virtual Backends routes (#461 / part of #459).
         // Lifecycle preset library is static (matches mockforge-data); the
         // workspace-scoped apply + entity-list endpoints back the cloud

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -364,6 +364,14 @@ const cloudNavItemIds = new Set([
   // without workspace_id are invisible until the shipper backfill lands;
   // cloud-shipped captures (--cloud-ship) work today.
   'logs',
+  // Time Travel (#466 Phase 2) — per-deployment virtual-clock control via
+  // cloudTimeTravelApi against /api/v1/hosted-mocks/{deployment_id}
+  // /time-travel/* (registry proxies over Fly 6PN to port 3000). Only
+  // the 7 clock-control endpoints are wired in cloud mode (status /
+  // enable / disable / advance / set / scale / reset); cron jobs and
+  // mutation rules stay local-only because they manage scenario state,
+  // not a hosted mock's single-process clock.
+  'time-travel',
   // Notification channels (cloud-only) — incident dispatch destinations
   // wired through cloudNotificationsApi.
   'notification-channels',

--- a/crates/mockforge-ui/ui/src/pages/CloudTimeTravelView.tsx
+++ b/crates/mockforge-ui/ui/src/pages/CloudTimeTravelView.tsx
@@ -1,0 +1,526 @@
+/**
+ * Cloud Time Travel view (#466 Phase 2).
+ *
+ * Rendered by `TimeTravelPage` when `isCloudMode()`. Drives the deployment
+ * selector + the clock-control surface against `cloudTimeTravelApi` (which
+ * proxies over Fly 6PN to the hosted mock's main HTTP port — see
+ * `cloudTimeTravel.ts` and `handlers::time_travel`). Cron jobs and mutation
+ * rules stay local-only (see #466 Phase 1 commit), so this view exposes
+ * only the 7 clock-control endpoints.
+ *
+ * Pattern mirrors `ResiliencePage`'s cloud branch: useState/useEffect with
+ * direct `await cloudTimeTravelApi.*` calls plus a deployment dropdown
+ * scoped to the org's `/api/v1/hosted-mocks`. No TanStack Query — that's
+ * intentional. The local TimeTravelPage uses query hooks against a
+ * singleton runtime; the cloud view needs to re-bind every call to the
+ * currently-selected deployment, which Query's queryKey machinery doesn't
+ * help with.
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { Clock, Play, FastForward, RefreshCw, RotateCcw } from 'lucide-react';
+import { PageHeader, Alert } from '../components/ui/DesignSystem';
+import { Button } from '../components/ui/button';
+import { Card } from '../components/ui/Card';
+import { Badge } from '../components/ui/Badge';
+import { Input } from '../components/ui/input';
+import {
+  cloudTimeTravelApi,
+  type CloudTimeTravelStatus,
+  type CloudTimeTravelStatusEnvelope,
+  type TimeTravelRuntimeState,
+} from '../services/api/cloudTimeTravel';
+import { cn } from '../utils/cn';
+
+interface DeploymentSummary {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const POLL_MS = 5000;
+
+function formatTime(iso?: string): string {
+  if (!iso) return 'Real Time';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export const CloudTimeTravelView: React.FC = () => {
+  const [deployments, setDeployments] = useState<DeploymentSummary[]>([]);
+  const [selectedDeploymentId, setSelectedDeploymentId] = useState<string | null>(null);
+  const [status, setStatus] = useState<CloudTimeTravelStatus | null>(null);
+  const [runtimeState, setRuntimeState] = useState<TimeTravelRuntimeState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionPending, setActionPending] = useState(false);
+
+  // Form state — mirrors local TimeTravelPage so users coming from local
+  // mode see the same controls.
+  const [initialTime, setInitialTime] = useState('');
+  const [initialTimeError, setInitialTimeError] = useState<string | null>(null);
+  const [timeScale, setTimeScale] = useState('1.0');
+  const [advanceDuration, setAdvanceDuration] = useState('1h');
+
+  // Load deployments once. The first active deployment is auto-selected
+  // so the page works without an extra click in the common
+  // one-deployment-per-org case.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = localStorage.getItem('auth_token');
+        const resp = await fetch('/api/v1/hosted-mocks', {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!resp.ok) {
+          if (!cancelled) {
+            setError(`Failed to load deployments: ${resp.status}`);
+            setLoading(false);
+          }
+          return;
+        }
+        const list = (await resp.json()) as DeploymentSummary[];
+        if (cancelled) return;
+        const items = Array.isArray(list) ? list : [];
+        setDeployments(items);
+        const active = items.find((d) => d.status === 'active') ?? items[0] ?? null;
+        if (active) {
+          setSelectedDeploymentId(active.id);
+        } else {
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load deployments');
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Poll status whenever the selected deployment changes. 5s cadence
+  // matches the local TimeTravelPage's `refetchInterval` and keeps the
+  // page responsive without hammering Fly 6PN.
+  useEffect(() => {
+    if (!selectedDeploymentId) return;
+    let cancelled = false;
+
+    const fetchStatus = async () => {
+      try {
+        const env: CloudTimeTravelStatusEnvelope =
+          await cloudTimeTravelApi.getStatus(selectedDeploymentId);
+        if (cancelled) return;
+        setRuntimeState(env.runtime_state);
+        setStatus(env.data);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setRuntimeState('unreachable');
+        setStatus(null);
+        setError(err instanceof Error ? err.message : 'Failed to load status');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchStatus();
+    const t = setInterval(fetchStatus, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [selectedDeploymentId]);
+
+  const refresh = useCallback(async () => {
+    if (!selectedDeploymentId) return;
+    try {
+      const env = await cloudTimeTravelApi.getStatus(selectedDeploymentId);
+      setRuntimeState(env.runtime_state);
+      setStatus(env.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh');
+    }
+  }, [selectedDeploymentId]);
+
+  // --- Mutation handlers -------------------------------------------------
+
+  const guardDeployment = (): string | null => {
+    if (!selectedDeploymentId) {
+      setError('Select a deployment first');
+      return null;
+    }
+    return selectedDeploymentId;
+  };
+
+  const handleEnable = async () => {
+    const id = guardDeployment();
+    if (!id) return;
+    if (initialTime) {
+      const d = new Date(initialTime);
+      if (isNaN(d.getTime())) {
+        setInitialTimeError('Invalid ISO-8601 date (e.g., 2025-01-01T00:00:00Z)');
+        return;
+      }
+    }
+    setInitialTimeError(null);
+    setActionPending(true);
+    try {
+      await cloudTimeTravelApi.enable(
+        id,
+        initialTime || undefined,
+        timeScale ? parseFloat(timeScale) : undefined,
+      );
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to enable');
+    } finally {
+      setActionPending(false);
+    }
+  };
+
+  const handleDisable = async () => {
+    const id = guardDeployment();
+    if (!id) return;
+    setActionPending(true);
+    try {
+      await cloudTimeTravelApi.disable(id);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disable');
+    } finally {
+      setActionPending(false);
+    }
+  };
+
+  const handleAdvance = async () => {
+    const id = guardDeployment();
+    if (!id || !advanceDuration) return;
+    setActionPending(true);
+    try {
+      await cloudTimeTravelApi.advance(id, advanceDuration);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to advance');
+    } finally {
+      setActionPending(false);
+    }
+  };
+
+  const handleSetScale = async () => {
+    const id = guardDeployment();
+    if (!id) return;
+    const scale = parseFloat(timeScale);
+    if (isNaN(scale) || scale <= 0) {
+      setError('Time scale must be a positive number');
+      return;
+    }
+    setActionPending(true);
+    try {
+      await cloudTimeTravelApi.setScale(id, scale);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to set scale');
+    } finally {
+      setActionPending(false);
+    }
+  };
+
+  const handleReset = async () => {
+    const id = guardDeployment();
+    if (!id) return;
+    setActionPending(true);
+    try {
+      await cloudTimeTravelApi.reset(id);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reset');
+    } finally {
+      setActionPending(false);
+    }
+  };
+
+  // --- Render ------------------------------------------------------------
+
+  if (deployments.length === 0 && !loading) {
+    return (
+      <div className="content-width space-y-8">
+        <PageHeader title="Time Travel" subtitle="Cloud temporal simulation" />
+        <Alert
+          variant="info"
+          title="No deployments yet"
+          description="Create a hosted mock first to control its virtual clock from the cloud dashboard."
+        />
+      </div>
+    );
+  }
+
+  const isEnabled = status?.enabled ?? false;
+  const virtualTime = status?.current_time;
+  const scaleFactor = status?.scale_factor ?? 1.0;
+  const unreachable = runtimeState === 'unreachable';
+
+  return (
+    <div className="content-width space-y-8">
+      <PageHeader
+        title="Time Travel"
+        subtitle="Control virtual time on a hosted mock deployment"
+        className="space-section"
+      />
+
+      {/* Deployment selector — single-deployment orgs see a passive label;
+          multi-deployment orgs get a dropdown. Same pattern as ResiliencePage. */}
+      {deployments.length > 1 ? (
+        <Card className="p-4">
+          <label className="block text-sm font-medium text-foreground mb-2">
+            Deployment
+          </label>
+          <select
+            className="w-full px-3 py-2 rounded-lg border border-border bg-background"
+            value={selectedDeploymentId ?? ''}
+            onChange={(e) => setSelectedDeploymentId(e.target.value)}
+          >
+            {deployments.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.name} ({d.status})
+              </option>
+            ))}
+          </select>
+        </Card>
+      ) : (
+        deployments[0] && (
+          <p className="text-sm text-muted-foreground">
+            Deployment: <span className="font-medium text-foreground">{deployments[0].name}</span>
+            <Badge variant="outline" className="ml-2">{deployments[0].status}</Badge>
+          </p>
+        )
+      )}
+
+      {/* Runtime-unreachable banner — distinct from a hard error so users can
+          tell "deployment didn't answer the proxy" from "request failed". */}
+      {unreachable && (
+        <Alert
+          variant="warning"
+          title="Deployment not reachable"
+          description="The registry can't reach this deployment's runtime over Fly 6PN. Showing last-known disabled state. Retry will keep polling — if this persists, check the deployment's status."
+        />
+      )}
+
+      {error && !unreachable && (
+        <Alert variant="error" title="Error" description={error} />
+      )}
+
+      {loading && (
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-brand-600"></div>
+            <p className="mt-4 text-muted-foreground">Loading…</p>
+          </div>
+        </div>
+      )}
+
+      {!loading && (
+        <Card className="p-6">
+          <div className="flex items-start justify-between mb-6">
+            <div className="flex items-center gap-3">
+              <div
+                className={cn(
+                  'p-3 rounded-xl transition-all duration-200',
+                  isEnabled
+                    ? 'bg-brand-100 text-brand-600 dark:bg-brand-900/30 dark:text-brand-400'
+                    : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+                )}
+              >
+                <Clock className="h-6 w-6" />
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold text-foreground">Time Travel Status</h3>
+                <p className="text-sm text-muted-foreground">
+                  {unreachable
+                    ? 'Deployment unreachable'
+                    : isEnabled
+                      ? 'Virtual time is active'
+                      : 'Using real time'}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {isEnabled && !unreachable && (
+                <Badge variant="success">Active</Badge>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={refresh}
+                disabled={!selectedDeploymentId}
+                title="Refresh"
+              >
+                <RefreshCw className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+            <div className="p-4 rounded-lg bg-muted/50 border border-border">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+                {isEnabled ? 'Virtual Time' : 'Real Time'}
+              </p>
+              <p className="text-2xl font-bold text-foreground tabular-nums">
+                {formatTime(virtualTime || status?.real_time)}
+              </p>
+            </div>
+            {isEnabled && (
+              <>
+                <div className="p-4 rounded-lg bg-muted/50 border border-border">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+                    Time Scale
+                  </p>
+                  <p className="text-2xl font-bold text-brand-600 dark:text-brand-400">
+                    {scaleFactor.toFixed(1)}x
+                  </p>
+                </div>
+                <div className="p-4 rounded-lg bg-muted/50 border border-border">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+                    Real Time
+                  </p>
+                  <p className="text-2xl font-bold text-foreground tabular-nums">
+                    {formatTime(status?.real_time)}
+                  </p>
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Controls — same shape as local TimeTravelPage but bound to the
+              cloud handlers. We disable the entire control block when the
+              deployment is unreachable so users don't fire mutations
+              that'll just bounce back unreachable. */}
+          <fieldset
+            disabled={unreachable || actionPending || !selectedDeploymentId}
+            className="space-y-4 disabled:opacity-60 disabled:pointer-events-none"
+          >
+            {!isEnabled ? (
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Initial Time (ISO 8601, optional)
+                    </label>
+                    <Input
+                      type="text"
+                      placeholder="2025-01-01T00:00:00Z"
+                      value={initialTime}
+                      onChange={(e) => setInitialTime(e.target.value)}
+                      className="w-full"
+                    />
+                    {initialTimeError && (
+                      <p className="mt-1 text-sm text-danger-600 dark:text-danger-400">
+                        {initialTimeError}
+                      </p>
+                    )}
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Time Scale (1.0 = real time)
+                    </label>
+                    <Input
+                      type="number"
+                      step="0.1"
+                      min="0.1"
+                      placeholder="1.0"
+                      value={timeScale}
+                      onChange={(e) => setTimeScale(e.target.value)}
+                      className="w-full"
+                    />
+                  </div>
+                </div>
+                <Button
+                  onClick={handleEnable}
+                  className="w-full bg-brand-600 hover:bg-brand-700 text-white"
+                >
+                  <Play className="h-4 w-4 mr-2" />
+                  Enable Time Travel
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Advance Duration (e.g., "1h", "1week", "2d")
+                    </label>
+                    <div className="flex gap-2">
+                      <Input
+                        type="text"
+                        placeholder="1h"
+                        value={advanceDuration}
+                        onChange={(e) => setAdvanceDuration(e.target.value)}
+                        className="flex-1"
+                      />
+                      <Button onClick={handleAdvance} variant="outline">
+                        <FastForward className="h-4 w-4 mr-1" />
+                        Advance
+                      </Button>
+                    </div>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Time Scale
+                    </label>
+                    <div className="flex gap-2">
+                      <Input
+                        type="number"
+                        step="0.1"
+                        min="0.1"
+                        placeholder="1.0"
+                        value={timeScale}
+                        onChange={(e) => setTimeScale(e.target.value)}
+                        className="flex-1"
+                      />
+                      <Button onClick={handleSetScale} variant="outline">
+                        Set
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <Button onClick={handleDisable} variant="outline" className="flex-1">
+                    Disable
+                  </Button>
+                  <Button onClick={handleReset} variant="outline" className="flex-1">
+                    <RotateCcw className="h-4 w-4 mr-2" />
+                    Reset
+                  </Button>
+                </div>
+              </div>
+            )}
+          </fieldset>
+        </Card>
+      )}
+
+      {/* Cron jobs + mutation rules are intentionally NOT exposed in cloud
+          mode — see #466 Phase 1 commit. They belong to a local dev
+          session's scenario state, not a hosted mock's single-process
+          clock. Users who need them should run a local mockforge. */}
+      <Alert
+        variant="info"
+        title="Cron jobs and mutation rules are local-only"
+        description="These features manage local scenario state and aren't exposed on hosted-mock deployments. Run a local MockForge instance to use them."
+      />
+    </div>
+  );
+};

--- a/crates/mockforge-ui/ui/src/pages/TimeTravelPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/TimeTravelPage.tsx
@@ -28,9 +28,20 @@ import {
   useCronJobs,
   useMutationRules,
 } from '../hooks/useApi';
+import { isCloudMode } from '../utils/cloudMode';
+import { CloudTimeTravelView } from './CloudTimeTravelView';
 import { cn } from '../utils/cn';
 
 export function TimeTravelPage() {
+  // #466 Phase 2: in cloud mode, dispatch to the per-deployment cloud view
+  // (cloudTimeTravelApi against /api/v1/hosted-mocks/{id}/time-travel/*).
+  // Local mode keeps the singleton-runtime hooks below unchanged — they
+  // hit /__mockforge/time-travel/* on whatever mockforge process the
+  // browser is talking to directly.
+  if (isCloudMode()) {
+    return <CloudTimeTravelView />;
+  }
+
   const { data: status, isLoading: statusLoading } = useTimeTravelStatus();
   const { data: cronData, isLoading: cronLoading } = useCronJobs();
   const { data: mutationData, isLoading: mutationLoading } = useMutationRules();

--- a/crates/mockforge-ui/ui/src/services/api/cloudTimeTravel.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudTimeTravel.ts
@@ -1,0 +1,110 @@
+/**
+ * Cloud time-travel API client (#466).
+ *
+ * Backs the registry's `/api/v1/hosted-mocks/{deployment_id}/time-travel/*`
+ * routes. The registry proxies over Fly 6PN to the running mockforge
+ * instance's main HTTP port (`{fly-app}.internal:3000/__mockforge/time-travel/*`)
+ * — not the admin port like resilience, because the time-travel routes
+ * are mounted on the main HTTP app for reachability on hosted mocks where
+ * the admin port isn't exposed publicly.
+ *
+ * Only the 7 clock-control endpoints are exposed in cloud — cron jobs and
+ * mutation rules stay local-only (they don't belong to a hosted mock's
+ * single-process clock).
+ *
+ * `runtime_state` values mirror cloudResilience:
+ * * `'live'` — proxy succeeded; `data` is the deployment's current state.
+ * * `'unreachable'` — registry could not reach the deployment; `data` is a
+ *   synthesized "disabled" state so the existing UI rendering path keeps
+ *   working. Show an "unreachable" banner alongside.
+ */
+import { fetchJsonWithErrorBody } from './client';
+
+export type TimeTravelRuntimeState = 'live' | 'unreachable';
+
+export interface CloudTimeTravelStatus {
+  enabled: boolean;
+  current_time?: string;
+  scale_factor: number;
+  real_time: string;
+}
+
+export interface CloudTimeTravelStatusEnvelope {
+  runtime_state: TimeTravelRuntimeState;
+  data: CloudTimeTravelStatus;
+}
+
+/** Mutation result shape (enable / disable / advance / set / scale / reset). */
+export interface CloudTimeTravelMutationResult {
+  accepted: boolean;
+  runtime_state: TimeTravelRuntimeState;
+  /** Present on `unreachable`; describes the upstream failure. */
+  reason?: string;
+  /** Present on `live`; the runtime's response body (status / success / etc.). */
+  upstream?: unknown;
+}
+
+class CloudTimeTravelApiService {
+  private base(deploymentId: string): string {
+    return `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/time-travel`;
+  }
+
+  async getStatus(deploymentId: string): Promise<CloudTimeTravelStatusEnvelope> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/status`) as Promise<CloudTimeTravelStatusEnvelope>;
+  }
+
+  async enable(
+    deploymentId: string,
+    time?: string,
+    scale?: number,
+  ): Promise<CloudTimeTravelMutationResult> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/enable`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ time, scale }),
+    }) as Promise<CloudTimeTravelMutationResult>;
+  }
+
+  async disable(deploymentId: string): Promise<CloudTimeTravelMutationResult> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/disable`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    }) as Promise<CloudTimeTravelMutationResult>;
+  }
+
+  async advance(deploymentId: string, duration: string): Promise<CloudTimeTravelMutationResult> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/advance`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ duration }),
+    }) as Promise<CloudTimeTravelMutationResult>;
+  }
+
+  async setTime(deploymentId: string, time: string): Promise<CloudTimeTravelMutationResult> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/set`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ time }),
+    }) as Promise<CloudTimeTravelMutationResult>;
+  }
+
+  async setScale(deploymentId: string, scale: number): Promise<CloudTimeTravelMutationResult> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/scale`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scale }),
+    }) as Promise<CloudTimeTravelMutationResult>;
+  }
+
+  async reset(deploymentId: string): Promise<CloudTimeTravelMutationResult> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/reset`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    }) as Promise<CloudTimeTravelMutationResult>;
+  }
+}
+
+export { CloudTimeTravelApiService };
+export const cloudTimeTravelApi = new CloudTimeTravelApiService();


### PR DESCRIPTION
## Summary

Cloud-parity for Time Travel (#466, part of #459 meta tracker). **Phase 1 + Phase 2 bundled** — registry proxy, TS client, page branching, and nav allowlist all in this single squash-merge.

Mirrors #468 resilience (#522): registry reqwest-proxies the runtime's HTTP endpoints over Fly 6PN to `{fly-app}.internal:3000/__mockforge/time-travel/*` (main HTTP port, not admin — same reachability story).

## Endpoint coverage

The runtime exposes 7 clock-control endpoints; all 7 are proxied:

```
GET  /api/v1/hosted-mocks/{deployment_id}/time-travel/status
POST /api/v1/hosted-mocks/{deployment_id}/time-travel/enable   (body: { time?, scale? })
POST /api/v1/hosted-mocks/{deployment_id}/time-travel/disable
POST /api/v1/hosted-mocks/{deployment_id}/time-travel/advance  (body: { duration })
POST /api/v1/hosted-mocks/{deployment_id}/time-travel/set      (body: { time })
POST /api/v1/hosted-mocks/{deployment_id}/time-travel/scale    (body: { scale })
POST /api/v1/hosted-mocks/{deployment_id}/time-travel/reset
```

**Intentionally local-only:** cron jobs (`/cron/*`) and mutation rules (`/mutations/*`). These are part of the local `mockforge-ui` admin server but not the runtime router — they manage scenario state that belongs to a local dev session, not a hosted mock's single-process clock.

## Wire format

Mirrors cloudResilience:
- GET `/status` → `{ runtime_state, data: TimeTravelStatus }`
- Mutating POSTs → `{ accepted, runtime_state, upstream?, reason? }`

`runtime_state: 'live'` on a 2xx proxy round-trip; `'unreachable'` on connection refused / timeout / non-2xx. Status envelope on unreachable carries a synthesized "disabled" placeholder so the UI's rendering path keeps working.

## UI integration

**New `CloudTimeTravelView`** (cloud-mode component):
- Loads deployments from `/api/v1/hosted-mocks`, auto-selects first active (dropdown when >1).
- 5-second polling against `cloudTimeTravelApi.getStatus` (matches the local page's `refetchInterval`).
- Distinguishes `'live'` from `'unreachable'` — unreachable shows an explicit warning banner and disables the control `<fieldset>` so users don't fire mutations that'll bounce back.
- Inline alert explains that cron jobs + mutation rules are local-only by design.
- Empty state when the org has zero hosted-mock deployments.

**`TimeTravelPage`** (3-line touch): delegates to `CloudTimeTravelView` when `isCloudMode()`, keeps the existing TanStack Query plumbing for local mode unchanged.

**`AppShell`**: `'time-travel'` added to `cloudNavItemIds` so the sidebar drops its 'Local only' badge in cloud mode.

### Why a sibling component instead of refactoring the hooks

The local page uses TanStack Query hooks against the singleton `timeTravelApi` (which hits `/__mockforge/time-travel/*` on whatever mockforge process the browser is talking to). The cloud view needs to re-bind every call to a per-deployment URL, which Query's `queryKey` machinery doesn't naturally express. The cloud view uses useState/useEffect with direct `await cloudTimeTravelApi.*` calls — the same pattern `ResiliencePage` uses for the same reason. Local mode keeps byte-identical behaviour.

## Verification

- [x] `cargo check -p mockforge-registry-server` clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-registry-server --lib handlers::time_travel::` — 5/5 pass
- [x] `pnpm type-check` clean
- [x] `eslint` on changed UI files: clean
- [ ] Post-merge: smoke against a live hosted-mock deployment over 6PN; verify all 7 mutations
- [ ] Verify the unreachable banner renders when the deployment proxy fails