### PR TITLE
chore(precommit): scope clippy to changed crates (closes #538)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,9 +65,20 @@ repos:
     files: ^crates/[^/]+/migrations/.+\.sql$
   - id: clippy
     name: clippy
-    entry: cargo clippy --all-targets --all-features --workspace --exclude mockforge-desktop
+    # Scoped clippy — maps changed files to their owning workspace crate via
+    # `crates/<name>/...` and runs `cargo clippy -p <crate>` for each affected
+    # crate instead of the whole workspace. Falls back to a full --workspace
+    # run when a workspace-root file (Cargo.toml/Cargo.lock) changes, when a
+    # changed file lives outside crates/<name>/, or when >= 10 crates are
+    # affected. Matches the .claude/rules/self-verification.md policy.
+    # See `scripts/precommit/clippy_scoped.py` and issue #538.
+    entry: python3 scripts/precommit/clippy_scoped.py
     language: system
-    pass_filenames: false
+    pass_filenames: true
+    # Only fire on Rust source or Cargo manifest changes. Docs / UI / CI
+    # config edits skip clippy entirely, which is the big iteration-speed
+    # win (pre-commit clippy was 5-15 min per commit before this).
+    files: '(\.rs$|(^|/)Cargo\.toml$|(^|/)Cargo\.lock$)'
     # `cargo check` is intentionally NOT run here. `cargo clippy --all-targets
     # --all-features` is a strict superset of `cargo check --workspace` (clippy
     # type-checks everything check does, plus more targets/features). Running

--- a/scripts/precommit/clippy_scoped.py
+++ b/scripts/precommit/clippy_scoped.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Run clippy scoped to crates affected by the staged files.
+
+Invoked from the pre-commit `clippy` hook with `pass_filenames: true`.
+Maps each changed file to its owning workspace crate via the
+`crates/<name>/...` path prefix, then runs `cargo clippy -p <crate>` for
+each affected crate.
+
+Fallback to a full `cargo clippy --workspace` happens when:
+- A workspace-root file (`Cargo.toml`, `Cargo.lock`) changed — these
+  invalidate every member's metadata, so per-crate runs would be slower
+  than one workspace pass.
+- 10 or more crates are affected — past that point per-crate cold
+  compiles cost more than a single workspace run that shares deps.
+- A changed file lives outside `crates/<name>/` and we can't map it to a
+  package. Falling back is the safe choice rather than skipping.
+
+Matches the policy in `.claude/rules/self-verification.md`:
+"Do NOT run cargo clippy --workspace unless changes span 10+ crates".
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+WORKSPACE_THRESHOLD = 10
+
+WORKSPACE_CLIPPY_ARGS = [
+    "cargo",
+    "clippy",
+    "--all-targets",
+    "--all-features",
+    "--workspace",
+    "--exclude",
+    "mockforge-desktop",
+    "--",
+    "-D",
+    "warnings",
+]
+
+
+def crate_for(path: Path) -> str | None:
+    """Return the workspace crate name that owns `path`, or None.
+
+    Only `crates/<name>/...` paths are recognized. By convention every
+    crate under `crates/` has package name == directory name.
+    """
+    parts = path.parts
+    if len(parts) >= 2 and parts[0] == "crates":
+        return parts[1]
+    return None
+
+
+def main(argv: list[str]) -> int:
+    files = [Path(f) for f in argv]
+    if not files:
+        return 0
+
+    for f in files:
+        if str(f) in {"Cargo.toml", "Cargo.lock"}:
+            print(f"clippy: workspace-root file {f} changed → full workspace run", flush=True)
+            return subprocess.call(WORKSPACE_CLIPPY_ARGS)
+
+    affected: set[str] = set()
+    unmapped: list[Path] = []
+    for f in files:
+        crate = crate_for(f)
+        if crate:
+            affected.add(crate)
+        else:
+            unmapped.append(f)
+
+    if unmapped:
+        print(
+            f"clippy: {len(unmapped)} file(s) not under crates/<name>/ → full workspace run",
+            flush=True,
+        )
+        return subprocess.call(WORKSPACE_CLIPPY_ARGS)
+
+    if len(affected) >= WORKSPACE_THRESHOLD:
+        print(
+            f"clippy: {len(affected)} crates affected (>= {WORKSPACE_THRESHOLD}) → full workspace run",
+            flush=True,
+        )
+        return subprocess.call(WORKSPACE_CLIPPY_ARGS)
+
+    print(f"clippy: scoping to {len(affected)} crate(s): {sorted(affected)}", flush=True)
+    for crate in sorted(affected):
+        cmd = [
+            "cargo",
+            "clippy",
+            "-p",
+            crate,
+            "--all-targets",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ]
+        print(f"+ {' '.join(cmd)}", flush=True)
+        rc = subprocess.call(cmd)
+        if rc != 0:
+            return rc
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Closes #538.

The pre-commit `clippy` hook was running `cargo clippy --all-targets --all-features --workspace --exclude mockforge-desktop` on **every** commit. With a moderately-cold `target/` cache that's 5–15 min per commit, which pushed developers toward `--no-verify` and defeated the point of the hook.

Two changes:

1. **Path filter** on the hook (`files:` regex) so it only fires on `*.rs`, `Cargo.toml`, or `Cargo.lock` changes. Docs / UI / CI-config / shell-script commits skip clippy entirely. **This is the big iteration-speed win.** The first self-test of this PR's own commit confirmed `clippy ... Skipped`.

2. **Scope to changed crates** — new `scripts/precommit/clippy_scoped.py` wrapper that maps each changed file to its owning workspace crate via the `crates/<name>/...` prefix and runs `cargo clippy -p <crate>` per affected crate. Matches the existing policy in `.claude/rules/self-verification.md` ("Do NOT run cargo clippy --workspace unless changes span 10+ crates").

## Fallbacks that keep this correct

- **Workspace-root `Cargo.toml` / `Cargo.lock` change** → full `--workspace` run (these invalidate every member's metadata, per-crate would be strictly slower).
- **A changed file outside `crates/<name>/`** → full `--workspace` run (safer than skipping if we can't map to a package).
- **>= 10 affected crates** → full `--workspace` run (past that point shared-dep compilation costs flip the math).

## What does NOT change

- CI still runs full `cargo clippy --workspace` — the real safety net is unchanged.
- `.claude/rules/self-verification.md` policy is unchanged; this just makes the pre-commit hook match it.
- All other pre-commit hooks (typos, fmt, audit, migration-collisions, …) are unchanged.

## Test plan

- [x] Smoke-tested all four dispatch cases (root file / non-crates file / single crate / >= 10 crates) before committing
- [x] Hook's own commit (this PR) correctly skipped clippy because only `.yaml` and `.py` changed
- [x] Pre-commit suite green on this branch
- [ ] Auto-merge once green