### PR TITLE
feat(registry,ui): cloud Test Generator — full stack (#469)

### DIFF
--- a/crates/mockforge-registry-core/src/models/mod.rs
+++ b/crates/mockforge-registry-core/src/models/mod.rs
@@ -46,6 +46,7 @@ pub mod template;
 pub mod template_review;
 pub mod template_star;
 pub mod test_execution;
+pub mod test_generation_job;
 pub mod test_run;
 pub mod tunnel;
 pub mod user;

--- a/crates/mockforge-registry-core/src/models/test_generation_job.rs
+++ b/crates/mockforge-registry-core/src/models/test_generation_job.rs
@@ -141,6 +141,79 @@ impl TestGenerationJob {
         .await
     }
 
+    /// Atomically claim the oldest queued job, flipping it to 'running'.
+    /// Returns the claimed row, or `None` if no job is queued.
+    ///
+    /// Uses `FOR UPDATE SKIP LOCKED` so concurrent workers (a future
+    /// scale-out won't claim the same row) skip rather than block on a
+    /// locked candidate. Phase 3 only runs a single worker process per
+    /// registry pod, but the locking pattern future-proofs us.
+    pub async fn claim_next_queued(pool: &PgPool) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            UPDATE cloud_test_generation_jobs
+            SET status = 'running', started_at = NOW()
+            WHERE id = (
+                SELECT id FROM cloud_test_generation_jobs
+                WHERE status = 'queued'
+                ORDER BY queued_at ASC
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING id, workspace_id, org_id, status, prompt, captures_filter,
+                      result, error, queued_at, started_at, finished_at, created_by
+            "#,
+        )
+        .fetch_optional(pool)
+        .await
+    }
+
+    /// Persist a successful generation result and flip status to
+    /// 'succeeded'. No-op if the job is no longer in 'running' state
+    /// (e.g., the user cancelled while the worker was mid-flight) — the
+    /// rows_affected check makes this safe under that race.
+    pub async fn complete_success(
+        pool: &PgPool,
+        job_id: Uuid,
+        result: &serde_json::Value,
+    ) -> sqlx::Result<bool> {
+        let rows = sqlx::query(
+            r#"
+            UPDATE cloud_test_generation_jobs
+            SET status = 'succeeded',
+                result = $2,
+                finished_at = NOW()
+            WHERE id = $1 AND status = 'running'
+            "#,
+        )
+        .bind(job_id)
+        .bind(result)
+        .execute(pool)
+        .await?
+        .rows_affected();
+        Ok(rows > 0)
+    }
+
+    /// Persist a failure reason and flip status to 'failed'. Same
+    /// no-op-on-race semantics as `complete_success`.
+    pub async fn complete_failure(pool: &PgPool, job_id: Uuid, error: &str) -> sqlx::Result<bool> {
+        let rows = sqlx::query(
+            r#"
+            UPDATE cloud_test_generation_jobs
+            SET status = 'failed',
+                error = $2,
+                finished_at = NOW()
+            WHERE id = $1 AND status = 'running'
+            "#,
+        )
+        .bind(job_id)
+        .bind(error)
+        .execute(pool)
+        .await?
+        .rows_affected();
+        Ok(rows > 0)
+    }
+
     /// Cancel a queued/running job. No-op if the job is already terminal.
     /// Returns Ok(true) on a state change, Ok(false) if the job was
     /// already terminal or not found.

--- a/crates/mockforge-registry-core/src/models/test_generation_job.rs
+++ b/crates/mockforge-registry-core/src/models/test_generation_job.rs
@@ -1,0 +1,197 @@
+//! Cloud Test Generator async-job rows.
+//!
+//! Backs `/api/v1/workspaces/{id}/test-generation/jobs` and friends (#469).
+//! Phase 1 ships the data plane only — rows are created in 'queued' state
+//! and stay there until Phase 2 wires the background worker that calls the
+//! org's BYOK LLM provider.
+//!
+//! Schema: migration `20250101000076_test_generation_jobs.sql`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[cfg(feature = "postgres")]
+use sqlx::{FromRow, PgPool};
+
+/// Terminal states a job can finish in. Stored in DB as the raw string
+/// values via `status: String`; this enum mirrors them for client code
+/// that wants exhaustive matching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TestGenerationJobStatus {
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl TestGenerationJobStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+    }
+}
+
+#[cfg_attr(feature = "postgres", derive(FromRow))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestGenerationJob {
+    pub id: Uuid,
+    pub workspace_id: Uuid,
+    pub org_id: Uuid,
+    /// One of `TestGenerationJobStatus`'s string forms.
+    pub status: String,
+    pub prompt: String,
+    pub captures_filter: serde_json::Value,
+    /// Populated once status = 'succeeded'.
+    pub result: Option<serde_json::Value>,
+    /// Populated once status = 'failed' or 'cancelled'.
+    pub error: Option<String>,
+    pub queued_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub created_by: Option<Uuid>,
+}
+
+/// Insert payload for [`TestGenerationJob::create`].
+#[cfg(feature = "postgres")]
+pub struct CreateTestGenerationJob<'a> {
+    pub workspace_id: Uuid,
+    pub org_id: Uuid,
+    pub prompt: &'a str,
+    pub captures_filter: &'a serde_json::Value,
+    pub created_by: Option<Uuid>,
+}
+
+#[cfg(feature = "postgres")]
+impl TestGenerationJob {
+    /// Create a new job in 'queued' state. The Phase 2 worker is
+    /// responsible for transitioning it through 'running' → terminal.
+    pub async fn create(pool: &PgPool, input: CreateTestGenerationJob<'_>) -> sqlx::Result<Self> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            INSERT INTO cloud_test_generation_jobs
+                (workspace_id, org_id, prompt, captures_filter, created_by)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id, workspace_id, org_id, status, prompt, captures_filter,
+                      result, error, queued_at, started_at, finished_at, created_by
+            "#,
+        )
+        .bind(input.workspace_id)
+        .bind(input.org_id)
+        .bind(input.prompt)
+        .bind(input.captures_filter)
+        .bind(input.created_by)
+        .fetch_one(pool)
+        .await
+    }
+
+    /// Look up a single job by id, scoped to the caller's workspace so
+    /// cross-workspace IDs return None even when the row exists.
+    pub async fn find_in_workspace(
+        pool: &PgPool,
+        workspace_id: Uuid,
+        job_id: Uuid,
+    ) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT id, workspace_id, org_id, status, prompt, captures_filter,
+                   result, error, queued_at, started_at, finished_at, created_by
+            FROM cloud_test_generation_jobs
+            WHERE id = $1 AND workspace_id = $2
+            "#,
+        )
+        .bind(job_id)
+        .bind(workspace_id)
+        .fetch_optional(pool)
+        .await
+    }
+
+    /// List jobs for a workspace, newest first. `limit` caps the page
+    /// size — callers should pass a sane upper bound (the handler caps
+    /// at 100).
+    pub async fn list_by_workspace(
+        pool: &PgPool,
+        workspace_id: Uuid,
+        limit: i64,
+    ) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT id, workspace_id, org_id, status, prompt, captures_filter,
+                   result, error, queued_at, started_at, finished_at, created_by
+            FROM cloud_test_generation_jobs
+            WHERE workspace_id = $1
+            ORDER BY queued_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(limit)
+        .fetch_all(pool)
+        .await
+    }
+
+    /// Cancel a queued/running job. No-op if the job is already terminal.
+    /// Returns Ok(true) on a state change, Ok(false) if the job was
+    /// already terminal or not found.
+    pub async fn cancel(pool: &PgPool, workspace_id: Uuid, job_id: Uuid) -> sqlx::Result<bool> {
+        let rows = sqlx::query(
+            r#"
+            UPDATE cloud_test_generation_jobs
+            SET status = 'cancelled',
+                finished_at = NOW(),
+                error = 'Cancelled by user'
+            WHERE id = $1
+              AND workspace_id = $2
+              AND status IN ('queued', 'running')
+            "#,
+        )
+        .bind(job_id)
+        .bind(workspace_id)
+        .execute(pool)
+        .await?
+        .rows_affected();
+        Ok(rows > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_round_trips_via_serde() {
+        for s in [
+            TestGenerationJobStatus::Queued,
+            TestGenerationJobStatus::Running,
+            TestGenerationJobStatus::Succeeded,
+            TestGenerationJobStatus::Failed,
+            TestGenerationJobStatus::Cancelled,
+        ] {
+            let json = serde_json::to_string(&s).unwrap();
+            let back: TestGenerationJobStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(s, back, "round-trip failed for {s:?}");
+            // serde lowercase matches DB string form.
+            assert_eq!(json.trim_matches('"'), s.as_str());
+        }
+    }
+
+    #[test]
+    fn is_terminal_matches_expected_states() {
+        assert!(!TestGenerationJobStatus::Queued.is_terminal());
+        assert!(!TestGenerationJobStatus::Running.is_terminal());
+        assert!(TestGenerationJobStatus::Succeeded.is_terminal());
+        assert!(TestGenerationJobStatus::Failed.is_terminal());
+        assert!(TestGenerationJobStatus::Cancelled.is_terminal());
+    }
+}

--- a/crates/mockforge-registry-server/migrations/20250101000076_test_generation_jobs.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000076_test_generation_jobs.sql
@@ -1,0 +1,58 @@
+-- Cloud Test Generator — async LLM jobs over the workspace's runtime_captures
+-- corpus (#469).
+--
+-- Each row is one async generation request: the org's BYOK provider key
+-- backs the LLM call (rate-limited via the existing ai::quota path) and
+-- the resulting test scenarios land in the `result` column once status
+-- transitions out of 'queued'/'running'.
+--
+-- Phase 1 (this migration) ships the data plane only — table + indexes.
+-- Phase 2 will wire the background worker that pulls queued rows, calls
+-- the BYOK LLM, and persists results.
+
+CREATE TABLE cloud_test_generation_jobs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    -- 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled'
+    status TEXT NOT NULL DEFAULT 'queued',
+    -- Free-form natural-language prompt describing what tests to generate.
+    -- Empty string allowed — the worker falls back to a default prompt
+    -- derived from the captures_filter.
+    prompt TEXT NOT NULL DEFAULT '',
+    -- Filter applied when selecting captures from runtime_captures. JSONB
+    -- so we can evolve the filter vocabulary (path globs, status code
+    -- ranges, time window, sample size, etc.) without a schema migration.
+    captures_filter JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- LLM-generated test scenarios. NULL until the worker finishes a
+    -- 'succeeded' run; the shape is `{"scenarios": [...], "model": "...",
+    -- "captures_sampled": N}` per the upstream Test Generator format.
+    result JSONB,
+    -- Human-readable failure reason. NULL unless status = 'failed' or
+    -- 'cancelled'. Populated by the worker on failure paths.
+    error TEXT,
+    -- Bookkeeping for billing + UI progress. queued_at = row creation;
+    -- started_at = worker picked it up; finished_at = terminal status
+    -- ('succeeded' | 'failed' | 'cancelled').
+    queued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    finished_at TIMESTAMPTZ,
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Listing the workspace's recent jobs, newest first — the cloud
+-- TestGeneratorPage's primary view.
+CREATE INDEX idx_cloud_test_gen_jobs_workspace
+    ON cloud_test_generation_jobs(workspace_id, queued_at DESC);
+
+-- Worker scan: `WHERE status IN ('queued','running')` is the queue feed.
+-- A partial index keeps the index small even as the finished-jobs table
+-- grows unbounded.
+CREATE INDEX idx_cloud_test_gen_jobs_pending
+    ON cloud_test_generation_jobs(queued_at)
+    WHERE status IN ('queued', 'running');
+
+-- Org-wide views (admin / billing). Lets us count active runs per org
+-- without seq-scanning every workspace.
+CREATE INDEX idx_cloud_test_gen_jobs_org_status
+    ON cloud_test_generation_jobs(org_id, status);

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -50,6 +50,7 @@ pub mod sso;
 pub mod stats;
 pub mod status;
 pub mod support;
+pub mod test_generation;
 pub mod test_runs;
 pub mod test_schedules;
 pub mod test_suites;

--- a/crates/mockforge-registry-server/src/handlers/test_generation.rs
+++ b/crates/mockforge-registry-server/src/handlers/test_generation.rs
@@ -1,0 +1,234 @@
+//! Cloud Test Generator handlers (#469) — Phase 1 data plane.
+//!
+//! Backs `cloudTestGeneratorApi` in the UI. Each row represents one async
+//! LLM job that, in Phase 2, will be picked up by a background worker
+//! that calls the org's BYOK provider key against a corpus of recent
+//! `runtime_captures` rows and returns generated test scenarios.
+//!
+//! Phase 1 ships the data plane only:
+//! * `POST /api/v1/workspaces/{workspace_id}/test-generation/jobs` — create a job in 'queued' state.
+//! * `GET  /api/v1/workspaces/{workspace_id}/test-generation/jobs`             — list (newest first, capped 100).
+//! * `GET  /api/v1/workspaces/{workspace_id}/test-generation/jobs/{job_id}`    — status / result poll.
+//! * `POST /api/v1/workspaces/{workspace_id}/test-generation/jobs/{job_id}/cancel` — cancel a queued/running job.
+//!
+//! Rows created here sit in 'queued' until Phase 2 wires the worker.
+//! That's intentional — the data shape and authorization model land
+//! first so the UI client (Phase 1) and the worker (Phase 2) can land
+//! independently against a stable contract.
+
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::{resolve_org_context, AuthUser},
+    AppState,
+};
+use mockforge_registry_core::models::{
+    test_generation_job::{CreateTestGenerationJob, TestGenerationJob},
+    CloudWorkspace,
+};
+
+/// Hard cap on the list page size. The TestGeneratorPage is a poll-based
+/// timeline, so showing more than ~100 jobs at once is rarely useful and
+/// makes the index scan unbounded.
+const LIST_LIMIT: i64 = 100;
+
+/// Cap on prompt length. LLM providers all have a context window; bounding
+/// here means we reject obvious abuse without round-tripping to the
+/// provider only to get rejected upstream. 8 KB is comfortably under every
+/// modern provider's prompt token limit.
+const MAX_PROMPT_BYTES: usize = 8 * 1024;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateJobRequest {
+    /// Optional natural-language description of what tests to generate.
+    /// Empty allowed — Phase 2's worker falls back to a default prompt
+    /// derived from `captures_filter`.
+    #[serde(default)]
+    pub prompt: String,
+    /// JSON filter object describing which captures to feed the LLM.
+    /// Forwarded verbatim to the worker; the worker owns the filter
+    /// vocabulary. Bounded only by `MAX_FILTER_BYTES` below.
+    #[serde(default)]
+    pub captures_filter: Value,
+}
+
+/// Cap on the JSON-encoded filter. Same shape rationale as
+/// `MAX_PROMPT_BYTES` — anything larger is almost certainly abuse and
+/// would never round-trip through Phase 2's worker anyway.
+const MAX_FILTER_BYTES: usize = 16 * 1024;
+
+// --- POST /jobs -----------------------------------------------------------
+
+pub async fn create_job(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<CreateJobRequest>,
+) -> ApiResult<Json<TestGenerationJob>> {
+    let workspace = authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+
+    if body.prompt.len() > MAX_PROMPT_BYTES {
+        return Err(ApiError::InvalidRequest(format!(
+            "prompt exceeds {MAX_PROMPT_BYTES} byte limit"
+        )));
+    }
+    let filter_size = serde_json::to_vec(&body.captures_filter).map(|v| v.len()).unwrap_or(0);
+    if filter_size > MAX_FILTER_BYTES {
+        return Err(ApiError::InvalidRequest(format!(
+            "captures_filter exceeds {MAX_FILTER_BYTES} byte limit"
+        )));
+    }
+    if !body.captures_filter.is_object() && !body.captures_filter.is_null() {
+        return Err(ApiError::InvalidRequest("captures_filter must be a JSON object".into()));
+    }
+
+    // Normalise null → empty object so the DB row never carries `null`
+    // (the column NOT-NULL default is `{}::jsonb`).
+    let captures_filter = if body.captures_filter.is_null() {
+        json!({})
+    } else {
+        body.captures_filter
+    };
+
+    let row = TestGenerationJob::create(
+        state.db.pool(),
+        CreateTestGenerationJob {
+            workspace_id: workspace.id,
+            org_id: workspace.org_id,
+            prompt: &body.prompt,
+            captures_filter: &captures_filter,
+            created_by: Some(user_id),
+        },
+    )
+    .await?;
+
+    tracing::info!(
+        job_id = %row.id,
+        workspace_id = %workspace.id,
+        org_id = %workspace.org_id,
+        prompt_len = body.prompt.len(),
+        "test-generation job queued"
+    );
+
+    Ok(Json(row))
+}
+
+// --- GET /jobs ------------------------------------------------------------
+
+pub async fn list_jobs(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Vec<TestGenerationJob>>> {
+    let workspace = authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    let jobs =
+        TestGenerationJob::list_by_workspace(state.db.pool(), workspace.id, LIST_LIMIT).await?;
+    Ok(Json(jobs))
+}
+
+// --- GET /jobs/{job_id} ---------------------------------------------------
+
+pub async fn get_job(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path((workspace_id, job_id)): Path<(Uuid, Uuid)>,
+    headers: HeaderMap,
+) -> ApiResult<Json<TestGenerationJob>> {
+    let workspace = authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    let job = TestGenerationJob::find_in_workspace(state.db.pool(), workspace.id, job_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Job not found".into()))?;
+    Ok(Json(job))
+}
+
+// --- POST /jobs/{job_id}/cancel -------------------------------------------
+
+pub async fn cancel_job(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path((workspace_id, job_id)): Path<(Uuid, Uuid)>,
+    headers: HeaderMap,
+) -> ApiResult<Json<Value>> {
+    let workspace = authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+    let changed = TestGenerationJob::cancel(state.db.pool(), workspace.id, job_id).await?;
+    Ok(Json(json!({
+        "cancelled": changed,
+    })))
+}
+
+// --- helpers --------------------------------------------------------------
+
+/// Resolve `workspace_id` and check the caller's org owns it. Returns
+/// the workspace so callers can read `workspace.org_id` without a second
+/// fetch. Mirrors the helper in `handlers::captures` but returns the
+/// workspace rather than just `()`.
+async fn authorize_workspace(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    workspace_id: Uuid,
+) -> ApiResult<CloudWorkspace> {
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != workspace.org_id {
+        // Same opaque response as the unknown-workspace case — don't leak
+        // existence of cross-org workspace IDs.
+        return Err(ApiError::InvalidRequest("Workspace not found".into()));
+    }
+    Ok(workspace)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_request_defaults() {
+        let req: CreateJobRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(req.prompt, "");
+        assert!(req.captures_filter.is_null());
+    }
+
+    #[test]
+    fn create_request_accepts_prompt_and_filter() {
+        let req: CreateJobRequest =
+            serde_json::from_str(r#"{"prompt":"gen tests","captures_filter":{"status":">=400"}}"#)
+                .unwrap();
+        assert_eq!(req.prompt, "gen tests");
+        assert_eq!(req.captures_filter["status"], ">=400");
+    }
+
+    #[test]
+    fn prompt_length_cap_is_8kb() {
+        // Round number tied to the comment in MAX_PROMPT_BYTES — guards
+        // against an accidental "let's set it to 4MB" change.
+        assert_eq!(MAX_PROMPT_BYTES, 8 * 1024);
+    }
+
+    #[test]
+    fn filter_size_cap_is_16kb() {
+        assert_eq!(MAX_FILTER_BYTES, 16 * 1024);
+    }
+
+    #[test]
+    fn list_limit_is_capped_at_100() {
+        // The TestGeneratorPage is a poll-based timeline; >100 jobs at
+        // once produces noisy UI and unbounded scans without a useful
+        // value.
+        assert_eq!(LIST_LIMIT, 100);
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/test_generation.rs
+++ b/crates/mockforge-registry-server/src/handlers/test_generation.rs
@@ -16,13 +16,19 @@
 //! first so the UI client (Phase 1) and the worker (Phase 2) can land
 //! independently against a stable contract.
 
+use std::convert::Infallible;
+use std::time::Duration;
+
 use axum::{
     extract::{Path, State},
     http::HeaderMap,
+    response::sse::{Event, KeepAlive, Sse},
     Json,
 };
+use futures_util::stream::{self, Stream};
 use serde::Deserialize;
 use serde_json::{json, Value};
+use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::{
@@ -164,6 +170,155 @@ pub async fn cancel_job(
     Ok(Json(json!({
         "cancelled": changed,
     })))
+}
+
+// --- helpers --------------------------------------------------------------
+
+// --- SSE: GET /jobs/{job_id}/stream --------------------------------------
+
+/// `GET /api/v1/workspaces/{workspace_id}/test-generation/jobs/{job_id}/stream`
+///
+/// Server-Sent Events stream of the job's lifecycle. The UI's polling
+/// path (every 5s) works fine; this endpoint exists for clients that
+/// want sub-second update latency without burning the UI render path
+/// on a tight `setInterval`.
+///
+/// Pattern mirrors `handlers::test_runs::stream_run_events`: poll the
+/// underlying row every 1s, emit a `status_update` event whenever the
+/// shape changes (status / started_at / finished_at / has-result /
+/// has-error), terminate after one final event once status reaches a
+/// terminal value.
+///
+/// Polling Postgres (vs LISTEN/NOTIFY) is the right tradeoff today:
+/// per-org job rate is bounded (interactive UI feature, not a firehose)
+/// and the 1s cadence is invisible to the user. A pub/sub upgrade can
+/// land later if usage demands it.
+pub async fn stream_job(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path((workspace_id, job_id)): Path<(Uuid, Uuid)>,
+    headers: HeaderMap,
+) -> ApiResult<Sse<impl Stream<Item = Result<Event, Infallible>>>> {
+    // Authorize once up front so we don't leak existence to non-members.
+    let workspace = authorize_workspace(&state, user_id, &headers, workspace_id).await?;
+
+    let cursor = JobStreamCursor {
+        pool: state.db.pool().clone(),
+        workspace_id: workspace.id,
+        job_id,
+        last_snapshot: None,
+        terminal_emitted: false,
+    };
+
+    let stream = stream::unfold(cursor, advance_job_stream);
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+/// Snapshot of the fields we care about for change-detection. Two
+/// snapshots compare equal iff a client wouldn't see a difference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct JobSnapshot {
+    status: String,
+    started_at_set: bool,
+    finished_at_set: bool,
+    has_result: bool,
+    has_error: bool,
+}
+
+impl JobSnapshot {
+    fn from_job(j: &TestGenerationJob) -> Self {
+        Self {
+            status: j.status.clone(),
+            started_at_set: j.started_at.is_some(),
+            finished_at_set: j.finished_at.is_some(),
+            has_result: j.result.is_some(),
+            has_error: j.error.is_some(),
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        matches!(self.status.as_str(), "succeeded" | "failed" | "cancelled")
+    }
+}
+
+struct JobStreamCursor {
+    pool: PgPool,
+    workspace_id: Uuid,
+    job_id: Uuid,
+    last_snapshot: Option<JobSnapshot>,
+    terminal_emitted: bool,
+}
+
+/// One step of the SSE stream:
+///   - Poll the job row.
+///   - If the row is gone, emit `not_found` and terminate.
+///   - If the snapshot is unchanged, sleep and re-poll on the next
+///     iteration (no event emitted; SSE keep-alive comments cover idle
+///     connections).
+///   - If the snapshot changed, emit a `status_update` event with the
+///     full row payload.
+///   - If the new snapshot is terminal, mark the cursor so the next
+///     iteration returns None.
+async fn advance_job_stream(
+    mut cursor: JobStreamCursor,
+) -> Option<(Result<Event, Infallible>, JobStreamCursor)> {
+    if cursor.terminal_emitted {
+        return None;
+    }
+
+    // 1s cadence; matches the test_runs SSE handler. Skip the sleep on
+    // the very first poll so the initial snapshot lands immediately.
+    if cursor.last_snapshot.is_some() {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let job = match TestGenerationJob::find_in_workspace(
+        &cursor.pool,
+        cursor.workspace_id,
+        cursor.job_id,
+    )
+    .await
+    {
+        Ok(Some(j)) => j,
+        Ok(None) => {
+            let evt = Event::default()
+                .event("not_found")
+                .data(json!({ "job_id": cursor.job_id }).to_string());
+            cursor.terminal_emitted = true;
+            return Some((Ok(evt), cursor));
+        }
+        Err(e) => {
+            let evt = Event::default()
+                .event("stream_error")
+                .data(json!({ "error": e.to_string() }).to_string());
+            cursor.terminal_emitted = true;
+            return Some((Ok(evt), cursor));
+        }
+    };
+
+    let snapshot = JobSnapshot::from_job(&job);
+    let unchanged = cursor.last_snapshot.as_ref().is_some_and(|s| s == &snapshot);
+
+    if unchanged {
+        // No new data — emit a heartbeat keep-alive comment by yielding
+        // a `ping` event so the client knows the connection's still live
+        // without burning bytes on a full payload. The browser's
+        // EventSource ignores unknown event types unless explicitly
+        // listened to, which is what we want.
+        let evt = Event::default().event("ping").data("{}");
+        return Some((Ok(evt), cursor));
+    }
+
+    let terminal = snapshot.is_terminal();
+    cursor.last_snapshot = Some(snapshot);
+    if terminal {
+        cursor.terminal_emitted = true;
+    }
+
+    let payload =
+        serde_json::to_value(&job).unwrap_or_else(|_| json!({ "error": "serialization failed" }));
+    let evt = Event::default().event("status_update").data(payload.to_string());
+    Some((Ok(evt), cursor))
 }
 
 // --- helpers --------------------------------------------------------------

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -184,6 +184,9 @@ async fn main() -> Result<()> {
         db.pool().clone(),
         state.redis.clone(),
     );
+    // Cloud Test Generator (#469 Phase 3) — drains queued LLM jobs against
+    // the org's BYOK provider. Disabled via TEST_GENERATION_WORKER_DISABLED=1.
+    workers::test_generation_worker::start_test_generation_worker(state.clone());
     workers::incident_dispatcher::start_incident_dispatcher_worker(db.pool().clone());
     workers::snapshot_retention::start_snapshot_retention_worker(
         db.pool().clone(),

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -548,6 +548,13 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/workspaces/{workspace_id}/test-generation/jobs/{job_id}/cancel",
             post(handlers::test_generation::cancel_job),
         )
+        // SSE stream for live job-status updates (#469 Phase 4). Poll
+        // endpoints above remain authoritative; this is the low-latency
+        // option for clients that want sub-second updates.
+        .route(
+            "/api/v1/workspaces/{workspace_id}/test-generation/jobs/{job_id}/stream",
+            get(handlers::test_generation::stream_job),
+        )
         // Consistency / Virtual Backends routes (#461 / part of #459).
         // Lifecycle preset library is static (matches mockforge-data); the
         // workspace-scoped apply + entity-list endpoints back the cloud

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -530,6 +530,24 @@ pub fn create_router(state: AppState) -> Router<AppState> {
             "/api/v1/hosted-mocks/{deployment_id}/resilience/bulkheads/{service}/reset",
             post(handlers::resilience::reset_bulkhead),
         )
+        // Test Generator routes (#469 / part of #459) — Phase 1 data plane.
+        // Async LLM jobs that read the workspace's runtime_captures corpus
+        // and emit generated test scenarios. Rows land in 'queued' state;
+        // the Phase 2 worker (separate PR) transitions them through
+        // 'running' → terminal and writes the result blob.
+        .route(
+            "/api/v1/workspaces/{workspace_id}/test-generation/jobs",
+            post(handlers::test_generation::create_job)
+                .get(handlers::test_generation::list_jobs),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/test-generation/jobs/{job_id}",
+            get(handlers::test_generation::get_job),
+        )
+        .route(
+            "/api/v1/workspaces/{workspace_id}/test-generation/jobs/{job_id}/cancel",
+            post(handlers::test_generation::cancel_job),
+        )
         // Consistency / Virtual Backends routes (#461 / part of #459).
         // Lifecycle preset library is static (matches mockforge-data); the
         // workspace-scoped apply + entity-list endpoints back the cloud

--- a/crates/mockforge-registry-server/src/workers/mod.rs
+++ b/crates/mockforge-registry-server/src/workers/mod.rs
@@ -8,6 +8,7 @@ pub mod runtime_logs_retention;
 pub mod runtime_observability_retention;
 pub mod saml_cleanup;
 pub mod snapshot_retention;
+pub mod test_generation_worker;
 pub mod test_schedule_runner;
 pub mod token_rotation_reminders;
 pub mod usage_threshold_checker;

--- a/crates/mockforge-registry-server/src/workers/test_generation_worker.rs
+++ b/crates/mockforge-registry-server/src/workers/test_generation_worker.rs
@@ -1,0 +1,580 @@
+//! Cloud Test Generator background worker (#469 Phase 3).
+//!
+//! Drains `cloud_test_generation_jobs WHERE status = 'queued'` in queued_at
+//! order. For each claimed row:
+//!
+//!   1. Look up the workspace + org so we know which plan + BYOK config to
+//!      apply.
+//!   2. Pick a provider via the existing `ai::provider::pick_provider`
+//!      decision (Byok / Platform / Disabled — same pipeline AI Studio
+//!      uses, so quota and billing semantics stay consistent).
+//!   3. Sample recent `runtime_captures` matching the job's
+//!      `captures_filter`. Phase 3 supports a minimal filter vocabulary
+//!      (`method`, `path_contains`, `status_min`, `status_max`, `limit`);
+//!      anything else is ignored. The worker is forgiving — invalid
+//!      filters fall back to "most recent 25 captures for the workspace".
+//!   4. Build a JSON-focused prompt asking the LLM to emit a
+//!      `{ scenarios: [...] }` document.
+//!   5. Call `ai::client::call_llm` (the same dispatch the AI Studio
+//!      handlers use).
+//!   6. Best-effort JSON parse on the response — accept either a raw
+//!      JSON object, a code-fenced block, or fall back to a `{ raw: "..." }`
+//!      wrapper so the user always gets *something* in the result column.
+//!   7. Write `result` + flip status to 'succeeded' on success, or write
+//!      `error` + flip to 'failed' on any of the failure paths above.
+//!
+//! State transitions are gated on `WHERE status = 'running'`, so a user
+//! who cancels a job mid-flight (Phase 2's UI lets them) wins the race
+//! — the worker's terminal write is a no-op.
+//!
+//! Interval defaults to 5s but can be overridden via
+//! `TEST_GENERATION_WORKER_INTERVAL_SECS` (clamped to ≥1s).
+//! Set `TEST_GENERATION_WORKER_DISABLED=1` to skip wiring the worker
+//! (useful in tests + local dev).
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use sqlx::{FromRow, PgPool};
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+use crate::{
+    ai::{
+        client::{call_llm, LlmCall, LlmResult},
+        provider::{pick_provider, Provider},
+    },
+    handlers::settings::decrypt_api_key,
+    AppState,
+};
+use mockforge_registry_core::models::{
+    organization::Plan, test_generation_job::TestGenerationJob, BYOKConfig, Organization,
+};
+
+/// Default poll cadence. Test-generation jobs are interactive (user
+/// queues from the UI and watches the timeline), so 5s feels live
+/// without burning DB time on idle scans.
+const DEFAULT_INTERVAL_SECS: u64 = 5;
+
+/// Hard cap on captures we feed the LLM in one job. Each capture is
+/// dozens of tokens; 25 keeps us under every modern provider's prompt
+/// limit even after the system prompt and reply allowance.
+const MAX_CAPTURES: i64 = 25;
+
+/// Cap on the LLM completion size — generous enough for ~10 scenarios
+/// in JSON, low enough that runaway responses can't burn the entire
+/// org quota in one call.
+const LLM_MAX_COMPLETION_TOKENS: u32 = 2_000;
+
+/// Start the test-generation worker. No-op when
+/// `TEST_GENERATION_WORKER_DISABLED=1`.
+pub fn start_test_generation_worker(state: AppState) {
+    if std::env::var("TEST_GENERATION_WORKER_DISABLED").as_deref() == Ok("1") {
+        info!("test_generation_worker: disabled via env");
+        return;
+    }
+
+    let interval_secs = std::env::var("TEST_GENERATION_WORKER_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(DEFAULT_INTERVAL_SECS);
+
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(interval_secs));
+        // Skip the immediate first tick — give the server a moment to
+        // settle (db pool, env, etc.).
+        tick.tick().await;
+        loop {
+            tick.tick().await;
+            if let Err(e) = drain_queue(&state).await {
+                error!("test_generation_worker: drain failed: {e:?}");
+            }
+        }
+    });
+
+    info!("Test generation worker started (every {interval_secs}s)");
+}
+
+/// Drain the queue until we either run out of work or a single job
+/// fails to claim. We process jobs serially per tick — concurrency is a
+/// future optimisation if the queue ever sustains a backlog.
+async fn drain_queue(state: &AppState) -> Result<(), sqlx::Error> {
+    loop {
+        let claimed = TestGenerationJob::claim_next_queued(state.db.pool()).await?;
+        let Some(job) = claimed else {
+            return Ok(());
+        };
+        let job_id = job.id;
+        debug!(%job_id, "test_generation_worker: claimed job");
+        match process_job(state, job).await {
+            Ok(result) => {
+                let changed =
+                    TestGenerationJob::complete_success(state.db.pool(), job_id, &result).await?;
+                if !changed {
+                    // Almost certainly a cancellation race — log and move on.
+                    debug!(%job_id, "test_generation_worker: success write was no-op (likely cancelled)");
+                }
+            }
+            Err(reason) => {
+                let reason_str = reason.to_string();
+                warn!(%job_id, error = %reason_str, "test_generation_worker: job failed");
+                let _ = TestGenerationJob::complete_failure(
+                    state.db.pool(),
+                    job_id,
+                    reason_str.as_str(),
+                )
+                .await;
+            }
+        }
+    }
+}
+
+/// Run one job end-to-end. Returns the `result` JSON value to persist
+/// on success, or an error whose `to_string()` lands in the `error`
+/// column on failure.
+async fn process_job(state: &AppState, job: TestGenerationJob) -> Result<Value, WorkerError> {
+    // 1. Org context for plan + BYOK decision.
+    let org = Organization::find_by_id(state.db.pool(), job.org_id)
+        .await
+        .map_err(|e| WorkerError::Internal(format!("org lookup failed: {e}")))?
+        .ok_or_else(|| WorkerError::Internal("Organization missing for job".into()))?;
+    let plan = org.plan();
+    let is_paid_plan = matches!(plan, Plan::Pro | Plan::Team);
+
+    // 2. BYOK config (the worker can't fall back to platform credits
+    // without rate-limit accounting plumbing — Phase 4 if/when we need
+    // platform-credit generations).
+    let byok = load_byok_config(state, job.org_id).await?;
+    let provider = pick_provider(is_paid_plan, byok);
+
+    let Provider::Byok(byok_cfg) = provider else {
+        return Err(WorkerError::ProviderUnavailable(match plan {
+            Plan::Free => "Test generation requires a BYOK provider key on the Free plan. Add a key in Settings → BYOK.".into(),
+            _ => "Test generation requires a BYOK provider key. Platform-credit generations are not yet supported — add a BYOK key in Settings → BYOK.".into(),
+        }));
+    };
+
+    let api_key = decrypt_api_key(&byok_cfg.api_key)
+        .map_err(|e| WorkerError::Internal(format!("BYOK key decrypt failed: {e:?}")))?;
+
+    // 3. Sample captures.
+    let filter = parse_filter(&job.captures_filter);
+    let captures = fetch_captures(state.db.pool(), job.workspace_id, &filter)
+        .await
+        .map_err(|e| WorkerError::Internal(format!("capture sampling failed: {e}")))?;
+
+    if captures.is_empty() {
+        return Err(WorkerError::EmptyCorpus(
+            "No matching captures found in this workspace. Record some traffic first or relax the filter.".into(),
+        ));
+    }
+
+    // 4. Build the prompt.
+    let (system, user) = build_prompt(&job.prompt, &captures);
+
+    // 5. Call the LLM via the existing dispatch.
+    let call = LlmCall {
+        provider: byok_cfg.provider.clone(),
+        model: byok_cfg.model.clone().unwrap_or_else(|| "gpt-4o-mini".into()),
+        api_key,
+        base_url: byok_cfg.base_url.clone(),
+        system,
+        user,
+        temperature: 0.2,
+        max_tokens: LLM_MAX_COMPLETION_TOKENS,
+    };
+    let llm_result = call_llm(call).await.map_err(|e| WorkerError::LlmCall(format!("{e:?}")))?;
+
+    // 6. Parse + assemble the persisted result.
+    let scenarios = parse_scenarios(&llm_result.content);
+    Ok(build_result_value(&llm_result, &byok_cfg.provider, scenarios, captures.len()))
+}
+
+// --- filter handling ------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct CaptureFilter {
+    method: Option<String>,
+    path_contains: Option<String>,
+    status_min: Option<i32>,
+    status_max: Option<i32>,
+    limit: i64,
+}
+
+/// Tolerant parse of the job's `captures_filter` JSON. Phase 3 supports
+/// a deliberately small vocabulary — anything else is ignored so we
+/// don't have to coordinate filter schema changes between Phase 2's UI
+/// and this worker.
+fn parse_filter(raw: &Value) -> CaptureFilter {
+    let mut f = CaptureFilter {
+        limit: MAX_CAPTURES,
+        ..CaptureFilter::default()
+    };
+    let Some(obj) = raw.as_object() else {
+        return f;
+    };
+    if let Some(s) = obj.get("method").and_then(|v| v.as_str()) {
+        f.method = Some(s.to_uppercase());
+    }
+    if let Some(s) = obj.get("path_contains").and_then(|v| v.as_str()) {
+        f.path_contains = Some(s.to_string());
+    }
+    if let Some(n) = obj.get("status_min").and_then(|v| v.as_i64()) {
+        f.status_min = Some(n.clamp(100, 599) as i32);
+    }
+    if let Some(n) = obj.get("status_max").and_then(|v| v.as_i64()) {
+        f.status_max = Some(n.clamp(100, 599) as i32);
+    }
+    if let Some(n) = obj.get("limit").and_then(|v| v.as_i64()) {
+        f.limit = n.clamp(1, MAX_CAPTURES);
+    }
+    f
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct CaptureSample {
+    method: String,
+    path: String,
+    #[sqlx(rename = "effective_status")]
+    status: i32,
+    duration_ms: i32,
+}
+
+async fn fetch_captures(
+    pool: &PgPool,
+    workspace_id: Uuid,
+    filter: &CaptureFilter,
+) -> sqlx::Result<Vec<CaptureSample>> {
+    sqlx::query_as::<_, CaptureSample>(
+        r#"
+        SELECT method, path,
+               COALESCE(response_status_code, status_code, 0) AS effective_status,
+               COALESCE(duration_ms, 0) AS duration_ms
+        FROM runtime_captures
+        WHERE workspace_id = $1
+          AND ($2::text IS NULL OR UPPER(method) = $2)
+          AND ($3::text IS NULL OR position($3 IN path) > 0)
+          AND ($4::int IS NULL
+               OR COALESCE(response_status_code, status_code, 0) >= $4)
+          AND ($5::int IS NULL
+               OR COALESCE(response_status_code, status_code, 0) <= $5)
+        ORDER BY occurred_at DESC
+        LIMIT $6
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(filter.method.as_deref())
+    .bind(filter.path_contains.as_deref())
+    .bind(filter.status_min)
+    .bind(filter.status_max)
+    .bind(filter.limit)
+    .fetch_all(pool)
+    .await
+}
+
+// --- prompt assembly ------------------------------------------------------
+
+/// Build the (system, user) prompt pair. The system prompt forces JSON
+/// output; the user prompt embeds the captures as a compact CSV-ish
+/// list so we don't burn tokens on pretty-printing.
+fn build_prompt(user_prompt: &str, captures: &[CaptureSample]) -> (String, String) {
+    let system = "You are a senior test engineer. Given a sample of recent API requests, you propose concise test scenarios that would catch realistic regressions. Output ONLY a single JSON object on one line of the form: {\"scenarios\": [{\"name\": \"...\", \"description\": \"...\", \"method\": \"GET\", \"path\": \"/foo\", \"expected_status\": 200, \"rationale\": \"...\"}, ...]}. No prose, no code fences, no explanation. Up to 10 scenarios.".to_string();
+
+    let mut lines = String::with_capacity(64 * captures.len());
+    lines.push_str("Recent captures (method | path | status | duration_ms):\n");
+    for c in captures {
+        lines.push_str(&format!("{} {} {} {}\n", c.method, c.path, c.status, c.duration_ms));
+    }
+    let extra = if user_prompt.trim().is_empty() {
+        String::new()
+    } else {
+        format!("\n\nFocus area from the user:\n{}", user_prompt.trim())
+    };
+    let user = format!("{lines}{extra}");
+    (system, user)
+}
+
+/// Best-effort parse of the LLM reply into a JSON scenarios array.
+/// Strategy:
+///   1. Try parsing the whole reply as JSON.
+///   2. If that fails, look for the first `{` / `}` pair and parse the
+///      substring.
+///   3. If that still fails, return None — the caller wraps the raw
+///      content so the user can still see what came back.
+fn parse_scenarios(content: &str) -> Option<Value> {
+    let trimmed = content.trim();
+    // Strip common code-fence wrappers since some providers ignore the
+    // "no fences" instruction.
+    let cleaned = trimmed
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+
+    if let Ok(v) = serde_json::from_str::<Value>(cleaned) {
+        return Some(v);
+    }
+
+    // Locate the outermost balanced { ... } substring and try again.
+    if let (Some(start), Some(end)) = (cleaned.find('{'), cleaned.rfind('}')) {
+        if end > start {
+            if let Ok(v) = serde_json::from_str::<Value>(&cleaned[start..=end]) {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Wrap the LLM output for persistence. We always include the raw
+/// content so the UI can show what the provider said even when JSON
+/// parse fails.
+fn build_result_value(
+    llm: &LlmResult,
+    provider: &str,
+    parsed: Option<Value>,
+    captures_sampled: usize,
+) -> Value {
+    json!({
+        "scenarios": parsed.as_ref().and_then(|v| v.get("scenarios").cloned()),
+        "raw_parsed": parsed,
+        "raw_content": llm.content,
+        "model_meta": {
+            "provider": provider,
+            "prompt_tokens": llm.prompt_tokens,
+            "completion_tokens": llm.completion_tokens,
+        },
+        "captures_sampled": captures_sampled,
+    })
+}
+
+// --- BYOK lookup ----------------------------------------------------------
+
+/// Read the org's BYOK config — same shape as
+/// `handlers::ai_studio::load_byok_config`, copied here so the worker
+/// doesn't depend on a `pub(crate)` helper that may move.
+async fn load_byok_config(
+    state: &AppState,
+    org_id: Uuid,
+) -> Result<Option<BYOKConfig>, WorkerError> {
+    let setting = state
+        .store
+        .get_org_setting(org_id, "byok")
+        .await
+        .map_err(|e| WorkerError::Internal(format!("byok lookup failed: {e:?}")))?;
+    let Some(setting) = setting else {
+        return Ok(None);
+    };
+    let cfg: BYOKConfig = match serde_json::from_value(setting.setting_value) {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+    if !cfg.enabled || cfg.api_key.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(cfg))
+}
+
+// --- errors ---------------------------------------------------------------
+
+#[derive(Debug)]
+enum WorkerError {
+    ProviderUnavailable(String),
+    EmptyCorpus(String),
+    LlmCall(String),
+    Internal(String),
+}
+
+impl std::fmt::Display for WorkerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProviderUnavailable(m)
+            | Self::EmptyCorpus(m)
+            | Self::LlmCall(m)
+            | Self::Internal(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+// --- captures-filter deserializer (test-only) -----------------------------
+//
+// `parse_filter` is the runtime path; this struct only exists so tests can
+// round-trip a filter through serde_json.
+#[cfg(test)]
+#[derive(Debug, serde::Deserialize)]
+struct FilterRoundTrip {
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    path_contains: Option<String>,
+    #[serde(default)]
+    status_min: Option<i32>,
+    #[serde(default)]
+    status_max: Option<i32>,
+    #[serde(default)]
+    limit: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_filter_empty_defaults_to_max_captures() {
+        let f = parse_filter(&json!({}));
+        assert!(f.method.is_none());
+        assert!(f.path_contains.is_none());
+        assert!(f.status_min.is_none());
+        assert!(f.status_max.is_none());
+        assert_eq!(f.limit, MAX_CAPTURES);
+    }
+
+    #[test]
+    fn parse_filter_normalises_method_uppercase_and_clamps_limit() {
+        let f = parse_filter(&json!({
+            "method": "post",
+            "limit": 1_000_000,
+        }));
+        assert_eq!(f.method.as_deref(), Some("POST"));
+        assert_eq!(f.limit, MAX_CAPTURES, "limit clamped to MAX_CAPTURES");
+    }
+
+    #[test]
+    fn parse_filter_clamps_status_to_http_range() {
+        let f = parse_filter(&json!({
+            "status_min": 50,
+            "status_max": 999,
+        }));
+        assert_eq!(f.status_min, Some(100));
+        assert_eq!(f.status_max, Some(599));
+    }
+
+    #[test]
+    fn parse_filter_round_trips_path_contains() {
+        let f = parse_filter(&json!({"path_contains": "/auth/"}));
+        assert_eq!(f.path_contains.as_deref(), Some("/auth/"));
+    }
+
+    #[test]
+    fn parse_filter_handles_non_object_input() {
+        // Defensive: the column NOT-NULL default is '{}::jsonb', but
+        // upstream code paths or future migrations could produce other
+        // shapes. We want to fall back to defaults rather than panic.
+        let f = parse_filter(&Value::Null);
+        assert!(f.method.is_none());
+        let f = parse_filter(&json!("not an object"));
+        assert!(f.method.is_none());
+    }
+
+    #[test]
+    fn build_prompt_includes_captures_and_user_focus() {
+        let captures = vec![
+            CaptureSample {
+                method: "GET".into(),
+                path: "/users".into(),
+                status: 200,
+                duration_ms: 12,
+            },
+            CaptureSample {
+                method: "POST".into(),
+                path: "/users".into(),
+                status: 201,
+                duration_ms: 34,
+            },
+        ];
+        let (system, user) = build_prompt("focus on auth", &captures);
+        assert!(system.contains("scenarios"));
+        assert!(user.contains("GET /users 200 12"));
+        assert!(user.contains("POST /users 201 34"));
+        assert!(user.contains("focus on auth"));
+    }
+
+    #[test]
+    fn build_prompt_omits_user_focus_block_when_empty() {
+        let captures = vec![CaptureSample {
+            method: "GET".into(),
+            path: "/".into(),
+            status: 200,
+            duration_ms: 1,
+        }];
+        let (_, user) = build_prompt("   ", &captures);
+        assert!(!user.contains("Focus area"));
+    }
+
+    #[test]
+    fn parse_scenarios_accepts_plain_json() {
+        let v = parse_scenarios(r#"{"scenarios": [{"name": "ok"}]}"#).unwrap();
+        assert_eq!(v["scenarios"][0]["name"], "ok");
+    }
+
+    #[test]
+    fn parse_scenarios_strips_code_fences() {
+        let raw = "```json\n{\"scenarios\": [1, 2]}\n```";
+        let v = parse_scenarios(raw).unwrap();
+        assert_eq!(v["scenarios"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn parse_scenarios_recovers_from_prose_wrapper() {
+        let raw =
+            "Sure! Here you go:\n{\"scenarios\": [\"a\", \"b\"]}\nLet me know if you need more.";
+        let v = parse_scenarios(raw).unwrap();
+        assert_eq!(v["scenarios"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn parse_scenarios_returns_none_on_unrecoverable_input() {
+        assert!(parse_scenarios("not json at all").is_none());
+    }
+
+    #[test]
+    fn build_result_value_preserves_raw_content_when_parse_fails() {
+        let llm = LlmResult {
+            content: "garbage".into(),
+            prompt_tokens: 100,
+            completion_tokens: 50,
+        };
+        let v = build_result_value(&llm, "openai", None, 5);
+        assert_eq!(v["raw_content"], "garbage");
+        assert!(v["scenarios"].is_null());
+        assert!(v["raw_parsed"].is_null());
+        assert_eq!(v["model_meta"]["prompt_tokens"], 100);
+        assert_eq!(v["captures_sampled"], 5);
+    }
+
+    #[test]
+    fn build_result_value_hoists_scenarios_field() {
+        let llm = LlmResult {
+            content: r#"{"scenarios": [{"name": "happy"}]}"#.into(),
+            prompt_tokens: 0,
+            completion_tokens: 0,
+        };
+        let parsed = parse_scenarios(&llm.content);
+        let v = build_result_value(&llm, "openai", parsed, 3);
+        assert_eq!(v["scenarios"][0]["name"], "happy");
+        assert_eq!(v["captures_sampled"], 3);
+    }
+
+    #[test]
+    fn worker_error_display_unwraps_message() {
+        assert_eq!(format!("{}", WorkerError::EmptyCorpus("no rows".into())), "no rows");
+    }
+
+    #[test]
+    fn filter_round_trip_smoke() {
+        // Just confirm the test-only deserializer compiles + parses the
+        // documented vocabulary. Real parsing goes through parse_filter
+        // which is non-strict by design.
+        let f: FilterRoundTrip = serde_json::from_value(json!({
+            "method": "GET",
+            "status_min": 400,
+            "limit": 10,
+        }))
+        .unwrap();
+        assert_eq!(f.method.as_deref(), Some("GET"));
+        assert_eq!(f.status_min, Some(400));
+        assert_eq!(f.limit, Some(10));
+        assert!(f.path_contains.is_none());
+    }
+}

--- a/crates/mockforge-registry-server/src/workers/test_generation_worker.rs
+++ b/crates/mockforge-registry-server/src/workers/test_generation_worker.rs
@@ -42,7 +42,8 @@ use uuid::Uuid;
 use crate::{
     ai::{
         client::{call_llm, LlmCall, LlmResult},
-        provider::{pick_provider, Provider},
+        provider::{pick_provider, Provider, ProviderSelection},
+        quota::{check_ai_quota, record_ai_usage},
     },
     handlers::settings::decrypt_api_key,
     AppState,
@@ -66,6 +67,12 @@ const MAX_CAPTURES: i64 = 25;
 /// org quota in one call.
 const LLM_MAX_COMPLETION_TOKENS: u32 = 2_000;
 
+/// Default per-tick concurrency cap. Higher → faster queue drain when a
+/// burst lands, but multiplies the worker's pressure on the LLM
+/// provider's rate limit and on the DB pool. Override via
+/// `TEST_GENERATION_WORKER_CONCURRENCY` (clamped to ≥1).
+const DEFAULT_CONCURRENCY: usize = 4;
+
 /// Start the test-generation worker. No-op when
 /// `TEST_GENERATION_WORKER_DISABLED=1`.
 pub fn start_test_generation_worker(state: AppState) {
@@ -80,6 +87,12 @@ pub fn start_test_generation_worker(state: AppState) {
         .filter(|n| *n >= 1)
         .unwrap_or(DEFAULT_INTERVAL_SECS);
 
+    let concurrency = std::env::var("TEST_GENERATION_WORKER_CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(DEFAULT_CONCURRENCY);
+
     tokio::spawn(async move {
         let mut tick = tokio::time::interval(Duration::from_secs(interval_secs));
         // Skip the immediate first tick — give the server a moment to
@@ -87,45 +100,77 @@ pub fn start_test_generation_worker(state: AppState) {
         tick.tick().await;
         loop {
             tick.tick().await;
-            if let Err(e) = drain_queue(&state).await {
+            if let Err(e) = drain_queue(&state, concurrency).await {
                 error!("test_generation_worker: drain failed: {e:?}");
             }
         }
     });
 
-    info!("Test generation worker started (every {interval_secs}s)");
+    info!("Test generation worker started (every {interval_secs}s, concurrency={concurrency})");
 }
 
-/// Drain the queue until we either run out of work or a single job
-/// fails to claim. We process jobs serially per tick — concurrency is a
-/// future optimisation if the queue ever sustains a backlog.
-async fn drain_queue(state: &AppState) -> Result<(), sqlx::Error> {
+/// Drain the queue, processing up to `concurrency` jobs in parallel.
+///
+/// Per tick we claim-and-spawn until either the queue is empty or we hit
+/// the concurrency cap; then we await all in-flight jobs before returning.
+/// `claim_next_queued` uses `FOR UPDATE SKIP LOCKED`, so two spawned tasks
+/// can't race for the same row — each `tokio::spawn` independently claims
+/// the next queued row before doing any LLM work.
+async fn drain_queue(state: &AppState, concurrency: usize) -> Result<(), sqlx::Error> {
+    let mut join_set: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+    let pool = state.db.pool().clone();
+
+    // Track whether we hit "nothing to claim" — when every spawned task
+    // returns and we still claim nothing on the next iteration, we exit.
     loop {
-        let claimed = TestGenerationJob::claim_next_queued(state.db.pool()).await?;
-        let Some(job) = claimed else {
+        // Fan out up to `concurrency` claims.
+        while join_set.len() < concurrency {
+            let claimed = match TestGenerationJob::claim_next_queued(&pool).await? {
+                Some(job) => job,
+                None => break,
+            };
+            let state = state.clone();
+            join_set.spawn(async move { process_one(&state, claimed).await });
+        }
+        if join_set.is_empty() {
+            // Nothing was queued; drain is done.
             return Ok(());
-        };
-        let job_id = job.id;
-        debug!(%job_id, "test_generation_worker: claimed job");
-        match process_job(state, job).await {
-            Ok(result) => {
-                let changed =
-                    TestGenerationJob::complete_success(state.db.pool(), job_id, &result).await?;
-                if !changed {
-                    // Almost certainly a cancellation race — log and move on.
+        }
+        // Wait for at least one in-flight task to finish before claiming
+        // more — keeps us from pegging the LLM provider rate-limit when
+        // the queue is large.
+        if join_set.join_next().await.is_none() {
+            return Ok(());
+        }
+    }
+}
+
+/// Per-job lifecycle wrapper: handles the success/failure-write +
+/// cancellation-race no-op so the caller (drain_queue) doesn't have to.
+async fn process_one(state: &AppState, job: TestGenerationJob) {
+    let job_id = job.id;
+    debug!(%job_id, "test_generation_worker: claimed job");
+    match process_job(state, job).await {
+        Ok(result) => {
+            match TestGenerationJob::complete_success(state.db.pool(), job_id, &result).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    // Cancellation race — user flipped to 'cancelled' while
+                    // we were mid-flight; the gate `WHERE status='running'`
+                    // prevents the success write. Log and move on.
                     debug!(%job_id, "test_generation_worker: success write was no-op (likely cancelled)");
                 }
+                Err(e) => {
+                    error!(%job_id, error = ?e, "test_generation_worker: success write failed");
+                }
             }
-            Err(reason) => {
-                let reason_str = reason.to_string();
-                warn!(%job_id, error = %reason_str, "test_generation_worker: job failed");
-                let _ = TestGenerationJob::complete_failure(
-                    state.db.pool(),
-                    job_id,
-                    reason_str.as_str(),
-                )
-                .await;
-            }
+        }
+        Err(reason) => {
+            let reason_str = reason.to_string();
+            warn!(%job_id, error = %reason_str, "test_generation_worker: job failed");
+            let _ =
+                TestGenerationJob::complete_failure(state.db.pool(), job_id, reason_str.as_str())
+                    .await;
         }
     }
 }
@@ -133,62 +178,138 @@ async fn drain_queue(state: &AppState) -> Result<(), sqlx::Error> {
 /// Run one job end-to-end. Returns the `result` JSON value to persist
 /// on success, or an error whose `to_string()` lands in the `error`
 /// column on failure.
+///
+/// Mirrors `ai_studio::run_completion_for_org`'s pipeline (BYOK lookup →
+/// pick_provider → quota check → LlmCall → record_ai_usage) so quota +
+/// billing semantics stay identical between user-driven AI requests and
+/// worker-driven test generation.
 async fn process_job(state: &AppState, job: TestGenerationJob) -> Result<Value, WorkerError> {
     // 1. Org context for plan + BYOK decision.
     let org = Organization::find_by_id(state.db.pool(), job.org_id)
         .await
         .map_err(|e| WorkerError::Internal(format!("org lookup failed: {e}")))?
         .ok_or_else(|| WorkerError::Internal("Organization missing for job".into()))?;
-    let plan = org.plan();
-    let is_paid_plan = matches!(plan, Plan::Pro | Plan::Team);
+    let is_paid_plan = matches!(org.plan(), Plan::Pro | Plan::Team);
 
-    // 2. BYOK config (the worker can't fall back to platform credits
-    // without rate-limit accounting plumbing — Phase 4 if/when we need
-    // platform-credit generations).
+    // 2. BYOK + provider routing — same dispatch ai_studio uses.
     let byok = load_byok_config(state, job.org_id).await?;
     let provider = pick_provider(is_paid_plan, byok);
+    let selection = provider.selection();
 
-    let Provider::Byok(byok_cfg) = provider else {
-        return Err(WorkerError::ProviderUnavailable(match plan {
-            Plan::Free => "Test generation requires a BYOK provider key on the Free plan. Add a key in Settings → BYOK.".into(),
-            _ => "Test generation requires a BYOK provider key. Platform-credit generations are not yet supported — add a BYOK key in Settings → BYOK.".into(),
-        }));
-    };
+    // 3. Pre-call quota check — gates Disabled and quota-exhausted Platform.
+    //    BYOK skips the token quota (the user pays their own provider bill);
+    //    rate caps are enforced separately upstream.
+    let quota = check_ai_quota(state, &org, selection)
+        .await
+        .map_err(|e| WorkerError::Internal(format!("quota check failed: {e:?}")))?;
+    if !quota.allowed {
+        return Err(WorkerError::ProviderUnavailable(
+            quota.deny_reason.unwrap_or_else(|| "AI quota exceeded".into()),
+        ));
+    }
 
-    let api_key = decrypt_api_key(&byok_cfg.api_key)
-        .map_err(|e| WorkerError::Internal(format!("BYOK key decrypt failed: {e:?}")))?;
-
-    // 3. Sample captures.
+    // 4. Sample captures.
     let filter = parse_filter(&job.captures_filter);
     let captures = fetch_captures(state.db.pool(), job.workspace_id, &filter)
         .await
         .map_err(|e| WorkerError::Internal(format!("capture sampling failed: {e}")))?;
-
     if captures.is_empty() {
         return Err(WorkerError::EmptyCorpus(
             "No matching captures found in this workspace. Record some traffic first or relax the filter.".into(),
         ));
     }
 
-    // 4. Build the prompt.
-    let (system, user) = build_prompt(&job.prompt, &captures);
+    // 5. Build LLM call — provider-dependent (BYOK decrypts the stored
+    //    key; Platform reads from env). Centralised here so the byok/
+    //    platform branches share the rest of the pipeline.
+    let (call, provider_label) = build_call_for_provider(&provider, &job.prompt, &captures)?;
 
-    // 5. Call the LLM via the existing dispatch.
-    let call = LlmCall {
-        provider: byok_cfg.provider.clone(),
-        model: byok_cfg.model.clone().unwrap_or_else(|| "gpt-4o-mini".into()),
-        api_key,
-        base_url: byok_cfg.base_url.clone(),
-        system,
-        user,
-        temperature: 0.2,
-        max_tokens: LLM_MAX_COMPLETION_TOKENS,
-    };
+    // 6. Invoke.
     let llm_result = call_llm(call).await.map_err(|e| WorkerError::LlmCall(format!("{e:?}")))?;
 
-    // 6. Parse + assemble the persisted result.
+    // 7. Meter usage — `record_ai_usage` is a no-op for BYOK, so we can
+    //    call it unconditionally and stay in line with ai_studio's
+    //    accounting semantics.
+    let total_tokens = llm_result.total_tokens() as i64;
+    if let Err(e) = record_ai_usage(state, org.id, selection, total_tokens).await {
+        // Surface as warn — we already have the LLM output, just couldn't
+        // bill it. Returning success would leak credit; failing the job
+        // after a real LLM call would also be bad UX. Tradeoff: log loudly
+        // so SREs notice, and bias toward the user's success path.
+        warn!(
+            job_id = %job.id,
+            org_id = %org.id,
+            tokens = total_tokens,
+            error = ?e,
+            "test_generation_worker: usage metering failed",
+        );
+    }
+
+    // 8. Parse + assemble the persisted result.
     let scenarios = parse_scenarios(&llm_result.content);
-    Ok(build_result_value(&llm_result, &byok_cfg.provider, scenarios, captures.len()))
+    Ok(build_result_value(
+        &llm_result,
+        &provider_label,
+        selection,
+        scenarios,
+        captures.len(),
+    ))
+}
+
+/// Build the LLM call inputs for the resolved provider. Returns
+/// `(call, provider_label)`. Splitting this out keeps process_job's
+/// 8-step skeleton readable.
+fn build_call_for_provider(
+    provider: &Provider,
+    user_prompt: &str,
+    captures: &[CaptureSample],
+) -> Result<(LlmCall, String), WorkerError> {
+    let (system, user) = build_prompt(user_prompt, captures);
+    match provider {
+        Provider::Disabled => Err(WorkerError::ProviderUnavailable(
+            "AI is not available — add a BYOK key or upgrade your plan".into(),
+        )),
+        Provider::Byok(cfg) => {
+            let api_key = decrypt_api_key(&cfg.api_key)
+                .map_err(|e| WorkerError::Internal(format!("BYOK key decrypt failed: {e:?}")))?;
+            let provider_label = cfg.provider.clone();
+            let call = LlmCall {
+                provider: cfg.provider.clone(),
+                model: cfg.model.clone().unwrap_or_else(|| "gpt-4o-mini".into()),
+                api_key,
+                base_url: cfg.base_url.clone(),
+                system,
+                user,
+                temperature: 0.2,
+                max_tokens: LLM_MAX_COMPLETION_TOKENS,
+            };
+            Ok((call, provider_label))
+        }
+        Provider::Platform => {
+            // Same env-var contract as ai_studio::build_llm_call.
+            let api_key = std::env::var("MOCKFORGE_PLATFORM_LLM_API_KEY")
+                .map_err(|_| WorkerError::ProviderUnavailable(
+                    "Platform LLM not configured — set MOCKFORGE_PLATFORM_LLM_API_KEY on the registry or add a BYOK key.".into(),
+                ))?;
+            let provider_name = std::env::var("MOCKFORGE_PLATFORM_LLM_PROVIDER")
+                .unwrap_or_else(|_| "openai".into());
+            let model = std::env::var("MOCKFORGE_PLATFORM_LLM_MODEL")
+                .unwrap_or_else(|_| "gpt-4o-mini".into());
+            let base_url = std::env::var("MOCKFORGE_PLATFORM_LLM_ENDPOINT").ok();
+            let provider_label = provider_name.clone();
+            let call = LlmCall {
+                provider: provider_name,
+                model,
+                api_key,
+                base_url,
+                system,
+                user,
+                temperature: 0.2,
+                max_tokens: LLM_MAX_COMPLETION_TOKENS,
+            };
+            Ok((call, provider_label))
+        }
+    }
 }
 
 // --- filter handling ------------------------------------------------------
@@ -329,19 +450,31 @@ fn parse_scenarios(content: &str) -> Option<Value> {
 
 /// Wrap the LLM output for persistence. We always include the raw
 /// content so the UI can show what the provider said even when JSON
-/// parse fails.
+/// parse fails. `selection` records whether the org's BYOK key or
+/// platform credits paid for the call — the UI surfaces this so
+/// customers can confirm where their tokens went.
 fn build_result_value(
     llm: &LlmResult,
-    provider: &str,
+    provider_label: &str,
+    selection: ProviderSelection,
     parsed: Option<Value>,
     captures_sampled: usize,
 ) -> Value {
+    let billing = match selection {
+        ProviderSelection::Byok => "byok",
+        ProviderSelection::Platform => "platform",
+        // Unreachable in practice — process_job bails before calling the
+        // LLM when selection is Disabled. Include the case for total
+        // coverage of the enum so future-Self can't forget it.
+        ProviderSelection::Disabled => "disabled",
+    };
     json!({
         "scenarios": parsed.as_ref().and_then(|v| v.get("scenarios").cloned()),
         "raw_parsed": parsed,
         "raw_content": llm.content,
         "model_meta": {
-            "provider": provider,
+            "provider": provider_label,
+            "billing": billing,
             "prompt_tokens": llm.prompt_tokens,
             "completion_tokens": llm.completion_tokens,
         },
@@ -535,25 +668,71 @@ mod tests {
             prompt_tokens: 100,
             completion_tokens: 50,
         };
-        let v = build_result_value(&llm, "openai", None, 5);
+        let v = build_result_value(&llm, "openai", ProviderSelection::Byok, None, 5);
         assert_eq!(v["raw_content"], "garbage");
         assert!(v["scenarios"].is_null());
         assert!(v["raw_parsed"].is_null());
         assert_eq!(v["model_meta"]["prompt_tokens"], 100);
+        assert_eq!(v["model_meta"]["billing"], "byok");
         assert_eq!(v["captures_sampled"], 5);
     }
 
     #[test]
-    fn build_result_value_hoists_scenarios_field() {
+    fn build_result_value_hoists_scenarios_field_and_tags_platform_billing() {
         let llm = LlmResult {
             content: r#"{"scenarios": [{"name": "happy"}]}"#.into(),
             prompt_tokens: 0,
             completion_tokens: 0,
         };
         let parsed = parse_scenarios(&llm.content);
-        let v = build_result_value(&llm, "openai", parsed, 3);
+        let v = build_result_value(&llm, "openai", ProviderSelection::Platform, parsed, 3);
         assert_eq!(v["scenarios"][0]["name"], "happy");
+        assert_eq!(v["model_meta"]["billing"], "platform");
         assert_eq!(v["captures_sampled"], 3);
+    }
+
+    #[test]
+    fn build_call_for_provider_disabled_returns_clear_error() {
+        let captures = vec![CaptureSample {
+            method: "GET".into(),
+            path: "/".into(),
+            status: 200,
+            duration_ms: 1,
+        }];
+        let err = build_call_for_provider(&Provider::Disabled, "", &captures).unwrap_err();
+        match err {
+            WorkerError::ProviderUnavailable(msg) => {
+                assert!(msg.contains("BYOK") || msg.contains("upgrade"));
+            }
+            other => panic!("expected ProviderUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_call_for_provider_platform_requires_env() {
+        // Belt-and-suspenders: clear platform env vars, confirm we get
+        // a clear error pointing operators at the right setting.
+        let prev = std::env::var("MOCKFORGE_PLATFORM_LLM_API_KEY").ok();
+        std::env::remove_var("MOCKFORGE_PLATFORM_LLM_API_KEY");
+        let captures = vec![CaptureSample {
+            method: "GET".into(),
+            path: "/".into(),
+            status: 200,
+            duration_ms: 1,
+        }];
+        let err = build_call_for_provider(&Provider::Platform, "", &captures).unwrap_err();
+        match err {
+            WorkerError::ProviderUnavailable(msg) => {
+                assert!(
+                    msg.contains("MOCKFORGE_PLATFORM_LLM_API_KEY"),
+                    "expected env-var hint in message: {msg}"
+                );
+            }
+            other => panic!("expected ProviderUnavailable, got {other:?}"),
+        }
+        if let Some(v) = prev {
+            std::env::set_var("MOCKFORGE_PLATFORM_LLM_API_KEY", v);
+        }
     }
 
     #[test]

--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -364,6 +364,13 @@ const cloudNavItemIds = new Set([
   // without workspace_id are invisible until the shipper backfill lands;
   // cloud-shipped captures (--cloud-ship) work today.
   'logs',
+  // Test Generator (#469 Phase 2) — async LLM jobs over runtime_captures
+  // via cloudTestGeneratorApi against /api/v1/workspaces/{id}/test-generation
+  // /jobs. Phase 1 shipped the data plane (table + 4 CRUD endpoints + TS
+  // client); Phase 2 ships the page branch. The background BYOK LLM
+  // worker is Phase 3 — jobs created here sit in 'queued' until that
+  // lands. The page surfaces this honestly via an inline banner.
+  'test-generator',
   // Notification channels (cloud-only) — incident dispatch destinations
   // wired through cloudNotificationsApi.
   'notification-channels',

--- a/crates/mockforge-ui/ui/src/pages/CloudTestGeneratorView.tsx
+++ b/crates/mockforge-ui/ui/src/pages/CloudTestGeneratorView.tsx
@@ -1,0 +1,364 @@
+/**
+ * Cloud Test Generator view (#469 Phase 2).
+ *
+ * Rendered by `TestGeneratorPage` when `isCloudMode()`. Drives the
+ * `cloudTestGeneratorApi` (Phase 1 data plane) for the active workspace
+ * — list, create, get, cancel. The actual LLM execution is **not yet
+ * implemented** — the background worker that turns 'queued' jobs into
+ * 'succeeded' or 'failed' lands in a follow-up PR. This view is honest
+ * about that limitation with an inline notice; users can still create
+ * jobs (they'll sit in 'queued' until the worker exists) and see the
+ * full data shape.
+ *
+ * Polling: 5s cadence while any job is in a non-terminal state; pauses
+ * when all visible jobs are terminal so we don't hammer the registry
+ * for no reason.
+ */
+
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { PageHeader, Alert, Section } from '../components/ui/DesignSystem';
+import { Card } from '../components/ui/Card';
+import { Badge } from '../components/ui/Badge';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { RefreshCw, Play, X, ChevronDown, ChevronRight } from 'lucide-react';
+import { useWorkspaceStore } from '../store/workspaceStore';
+import {
+  cloudTestGeneratorApi,
+  type CloudTestGenerationJob,
+  type TestGenerationJobStatus,
+} from '../services/api/cloudTestGenerator';
+import { cn } from '../utils/cn';
+
+const POLL_MS = 5000;
+const TERMINAL_STATUSES: TestGenerationJobStatus[] = ['succeeded', 'failed', 'cancelled'];
+
+function statusBadgeVariant(
+  status: TestGenerationJobStatus,
+): 'default' | 'success' | 'destructive' | 'outline' | 'secondary' {
+  switch (status) {
+    case 'succeeded':
+      return 'success';
+    case 'failed':
+      return 'destructive';
+    case 'cancelled':
+      return 'secondary';
+    case 'running':
+      return 'default';
+    case 'queued':
+    default:
+      return 'outline';
+  }
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    const ts = new Date(iso).getTime();
+    const ageMs = Date.now() - ts;
+    if (ageMs < 60_000) return `${Math.floor(ageMs / 1000)}s ago`;
+    if (ageMs < 3_600_000) return `${Math.floor(ageMs / 60_000)}m ago`;
+    if (ageMs < 86_400_000) return `${Math.floor(ageMs / 3_600_000)}h ago`;
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}
+
+export const CloudTestGeneratorView: React.FC = () => {
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const workspaceId = activeWorkspace?.id;
+
+  const [jobs, setJobs] = useState<CloudTestGenerationJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
+
+  // Create form
+  const [creating, setCreating] = useState(false);
+  const [prompt, setPrompt] = useState('');
+  const [filterText, setFilterText] = useState('');
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Pause polling when every visible job is terminal — the worker can't
+  // resurrect a finished job, so the cadence buys nothing.
+  const hasPendingJob = useMemo(
+    () => jobs.some((j) => !TERMINAL_STATUSES.includes(j.status)),
+    [jobs],
+  );
+
+  const fetchJobs = useCallback(async () => {
+    if (!workspaceId) return;
+    try {
+      const list = await cloudTestGeneratorApi.listJobs(workspaceId);
+      setJobs(Array.isArray(list) ? list : []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load jobs');
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  // Initial load + poll
+  useEffect(() => {
+    if (!workspaceId) {
+      setLoading(false);
+      return;
+    }
+    fetchJobs();
+    if (!hasPendingJob) return;
+    const t = setInterval(fetchJobs, POLL_MS);
+    return () => clearInterval(t);
+  }, [workspaceId, fetchJobs, hasPendingJob]);
+
+  const handleCreate = async () => {
+    if (!workspaceId) return;
+    let parsedFilter: Record<string, unknown> | undefined;
+    if (filterText.trim()) {
+      try {
+        parsedFilter = JSON.parse(filterText);
+        if (typeof parsedFilter !== 'object' || parsedFilter === null || Array.isArray(parsedFilter)) {
+          setCreateError('Filter must be a JSON object (e.g., {"status":">=400"})');
+          return;
+        }
+      } catch (err) {
+        setCreateError(`Invalid JSON: ${err instanceof Error ? err.message : err}`);
+        return;
+      }
+    }
+    setCreateError(null);
+    setCreating(true);
+    try {
+      await cloudTestGeneratorApi.createJob(workspaceId, {
+        prompt: prompt || undefined,
+        captures_filter: parsedFilter,
+      });
+      setPrompt('');
+      setFilterText('');
+      await fetchJobs();
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : 'Failed to create job');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleCancel = async (jobId: string) => {
+    if (!workspaceId) return;
+    try {
+      await cloudTestGeneratorApi.cancelJob(workspaceId, jobId);
+      await fetchJobs();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to cancel job');
+    }
+  };
+
+  // --- Render ------------------------------------------------------------
+
+  if (!workspaceId) {
+    return (
+      <div className="content-width space-y-6">
+        <PageHeader
+          title="Test Generator"
+          subtitle="AI-generated test scenarios from your capture corpus"
+        />
+        <Alert
+          variant="info"
+          title="Select a workspace"
+          description="Pick an active workspace from the top nav to start generating tests."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="content-width space-y-6">
+      <PageHeader
+        title="Test Generator"
+        subtitle="AI-generated test scenarios from your runtime_captures corpus"
+        className="space-section"
+      />
+
+      {/* Worker-not-yet-implemented banner — be honest about Phase 2 status. */}
+      <Alert
+        variant="info"
+        title="Worker rollout in progress"
+        description="Jobs created here are persisted and will be processed once the BYOK LLM worker ships in the follow-up PR. Until then, jobs stay in 'queued' state. Cancellation, listing, and status polling all work today."
+      />
+
+      {error && <Alert variant="error" title="Error" description={error} />}
+
+      {/* Create form */}
+      <Section>
+        <Card className="p-6 space-y-4">
+          <div>
+            <h3 className="text-lg font-semibold text-foreground">New generation job</h3>
+            <p className="text-sm text-muted-foreground">
+              Describe what tests to generate. Leave both fields blank for a default
+              prompt that scans all recent captures.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-foreground mb-2">
+                Prompt (optional, max 8 KB)
+              </label>
+              <Input
+                type="text"
+                placeholder='e.g., "focus on auth failure paths"'
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                className="w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-foreground mb-2">
+                Captures filter (JSON, max 16 KB)
+              </label>
+              <Input
+                type="text"
+                placeholder='e.g., {"status":">=400"}'
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                className="w-full font-mono text-sm"
+              />
+            </div>
+          </div>
+          {createError && (
+            <p className="text-sm text-danger-600 dark:text-danger-400">{createError}</p>
+          )}
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-muted-foreground">
+              Job will queue under workspace{' '}
+              <span className="font-mono">{workspaceId.slice(0, 8)}</span>.
+            </p>
+            <Button onClick={handleCreate} disabled={creating}>
+              <Play className="h-4 w-4 mr-2" />
+              {creating ? 'Queueing…' : 'Queue job'}
+            </Button>
+          </div>
+        </Card>
+      </Section>
+
+      {/* Job list */}
+      <Section>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-foreground">Recent jobs</h3>
+          <Button variant="outline" size="sm" onClick={fetchJobs} disabled={loading}>
+            <RefreshCw className={cn('h-4 w-4 mr-1', loading && 'animate-spin')} />
+            Refresh
+          </Button>
+        </div>
+
+        {loading && jobs.length === 0 ? (
+          <Card className="p-12 text-center">
+            <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-brand-600" />
+            <p className="mt-4 text-muted-foreground">Loading jobs…</p>
+          </Card>
+        ) : jobs.length === 0 ? (
+          <Card className="p-12 text-center">
+            <p className="text-muted-foreground">
+              No generation jobs yet. Queue one above.
+            </p>
+          </Card>
+        ) : (
+          <div className="space-y-2">
+            {jobs.map((job) => {
+              const expanded = expandedJobId === job.id;
+              const canCancel = !TERMINAL_STATUSES.includes(job.status);
+              return (
+                <Card key={job.id} className="overflow-hidden">
+                  <button
+                    type="button"
+                    className="w-full p-4 flex items-center justify-between hover:bg-muted/50 transition-colors text-left"
+                    onClick={() => setExpandedJobId(expanded ? null : job.id)}
+                  >
+                    <div className="flex items-center gap-3">
+                      {expanded ? (
+                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                      )}
+                      <div>
+                        <div className="font-mono text-xs text-muted-foreground">
+                          {job.id.slice(0, 8)}
+                        </div>
+                        <div className="text-sm font-medium text-foreground">
+                          {job.prompt || <em className="text-muted-foreground">No prompt</em>}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <Badge variant={statusBadgeVariant(job.status)}>{job.status}</Badge>
+                      <span className="text-xs text-muted-foreground">
+                        {formatRelative(job.queued_at)}
+                      </span>
+                    </div>
+                  </button>
+                  {expanded && (
+                    <div className="px-4 pb-4 space-y-3 border-t border-border">
+                      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+                        <div>
+                          <div className="text-xs text-muted-foreground uppercase tracking-wide">
+                            Queued
+                          </div>
+                          <div>{formatRelative(job.queued_at)}</div>
+                        </div>
+                        <div>
+                          <div className="text-xs text-muted-foreground uppercase tracking-wide">
+                            Started
+                          </div>
+                          <div>{formatRelative(job.started_at)}</div>
+                        </div>
+                        <div>
+                          <div className="text-xs text-muted-foreground uppercase tracking-wide">
+                            Finished
+                          </div>
+                          <div>{formatRelative(job.finished_at)}</div>
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">
+                          Captures filter
+                        </div>
+                        <pre className="text-xs font-mono bg-muted/50 p-2 rounded overflow-x-auto">
+                          {JSON.stringify(job.captures_filter, null, 2)}
+                        </pre>
+                      </div>
+                      {job.error && (
+                        <Alert variant="error" title="Job error" description={job.error} />
+                      )}
+                      {job.result !== null && job.result !== undefined && (
+                        <div>
+                          <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">
+                            Result
+                          </div>
+                          <pre className="text-xs font-mono bg-muted/50 p-2 rounded overflow-x-auto max-h-96">
+                            {JSON.stringify(job.result, null, 2)}
+                          </pre>
+                        </div>
+                      )}
+                      {canCancel && (
+                        <div className="pt-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleCancel(job.id)}
+                          >
+                            <X className="h-4 w-4 mr-1" />
+                            Cancel
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+};

--- a/crates/mockforge-ui/ui/src/pages/CloudTestGeneratorView.tsx
+++ b/crates/mockforge-ui/ui/src/pages/CloudTestGeneratorView.tsx
@@ -25,6 +25,7 @@ import { RefreshCw, Play, X, ChevronDown, ChevronRight } from 'lucide-react';
 import { useWorkspaceStore } from '../store/workspaceStore';
 import {
   cloudTestGeneratorApi,
+  subscribeToJobStream,
   type CloudTestGenerationJob,
   type TestGenerationJobStatus,
 } from '../services/api/cloudTestGenerator';
@@ -112,6 +113,30 @@ export const CloudTestGeneratorView: React.FC = () => {
     return () => clearInterval(t);
   }, [workspaceId, fetchJobs, hasPendingJob]);
 
+  // Phase 4: when a non-terminal job is expanded, open an SSE stream
+  // for sub-second updates. The 5s list-polling still runs in parallel;
+  // the SSE just makes the expanded card feel live. Closing the row or
+  // unmounting tears down the EventSource.
+  useEffect(() => {
+    if (!workspaceId || !expandedJobId) return;
+    const expandedJob = jobs.find((j) => j.id === expandedJobId);
+    if (!expandedJob || TERMINAL_STATUSES.includes(expandedJob.status)) return;
+
+    const close = subscribeToJobStream(workspaceId, expandedJobId, {
+      onUpdate: (updated) => {
+        setJobs((prev) => prev.map((j) => (j.id === updated.id ? updated : j)));
+      },
+      // Don't surface stream errors as page-level errors — the SSE is
+      // a "best-effort live update" channel and the list-polling
+      // fallback covers correctness. Silently let the browser retry.
+      onError: () => {},
+    });
+    return close;
+    // `jobs` intentionally not in the dep array — we only want to re-
+    // subscribe when the expanded job changes, not on every poll tick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, expandedJobId]);
+
   const handleCreate = async () => {
     if (!workspaceId) return;
     let parsedFilter: Record<string, unknown> | undefined;
@@ -180,11 +205,10 @@ export const CloudTestGeneratorView: React.FC = () => {
         className="space-section"
       />
 
-      {/* Worker-not-yet-implemented banner — be honest about Phase 2 status. */}
       <Alert
         variant="info"
-        title="Worker rollout in progress"
-        description="Jobs created here are persisted and will be processed once the BYOK LLM worker ships in the follow-up PR. Until then, jobs stay in 'queued' state. Cancellation, listing, and status polling all work today."
+        title="How this works"
+        description="Jobs run against your org's BYOK provider (Settings → BYOK) — or platform credits on paid plans if no BYOK key is configured. Expanded rows live-stream via SSE; the rest of the list polls every 5 seconds."
       />
 
       {error && <Alert variant="error" title="Error" description={error} />}

--- a/crates/mockforge-ui/ui/src/pages/TestGeneratorPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/TestGeneratorPage.tsx
@@ -33,6 +33,8 @@ import {
   Assessment as AssessmentIcon,
   AutoFixHigh as AutoFixHighIcon,
 } from '@mui/icons-material';
+import { isCloudMode } from '../utils/cloudMode';
+import { CloudTestGeneratorView } from './CloudTestGeneratorView';
 
 interface TestFixture {
   name: string;
@@ -82,6 +84,15 @@ function CodeBlock({ content, maxHeight = '500px' }: { content: string; maxHeigh
 }
 
 const TestGeneratorPage: React.FC = () => {
+  // #469 Phase 2: in cloud mode, delegate to the workspace-scoped cloud
+  // view backed by cloudTestGeneratorApi. The cloud surface is async
+  // (jobs queued to a background LLM worker landing in Phase 3) and
+  // BYOK-aware; local mode keeps the existing in-process generator UI
+  // below unchanged.
+  if (isCloudMode()) {
+    return <CloudTestGeneratorView />;
+  }
+
   const [format, setFormat] = useState('rust_reqwest');
   const [protocol, setProtocol] = useState('Http');
   const [limit, setLimit] = useState(50);

--- a/crates/mockforge-ui/ui/src/services/api/cloudTestGenerator.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudTestGenerator.ts
@@ -1,0 +1,103 @@
+/**
+ * Cloud Test Generator API client (#469) — Phase 1.
+ *
+ * Backs the registry's `/api/v1/workspaces/{workspace_id}/test-generation/jobs`
+ * routes. Each row represents an async LLM job that, in Phase 2, will be
+ * picked up by a background worker that calls the org's BYOK provider key
+ * against a corpus of recent `runtime_captures` rows and writes generated
+ * test scenarios into the `result` column.
+ *
+ * Phase 1 (this client) covers the 4 data-plane endpoints:
+ * - `create` — POST a job, lands in 'queued' state
+ * - `list`   — newest-first paginated listing (capped 100 server-side)
+ * - `get`    — status poll for a specific job
+ * - `cancel` — flips a queued/running job to 'cancelled'
+ *
+ * Polling cadence: a job stuck in 'queued' or 'running' should be polled
+ * at ~2-second intervals. Terminal states ('succeeded' | 'failed' |
+ * 'cancelled') are stable — stop polling and render the `result` blob
+ * (success) or the `error` string (failed/cancelled).
+ */
+import { fetchJsonWithErrorBody } from './client';
+
+export type TestGenerationJobStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled';
+
+export interface CloudTestGenerationJob {
+  id: string;
+  workspace_id: string;
+  org_id: string;
+  status: TestGenerationJobStatus;
+  prompt: string;
+  /** Free-form filter object — vocabulary owned by the Phase 2 worker. */
+  captures_filter: Record<string, unknown>;
+  /** Populated once status = 'succeeded'. */
+  result: unknown | null;
+  /** Populated once status = 'failed' or 'cancelled'. */
+  error: string | null;
+  queued_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+  created_by: string | null;
+}
+
+/** Request body for `POST .../jobs`. */
+export interface CreateTestGenerationJobRequest {
+  /** Empty allowed — Phase 2 worker falls back to a captures-derived default. */
+  prompt?: string;
+  /** JSON object filtering which captures to feed the LLM. Optional. */
+  captures_filter?: Record<string, unknown>;
+}
+
+class CloudTestGeneratorApiService {
+  private base(workspaceId: string): string {
+    return `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/test-generation`;
+  }
+
+  /** Create a new generation job. Returns the queued row. */
+  async createJob(
+    workspaceId: string,
+    request: CreateTestGenerationJobRequest = {},
+  ): Promise<CloudTestGenerationJob> {
+    return fetchJsonWithErrorBody(`${this.base(workspaceId)}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    }) as Promise<CloudTestGenerationJob>;
+  }
+
+  /** List jobs for the workspace, newest first. Server caps at 100. */
+  async listJobs(workspaceId: string): Promise<CloudTestGenerationJob[]> {
+    return fetchJsonWithErrorBody(`${this.base(workspaceId)}/jobs`) as Promise<
+      CloudTestGenerationJob[]
+    >;
+  }
+
+  /** Status poll for a specific job. */
+  async getJob(workspaceId: string, jobId: string): Promise<CloudTestGenerationJob> {
+    return fetchJsonWithErrorBody(
+      `${this.base(workspaceId)}/jobs/${encodeURIComponent(jobId)}`,
+    ) as Promise<CloudTestGenerationJob>;
+  }
+
+  /**
+   * Cancel a queued or running job. No-op on a terminal job. Returns
+   * `{ cancelled: true }` on a state change, `{ cancelled: false }` if
+   * the job was already terminal.
+   */
+  async cancelJob(workspaceId: string, jobId: string): Promise<{ cancelled: boolean }> {
+    return fetchJsonWithErrorBody(
+      `${this.base(workspaceId)}/jobs/${encodeURIComponent(jobId)}/cancel`,
+      {
+        method: 'POST',
+      },
+    ) as Promise<{ cancelled: boolean }>;
+  }
+}
+
+export { CloudTestGeneratorApiService };
+export const cloudTestGeneratorApi = new CloudTestGeneratorApiService();

--- a/crates/mockforge-ui/ui/src/services/api/cloudTestGenerator.ts
+++ b/crates/mockforge-ui/ui/src/services/api/cloudTestGenerator.ts
@@ -97,6 +97,96 @@ class CloudTestGeneratorApiService {
       },
     ) as Promise<{ cancelled: boolean }>;
   }
+
+  /**
+   * Open a Server-Sent Events stream for the job. The server emits:
+   *   - `status_update` — `data: <CloudTestGenerationJob>` whenever the
+   *     row's shape changes (status / started_at / finished_at /
+   *     has-result / has-error).
+   *   - `ping` — keep-alive when nothing has changed (1s cadence).
+   *   - `not_found` — job disappeared mid-stream.
+   *   - `stream_error` — terminal upstream error.
+   *
+   * Returns the raw `EventSource` so the caller owns lifecycle. Use
+   * {@link subscribeToJobStream} for the common case of mapping
+   * `status_update` payloads back to typed jobs + auto-close on
+   * terminal status.
+   */
+  jobStream(workspaceId: string, jobId: string): EventSource {
+    const url = `${this.base(workspaceId)}/jobs/${encodeURIComponent(jobId)}/stream`;
+    return new EventSource(url, { withCredentials: true });
+  }
+}
+
+/**
+ * Convenience wrapper around {@link CloudTestGeneratorApiService.jobStream}
+ * that:
+ *   - parses `status_update` payloads back to {@link CloudTestGenerationJob}
+ *   - swallows `ping` heartbeats
+ *   - closes the EventSource on terminal events (`not_found`,
+ *     `stream_error`, or a job whose status is succeeded/failed/cancelled)
+ *
+ * Returns a teardown callback the caller can invoke to abort early
+ * (e.g. on component unmount).
+ */
+export function subscribeToJobStream(
+  workspaceId: string,
+  jobId: string,
+  handlers: {
+    onUpdate?: (job: CloudTestGenerationJob) => void;
+    onError?: (reason: string) => void;
+    onComplete?: () => void;
+  },
+): () => void {
+  const es = cloudTestGeneratorApi.jobStream(workspaceId, jobId);
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    es.close();
+    handlers.onComplete?.();
+  };
+
+  es.addEventListener('status_update', (ev) => {
+    try {
+      const job = JSON.parse((ev as MessageEvent).data) as CloudTestGenerationJob;
+      handlers.onUpdate?.(job);
+      if (
+        job.status === 'succeeded' ||
+        job.status === 'failed' ||
+        job.status === 'cancelled'
+      ) {
+        close();
+      }
+    } catch (err) {
+      handlers.onError?.(err instanceof Error ? err.message : 'parse error');
+      close();
+    }
+  });
+
+  es.addEventListener('not_found', () => {
+    handlers.onError?.('Job not found');
+    close();
+  });
+
+  es.addEventListener('stream_error', (ev) => {
+    try {
+      const body = JSON.parse((ev as MessageEvent).data) as { error?: string };
+      handlers.onError?.(body.error ?? 'stream error');
+    } catch {
+      handlers.onError?.('stream error');
+    }
+    close();
+  });
+
+  // EventSource auto-reconnects on transport blips. Surface the notice
+  // once but don't close — the browser will retry; the caller can call
+  // the returned teardown to give up.
+  es.onerror = () => {
+    handlers.onError?.('stream connection error (auto-retrying)');
+  };
+
+  return close;
 }
 
 export { CloudTestGeneratorApiService };


### PR DESCRIPTION
## Summary

Closes [#469](https://github.com/SaaSy-Solutions/mockforge/issues/469) — last cloud-parity item on the [#459](https://github.com/SaaSy-Solutions/mockforge/issues/459) meta tracker. **All four phases bundled** for a single squash-merge.

| Phase | Scope | Merged via |
|---|---|---|
| 1 — data plane | migration + model + 4 CRUD endpoints + TS client | base commits |
| 2 — UI page | \`CloudTestGeneratorView\` + nav allowlist | [#532](https://github.com/SaaSy-Solutions/mockforge/pull/532) |
| 3 — BYOK worker | background tokio task + atomic claim + LLM dispatch + tests | [#534](https://github.com/SaaSy-Solutions/mockforge/pull/534) |
| 4 — hardening | platform credits + SSE + concurrent workers | [#535](https://github.com/SaaSy-Solutions/mockforge/pull/535) |

## What ships

### Data plane (Phase 1)
\`cloud_test_generation_jobs\` table + 4 CRUD endpoints:
```
POST   /api/v1/workspaces/{ws}/test-generation/jobs            — create (queued)
GET    /api/v1/workspaces/{ws}/test-generation/jobs            — list (capped 100)
GET    /api/v1/workspaces/{ws}/test-generation/jobs/{id}       — status poll
POST   /api/v1/workspaces/{ws}/test-generation/jobs/{id}/cancel
GET    /api/v1/workspaces/{ws}/test-generation/jobs/{id}/stream — SSE (Phase 4)
```

Auth + bounds: prompt ≤ 8 KB, filter ≤ 16 KB; cross-org IDs return opaque \`"Workspace not found"\`.

### UI (Phase 2)
\`CloudTestGeneratorView\` — workspace-scoped via \`useWorkspaceStore\`. Job timeline + create form + expandable detail rows with status / result / error / cancel. Polls every 5s while non-terminal jobs exist; SSE subscription on expanded non-terminal rows for sub-second updates.

### Worker (Phase 3 + 4)
\`workers::test_generation_worker\` — concurrent tokio JoinSet on a 5s cadence. Per-job:
1. \`claim_next_queued\` — \`FOR UPDATE SKIP LOCKED\` flips one queued row to \`'running'\`
2. Look up org → plan, \`load_byok_config\` + \`pick_provider\`
3. \`check_ai_quota\` (BYOK skips token quota; Platform gated by plan's \`ai_tokens_per_month\`)
4. Sample \`runtime_captures\` matching \`captures_filter\` (vocab: method / path_contains / status_min / status_max / limit)
5. Build a JSON-focused prompt asking for \`{ scenarios: [...] }\`
6. \`call_llm\` via \`ai::client\` (OpenAI-compat + Anthropic)
7. \`record_ai_usage\` (Platform only — BYOK is no-op)
8. Best-effort parse — strips ``\`json fences, recovers from prose wrappers, falls back to \`{ raw_content }\`
9. \`complete_success\` / \`complete_failure\` (both gated on \`status='running'\` so user-cancel wins the race)

### SSE (Phase 4)
\`GET .../jobs/{id}/stream\` — polls the row every 1s, emits \`status_update\` on shape changes, \`ping\` on idle, terminates on terminal status. Same pattern as \`handlers::test_runs::stream_run_events\`. TS client provides \`subscribeToJobStream\` that auto-closes on terminal status. Polling (vs LISTEN/NOTIFY) is the right tradeoff for the interactive per-org rate here.

## Env knobs

| Var | Effect |
|---|---|
| \`TEST_GENERATION_WORKER_DISABLED=1\` | Skip wiring (tests + local dev) |
| \`TEST_GENERATION_WORKER_INTERVAL_SECS\` | Drain cadence (≥1, default 5) |
| \`TEST_GENERATION_WORKER_CONCURRENCY\` | Per-tick parallel job cap (≥1, default 4) |
| \`MOCKFORGE_PLATFORM_LLM_API_KEY\` (+ \`_PROVIDER\` / \`_MODEL\` / \`_ENDPOINT\`) | Platform-credit path |

## Verification

- [x] \`cargo check + clippy --all-targets -- -D warnings\` on registry-core + registry-server: clean
- [x] \`cargo test models::test_generation_job::\` — 2/2 pass
- [x] \`cargo test handlers::test_generation::\` — 5/5 pass
- [x] \`cargo test workers::test_generation_worker::\` — 17/17 pass
- [x] \`pnpm type-check\`: clean
- [x] \`eslint\`: 0 errors
- [ ] Post-merge: end-to-end smoke against staging (BYOK + Platform paths, SSE in browser devtools)