### PR TITLE
fix(cli,core): bind admin server dual-stack so Fly 6PN can reach it (#468)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,8 +118,10 @@ ENV MOCKFORGE_RESPONSE_TEMPLATE_EXPAND=true
 ENV MOCKFORGE_RESPONSE_VALIDATION=1
 # Mark that we're running in Docker (for Admin UI host detection)
 ENV DOCKER_CONTAINER=true
-# Default Admin UI to be accessible from outside container
-ENV MOCKFORGE_ADMIN_HOST=0.0.0.0
+# Dual-stack admin bind (IPv4 + IPv6). On Linux with bindv6only=0 (default), a
+# `::` listener accepts both IPv4-mapped and native IPv6 — making the admin
+# port reachable on Fly 6PN where private traffic is IPv6-only (#468).
+ENV MOCKFORGE_ADMIN_HOST=::
 
 # Default command
 # Use full path to ensure binary is found regardless of PATH

--- a/crates/mockforge-cli/src/progress.rs
+++ b/crates/mockforge-cli/src/progress.rs
@@ -187,8 +187,31 @@ pub fn parse_address(addr_str: &str, context: &str) -> Result<SocketAddr, CliErr
             format!("Invalid {} address '{}': {}", context, addr_str, e),
             ExitCode::ConfigurationError,
         )
-        .with_suggestion("Ensure the address is in the correct format (e.g., '127.0.0.1:8080' or '0.0.0.0:3000')".to_string())
+        .with_suggestion("Ensure the address is in the correct format (e.g., '127.0.0.1:8080', '0.0.0.0:3000', or '[::]:8080' for IPv6)".to_string())
     })
+}
+
+/// Build a `host:port` string that handles bare IPv6 hosts correctly.
+///
+/// `SocketAddr::from_str` requires IPv6 literals to be wrapped in `[...]`,
+/// so naively `format!("{host}:{port}")` with `host = "::"` yields the
+/// ambiguous `":::9080"` and fails to parse. This helper detects unbracketed
+/// IPv6 hosts (anything containing `:` that doesn't already start with `[`)
+/// and adds the brackets. IPv4 hosts and already-bracketed IPv6 hosts pass
+/// through unchanged.
+///
+/// Examples:
+/// * `("0.0.0.0", 80)` → `"0.0.0.0:80"`
+/// * `("127.0.0.1", 80)` → `"127.0.0.1:80"`
+/// * `("::", 80)` → `"[::]:80"`
+/// * `("::1", 80)` → `"[::1]:80"`
+/// * `("[::]", 80)` → `"[::]:80"`
+pub fn format_bind_address(host: &str, port: u16) -> String {
+    if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
 }
 
 /// Helper function to require a config value with a meaningful error
@@ -690,5 +713,44 @@ mod tests {
         let result = utils::validate_output_dir(&file_path);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().exit_code, ExitCode::InvalidArguments);
+    }
+
+    // format_bind_address tests — covers the IPv6 bracketing bug that
+    // surfaced as `:::9080` parse failures during the #468 cloud rollout.
+
+    #[test]
+    fn format_bind_address_ipv4_passes_through() {
+        assert_eq!(format_bind_address("0.0.0.0", 80), "0.0.0.0:80");
+        assert_eq!(format_bind_address("127.0.0.1", 3000), "127.0.0.1:3000");
+    }
+
+    #[test]
+    fn format_bind_address_ipv6_unbracketed_gets_brackets() {
+        // Bare IPv6 literals. SocketAddr::parse needs them wrapped — this
+        // is the actual bug the helper exists to fix.
+        assert_eq!(format_bind_address("::", 9080), "[::]:9080");
+        assert_eq!(format_bind_address("::1", 9080), "[::1]:9080");
+        assert_eq!(format_bind_address("fe80::1", 9080), "[fe80::1]:9080");
+    }
+
+    #[test]
+    fn format_bind_address_ipv6_already_bracketed_passes_through() {
+        assert_eq!(format_bind_address("[::]", 9080), "[::]:9080");
+        assert_eq!(format_bind_address("[::1]", 9080), "[::1]:9080");
+    }
+
+    #[test]
+    fn format_bind_address_then_parse_round_trips() {
+        // The whole point of the helper: feed its output to parse_address
+        // and get a valid SocketAddr.
+        for (host, port) in [
+            ("0.0.0.0", 80),
+            ("127.0.0.1", 3000),
+            ("::", 9080),
+            ("::1", 9080),
+        ] {
+            let s = format_bind_address(host, port);
+            parse_address(&s, "test").unwrap_or_else(|e| panic!("failed on {s:?}: {e:?}"));
+        }
     }
 }

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -2818,20 +2818,25 @@ pub async fn handle_serve(
             }
         });
         Some(tokio::spawn(async move {
-            // Parse addresses with proper error handling
-            use crate::progress::parse_address;
-            let addr = match parse_address(&format!("{}:{}", admin_host, admin_port), "admin UI") {
-                Ok(addr) => addr,
-                Err(e) => {
-                    return Err(format!(
-                        "Failed to bind Admin UI to {}:{}: {}",
-                        admin_host, admin_port, e.message
-                    ))
-                }
-            };
+            // Parse addresses with proper error handling. `format_bind_address`
+            // wraps bare IPv6 literals (e.g. `::`) in brackets so SocketAddr
+            // parses cleanly — without it, `format!("{host}:{port}")` with
+            // host=`::` produces the ambiguous `":::9080"` and fails (this is
+            // what blocked Fly 6PN reachability for #468 Phase 3).
+            use crate::progress::{format_bind_address, parse_address};
+            let addr =
+                match parse_address(&format_bind_address(&admin_host, admin_port), "admin UI") {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        return Err(format!(
+                            "Failed to bind Admin UI to {}:{}: {}",
+                            admin_host, admin_port, e.message
+                        ))
+                    }
+                };
 
             let http_addr =
-                match parse_address(&format!("{}:{}", http_host, http_port), "HTTP server") {
+                match parse_address(&format_bind_address(&http_host, http_port), "HTTP server") {
                     Ok(addr) => Some(addr),
                     Err(e) => {
                         return Err(format!(
@@ -2841,7 +2846,7 @@ pub async fn handle_serve(
                     }
                 };
             let ws_addr =
-                match parse_address(&format!("{}:{}", ws_host, ws_port), "WebSocket server") {
+                match parse_address(&format_bind_address(&ws_host, ws_port), "WebSocket server") {
                     Ok(addr) => Some(addr),
                     Err(e) => {
                         return Err(format!(
@@ -2851,7 +2856,7 @@ pub async fn handle_serve(
                     }
                 };
             let grpc_addr =
-                match parse_address(&format!("{}:{}", grpc_host, grpc_port), "gRPC server") {
+                match parse_address(&format_bind_address(&grpc_host, grpc_port), "gRPC server") {
                     Ok(addr) => Some(addr),
                     Err(e) => {
                         return Err(format!(

--- a/crates/mockforge-core/src/config/protocol.rs
+++ b/crates/mockforge-core/src/config/protocol.rs
@@ -720,13 +720,21 @@ pub struct AdminConfig {
 
 impl Default for AdminConfig {
     fn default() -> Self {
-        // Default to 0.0.0.0 if running in Docker (detected via common Docker env vars)
-        // This makes Admin UI accessible from outside the container by default
+        // Bind dual-stack (`::`) when we detect we're in a container so the
+        // admin port is reachable on both IPv4 and IPv6. The IPv6 side is what
+        // Fly.io 6PN uses (`fdaa::/16` private network) to reach the admin
+        // endpoint from sibling apps — bare `0.0.0.0` is IPv4-only on Linux
+        // and breaks the cloud Resilience proxy (#468).
+        //
+        // On Linux the kernel's default `net.ipv6.bindv6only=0` means a `::`
+        // listener also accepts IPv4 connections via IPv4-mapped IPv6
+        // addresses (`::ffff:x.y.z.w`), so this single bind covers both.
+        // Outside the container the default stays loopback for safety.
         let default_host = if std::env::var("DOCKER_CONTAINER").is_ok()
             || std::env::var("container").is_ok()
             || Path::new("/.dockerenv").exists()
         {
-            "0.0.0.0".to_string()
+            "::".to_string()
         } else {
             "127.0.0.1".to_string()
         };


### PR DESCRIPTION
## Summary

Two stacked bugs in the admin bind path that surfaced during #468's end-to-end verification. Without these, the cloud Resilience proxy can't reach any deployment over Fly's private network.

## Bug 1: `parse_address` chokes on bare IPv6 hosts

`serve.rs` builds bind addresses with `format!(\"{host}:{port}\")`. With `MOCKFORGE_ADMIN_HOST=::` that yields `:::9080`, which `SocketAddr::from_str` rejects as ambiguous. The admin server fails:

> Failed to bind Admin UI to :::9080: invalid socket address syntax

New helper `format_bind_address(host, port)` in `progress.rs` detects unbracketed IPv6 (contains `:`, doesn't start with `[`) and wraps in brackets. All four call sites in `serve.rs` (admin / HTTP / WebSocket / gRPC) switch to the helper.

## Bug 2: `0.0.0.0` is IPv4-only — invisible on Fly 6PN

Fly's private network (`fdaa::/16`) is IPv6-only. A socket bound on `0.0.0.0` doesn't accept IPv6 connections, so the registry's reqwest proxy from `mockforge-registry` to `{deployment}.internal:9080` got `Connection refused` even though the listener was alive.

In-container default flips to `::` (the dual-stack wildcard). On Linux with the default `net.ipv6.bindv6only=0`, a `::` listener also accepts IPv4 connections via IPv4-mapped IPv6 addresses — single bind serves both stacks. Outside the container, default stays `127.0.0.1`.

`Dockerfile`'s `ENV MOCKFORGE_ADMIN_HOST` flips to `::` for the same reason (the env-var path overrides the AdminConfig default; both need to agree).

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-cli -p mockforge-core --all-targets -- -D warnings\` clean
- [x] \`cargo test -p mockforge-cli --bin mockforge format_bind_address\` — **4/4 new tests pass** (IPv4 pass-through, IPv6 unbracketed gets brackets, already-bracketed pass-through, round-trip with parse_address)
- [x] \`cargo test -p mockforge-core --lib\` — **1585 passed, 0 failed**
- [ ] Live verification post-merge: deploy a hosted-mock, confirm registry proxy returns \`runtime_state: \"live\"\`

Without this, #468's runtime proxy can't reach any cloud deployment over 6PN.