### PR TITLE
fix(ui,docker): pin pnpm to 10.15.0 (pre-managed-builds policy)

### DIFF
--- a/crates/mockforge-ui/ui/package.json
+++ b/crates/mockforge-ui/ui/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@10.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",


### PR DESCRIPTION
## Summary

#525 + #533 tried to satisfy pnpm 11's managed-builds policy via `onlyBuiltDependencies`. The allowlist is present in both `package.json#pnpm` and `pnpm-workspace.yaml`, but pnpm 11.1.2 still emits `ERR_PNPM_IGNORED_BUILDS` for esbuild + vue-demi and exits 1 in the docker build. The actual ignored entries match the allowlist by package name, so something else in the v11 behavior is gating them — not interesting enough to spelunk right now.

Pinning Corepack to pnpm 10.15.0 via the `packageManager` field. pnpm 10 runs build scripts automatically (no managed-builds policy), which is what the existing lockfile + Dockerfile expect.

## Why now

This is the last thing keeping #468's resilience proxy from showing live data — without a fresh GHCR image, the registry's `MOCKFORGE_DOCKER_IMAGE` stays pinned to a pre-#518 mirror.

## Test plan

- [ ] docker-build run on this branch publishes a fresh image to GHCR
- [ ] After merge: bump `MOCKFORGE_DOCKER_IMAGE` on `mockforge-registry` to the new tag, redo the #468 E2E test