### PR TITLE
chore(ui): hide api-explorer from cloud sidebar (#459 follow-up)

### DIFF
--- a/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
+++ b/crates/mockforge-ui/ui/src/components/layout/AppShell.tsx
@@ -402,6 +402,12 @@ const cloudHiddenNavItemIds = new Set([
   // cloud-enabled — keeping both visible just adds sidebar noise.
   'metrics',                // → pillar-analytics (request rate / latency / errors live there)
   'performance',            // → cloud-test-runs (k6 / load runs already covered)
+  // ApiExplorerPage is already cloud-aware (takes a `deployment` prop and
+  // fetches the OpenAPI spec from the runtime). It is reached by clicking
+  // "Open" on a deployment in HostedMocksPage, not standalone from the
+  // sidebar — keeping it visible suggested a global explorer that does not
+  // exist in cloud mode.
+  'api-explorer',           // → reached via HostedMocksPage "Open" action
 ]);
 
 // In cloud mode, items outside the allowlist are shown as disabled "Local only"


### PR DESCRIPTION
## Summary

- `ApiExplorerPage` is already cloud-aware (takes a `deployment` prop, fetches OpenAPI spec from `${deployment.deployment_url}/__mockforge/api/spec`) and is reached from `HostedMocksPage` via the "Open" action.
- Showing it as a top-level sidebar entry in cloud mode suggested a global "all specs" explorer that does not exist in cloud, so users would land on an empty / confusing page.
- Add `'api-explorer'` to `cloudHiddenNavItemIds` in `AppShell.tsx` alongside the other cloud-superseded items. Self-hosted mode is unaffected.

This was the only actionable finding from the `#459` cloudNavItemIds audit — the remaining 6 "Local only" items are either correctly local-only (brokers, per #470–#473) or already covered by an in-flight PR (#527 / #529).

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (0 errors)
- [ ] Auto-merge once green