### PR TITLE
fix(ui,docker): move onlyBuiltDependencies to pnpm-workspace.yaml (#525 follow-up)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN corepack enable
 # Install deps first for layer caching. Skip the Playwright browser download —
 # the image only needs Vite/TS build tooling, not the e2e runner.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-COPY crates/mockforge-ui/ui/package.json crates/mockforge-ui/ui/pnpm-lock.yaml ./
+COPY crates/mockforge-ui/ui/package.json crates/mockforge-ui/ui/pnpm-lock.yaml crates/mockforge-ui/ui/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Copy UI source and build the production bundle (outputs to /ui/dist)

--- a/crates/mockforge-ui/ui/pnpm-workspace.yaml
+++ b/crates/mockforge-ui/ui/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+# pnpm 11 managed-builds policy. Without this, `pnpm install --frozen-lockfile`
+# exits non-zero with `ERR_PNPM_IGNORED_BUILDS` for esbuild/vue-demi (their
+# postinstall scripts fetch the native bundler binary / generate the legacy
+# Vue 2/3 shim). Putting it here rather than `package.json#pnpm` matches the
+# v11 docs — the `pnpm` field in package.json is still accepted, but the
+# CI image's pnpm appears to read this file first.
+onlyBuiltDependencies:
+  - esbuild
+  - vue-demi


### PR DESCRIPTION
## Summary

#525 added `pnpm.onlyBuiltDependencies` to `package.json`, but pnpm 11.1.2 still emits `ERR_PNPM_IGNORED_BUILDS` and fails docker-build. Per the pnpm v11 docs, the canonical location for managed-builds config is `pnpm-workspace.yaml`. Adds that file with the same `esbuild`/`vue-demi` allowlist and updates the Dockerfile to copy it into the ui-builder stage.

## Test plan
- [ ] docker-build run on this branch goes green