### PR TITLE
feat(registry,ui): cloud World State — proxy + page branch (#464)

### DIFF
--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -60,6 +60,7 @@ pub mod two_factor;
 pub mod usage;
 pub mod users_me;
 pub mod verification;
+pub mod world_state;
 
 // Marketplace, settings, security, GDPR, and audit handlers
 pub mod audit;

--- a/crates/mockforge-registry-server/src/handlers/world_state.rs
+++ b/crates/mockforge-registry-server/src/handlers/world_state.rs
@@ -1,0 +1,322 @@
+//! Cloud world-state handlers (#464) — Phase 1 runtime proxy.
+//!
+//! Live world-state snapshot + graph + layers + query for a hosted mock.
+//! Each deployment runs `mockforge serve`, which mounts the world-state
+//! router at `/api/world-state` on the **main HTTP port (3000)** — same
+//! reachability story as time-travel (#466): the admin port isn't always
+//! exposed publicly on hosted mocks, so we target the main HTTP port over
+//! Fly 6PN.
+//!
+//! ## Phase 1 scope
+//!
+//! The runtime exposes 6 endpoints. We proxy the 5 HTTP ones in this PR.
+//! `GET /stream` is a WebSocket (full duplex bidirectional protocol over
+//! HTTP/1.1 Upgrade) — proxying that through the registry over 6PN
+//! requires a ws-aware tunnel and is intentionally deferred to Phase 2.
+//! The local UI polls every 5s as its default refresh anyway (see
+//! `useWorldStateLayers` and friends), so the cloud UI is fully functional
+//! with polling-only in Phase 1.
+//!
+//! ## Wire format
+//!
+//! Every GET returns `{ runtime_state, data }`:
+//! * `"live"` — proxy succeeded; `data` is the deployment's response.
+//! * `"unreachable"` — proxy failed (connection refused, timeout, non-2xx);
+//!   `data` is `null` so the UI can render an explicit empty state.
+//!
+//! Same `runtime_state` discriminator as [`crate::handlers::resilience`]
+//! and [`crate::handlers::time_travel`].
+//!
+//! ## Routes
+//!
+//! * `GET  /api/v1/hosted-mocks/{deployment_id}/world-state/snapshot`
+//! * `GET  /api/v1/hosted-mocks/{deployment_id}/world-state/snapshot/{snapshot_id}`
+//! * `GET  /api/v1/hosted-mocks/{deployment_id}/world-state/graph?layers=...`
+//! * `GET  /api/v1/hosted-mocks/{deployment_id}/world-state/layers`
+//! * `POST /api/v1/hosted-mocks/{deployment_id}/world-state/query`
+
+use std::time::Duration;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::HeaderMap,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    models::HostedMock,
+    AppState,
+};
+
+/// Main HTTP port the hosted mock listens on (PORT=3000 injected by the
+/// orchestrator on every Fly deploy).
+const RUNTIME_HTTP_PORT: u16 = 3000;
+
+/// Reqwest timeout for one proxy call. World-state graph queries can be
+/// larger than time-travel status, so this is a touch more generous than
+/// the 3s elsewhere — but still fail-fast: a slow snapshot lookup is the
+/// UI's polling problem, not a request-blocking one.
+const PROXY_TIMEOUT: Duration = Duration::from_secs(5);
+
+// --- Envelope -------------------------------------------------------------
+
+/// Envelope discriminating live proxy vs unreachable upstream.
+///
+/// Unlike resilience (`data: Vec<T>`) and time-travel (`data: T` with a
+/// synthesized placeholder), the world-state shapes are heterogeneous
+/// (snapshot vs graph vs layers vs query result), so we keep `data` as
+/// `serde_json::Value` and let the UI deserialize per-route.
+#[derive(Debug, Serialize)]
+pub struct WorldStateEnvelope {
+    pub runtime_state: &'static str,
+    pub data: Value,
+}
+
+impl WorldStateEnvelope {
+    fn live(data: Value) -> Self {
+        Self {
+            runtime_state: "live",
+            data,
+        }
+    }
+
+    fn unreachable() -> Self {
+        Self {
+            runtime_state: "unreachable",
+            data: Value::Null,
+        }
+    }
+}
+
+// --- Query/body shapes ----------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQueryParams {
+    /// Optional comma-separated list of layer ids to include. Forwarded
+    /// verbatim to the runtime — the runtime owns the filter semantics.
+    pub layers: Option<String>,
+}
+
+/// We accept arbitrary JSON for `/query` (the local handler uses
+/// `WorldStateQueryRequest` with optional `node_type`, `layer`, `since`
+/// fields, but we don't want to leak the runtime's struct into the
+/// registry — the runtime is the source of truth). Forward verbatim.
+type QueryRequestBody = Value;
+
+// --- GET handlers ---------------------------------------------------------
+
+pub async fn get_snapshot(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<WorldStateEnvelope>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/api/world-state/snapshot", runtime_base_url(&deployment));
+    Ok(Json(proxy_get(&url, deployment_id, "snapshot").await))
+}
+
+pub async fn get_snapshot_by_id(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path((deployment_id, snapshot_id)): Path<(Uuid, String)>,
+    headers: HeaderMap,
+) -> ApiResult<Json<WorldStateEnvelope>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!(
+        "{}/api/world-state/snapshot/{}",
+        runtime_base_url(&deployment),
+        urlencoding::encode(&snapshot_id),
+    );
+    Ok(Json(proxy_get(&url, deployment_id, "snapshot_by_id").await))
+}
+
+pub async fn get_graph(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    Query(params): Query<GraphQueryParams>,
+    headers: HeaderMap,
+) -> ApiResult<Json<WorldStateEnvelope>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = match params.layers {
+        Some(layers) if !layers.is_empty() => format!(
+            "{}/api/world-state/graph?layers={}",
+            runtime_base_url(&deployment),
+            urlencoding::encode(&layers),
+        ),
+        _ => format!("{}/api/world-state/graph", runtime_base_url(&deployment)),
+    };
+    Ok(Json(proxy_get(&url, deployment_id, "graph").await))
+}
+
+pub async fn get_layers(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<WorldStateEnvelope>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/api/world-state/layers", runtime_base_url(&deployment));
+    Ok(Json(proxy_get(&url, deployment_id, "layers").await))
+}
+
+// --- POST handlers --------------------------------------------------------
+
+pub async fn query(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(deployment_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<QueryRequestBody>,
+) -> ApiResult<Json<WorldStateEnvelope>> {
+    let deployment = authorize_deployment(&state, user_id, &headers, deployment_id).await?;
+    let url = format!("{}/api/world-state/query", runtime_base_url(&deployment));
+    Ok(Json(proxy_post_json(&url, &body, deployment_id, "query").await))
+}
+
+// --- helpers --------------------------------------------------------------
+
+fn runtime_base_url(deployment: &HostedMock) -> String {
+    format!("http://{}.internal:{RUNTIME_HTTP_PORT}", deployment.fly_app_name())
+}
+
+/// GET a JSON value, wrap in envelope. 2xx + valid JSON → live; anything
+/// else → unreachable + warning log.
+async fn proxy_get(url: &str, deployment_id: Uuid, op: &'static str) -> WorldStateEnvelope {
+    let client = match reqwest::Client::builder().timeout(PROXY_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::warn!(%deployment_id, op, error = %err, "reqwest client build failed");
+            return WorldStateEnvelope::unreachable();
+        }
+    };
+
+    match client.get(url).send().await {
+        Ok(resp) => match resp.error_for_status() {
+            Ok(resp) => match resp.json::<Value>().await {
+                Ok(body) => WorldStateEnvelope::live(body),
+                Err(err) => {
+                    tracing::warn!(%deployment_id, op, error = %err, "world-state proxy GET JSON parse failed");
+                    WorldStateEnvelope::unreachable()
+                }
+            },
+            Err(err) => {
+                tracing::warn!(%deployment_id, op, error = %err, "world-state proxy GET non-2xx");
+                WorldStateEnvelope::unreachable()
+            }
+        },
+        Err(err) => {
+            tracing::warn!(%deployment_id, op, error = %err, "world-state proxy GET failed");
+            WorldStateEnvelope::unreachable()
+        }
+    }
+}
+
+/// POST a JSON body, wrap response in envelope. Same error semantics as
+/// `proxy_get`.
+async fn proxy_post_json<B: Serialize>(
+    url: &str,
+    body: &B,
+    deployment_id: Uuid,
+    op: &'static str,
+) -> WorldStateEnvelope {
+    let client = match reqwest::Client::builder().timeout(PROXY_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::warn!(%deployment_id, op, error = %err, "reqwest client build failed");
+            return WorldStateEnvelope::unreachable();
+        }
+    };
+
+    match client.post(url).json(body).send().await {
+        Ok(resp) => match resp.error_for_status() {
+            Ok(resp) => match resp.json::<Value>().await {
+                Ok(body) => WorldStateEnvelope::live(body),
+                Err(err) => {
+                    tracing::warn!(%deployment_id, op, error = %err, "world-state proxy POST JSON parse failed");
+                    WorldStateEnvelope::unreachable()
+                }
+            },
+            Err(err) => {
+                tracing::warn!(%deployment_id, op, error = %err, "world-state proxy POST non-2xx");
+                WorldStateEnvelope::unreachable()
+            }
+        },
+        Err(err) => {
+            tracing::warn!(%deployment_id, op, error = %err, "world-state proxy POST failed");
+            WorldStateEnvelope::unreachable()
+        }
+    }
+}
+
+/// Resolve `deployment_id` to a `HostedMock`, after confirming the caller's
+/// org matches. Mirrors `resilience::authorize_deployment` and
+/// `time_travel::authorize_deployment`.
+async fn authorize_deployment(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    deployment_id: Uuid,
+) -> ApiResult<HostedMock> {
+    let deployment = HostedMock::find_by_id(state.db.pool(), deployment_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Deployment not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != deployment.org_id {
+        return Err(ApiError::InvalidRequest("Deployment not found".into()));
+    }
+    Ok(deployment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn envelope_live_round_trips_arbitrary_value() {
+        let env = WorldStateEnvelope::live(json!({
+            "snapshot_id": "snap-1",
+            "nodes": [],
+            "edges": [],
+        }));
+        let body = serde_json::to_value(&env).unwrap();
+        assert_eq!(body["runtime_state"], "live");
+        assert_eq!(body["data"]["snapshot_id"], "snap-1");
+        assert!(body["data"]["nodes"].is_array());
+    }
+
+    #[test]
+    fn envelope_unreachable_is_null_data() {
+        let env = WorldStateEnvelope::unreachable();
+        let body = serde_json::to_value(&env).unwrap();
+        assert_eq!(body["runtime_state"], "unreachable");
+        assert!(body["data"].is_null());
+    }
+
+    #[test]
+    fn graph_query_params_default_has_no_layers() {
+        // Constructing without `layers` mirrors what axum's `Query` extractor
+        // produces when the querystring is absent. We can't round-trip via
+        // serde_urlencoded here because it isn't a direct dep of this crate;
+        // verify the struct shape via JSON instead (Deserialize derives the
+        // same field-optional behaviour serde_urlencoded would).
+        let params: GraphQueryParams = serde_json::from_str("{}").unwrap();
+        assert!(params.layers.is_none());
+    }
+
+    #[test]
+    fn graph_query_params_carries_comma_list() {
+        let params: GraphQueryParams =
+            serde_json::from_str(r#"{"layers":"accounts,inventory"}"#).unwrap();
+        assert_eq!(params.layers.as_deref(), Some("accounts,inventory"));
+    }
+}

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -530,6 +530,33 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/hosted-mocks/{deployment_id}/resilience/bulkheads/{service}/reset",
             post(handlers::resilience::reset_bulkhead),
         )
+        // World-state routes (#464 / part of #459) — Phase 1 runtime proxy.
+        // Proxy the 5 HTTP endpoints of `mockforge-http::handlers::world_state`
+        // over Fly 6PN to `{fly-app}.internal:3000/api/world-state/*`. The
+        // WebSocket `/stream` is intentionally deferred to Phase 2 — the
+        // local UI polls every 5s as its default refresh, so cloud users
+        // get a fully functional snapshot/graph/layers/query surface from
+        // Phase 1 even without push deltas.
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/world-state/snapshot",
+            get(handlers::world_state::get_snapshot),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/world-state/snapshot/{snapshot_id}",
+            get(handlers::world_state::get_snapshot_by_id),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/world-state/graph",
+            get(handlers::world_state::get_graph),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/world-state/layers",
+            get(handlers::world_state::get_layers),
+        )
+        .route(
+            "/api/v1/hosted-mocks/{deployment_id}/world-state/query",
+            post(handlers::world_state::query),
+        )
         // Consistency / Virtual Backends routes (#461 / part of #459).
         // Lifecycle preset library is static (matches mockforge-data); the
         // workspace-scoped apply + entity-list endpoints back the cloud

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -364,6 +364,12 @@ const cloudNavItemIds = new Set([
   // without workspace_id are invisible until the shipper backfill lands;
   // cloud-shipped captures (--cloud-ship) work today.
   'logs',
+  // World State (#464 Phase 2) — per-deployment graph + snapshot + layers
+  // + slice query via cloudWorldStateApi against /api/v1/hosted-mocks/
+  // {deployment_id}/world-state/*. The local `/stream` WebSocket isn't
+  // proxied yet (Phase 2 follow-up); cloud mode polls every 5s, which
+  // matches the local TanStack Query refetchInterval.
+  'world-state',
   // Notification channels (cloud-only) — incident dispatch destinations
   // wired through cloudNotificationsApi.
   'notification-channels',

--- a/crates/mockforge-ui/ui/src/pages/CloudWorldStateView.tsx
+++ b/crates/mockforge-ui/ui/src/pages/CloudWorldStateView.tsx
@@ -1,0 +1,386 @@
+/**
+ * Cloud World State view (#464 Phase 2).
+ *
+ * Rendered by `WorldStatePage` when `isCloudMode()`. Drives a per-deployment
+ * world-state visualization against `cloudWorldStateApi` (the registry
+ * proxy from Phase 1 — see `cloudWorldState.ts` and
+ * `handlers::world_state`). Reuses the existing `StateLayerPanel`,
+ * `WorldStateGraph`, and `StateNodeInspector` components so the graph
+ * surface looks identical to local mode.
+ *
+ * Pattern mirrors `CloudTimeTravelView` (#466 Phase 2) and
+ * `ResiliencePage`'s cloud branch: useState/useEffect with direct
+ * `await cloudWorldStateApi.*` calls plus a deployment dropdown. The
+ * WebSocket `/stream` endpoint that the local view consumes is not
+ * proxied in Phase 1 — cloud mode polls every 5s instead, which matches
+ * the `refetchInterval` defaults on the local TanStack Query hooks.
+ */
+
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { PageHeader, Alert, Section } from '../components/ui/DesignSystem';
+import { Card } from '../components/ui/Card';
+import { Badge } from '../components/ui/Badge';
+import { Button } from '../components/ui/button';
+import { RefreshCw } from 'lucide-react';
+import { WorldStateGraph } from '../components/world-state/WorldStateGraph';
+import { StateLayerPanel, type StateLayer } from '../components/world-state/StateLayerPanel';
+import { StateNodeInspector } from '../components/world-state/StateNodeInspector';
+import {
+  cloudWorldStateApi,
+  type WorldStateRuntimeState,
+} from '../services/api/cloudWorldState';
+import type {
+  WorldStateNode,
+  WorldStateEdge,
+  WorldStateGraphResponse,
+} from '../hooks/useWorldState';
+
+interface DeploymentSummary {
+  id: string;
+  name: string;
+  status: string;
+}
+
+interface LayersResponse {
+  layers: Array<{ id: string; name: string }>;
+  count: number;
+}
+
+const POLL_MS = 5000;
+
+export const CloudWorldStateView: React.FC = () => {
+  const [deployments, setDeployments] = useState<DeploymentSummary[]>([]);
+  const [selectedDeploymentId, setSelectedDeploymentId] = useState<string | null>(null);
+
+  const [runtimeState, setRuntimeState] = useState<WorldStateRuntimeState | null>(null);
+  const [graphData, setGraphData] = useState<WorldStateGraphResponse | null>(null);
+  const [layersData, setLayersData] = useState<LayersResponse | null>(null);
+
+  const [enabledLayers, setEnabledLayers] = useState<Set<string>>(new Set());
+  const [selectedNode, setSelectedNode] = useState<WorldStateNode | null>(null);
+  const [selectedEdge, setSelectedEdge] = useState<WorldStateEdge | null>(null);
+  const [layout, setLayout] = useState<'force-directed' | 'hierarchical' | 'circular'>(
+    'force-directed',
+  );
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load deployments once + auto-select first active (same pattern as the
+  // other cloud views).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = localStorage.getItem('auth_token');
+        const resp = await fetch('/api/v1/hosted-mocks', {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!resp.ok) {
+          if (!cancelled) {
+            setError(`Failed to load deployments: ${resp.status}`);
+            setLoading(false);
+          }
+          return;
+        }
+        const list = (await resp.json()) as DeploymentSummary[];
+        if (cancelled) return;
+        const items = Array.isArray(list) ? list : [];
+        setDeployments(items);
+        const active = items.find((d) => d.status === 'active') ?? items[0] ?? null;
+        if (active) {
+          setSelectedDeploymentId(active.id);
+        } else {
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load deployments');
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Compute the layer filter string (comma-separated layer ids) from the
+  // enabled set. When no layer is explicitly toggled OR all layers are
+  // toggled, we omit the filter — Phase 1's proxy forwards the param
+  // verbatim, so an omitted filter is the runtime's default ("all").
+  const allLayerIds = useMemo(
+    () => (Array.isArray(layersData?.layers) ? layersData!.layers.map((l) => l.id) : []),
+    [layersData],
+  );
+
+  const layerFilter = useMemo(() => {
+    if (enabledLayers.size === 0) return undefined;
+    if (enabledLayers.size === allLayerIds.length) return undefined;
+    return Array.from(enabledLayers).join(',');
+  }, [enabledLayers, allLayerIds]);
+
+  // Poll graph + layers when deployment changes (or filter changes for
+  // graph). 5s cadence matches local mode's refetchInterval.
+  useEffect(() => {
+    if (!selectedDeploymentId) return;
+    let cancelled = false;
+
+    const fetchData = async () => {
+      try {
+        const [graphEnv, layersEnv] = await Promise.all([
+          cloudWorldStateApi.getGraph<WorldStateGraphResponse>(
+            selectedDeploymentId,
+            layerFilter,
+          ),
+          cloudWorldStateApi.getLayers<LayersResponse>(selectedDeploymentId),
+        ]);
+        if (cancelled) return;
+
+        // The proxy returns the same envelope for both calls; if either
+        // is unreachable we mark the whole view unreachable so the user
+        // gets one banner, not two.
+        if (
+          graphEnv.runtime_state === 'unreachable' ||
+          layersEnv.runtime_state === 'unreachable'
+        ) {
+          setRuntimeState('unreachable');
+        } else {
+          setRuntimeState('live');
+        }
+        setGraphData(graphEnv.data);
+        setLayersData(layersEnv.data);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setRuntimeState('unreachable');
+        setError(err instanceof Error ? err.message : 'Failed to load world state');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchData();
+    const t = setInterval(fetchData, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [selectedDeploymentId, layerFilter]);
+
+  // Layer panel state. Default: all layers enabled (so the view shows
+  // everything until the user filters explicitly).
+  const layers: StateLayer[] = useMemo(() => {
+    if (!layersData || !Array.isArray(layersData.layers)) return [];
+    return layersData.layers.map((layer) => ({
+      id: layer.id,
+      name: layer.name,
+      enabled: enabledLayers.size === 0 ? true : enabledLayers.has(layer.id),
+    }));
+  }, [layersData, enabledLayers]);
+
+  const displayNodes = useMemo(
+    () => (Array.isArray(graphData?.nodes) ? graphData!.nodes : []),
+    [graphData],
+  );
+  const displayEdges = useMemo(
+    () => (Array.isArray(graphData?.edges) ? graphData!.edges : []),
+    [graphData],
+  );
+
+  const filteredNodes = useMemo(() => {
+    if (enabledLayers.size === 0) return displayNodes;
+    return displayNodes.filter((node) => {
+      const layerId = node.layer.toLowerCase().replace(/\s+/g, '_');
+      return enabledLayers.has(layerId);
+    });
+  }, [displayNodes, enabledLayers]);
+
+  const filteredEdges = useMemo(() => {
+    const visibleNodeIds = new Set(filteredNodes.map((n) => n.id));
+    return displayEdges.filter((e) => visibleNodeIds.has(e.from) && visibleNodeIds.has(e.to));
+  }, [displayEdges, filteredNodes]);
+
+  // Handlers — same shape as local WorldStatePage so the inspector
+  // panel behaves identically.
+  const handleLayerToggle = useCallback((layerId: string, enabled: boolean) => {
+    setEnabledLayers((prev) => {
+      const next = new Set(prev);
+      if (enabled) next.add(layerId);
+      else next.delete(layerId);
+      return next;
+    });
+  }, []);
+
+  const handleNodeClick = useCallback((node: WorldStateNode) => {
+    setSelectedNode(node);
+    setSelectedEdge(null);
+  }, []);
+
+  const handleEdgeClick = useCallback((edge: WorldStateEdge) => {
+    setSelectedEdge(edge);
+    setSelectedNode(null);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!selectedDeploymentId) return;
+    try {
+      const [graphEnv, layersEnv] = await Promise.all([
+        cloudWorldStateApi.getGraph<WorldStateGraphResponse>(
+          selectedDeploymentId,
+          layerFilter,
+        ),
+        cloudWorldStateApi.getLayers<LayersResponse>(selectedDeploymentId),
+      ]);
+      setRuntimeState(
+        graphEnv.runtime_state === 'unreachable' || layersEnv.runtime_state === 'unreachable'
+          ? 'unreachable'
+          : 'live',
+      );
+      setGraphData(graphEnv.data);
+      setLayersData(layersEnv.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh');
+    }
+  }, [selectedDeploymentId, layerFilter]);
+
+  // --- Render ------------------------------------------------------------
+
+  if (deployments.length === 0 && !loading) {
+    return (
+      <div className="content-width space-y-8">
+        <PageHeader title="World State" subtitle="Cloud world-state visualization" />
+        <Alert
+          variant="info"
+          title="No deployments yet"
+          description="Create a hosted mock first to visualize its world state from the cloud dashboard."
+        />
+      </div>
+    );
+  }
+
+  const unreachable = runtimeState === 'unreachable';
+
+  return (
+    <div className="content-width space-y-6">
+      <PageHeader
+        title="World State"
+        subtitle="Per-deployment unified state graph"
+        className="space-section"
+      />
+
+      {/* Deployment selector */}
+      {deployments.length > 1 ? (
+        <Card className="p-4">
+          <label className="block text-sm font-medium text-foreground mb-2">Deployment</label>
+          <select
+            className="w-full px-3 py-2 rounded-lg border border-border bg-background"
+            value={selectedDeploymentId ?? ''}
+            onChange={(e) => setSelectedDeploymentId(e.target.value)}
+          >
+            {deployments.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.name} ({d.status})
+              </option>
+            ))}
+          </select>
+        </Card>
+      ) : (
+        deployments[0] && (
+          <p className="text-sm text-muted-foreground">
+            Deployment:{' '}
+            <span className="font-medium text-foreground">{deployments[0].name}</span>
+            <Badge variant="outline" className="ml-2">
+              {deployments[0].status}
+            </Badge>
+          </p>
+        )
+      )}
+
+      {unreachable && (
+        <Alert
+          variant="warning"
+          title="Deployment not reachable"
+          description="The registry couldn't reach this deployment's runtime over Fly 6PN. Showing the last successful snapshot if any; polling will keep retrying. If this persists, check the deployment's status."
+        />
+      )}
+
+      {error && !unreachable && <Alert variant="error" title="Error" description={error} />}
+
+      <Section>
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center space-x-4">
+            {/* The local mode toggle is "Real-time updates"; cloud mode
+                doesn't have a WS proxy yet (Phase 2 work), so we show a
+                static label noting the polling cadence instead. */}
+            <span className="text-xs text-muted-foreground">
+              Polling every {POLL_MS / 1000}s — WebSocket stream not yet proxied in cloud mode.
+            </span>
+            <Button variant="outline" size="sm" onClick={refresh} disabled={!selectedDeploymentId}>
+              <RefreshCw className="h-4 w-4 mr-1" />
+              Refresh
+            </Button>
+          </div>
+          <select
+            value={layout}
+            onChange={(e) =>
+              setLayout(e.target.value as 'force-directed' | 'hierarchical' | 'circular')
+            }
+            className="text-sm border rounded px-3 py-1"
+          >
+            <option value="force-directed">Force Directed</option>
+            <option value="hierarchical">Hierarchical</option>
+            <option value="circular">Circular</option>
+          </select>
+        </div>
+      </Section>
+
+      <div className="grid grid-cols-12 gap-6">
+        <div className="col-span-2">
+          <StateLayerPanel layers={layers} onLayerToggle={handleLayerToggle} />
+        </div>
+        <div className="col-span-7">
+          <div className="h-[600px] border rounded-lg overflow-hidden">
+            <WorldStateGraph
+              nodes={filteredNodes}
+              edges={filteredEdges}
+              onNodeClick={handleNodeClick}
+              onEdgeClick={handleEdgeClick}
+              selectedNodeId={selectedNode?.id}
+              selectedEdgeId={
+                selectedEdge
+                  ? `${selectedEdge.from}-${selectedEdge.to}-${selectedEdge.relationship_type}`
+                  : undefined
+              }
+              layout={layout}
+            />
+          </div>
+        </div>
+        <div className="col-span-3">
+          <StateNodeInspector node={selectedNode} edges={filteredEdges} />
+        </div>
+      </div>
+
+      <Section>
+        <div className="grid grid-cols-4 gap-4">
+          <div className="text-center">
+            <div className="text-2xl font-bold">{filteredNodes.length}</div>
+            <div className="text-sm text-muted-foreground">Nodes</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold">{filteredEdges.length}</div>
+            <div className="text-sm text-muted-foreground">Edges</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold">{layers.length}</div>
+            <div className="text-sm text-muted-foreground">Layers</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold">{layers.filter((l) => l.enabled).length}</div>
+            <div className="text-sm text-muted-foreground">Active Layers</div>
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+};

--- a/crates/mockforge-ui/ui/src/pages/WorldStatePage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/WorldStatePage.tsx
@@ -21,8 +21,19 @@ import {
   type WorldStateEdge,
 } from '../hooks/useWorldState';
 import { DashboardLoading, ErrorState } from '../components/ui/LoadingStates';
+import { isCloudMode } from '../utils/cloudMode';
+import { CloudWorldStateView } from './CloudWorldStateView';
 
 export const WorldStatePage: React.FC = () => {
+  // #464 Phase 2: in cloud mode, dispatch to the per-deployment cloud view
+  // backed by cloudWorldStateApi (/api/v1/hosted-mocks/{id}/world-state/*).
+  // Local mode keeps the singleton-runtime hooks below unchanged — they
+  // hit /api/world-state/* directly on the mockforge process the browser
+  // is talking to.
+  if (isCloudMode()) {
+    return <CloudWorldStateView />;
+  }
+
   const [selectedNode, setSelectedNode] = useState<WorldStateNode | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<WorldStateEdge | null>(null);
   const [enabledLayers, setEnabledLayers] = useState<Set<string>>(new Set());

--- a/crates/mockforge-ui/ui/src/services/api/cloudWorldState.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudWorldState.ts
@@ -1,0 +1,89 @@
+/**
+ * Cloud world-state API client (#464) — Phase 1.
+ *
+ * Backs the registry's `/api/v1/hosted-mocks/{deployment_id}/world-state/*`
+ * routes. The registry proxies over Fly 6PN to the running mockforge
+ * instance's main HTTP port (`{fly-app}.internal:3000/api/world-state/*`)
+ * — same reachability story as cloudTimeTravel (the admin port isn't
+ * always exposed publicly on hosted mocks).
+ *
+ * The runtime exposes 6 endpoints; this client covers the 5 HTTP ones.
+ * The WebSocket `/stream` endpoint is deferred to Phase 2 — for now
+ * cloud users get polling-based refresh (the local UI defaults to
+ * `refetchInterval: 5000` anyway, so behaviour is parity).
+ *
+ * `runtime_state` mirrors cloudResilience / cloudTimeTravel:
+ * * `'live'`        — proxy succeeded; `data` is the deployment's response.
+ * * `'unreachable'` — proxy failed; `data` is `null`. UI renders empty state.
+ */
+import { fetchJsonWithErrorBody } from './client';
+
+export type WorldStateRuntimeState = 'live' | 'unreachable';
+
+export interface CloudWorldStateEnvelope<T = unknown> {
+  runtime_state: WorldStateRuntimeState;
+  data: T | null;
+}
+
+class CloudWorldStateApiService {
+  private base(deploymentId: string): string {
+    return `/api/v1/hosted-mocks/${encodeURIComponent(deploymentId)}/world-state`;
+  }
+
+  /** Current snapshot of the deployment's world state. */
+  async getSnapshot<T = unknown>(deploymentId: string): Promise<CloudWorldStateEnvelope<T>> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/snapshot`) as Promise<
+      CloudWorldStateEnvelope<T>
+    >;
+  }
+
+  /** Historical snapshot by id. */
+  async getSnapshotById<T = unknown>(
+    deploymentId: string,
+    snapshotId: string,
+  ): Promise<CloudWorldStateEnvelope<T>> {
+    return fetchJsonWithErrorBody(
+      `${this.base(deploymentId)}/snapshot/${encodeURIComponent(snapshotId)}`,
+    ) as Promise<CloudWorldStateEnvelope<T>>;
+  }
+
+  /**
+   * State graph (nodes + edges + layers). Optional `layers` is a comma-
+   * separated list of layer ids; the runtime owns the filter semantics.
+   */
+  async getGraph<T = unknown>(
+    deploymentId: string,
+    layers?: string,
+  ): Promise<CloudWorldStateEnvelope<T>> {
+    const qs = layers && layers.length > 0 ? `?layers=${encodeURIComponent(layers)}` : '';
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/graph${qs}`) as Promise<
+      CloudWorldStateEnvelope<T>
+    >;
+  }
+
+  /** List of layers available on this deployment. */
+  async getLayers<T = unknown>(deploymentId: string): Promise<CloudWorldStateEnvelope<T>> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/layers`) as Promise<
+      CloudWorldStateEnvelope<T>
+    >;
+  }
+
+  /**
+   * Slice / filter query. Body is forwarded verbatim to the runtime's
+   * `WorldStateQueryRequest` schema (optional `node_type`, `layer`,
+   * `since` fields today; the runtime is the source of truth).
+   */
+  async query<T = unknown>(
+    deploymentId: string,
+    request: unknown,
+  ): Promise<CloudWorldStateEnvelope<T>> {
+    return fetchJsonWithErrorBody(`${this.base(deploymentId)}/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request ?? {}),
+    }) as Promise<CloudWorldStateEnvelope<T>>;
+  }
+}
+
+export { CloudWorldStateApiService };
+export const cloudWorldStateApi = new CloudWorldStateApiService();


### PR DESCRIPTION
## Summary

Cloud-parity for World State (#464, part of #459 meta tracker). **Phase 1 + Phase 2 bundled** — registry proxy, TS client, page branching, and nav allowlist all in this single squash-merge. (Phase 2 [#531](https://github.com/SaaSy-Solutions/mockforge/pull/531) auto-merged into this branch.)

## Endpoint coverage

The runtime exposes 6 endpoints (`mockforge-http::handlers::world_state::world_state_router`). 5 HTTP endpoints proxied:

```
GET  /api/v1/hosted-mocks/{deployment_id}/world-state/snapshot
GET  /api/v1/hosted-mocks/{deployment_id}/world-state/snapshot/{snapshot_id}
GET  /api/v1/hosted-mocks/{deployment_id}/world-state/graph?layers=...
GET  /api/v1/hosted-mocks/{deployment_id}/world-state/layers
POST /api/v1/hosted-mocks/{deployment_id}/world-state/query
```

Upstream target: `http://{fly-app}.internal:3000/api/world-state/*` (port 3000, not 9080 — same reachability story as time-travel).

**WebSocket `/stream` is NOT proxied** — that's a follow-up. Cloud view polls every 5s (matches local `refetchInterval`), which is functionally parity. WS-proxying through Fly 6PN needs a ws-aware tunnel; alternative is to add an SSE endpoint to the runtime.

## Wire format

Every endpoint returns `{ runtime_state, data }`:
- `runtime_state: "live"` — proxy 2xx; `data` is the runtime's verbatim response.
- `runtime_state: "unreachable"` — connection refused / timeout / non-2xx; `data` is `null`.

## UI integration

**New `CloudWorldStateView`** (cloud-mode component):
- Loads deployments from `/api/v1/hosted-mocks`, auto-selects first active (dropdown when >1).
- Reuses `StateLayerPanel` + `WorldStateGraph` + `StateNodeInspector` — graph visualization identical to local mode.
- 5s polling on graph + layers in parallel.
- Marks the view unreachable if either envelope is unreachable so the user sees one banner not two.
- Quiet hint at the top: "Polling every 5s — WebSocket stream not yet proxied in cloud mode."
- Empty state when org has no deployments.

**`WorldStatePage`** (3-line touch): delegates to `CloudWorldStateView` when `isCloudMode()`, keeps existing TanStack Query plumbing for local mode unchanged.

**`AppShell`**: `'world-state'` added to `cloudNavItemIds`.

## Verification

- [x] `cargo check -p mockforge-registry-server` clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-registry-server --lib handlers::world_state::` — 4/4 pass
- [x] `pnpm type-check` clean
- [x] `eslint` on changed UI files: clean
- [ ] Post-merge: smoke against a live hosted-mock deployment over 6PN
- [ ] Follow-up: WebSocket `/stream` proxy or SSE alternative