### PR TITLE
chore(ci): point security-audit pre-flight at the durable repair (closes #539)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,11 +200,33 @@ jobs:
       # `cargo install` rebuilds these from source on every run (~5 min total),
       # which dominated Security Audit wall-clock. Both tools change rarely;
       # we preinstall them on the runner and verify here with the same
-      # pattern used for protoc above. To upgrade: SSH the runner and run
-      # `sudo -u actions cargo install <tool> --locked --force`.
+      # pattern used for protoc above.
+      #
+      # IMPORTANT (#539): the durable install location is `/usr/local/bin/`,
+      # NOT `~/.cargo/bin/`. The `actions/rust-toolchain` setup re-runs
+      # `rustup-init` on each workflow, which wipes `/home/actions/.cargo/bin/`
+      # — so anything installed there with `cargo install` survives only until
+      # the next toolchain bump. `/usr/local/bin/` is root-owned, comes earlier
+      # in $PATH for the runner user, and is untouched by rustup-init.
+      #
+      # To repair a missing tool, SSH the runner and copy the binary into the
+      # durable location (binaries are statically linked, no rebuild needed):
+      #   ssh root@<runner-ip>
+      #   cp /home/actions/.cargo/bin/cargo-audit /usr/local/bin/
+      #   cp /home/actions/.cargo/bin/cargo-deny  /usr/local/bin/
+      # If `~/.cargo/bin/` is empty too, first build the tool once with
+      # `sudo -u actions cargo install <tool> --locked --force`, then copy.
+      # Long-term: runner provisioning in the saas-platform repo
+      # (`infrastructure/github-runners/`) should populate /usr/local/bin/
+      # directly.
       run: |
-        command -v cargo-audit > /dev/null || { echo "::error::cargo-audit missing on self-hosted runner. Run on the runner host: sudo -u actions cargo install cargo-audit --locked"; exit 1; }
-        command -v cargo-deny > /dev/null || { echo "::error::cargo-deny missing on self-hosted runner. Run on the runner host: sudo -u actions cargo install cargo-deny --locked"; exit 1; }
+        durable_repair_msg='Repair: ssh the runner and run `cp /home/actions/.cargo/bin/<tool> /usr/local/bin/` (cargo install into ~/.cargo/bin/ alone will be wiped by the next rustup-init run — see ci.yml comment).'
+        command -v cargo-audit > /dev/null || { echo "::error::cargo-audit missing on self-hosted runner. $durable_repair_msg"; exit 1; }
+        command -v cargo-deny  > /dev/null || { echo "::error::cargo-deny missing on self-hosted runner. $durable_repair_msg"; exit 1; }
+        # Surface which copy is on PATH so a future failure makes the
+        # ~/.cargo/bin vs /usr/local/bin distinction obvious in logs.
+        echo "cargo-audit: $(command -v cargo-audit)"
+        echo "cargo-deny:  $(command -v cargo-deny)"
         cargo-audit --version
         cargo-deny --version
 


### PR DESCRIPTION
## Summary

Closes #539.

The Security Audit job in `ci.yml` already has a pre-flight step that fails with an actionable error when `cargo-audit` or `cargo-deny` is missing from the self-hosted runner. The actionable message was pointing at the **fragile** fix though:

> Run on the runner host: `sudo -u actions cargo install cargo-audit --locked`

That puts the binary into `/home/actions/.cargo/bin/` — exactly the directory that the next `rustup-init` run will wipe (it's re-executed on toolchain bumps and `setup-rust-toolchain` action updates). So you fix CI, the next workflow that re-runs rustup, and the job goes red again with the same error. We've now hit this pattern at least twice.

## What this changes

Update the error message to point at the **durable** repair location instead:

```
cp /home/actions/.cargo/bin/<tool> /usr/local/bin/
```

`/usr/local/bin/` is root-owned, comes earlier in `$PATH` for the runner user, and is untouched by `rustup-init` — same playbook we already use for `runner-host-cleanup.sh`.

Also surface `command -v cargo-audit` / `command -v cargo-deny` output in the workflow log so a future failure makes the `~/.cargo/bin` vs `/usr/local/bin` distinction obvious without needing to SSH in to diagnose.

Long-term fix — runner provisioning populating `/usr/local/bin/` directly — lives in the `saas-platform` repo (`infrastructure/github-runners/`) and is noted in the comment block for whoever picks that up next.

## What does NOT change

- The pre-flight step still fails fast when the tools are missing (no behavior change on the happy path).
- Tools are still installed manually via the runner-host process; this PR doesn't change runner provisioning.
- All other CI jobs are unchanged.

## Test plan

- [x] YAML still parses (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)
- [x] Pre-commit suite green
- [x] Manual review of the error message wording — points at `cp ... /usr/local/bin/`, references rustup-init root cause
- [ ] Auto-merge once green