### PR TITLE
fix(bench): connections-opened counter + constant-scenario startVUs + --rps preflight (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [0.3.137] - 2026-05-17
+
+### Fixed
+
+- **[Reality]** Client-side "Connections opened" counter now appears for `--rps`-only runs (Issue #79 round 6 follow-up)
+  - Root cause: the parser was reading `http_req_connecting.values.count` from k6's `summary.json`, but k6's Trend metric never emits a `count` field — only `avg/min/med/max/p(90)/p(95)`. The field was always absent, so `tcp_connect_samples` was always 0 and the connection-count line never printed for non-`--cps` runs.
+  - Fix: the generated k6 script now declares a dedicated `mockforge_connections_opened` Counter and increments it whenever `res.timings.connecting > 0` (i.e. a fresh TCP socket was opened). The Rust parser reads this Counter's `count` directly. Works for both `--cps` runs (≈ total requests) and pooled-reuse runs (≈ `vus_max`).
+  - Also: TCP-connect / TLS-handshake timing lines now print whenever the Trend has a non-zero `avg`, not when `count > 0` (which was unreliable). New `test_connections_opened_counter_present` regression test guards both the Counter declaration and the per-request increment.
+
+- **[Reality]** `--scenario constant` now runs at full VU concurrency from t=0 (Issue #79 round 6 follow-up)
+  - Root cause: Srikanth reported that `--vus 5 -d 600s` took until the ~6-minute mark to reach 5 VUs and then ramped DOWN. The k6 template always wrote `startVUs: 0`, so even `--scenario constant`'s single `{duration: '600s', target: 5}` stage made `ramping-vus` linearly interpolate from 0 → 5 across the whole window.
+  - Fix: for `Constant`, `startVUs` is seeded at `max_vus` so concurrency is at full from the start. Ramping scenarios (`RampUp`/`Spike`/`Stress`/`Soak`) still start at 0 and let their stages drive the curve. Guarded by `test_constant_scenario_starts_at_target_vus`.
+
+### Added
+
+- **[DevX]** Pre-flight warning when `--vus` is too low for `--rps` (Issue #79 round 6 follow-up)
+  - `mockforge bench --rps N --vus M` now warns before launch when `M × 10 < N` (rule of thumb: 1 VU at ~100ms latency sustains ~10 req/s). The warning suggests a higher `--vus` value (`ceil(rps / 10)`), so users hit by k6's "Insufficient VUs, reached M active VUs and cannot initialize more" message know what to change.
+
 ## [0.3.136] - 2026-05-15
 
 ### Added
@@ -165,16 +183,16 @@
   - When set, the existing `--http-port` listener stays plain HTTP and a parallel TLS listener spins up on `--https-port`, sharing the same router and admin UI
   - Example: `mockforge serve --http-port 80 --https-port 443 --tls-cert server.pem --tls-key key.pem`
   - `--https-port` requires `--tls-cert` + `--tls-key` and must differ from `--http-port`
-- **[Bench]** `bench-chunked --spec` to drive the native chunked bench from POST/PUT/PATCH operations in an OpenAPI spec (#328, #79)
+- **[Reality]** `bench-chunked --spec` to drive the native chunked bench from POST/PUT/PATCH operations in an OpenAPI spec (#328, #79)
   - When `--spec` is set, `--target` becomes the base URL and the bench iterates each matching operation sequentially, each running for `--duration`
   - `--operation-id <id>` narrows to a single op
-- **[Bench]** `bench-chunked` now captures and prints up to five non-2xx response samples — status, `Server` header, first 256 bytes of body (#329, #79)
+- **[Reality]** `bench-chunked` now captures and prints up to five non-2xx response samples — status, `Server` header, first 256 bytes of body (#329, #79)
   - Critical for diagnosing the "503 from bench, 200 in MockForge log" pattern (almost always an upstream proxy timing out on a slow chunked upload)
   - Hint output for 5xx spells out the proxy-timeout math: each request takes >= `(total_size_bytes / chunk_size_bytes) * chunk_interval_ms` ms
 
 ### Changed
 
-- **[Bench]** `bench-chunked` CLI help: `--total-size-bytes` is now explicitly documented as **per-request** (not total over the run), with the chunks-per-request formula in the help text. Resolves repeat user confusion (#328, #79)
+- **[Reality]** `bench-chunked` CLI help: `--total-size-bytes` is now explicitly documented as **per-request** (not total over the run), with the chunks-per-request formula in the help text. Resolves repeat user confusion (#328, #79)
 
 ## [0.3.125] - 2026-05-02
 
@@ -191,7 +209,7 @@
   - `connection_error_kind: tcp_reset` — TCP RST at accept time (`SO_LINGER=0` then drop). Clients see `ECONNRESET`
   - `connection_error_kind: tcp_close` — TCP FIN at accept time. Clients see EOF before any HTTP response
   - `connection_error_kind: http_503` (default) — application-layer 503 on a healthy connection (back-compat)
-- **[Bench]** `mockforge bench-chunked` — native Rust chunked-encoding traffic generator (#306, #79)
+- **[Reality]** `mockforge bench-chunked` — native Rust chunked-encoding traffic generator (#306, #79)
   - Bypasses k6 entirely. Each worker streams body via `reqwest::Body::wrap_stream`, no Content-Length, guaranteed wire chunking
   - Supports `--concurrency`, `--duration`, `--chunk-size-bytes`, `--total-size-bytes`, `--chunk-interval-ms`, `--header`, `--insecure`
 - **[TUI]** Peak metrics tracked alongside current values in the dashboard (#306, #79)
@@ -206,7 +224,7 @@
 - **[Chaos]** `partial_response` now distinguishes chunked vs non-chunked truncation (#306, #79):
   - Non-chunked: truncates body but keeps original `Content-Length` header — clients see unexpected EOF
   - Chunked: truncates before terminating chunk — no `0\r\n\r\n`, real protocol violation
-- **[Bench]** k6 templates: `bench --chunked-request-bodies` adds `Transfer-Encoding: chunked` header (best-effort — k6/Go's `net/http` may still send Content-Length based on body type)
+- **[Reality]** k6 templates: `bench --chunked-request-bodies` adds `Transfer-Encoding: chunked` header (best-effort — k6/Go's `net/http` may still send Content-Length based on body type)
 
 ### Notes
 
@@ -276,15 +294,15 @@ The crates are all published and resolvable on crates.io
 
 ### Added
 
-- **[Bench]** Field-level schema validation errors in conformance failure details (#79)
+- **[Reality]** Field-level schema validation errors in conformance failure details (#79)
   - Violations now show specific field path, violation type, expected/actual values
   - Uses `jsonschema::validate()` instead of `is_valid()` for detailed error reporting
   - Displayed in terminal output and `conformance-failure-details.json`
-- **[Bench]** HAR-to-YAML generator: `mockforge har-to-conformance --har file.har` (#79)
+- **[Reality]** HAR-to-YAML generator: `mockforge har-to-conformance --har file.har` (#79)
   - Converts browser HAR captures to custom compliance YAML
   - Auto-detects base URL, filters static assets, extracts response headers and JSON body field types
   - Output compatible with `--conformance-custom`
-- **[Bench]** Multi-target conformance: `--conformance` + `--targets-file` now works (#79)
+- **[Reality]** Multi-target conformance: `--conformance` + `--targets-file` now works (#79)
   - Runs conformance tests against each target sequentially using native executor
   - Per-target reports in `output/target_N/conformance-report.json`
   - Combined summary in `multi-target-conformance-summary.json`
@@ -293,16 +311,16 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** Add `summary.json` to spec-driven conformance `handleSummary` (#79)
+- **[Reality]** Add `summary.json` to spec-driven conformance `handleSummary` (#79)
   - Custom conformance tests (via `--conformance-custom`) now generate `summary.json`
 
 ## [0.3.101] - 2026-03-26
 
 ### Fixed
 
-- **[Bench]** Skip automatic Authorization (Basic/Bearer) headers when Cookie header is provided via `--conformance-header` (#79)
+- **[Reality]** Skip automatic Authorization (Basic/Bearer) headers when Cookie header is provided via `--conformance-header` (#79)
   - Users managing session-based auth no longer get conflicting Basic Auth headers
-- **[Bench]** Add `summary.json` output to reference conformance generator's `handleSummary` (#79)
+- **[Reality]** Add `summary.json` output to reference conformance generator's `handleSummary` (#79)
 
 ## [0.3.100] - 2026-03-24
 
@@ -325,19 +343,19 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** Fix zero stats in multi-target summary — removed deprecated `--summary-export` flag; rely solely on `handleSummary()` for writing `summary.json` (#79)
-- **[Bench]** Fix failed_requests metric reading `.fails` (success count) instead of `.passes` (failure count) from k6 Rate metric (#79)
-- **[Bench]** Fix k6 script path not found when CWD is set to output dir — now uses absolute script path (#79)
-- **[Bench]** Fix `--summary-export` absolute path for CWD mismatch (#79)
-- **[Bench]** Fix k6 API server port conflict in multi-target mode — each parallel instance gets a unique port (#79)
-- **[Bench]** Treat k6 exit code 99 (thresholds crossed) as warning, still parse results (#79)
-- **[Bench]** Warn when `--conformance` is used with `--targets-file` (not yet supported) (#79)
+- **[Reality]** Fix zero stats in multi-target summary — removed deprecated `--summary-export` flag; rely solely on `handleSummary()` for writing `summary.json` (#79)
+- **[Reality]** Fix failed_requests metric reading `.fails` (success count) instead of `.passes` (failure count) from k6 Rate metric (#79)
+- **[Reality]** Fix k6 script path not found when CWD is set to output dir — now uses absolute script path (#79)
+- **[Reality]** Fix `--summary-export` absolute path for CWD mismatch (#79)
+- **[Reality]** Fix k6 API server port conflict in multi-target mode — each parallel instance gets a unique port (#79)
+- **[Reality]** Treat k6 exit code 99 (thresholds crossed) as warning, still parse results (#79)
+- **[Reality]** Warn when `--conformance` is used with `--targets-file` (not yet supported) (#79)
 - **[Core]** Downgrade contract diff `$ref` resolver warnings from WARN to DEBUG (#79)
 
 ### Added
 
-- **[Bench]** Total elapsed time in multi-target summary output and `aggregated_summary.json` (#79)
-- **[Bench]** `all_targets.csv` file with per-target metrics for easy parsing (#79)
+- **[Reality]** Total elapsed time in multi-target summary output and `aggregated_summary.json` (#79)
+- **[Reality]** `all_targets.csv` file with per-target metrics for easy parsing (#79)
 - **[UI]** Host header column in admin dashboard Recent Logs (#79)
 - **[TUI]** Client IP and Host columns in both Dashboard and Logs screens (#79)
 
@@ -367,9 +385,9 @@ The crates are all published and resolvable on crates.io
 
 ### Added
 
-- **[Bench]** `--conformance-delay` flag to add delay between conformance requests (#79)
-- **[Bench]** k6 output logging to file for debugging (#79)
-- **[Bench]** 429 rate-limit detection and error clarity in conformance output (#79)
+- **[Reality]** `--conformance-delay` flag to add delay between conformance requests (#79)
+- **[Reality]** k6 output logging to file for debugging (#79)
+- **[Reality]** 429 rate-limit detection and error clarity in conformance output (#79)
 
 ### Fixed
 
@@ -381,16 +399,16 @@ The crates are all published and resolvable on crates.io
 
 ### Added
 
-- **[Bench]** Native conformance executor with API, UI dashboard, and SDK integration (#79)
-- **[Bench]** Conformance report UX improvements and custom test authoring (#79)
-- **[Bench]** Full request/response detail capture for conformance failures (#79)
-- **[Bench]** OWASP API Top 10 coverage mapping in conformance reports (#79)
+- **[Reality]** Native conformance executor with API, UI dashboard, and SDK integration (#79)
+- **[Reality]** Conformance report UX improvements and custom test authoring (#79)
+- **[Reality]** Full request/response detail capture for conformance failures (#79)
+- **[Reality]** OWASP API Top 10 coverage mapping in conformance reports (#79)
 
 ### Fixed
 
-- **[Bench]** Eliminate misleading error rate in conformance output (#79)
-- **[Bench]** Deduplicate native executor checks, write failure details file (#79)
-- **[Bench]** Custom conformance checks now emit failure details (#79)
+- **[Reality]** Eliminate misleading error rate in conformance output (#79)
+- **[Reality]** Deduplicate native executor checks, write failure details file (#79)
+- **[Reality]** Custom conformance checks now emit failure details (#79)
 - **[Core/Bench]** Resolve 3 conformance test failures (#79)
 - **[UI/Bench]** Fix empty routes and add endpoint details to conformance (#79)
 
@@ -461,7 +479,7 @@ The crates are all published and resolvable on crates.io
 
 ### Changed
 
-- **[Bench]** Spec-driven conformance generator now sends `X-Mockforge-Response-Status` header for `response:400` and `response:404` checks (#79)
+- **[Reality]** Spec-driven conformance generator now sends `X-Mockforge-Response-Status` header for `response:400` and `response:404` checks (#79)
   - Tells the mock server which status code to return, enabling accurate status-code conformance testing
 
 ## [0.3.72] - 2026-03-04
@@ -472,17 +490,17 @@ The crates are all published and resolvable on crates.io
   - `validate_auth_config_on_startup()` now logs a warning instead of returning an error
   - Auto-generated JWT secret fallback so the admin UI works out of the box
   - Default users are seeded even without `ENVIRONMENT=development`, so login works immediately
-- **[Bench]** Fix duplicate session ID in conformance Cookie headers (#79)
+- **[Reality]** Fix duplicate session ID in conformance Cookie headers (#79)
   - Removed invalid `noCookies: true` from k6 options (not a real k6 option; k6 silently ignores it)
   - Added `http.cookieJar().clear(BASE_URL)` before and after each request when custom Cookie headers are present
   - Prevents k6's internal cookie jar from re-sending server `Set-Cookie` values alongside custom headers
   - Applied to both reference-mode (`generator.rs`) and spec-driven (`spec_driven.rs`) generators
-- **[Bench]** Fix missing single-quote escaping in spec-driven `format_headers()` (#79)
+- **[Reality]** Fix missing single-quote escaping in spec-driven `format_headers()` (#79)
   - Header values containing single quotes are now properly escaped, matching `generator.rs` behavior
 
 ### Added
 
-- **[Bench]** Conformance report now shows individual failed checks with pass/fail counts (#79)
+- **[Reality]** Conformance report now shows individual failed checks with pass/fail counts (#79)
   - New "Failed Checks" section after the category summary table lists each check that failed
   - When not using `--conformance-all-operations`, prints a tip suggesting it for endpoint-level detail
 
@@ -490,23 +508,23 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** Remove dead `CUSTOM_HEADERS` JS const from conformance generators (#79)
+- **[Reality]** Remove dead `CUSTOM_HEADERS` JS const from conformance generators (#79)
   - Custom header values are now inlined directly into each request instead of referencing an unused JS constant
   - Eliminates confusing dead code in generated k6 scripts
-- **[Bench]** Add `noCookies: true` to k6 options when Cookie header is in custom headers (#79)
+- **[Reality]** Add `noCookies: true` to k6 options when Cookie header is in custom headers (#79)
   - Prevents k6's automatic cookie jar from duplicating cookies on subsequent requests
   - Fixes duplicate session ID / authentication failures reported by @srikr
-- **[Bench]** Fix conformance report file not found after k6 execution (#79)
+- **[Reality]** Fix conformance report file not found after k6 execution (#79)
   - `handleSummary` now writes `conformance-report.json` to an absolute path matching the output directory
   - Previously wrote to a relative path based on k6's CWD, causing the CLI to report "Conformance report not generated"
 
 ### Added
 
-- **[Bench]** `--conformance-all-operations` flag for full-endpoint conformance testing (#79)
+- **[Reality]** `--conformance-all-operations` flag for full-endpoint conformance testing (#79)
   - Default mode tests one representative operation per feature check (fast feature-coverage)
   - New flag tests ALL operations with path-qualified check names (e.g., `method:GET:/api/users`)
   - Addresses user confusion about "only 5 endpoints tested"
-- **[Bench]** Conformance coverage summary output (#79)
+- **[Reality]** Conformance coverage summary output (#79)
   - After generating conformance tests, prints "Conformance: N operations analyzed, M unique checks generated"
   - When using default mode with fewer checks than operations, shows tip about `--conformance-all-operations`
 
@@ -525,40 +543,40 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** Spec-driven conformance: global security requirement detection (#79)
+- **[Reality]** Spec-driven conformance: global security requirement detection (#79)
   - `annotate_security()` now falls back to `spec.security` (root-level) when an operation has no operation-level security defined
   - APIs that only define security globally are now correctly detected
-- **[Bench]** Spec-driven conformance: SecurityScheme type resolution (#79)
+- **[Reality]** Spec-driven conformance: SecurityScheme type resolution (#79)
   - Security schemes are now resolved from `components.securitySchemes` to detect actual type (`HTTP/bearer`, `APIKey`, `HTTP/basic`) instead of relying on name heuristics alone
   - A scheme named "myAuth" that is actually an `apiKey` type is now correctly identified
   - Name-based heuristic retained as fallback for unresolvable schemes
-- **[Bench]** Spec-driven conformance: ContentNegotiation detection (#79)
+- **[Reality]** Spec-driven conformance: ContentNegotiation detection (#79)
   - `ContentNegotiation` feature is now detected when a response defines multiple content types (e.g., both `application/json` and `application/xml`)
   - Previously only worked in reference mode
-- **[Bench]** CLI help text for `--conformance-categories` now includes `response-validation` (#79)
+- **[Reality]** CLI help text for `--conformance-categories` now includes `response-validation` (#79)
 
 ### Added
 
-- **[Bench]** 5 new conformance tests: ResponseValidation with schema check, global security, SecurityScheme resolution, ContentNegotiation detection, single-type negative case (#79)
+- **[Reality]** 5 new conformance tests: ResponseValidation with schema check, global security, SecurityScheme resolution, ContentNegotiation detection, single-type negative case (#79)
 
 ## [0.3.56] - 2026-02-14
 
 ### Added
 
-- **[Bench]** Conformance category filtering (#79)
+- **[Reality]** Conformance category filtering (#79)
   - New `--conformance-categories` flag to run only specific conformance categories (e.g., `--conformance-categories "parameters,security"`)
   - Case-insensitive category matching with validation against known categories
-- **[Bench]** Spec-driven conformance testing (#79)
+- **[Reality]** Spec-driven conformance testing (#79)
   - When `--conformance --spec my-api.json` is provided, analyzes the user's actual OpenAPI spec to detect which features their API exercises
   - Generates conformance tests against real endpoints instead of reference `/conformance/` paths
   - Full `$ref` resolution with cycle detection for parameters, schemas, request bodies, and responses
   - Detects: parameter types, request body formats, schema types/composition/formats/constraints, response codes, security schemes
-- **[Bench]** Response schema validation (#79)
+- **[Reality]** Response schema validation (#79)
   - In spec-driven mode, validates response bodies against OpenAPI response schemas
   - `SchemaValidatorGenerator` produces JavaScript validation expressions from OpenAPI schemas
   - Supports object (required fields, property types), array, string (format regex, enum, length), integer/number (range), boolean validation
   - Wrapped in try-catch for resilient k6 execution
-- **[Bench]** SARIF 2.1.0 report output (#79)
+- **[Reality]** SARIF 2.1.0 report output (#79)
   - New `--conformance-report-format sarif` flag outputs conformance results in SARIF 2.1.0 format
   - Compatible with GitHub Code Scanning, VS Code SARIF Viewer, and CI/CD pipelines
   - Maps each conformance feature to a SARIF rule with OpenAPI spec section links
@@ -568,16 +586,16 @@ The crates are all published and resolvable on crates.io
 
 ### Added
 
-- **[Bench]** Per-server stats in multi-target mode (#79)
+- **[Reality]** Per-server stats in multi-target mode (#79)
   - `K6Results` now parses RPS, VUs, and full latency breakdown (min/med/p90/p95/p99/max) from k6 `summary.json`
   - `AggregatedMetrics` includes `total_rps`, `avg_rps`, `total_vus_max`
   - Multi-target reporter shows per-target RPS, VUs, and full latency breakdown
   - `aggregated_summary.json` includes all new metrics in both aggregated and per-target sections
-- **[Bench]** Per-target spec support for multi-target mode (#79)
+- **[Reality]** Per-target spec support for multi-target mode (#79)
   - Targets file JSON format now supports `"spec"` field for per-target OpenAPI specs
   - Each target can use a different spec file for heterogeneous fan-out
   - Example: `[{"url": "https://server1", "spec": "spec_a.json"}, {"url": "https://server2", "spec": "spec_b.json"}]`
-- **[Bench]** OpenAPI 3.0.0 conformance testing (#79)
+- **[Reality]** OpenAPI 3.0.0 conformance testing (#79)
   - New `--conformance` flag generates and runs comprehensive k6 scripts exercising 47 OpenAPI 3.0.0 features across 10 categories (Parameters, Request Bodies, Schema Types, Composition, String Formats, Constraints, Response Codes, HTTP Methods, Content Negotiation, Security)
   - Reports per-category pass/fail rates with colored terminal output
   - Supports `--conformance-api-key`, `--conformance-basic-auth`, `--conformance-report` for security scheme testing
@@ -587,7 +605,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): deliver CRS payloads as path injection + form-encoded body (#79)
+- **[Reality]** fix(bench): deliver CRS payloads as path injection + form-encoded body (#79)
   - Added `inject_as_path` field to `SecurityPayload` — URI payloads without query params (e.g., CRS 942101: `POST /1234%20OR%201=1`) now replace the request path via `encodeURI()` so WAFs inspect `REQUEST_FILENAME` instead of `ARGS`
   - Added `form_encoded_body` field to `SecurityPayload` — body payloads from CRS tests (e.g., 942432: `var=;;dd foo bar`) now sent as `application/x-www-form-urlencoded` so WAFs parse form data into `ARGS` for character counting
   - Updated `k6_script.hbs` and `k6_crud_flow.hbs` templates to handle both new delivery mechanisms
@@ -598,7 +616,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): URL-encode URI payloads + strip form keys from body payloads (#79)
+- **[Reality]** fix(bench): URL-encode URI payloads + strip form keys from body payloads (#79)
   - URI security payloads now wrapped in `encodeURIComponent()` for valid HTTP transport — WAFs decode before inspection (fixes 942101)
   - Form-encoded body payloads now have form key prefix stripped (`var=;;dd foo bar` → `;;dd foo bar`) so WAF ARGS parsing sees the attack payload directly (fixes 942432)
   - Confirmed SQLi detection: 45/46 rules (97.8%), up from 43/46 (93.5%)
@@ -607,7 +625,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): Group multi-part WAFBench payloads + decode body payloads + fix Cookie/CookieJar conflict (#79)
+- **[Reality]** fix(bench): Group multi-part WAFBench payloads + decode body payloads + fix Cookie/CookieJar conflict (#79)
   - Multi-part CRS test cases (URI + headers + body) now grouped by `group_id` and sent together in one HTTP request instead of being split across separate requests (fixes 942290)
   - Body payloads from CRS YAML files are now form-URL-decoded before injection (`%22+WAITFOR+DELAY+%27` → `" WAITFOR DELAY '`) so WAFs see actual SQL patterns in JSON bodies (fixes 942240, 942320, 942432)
   - URI payloads from path-only CRS tests are now URL-decoded and stripped of leading `/` artifact (fixes 942101)
@@ -620,7 +638,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): Accept all WAFBench CRS payloads without attack-pattern filter (#79)
+- **[Reality]** fix(bench): Accept all WAFBench CRS payloads without attack-pattern filter (#79)
   - Removed overly strict `attack-pattern` category filter that was silently dropping valid CRS test cases
   - All CRS YAML test cases now loaded regardless of their `attack_type` metadata
 
@@ -628,7 +646,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): Use per-request CookieJar instead of shared EMPTY_JAR (#79)
+- **[Reality]** fix(bench): Use per-request CookieJar instead of shared EMPTY_JAR (#79)
   - Each HTTP request now creates its own `new http.CookieJar()` instead of sharing a global empty jar
   - Prevents cookie cross-contamination between requests in security testing
 
@@ -636,7 +654,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): Send raw security payloads + use dedicated empty cookie jar (#79)
+- **[Reality]** fix(bench): Send raw security payloads + use dedicated empty cookie jar (#79)
   - Security payloads now sent as raw strings without additional encoding
   - Dedicated empty CookieJar per request prevents k6's default cookie accumulation
 
@@ -644,7 +662,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): Cycle security payloads per-operation + clear cookies in API2 tests (#79)
+- **[Reality]** fix(bench): Cycle security payloads per-operation + clear cookies in API2 tests (#79)
   - Security payloads now cycle per-operation block (each API endpoint gets a different payload)
   - Previously all operations in one VU iteration used the same payload
   - OWASP API2 (Broken Auth) tests now properly clear cookies between requests
@@ -660,7 +678,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): Security payloads now injected + cookie dedup in all templates (#79)
+- **[Reality]** fix(bench): Security payloads now injected + cookie dedup in all templates (#79)
   - Security payloads now properly injected in both k6_script.hbs and k6_crud_flow.hbs templates
   - Cookie deduplication applied to all HTTP request paths in both templates
   - Comprehensive test suite added for issue #79 security pipeline
@@ -674,13 +692,13 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): WAFBench payloads now distributed across VUs for better coverage (#79)
+- **[Reality]** fix(bench): WAFBench payloads now distributed across VUs for better coverage (#79)
   - Changed payload cycling to use VU-based offset: `(__VU - 1) % payloads.length`
   - Previously all 50 VUs started at index 0 and cycled through same sequence
   - Now each VU starts at a different payload, maximizing attack coverage in shorter test runs
   - With 50 VUs and 30 payloads, all payloads are tested from the start
 
-- **[Bench]** fix(bench): OWASP API tests now include custom headers in all requests (#79)
+- **[Reality]** fix(bench): OWASP API tests now include custom headers in all requests (#79)
   - Added `CUSTOM_HEADERS` to API8 verbose error test (malformed JSON body test)
   - Added `CUSTOM_HEADERS` to API9 discovery paths test
   - Added `CUSTOM_HEADERS` to API9 API versions test
@@ -690,7 +708,7 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): Security payloads now actually applied to requests in k6 scripts (#79)
+- **[Reality]** fix(bench): Security payloads now actually applied to requests in k6 scripts (#79)
   - Updated k6_script.hbs template to call `getNextSecurityPayload()` and `applySecurityPayload()`
   - Previously, security payload functions were defined but never called in generated scripts
   - Security payloads now properly injected into request bodies for POST/PUT/PATCH
@@ -700,10 +718,10 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): XSS payloads now inject into ALL string fields, not just the first one (#79)
+- **[Reality]** fix(bench): XSS payloads now inject into ALL string fields, not just the first one (#79)
   - Removed `break` statement from `applySecurityPayload()` loop in security_payloads.rs
   - Ensures WAF can detect payloads regardless of which field it scans
-- **[Bench]** fix(bench): Added `jar: null` to remaining OWASP HTTP calls to prevent cookie duplication (#79)
+- **[Reality]** fix(bench): Added `jar: null` to remaining OWASP HTTP calls to prevent cookie duplication (#79)
   - Fixed testBrokenAuth empty token test
   - Fixed testMisconfiguration verbose error test
   - Fixed testInventory discovery paths and API versions checks
@@ -715,11 +733,11 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): WAFBench XSS attacks now properly injected into request body (#79)
+- **[Reality]** fix(bench): WAFBench XSS attacks now properly injected into request body (#79)
   - Removed location check from `applySecurityPayload()` - ALL payloads now injected into body for POST/PUT
   - WAFBench payloads correctly pass location info (uri/header/body) to k6 scripts
   - Header payloads include header name for proper injection into specified headers
-- **[Bench]** fix(bench): Cookie header duplication in OWASP and security tests (#79)
+- **[Reality]** fix(bench): Cookie header duplication in OWASP and security tests (#79)
   - Added `jar: null` to all HTTP request params to disable k6's automatic cookie jar
   - Prevents duplicate cookies when user provides Cookie header via `--headers` flag
   - Applied to k6_script.hbs, k6_crud_flow.hbs, and OWASP generator
@@ -728,40 +746,40 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): pass custom headers from `--headers` flag to OWASP tests (#79)
+- **[Reality]** fix(bench): pass custom headers from `--headers` flag to OWASP tests (#79)
   - Cookie and other custom headers are now included in all OWASP request helpers
   - Fixes issue where `avi-sessionid=None` was being sent instead of actual cookie values
-- **[Bench]** fix(bench): WAFBench loader now handles single YAML file paths (#79)
+- **[Reality]** fix(bench): WAFBench loader now handles single YAML file paths (#79)
   - Previously only directories or glob patterns were supported
   - Single file paths like `/path/to/941100.yaml` now work correctly
-- **[Bench]** Verified CRS v3.3 format compatibility with full CoreRuleSet test suite
+- **[Reality]** Verified CRS v3.3 format compatibility with full CoreRuleSet test suite
   - Tested with 175 files, 1512 payloads (692 XSS, 505 SQLi, 304 Command Injection, 11 Path Traversal)
 
 ## [0.3.37] - 2026-01-12
 
 ### Added
 
-- **[Bench]** feat(bench): add WAFBench cycle-all mode (`--wafbench-cycle-all`) to test all payloads sequentially (#79)
-- **[Bench]** feat(bench): add `--owasp-iterations` parameter to control OWASP test iterations per VU (#79)
-- **[Bench]** feat(bench): OWASP tests now respect `--vus` parameter for concurrent testing (#79)
+- **[Reality]** feat(bench): add WAFBench cycle-all mode (`--wafbench-cycle-all`) to test all payloads sequentially (#79)
+- **[Reality]** feat(bench): add `--owasp-iterations` parameter to control OWASP test iterations per VU (#79)
+- **[Reality]** feat(bench): OWASP tests now respect `--vus` parameter for concurrent testing (#79)
 
 ### Fixed
 
-- **[Bench]** fix(bench): WAFBench payloads now properly injected in standard bench mode (not just CRUD flow)
-- **[Bench]** fix(bench): OWASP APIs now use random UUIDs per request instead of static IDs for BOLA testing (#79)
-- **[Bench]** fix(bench): OWASP auth tokens with special characters (quotes, backslashes) now properly escaped (#79)
-- **[Bench]** fix(bench): prevent Handlebars double-escaping of pre-escaped JavaScript values
-- **[Bench]** fix(bench): WAFBench security payloads now integrated into CRUD flow requests (#79)
-- **[Bench]** fix(owasp): use `http.del()` instead of `http.delete()` for k6 compatibility (#79)
-- **[Bench]** fix(owasp): add `--base-path` support for OWASP API testing (#79)
-- **[Bench]** fix(bench): remove undefined `totalRequestCount` variable reference
-- **[Bench]** fix(bench): support CRS v3.3 WAFBench format and pass `--insecure` to OWASP tests
+- **[Reality]** fix(bench): WAFBench payloads now properly injected in standard bench mode (not just CRUD flow)
+- **[Reality]** fix(bench): OWASP APIs now use random UUIDs per request instead of static IDs for BOLA testing (#79)
+- **[Reality]** fix(bench): OWASP auth tokens with special characters (quotes, backslashes) now properly escaped (#79)
+- **[Reality]** fix(bench): prevent Handlebars double-escaping of pre-escaped JavaScript values
+- **[Reality]** fix(bench): WAFBench security payloads now integrated into CRUD flow requests (#79)
+- **[Reality]** fix(owasp): use `http.del()` instead of `http.delete()` for k6 compatibility (#79)
+- **[Reality]** fix(owasp): add `--base-path` support for OWASP API testing (#79)
+- **[Reality]** fix(bench): remove undefined `totalRequestCount` variable reference
+- **[Reality]** fix(bench): support CRS v3.3 WAFBench format and pass `--insecure` to OWASP tests
 
 ## [0.3.33] - 2026-01-10
 
 ### Fixed
 
-- **[Bench]** fix(bench): multiple fixes for OWASP and WAFBench testing
+- **[Reality]** fix(bench): multiple fixes for OWASP and WAFBench testing
   - Support CRS v3.3 format in WAFBench parser
   - Pass `--insecure` flag to OWASP tests for self-signed certificates
 
@@ -769,48 +787,48 @@ The crates are all published and resolvable on crates.io
 
 ### Fixed
 
-- **[Bench]** fix(bench): fix extracted value substitution in CRUD flows
-- **[Bench]** fix(bench): OWASP k6 configuration improvements
+- **[Reality]** fix(bench): fix extracted value substitution in CRUD flows
+- **[Reality]** fix(bench): OWASP k6 configuration improvements
 
 ## [0.3.30] - 2026-01-07
 
 ### Added
 
-- **[Bench]** feat(bench): add `merge_body` support for CRUD flows - merge extracted values with request body
-- **[Bench]** feat(bench): add `inject_attacks` data model for security testing in CRUD flows
+- **[Reality]** feat(bench): add `merge_body` support for CRUD flows - merge extracted values with request body
+- **[Reality]** feat(bench): add `inject_attacks` data model for security testing in CRUD flows
 
 ## [0.3.28] - 2026-01-06
 
 ### Added
 
-- **[Bench]** feat(bench): add nested path extraction for CRUD flows (e.g., `results[0].id`)
-- **[Bench]** feat(bench): add filter extraction for CRUD flows (e.g., `results[?name=='test'].id`)
+- **[Reality]** feat(bench): add nested path extraction for CRUD flows (e.g., `results[0].id`)
+- **[Reality]** feat(bench): add filter extraction for CRUD flows (e.g., `results[?name=='test'].id`)
 
 ## [0.3.27] - 2026-01-05
 
 ### Added
 
-- **[Bench]** feat(bench): add full body extraction for CRUD flows
-- **[Bench]** feat(bench): add key filtering for extracted values
+- **[Reality]** feat(bench): add full body extraction for CRUD flows
+- **[Reality]** feat(bench): add key filtering for extracted values
 
 ## [0.3.26] - 2026-01-04
 
 ### Added
 
-- **[Bench]** feat(bench): add aliased extraction for CRUD flow value chaining
+- **[Reality]** feat(bench): add aliased extraction for CRUD flow value chaining
   - Extract values with aliases (e.g., `id as poolId`) for use in subsequent requests
 
 ## [0.3.24] - 2026-01-03
 
 ### Fixed
 
-- **[Bench]** fix(bench): use correct variable name in CRUD flow extracted value replacement
+- **[Reality]** fix(bench): use correct variable name in CRUD flow extracted value replacement
 
 ## [0.3.22] - 2026-01-02
 
 ### Added
 
-- **[Bench]** feat(bench): add OWASP API Security Top 10 testing mode (#79)
+- **[Reality]** feat(bench): add OWASP API Security Top 10 testing mode (#79)
   - Test for BOLA (API1), Broken Auth (API2), Mass Assignment (API3), Resource Consumption (API4)
   - Test for Function Auth (API5), SSRF (API7), Misconfiguration (API8), Inventory (API9), Unsafe Consumption (API10)
   - Configurable test categories with `--owasp-categories`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7652,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7869,7 +7869,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7900,7 +7900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8004,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8037,7 +8037,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8060,7 +8060,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8081,7 +8081,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8145,7 +8145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8267,7 +8267,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8285,7 +8285,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8378,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8403,7 +8403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8450,7 +8450,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8466,7 +8466,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8495,7 +8495,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8590,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8630,7 +8630,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8692,7 +8692,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8739,7 +8739,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8777,7 +8777,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -8847,7 +8847,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8867,7 +8867,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8902,7 +8902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8939,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8967,7 +8967,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8997,7 +8997,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9024,7 +9024,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9048,14 +9048,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9082,7 +9082,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9133,7 +9133,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9156,7 +9156,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9187,7 +9187,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9274,7 +9274,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9285,7 +9285,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9302,7 +9302,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -14964,7 +14964,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.136"
+version = "0.3.137"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.136"
+version = "0.3.137"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,23 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.137] - 2026-05-17
+
+### Fixed
+
+- **[Reality]** Client-side "Connections opened" counter now appears for `--rps`-only runs (Issue #79 round 6 follow-up)
+  - Root cause: the parser was reading `http_req_connecting.values.count` from k6's `summary.json`, but k6's Trend metric never emits a `count` field — only `avg/min/med/max/p(90)/p(95)`. The field was always absent, so `tcp_connect_samples` was always 0 and the connection-count line never printed for non-`--cps` runs.
+  - Fix: the generated k6 script now declares a dedicated `mockforge_connections_opened` Counter and increments it whenever `res.timings.connecting > 0` (i.e. a fresh TCP socket was opened). The Rust parser reads this Counter's `count` directly. Works for both `--cps` runs (≈ total requests) and pooled-reuse runs (≈ `vus_max`).
+  - Also: TCP-connect / TLS-handshake timing lines now print whenever the Trend has a non-zero `avg`, not when `count > 0` (which was unreliable). New `test_connections_opened_counter_present` regression test guards both the Counter declaration and the per-request increment.
+
+- **[Reality]** `--scenario constant` now runs at full VU concurrency from t=0 (Issue #79 round 6 follow-up)
+  - Root cause: Srikanth reported that `--vus 5 -d 600s` took until the ~6-minute mark to reach 5 VUs and then ramped DOWN. The k6 template always wrote `startVUs: 0`, so even `--scenario constant`'s single `{duration: '600s', target: 5}` stage made `ramping-vus` linearly interpolate from 0 → 5 across the whole window.
+  - Fix: for `Constant`, `startVUs` is seeded at `max_vus` so concurrency is at full from the start. Ramping scenarios (`RampUp`/`Spike`/`Stress`/`Soak`) still start at 0 and let their stages drive the curve. Guarded by `test_constant_scenario_starts_at_target_vus`.
+
+### Added
+
+- **[DevX]** Pre-flight warning when `--vus` is too low for `--rps` (Issue #79 round 6 follow-up)
+  - `mockforge bench --rps N --vus M` now warns before launch when `M × 10 < N` (rule of thumb: 1 VU at ~100ms latency sustains ~10 req/s). The warning suggests a higher `--vus` value (`ceil(rps / 10)`), so users hit by k6's "Insufficient VUs, reached M active VUs and cannot initialize more" message know what to change.
+
 ## [0.3.132] - 2026-05-12
 
 ### Added

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -817,6 +817,10 @@ fn parse_k6_summary(bytes: &[u8]) -> Result<K6Results> {
     let server_fault = &json["metrics"]["mockforge_server_fault_total"]["values"]["count"];
     let tcp_connecting = &json["metrics"]["http_req_connecting"]["values"];
     let tls_handshake = &json["metrics"]["http_req_tls_handshaking"]["values"];
+    // Counter that the template increments when res.timings.connecting > 0
+    // (i.e. a fresh TCP socket was established). See executor::parse_results
+    // for the reason we can't use the Trend's count.
+    let mf_conns_opened = &json["metrics"]["mockforge_connections_opened"]["values"]["count"];
     Ok(K6Results {
         total_requests: json["metrics"]["http_reqs"]["values"]["count"].as_u64().unwrap_or(0),
         // See `K6Executor::parse_results` for the rationale on why
@@ -839,10 +843,14 @@ fn parse_k6_summary(bytes: &[u8]) -> Result<K6Results> {
         server_injected_jitter_samples: server_jitter["count"].as_u64().unwrap_or(0),
         server_injected_jitter_avg_ms: server_jitter["avg"].as_f64().unwrap_or(0.0),
         server_reported_faults: server_fault.as_u64().unwrap_or(0),
-        tcp_connect_samples: tcp_connecting["count"].as_u64().unwrap_or(0),
+        tcp_connect_samples: mf_conns_opened.as_u64().unwrap_or(0),
         tcp_connect_avg_ms: tcp_connecting["avg"].as_f64().unwrap_or(0.0),
         tcp_connect_max_ms: tcp_connecting["max"].as_f64().unwrap_or(0.0),
-        tls_handshake_samples: tls_handshake["count"].as_u64().unwrap_or(0),
+        tls_handshake_samples: if tls_handshake["avg"].as_f64().unwrap_or(0.0) > 0.0 {
+            mf_conns_opened.as_u64().unwrap_or(0)
+        } else {
+            0
+        },
         tls_handshake_avg_ms: tls_handshake["avg"].as_f64().unwrap_or(0.0),
         tls_handshake_max_ms: tls_handshake["max"].as_f64().unwrap_or(0.0),
     })

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -417,6 +417,28 @@ impl BenchCommand {
 
         let security_testing_enabled = self.security_test || self.wafbench_dir.is_some();
 
+        // Issue #79 round 6 follow-up — Srikanth reported k6 emitting
+        // "Insufficient VUs, reached 5 active VUs and cannot initialize more"
+        // when running `--rps 100 --vus 5`. With the `constant-arrival-rate`
+        // executor, k6 needs roughly `rps × avg_request_seconds` VUs to keep
+        // up; if `--vus` is too low it can't sustain the rate. Warn pre-flight
+        // so users know to bump `--vus` rather than chase the warning.
+        if let Some(rps) = self.target_rps {
+            // Rule of thumb: at ~100ms avg latency, 1 VU sustains ~10 req/s.
+            // If `--vus * 10 < --rps`, the configured VU pool likely can't
+            // drive the requested rate end-to-end and k6 will warn.
+            if self.vus.saturating_mul(10) < rps {
+                TerminalReporter::print_warning(&format!(
+                    "--vus {} may be insufficient for --rps {}. k6 needs roughly \
+                     rps × avg_request_seconds VUs to sustain the rate; bump --vus \
+                     (e.g. --vus {}) if you see \"Insufficient VUs\" warnings.",
+                    self.vus,
+                    rps,
+                    rps.div_ceil(10).max(self.vus + 1),
+                ));
+            }
+        }
+
         let k6_config = K6Config {
             target_url: self.target.clone(),
             base_path,

--- a/crates/mockforge-bench/src/executor.rs
+++ b/crates/mockforge-bench/src/executor.rs
@@ -312,11 +312,18 @@ impl K6Executor {
         let server_fault = &json["metrics"]["mockforge_server_fault_total"]["values"]["count"];
 
         // Issue #79 (round 5) — surface TCP connect / TLS handshake stats and
-        // a connection-rate count for `--cps` runs. k6's `http_req_connecting`
-        // is "time spent establishing TCP connection"; with `noConnectionReuse`
-        // it fires per request, so `count` is effectively connections opened.
+        // a connection-rate count for `--cps` runs.
+        //
+        // Round 6 follow-up: k6's `http_req_connecting` Trend doesn't expose a
+        // `count` field in summary.json (only avg/min/med/max/p90/p95), so we
+        // can't use it for "connections opened". The template now feeds a
+        // dedicated Counter, `mockforge_connections_opened`, every time a
+        // request's `res.timings.connecting > 0`. That gives us an accurate
+        // count for both `--cps` (≈ total_requests) and pooled-reuse (≈ vus_max)
+        // runs. The Trend is still useful for the avg/max timing display.
         let tcp_connecting = &json["metrics"]["http_req_connecting"]["values"];
         let tls_handshake = &json["metrics"]["http_req_tls_handshaking"]["values"];
+        let mf_conns_opened = &json["metrics"]["mockforge_connections_opened"]["values"]["count"];
 
         Ok(K6Results {
             total_requests: json["metrics"]["http_reqs"]["values"]["count"].as_u64().unwrap_or(0),
@@ -341,10 +348,19 @@ impl K6Executor {
             server_injected_jitter_samples: server_jitter["count"].as_u64().unwrap_or(0),
             server_injected_jitter_avg_ms: server_jitter["avg"].as_f64().unwrap_or(0.0),
             server_reported_faults: server_fault.as_u64().unwrap_or(0),
-            tcp_connect_samples: tcp_connecting["count"].as_u64().unwrap_or(0),
+            // Counter from the template, not the Trend's count (which is
+            // absent in k6 summary JSON).
+            tcp_connect_samples: mf_conns_opened.as_u64().unwrap_or(0),
             tcp_connect_avg_ms: tcp_connecting["avg"].as_f64().unwrap_or(0.0),
             tcp_connect_max_ms: tcp_connecting["max"].as_f64().unwrap_or(0.0),
-            tls_handshake_samples: tls_handshake["count"].as_u64().unwrap_or(0),
+            // TLS handshake Trend has no `count` either; gate display on avg>0.
+            tls_handshake_samples: if tls_handshake["avg"].as_f64().unwrap_or(0.0) > 0.0 {
+                // Use connection count as a proxy — every new TLS session
+                // requires a handshake.
+                mf_conns_opened.as_u64().unwrap_or(0)
+            } else {
+                0
+            },
             tls_handshake_avg_ms: tls_handshake["avg"].as_f64().unwrap_or(0.0),
             tls_handshake_max_ms: tls_handshake["max"].as_f64().unwrap_or(0.0),
         })

--- a/crates/mockforge-bench/src/k6_gen.rs
+++ b/crates/mockforge-bench/src/k6_gen.rs
@@ -57,6 +57,17 @@ pub struct K6ScriptTemplateData {
     /// Max VUs to pre-allocate for the `constant-arrival-rate` executor.
     /// Issue #79 (round 5).
     pub max_vus: u32,
+    /// Starting VU count for the `ramping-vus` executor. For
+    /// `--scenario constant` this is set to `max_vus` so the test runs at
+    /// full concurrency immediately. For ramping scenarios it's 0 so the
+    /// stages drive the ramp.
+    ///
+    /// Issue #79 round 6 follow-up: Srikanth reported that `--vus 5 -d 600s`
+    /// took until the ~6-minute mark to reach 5 VUs because `startVUs: 0` +
+    /// a single `{duration: '600s', target: 5}` stage made `ramping-vus`
+    /// linearly ramp from 0 → 5 across the whole window. Setting startVUs
+    /// to the target for `Constant` collapses that ramp.
+    pub start_vus: u32,
 }
 
 /// Typed template data for `k6_crud_flow.hbs`.
@@ -366,6 +377,13 @@ impl K6ScriptGenerator {
             no_keep_alive: self.config.no_keep_alive,
             duration_secs: self.config.duration_secs,
             max_vus: self.config.max_vus,
+            // For Constant we want the test at full VU count from t=0; for the
+            // ramping scenarios (RampUp / Spike / Stress / Soak) k6 needs to
+            // start from 0 and let the stages drive the curve.
+            start_vus: match self.config.scenario {
+                LoadScenario::Constant => self.config.max_vus,
+                _ => 0,
+            },
         })
     }
 
@@ -926,6 +944,150 @@ mod tests {
         assert!(
             script.contains("Connection Rate:"),
             "--cps summary must include 'Connection Rate:' (Srikanth's round-5 ask)"
+        );
+    }
+
+    /// Issue #79 round 6 follow-up: Srikanth reported `--vus 5 -d 600s` taking
+    /// until the 6-minute mark to reach 5 VUs because the script always set
+    /// `startVUs: 0`, so k6's `ramping-vus` linearly ramped 0 → 5 over the
+    /// whole window. For `--scenario constant` we now seed startVUs at the
+    /// target so the test runs at full concurrency from t=0.
+    #[test]
+    fn test_constant_scenario_starts_at_target_vus() {
+        use crate::spec_parser::ApiOperation;
+        use openapiv3::Operation;
+
+        let operation = ApiOperation {
+            method: "get".to_string(),
+            path: "/u".to_string(),
+            operation: Operation::default(),
+            operation_id: Some("u".to_string()),
+        };
+        let template = RequestTemplate {
+            operation,
+            path_params: HashMap::new(),
+            query_params: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        let config = K6Config {
+            target_url: "https://api.example.com".to_string(),
+            base_path: None,
+            scenario: LoadScenario::Constant,
+            duration_secs: 600,
+            max_vus: 5,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            auth_header: None,
+            custom_headers: HashMap::new(),
+            skip_tls_verify: false,
+            security_testing_enabled: false,
+            chunked_request_bodies: false,
+            target_rps: None,
+            no_keep_alive: false,
+        };
+        let script = K6ScriptGenerator::new(config, vec![template]).generate().unwrap();
+        assert!(
+            script.contains("startVUs: 5,"),
+            "--scenario constant must seed startVUs at max_vus, not 0; got:\n{}",
+            script
+        );
+        // RampUp should still start at 0 — confirm we didn't break ramps.
+        let ramp_config = K6Config {
+            target_url: "https://api.example.com".to_string(),
+            base_path: None,
+            scenario: LoadScenario::RampUp,
+            duration_secs: 600,
+            max_vus: 5,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            auth_header: None,
+            custom_headers: HashMap::new(),
+            skip_tls_verify: false,
+            security_testing_enabled: false,
+            chunked_request_bodies: false,
+            target_rps: None,
+            no_keep_alive: false,
+        };
+        let ramp_template = RequestTemplate {
+            operation: ApiOperation {
+                method: "get".to_string(),
+                path: "/u".to_string(),
+                operation: Operation::default(),
+                operation_id: Some("u".to_string()),
+            },
+            path_params: HashMap::new(),
+            query_params: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        let ramp_script =
+            K6ScriptGenerator::new(ramp_config, vec![ramp_template]).generate().unwrap();
+        assert!(
+            ramp_script.contains("startVUs: 0,"),
+            "--scenario ramp-up must keep startVUs at 0 so stages drive the ramp; got:\n{}",
+            ramp_script
+        );
+    }
+
+    /// Issue #79 round 6 follow-up: srikr's `--rps 100 --vus 5` summary showed
+    /// no "Connections opened" line because the client-side connection counter
+    /// was reading `http_req_connecting.values.count` — a field that doesn't
+    /// exist (k6's Trend metric only emits avg/min/med/max/p90/p95). The fix
+    /// adds a dedicated Counter (`mockforge_connections_opened`) that the
+    /// template increments whenever `res.timings.connecting > 0`. This test
+    /// guards both the metric declaration and the per-request increment so
+    /// the connection counter can't silently regress.
+    #[test]
+    fn test_connections_opened_counter_present() {
+        use crate::spec_parser::ApiOperation;
+        use openapiv3::Operation;
+
+        let operation = ApiOperation {
+            method: "get".to_string(),
+            path: "/u".to_string(),
+            operation: Operation::default(),
+            operation_id: Some("u".to_string()),
+        };
+        let template = RequestTemplate {
+            operation,
+            path_params: HashMap::new(),
+            query_params: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        let config = K6Config {
+            target_url: "https://api.example.com".to_string(),
+            base_path: None,
+            scenario: LoadScenario::Constant,
+            duration_secs: 30,
+            max_vus: 5,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            auth_header: None,
+            custom_headers: HashMap::new(),
+            skip_tls_verify: false,
+            security_testing_enabled: false,
+            chunked_request_bodies: false,
+            target_rps: Some(50),
+            no_keep_alive: false,
+        };
+        let script = K6ScriptGenerator::new(config, vec![template]).generate().unwrap();
+        assert!(
+            script.contains("new Counter('mockforge_connections_opened')"),
+            "template must declare the mockforge_connections_opened Counter"
+        );
+        assert!(
+            script.contains("mockforge_connections_opened.add(1)"),
+            "template must increment mockforge_connections_opened on new TCP connect"
+        );
+        assert!(
+            script.contains("res.timings.connecting > 0"),
+            "template must gate the connection-opened increment on \
+             res.timings.connecting > 0 (only fires when a fresh socket was opened)"
         );
     }
 

--- a/crates/mockforge-bench/src/reporter.rs
+++ b/crates/mockforge-bench/src/reporter.rs
@@ -85,30 +85,35 @@ impl TerminalReporter {
         // when k6 actually opened sockets. Helpful even without `--cps`
         // because it lets you compare "k6 opened N connections" against
         // the server's `connections_total_opened` and detect whether
-        // your proxy is keeping the upstream pool warm. `tcp_connect_samples`
-        // is k6's `http_req_connecting.count`, which is the number of
-        // request iterations that had to wait for a new TCP socket — i.e.
-        // a fresh connection.
-        if results.tcp_connect_samples > 0 {
-            if !cps_mode {
-                // Surface the count in non-CPS mode too — Srikanth's "open
-                // connection on the client" ask.
-                println!(
-                    "  Connections opened:   {} ({} conn/s avg)",
-                    results.tcp_connect_samples.to_string().cyan(),
-                    format!(
-                        "{:.1}",
-                        results.tcp_connect_samples as f64 / duration_secs.max(1) as f64
-                    )
+        // your proxy is keeping the upstream pool warm.
+        //
+        // Round 6 follow-up: `tcp_connect_samples` is now sourced from the
+        // template's `mockforge_connections_opened` Counter (incremented when
+        // `res.timings.connecting > 0`). That gives an accurate count for
+        // both `--cps` (≈ total requests) and the pooled-reuse case (≈ vus_max)
+        // — Srikanth's "Open/Closed Connection Counter not showing for RPS"
+        // report on Issue #79.
+        if results.tcp_connect_samples > 0 && !cps_mode {
+            // Surface the count in non-CPS mode too — Srikanth's "open
+            // connection on the client" ask.
+            println!(
+                "  Connections opened:   {} ({} conn/s avg)",
+                results.tcp_connect_samples.to_string().cyan(),
+                format!("{:.1}", results.tcp_connect_samples as f64 / duration_secs.max(1) as f64)
                     .cyan(),
-                );
-            }
+            );
+        }
+        // Print TCP/TLS timing whenever the avg is non-zero. Don't gate on
+        // samples count — k6's Trend metric exposes avg/max in summary.json
+        // but not count, so the count check was always false even when k6
+        // had real samples. Issue #79 round 6 follow-up.
+        if results.tcp_connect_avg_ms > 0.0 || results.tcp_connect_max_ms > 0.0 {
             println!(
                 "  TCP connect:          avg {:.2}ms, max {:.2}ms",
                 results.tcp_connect_avg_ms, results.tcp_connect_max_ms,
             );
         }
-        if results.tls_handshake_samples > 0 {
+        if results.tls_handshake_avg_ms > 0.0 || results.tls_handshake_max_ms > 0.0 {
             println!(
                 "  TLS handshake:        avg {:.2}ms, max {:.2}ms",
                 results.tls_handshake_avg_ms, results.tls_handshake_max_ms,
@@ -120,7 +125,9 @@ impl TerminalReporter {
         // bound on streams, not sockets. Surface it as an open-connection
         // ceiling so users can sanity-check against the server's
         // `connections_open` gauge.
-        if results.vus_max > 0 && (cps_mode || results.tcp_connect_samples > 0) {
+        if results.vus_max > 0
+            && (cps_mode || results.tcp_connect_samples > 0 || results.tcp_connect_avg_ms > 0.0)
+        {
             println!(
                 "  Peak concurrent VUs:  {} (max open conns from client side)",
                 results.vus_max.to_string().cyan(),

--- a/crates/mockforge-bench/src/templates/k6_script.hbs
+++ b/crates/mockforge-bench/src/templates/k6_script.hbs
@@ -26,6 +26,14 @@ const server_injected_latency_ms = new Trend('mockforge_server_injected_latency_
 const server_injected_jitter_ms = new Trend('mockforge_server_injected_jitter_ms');
 const server_fault_total = new Counter('mockforge_server_fault_total');
 
+// Issue #79 round 6 follow-up — k6's built-in `http_req_connecting` is a Trend
+// (no `count` field in summary.json), so we can't read total connections opened
+// from it. Track explicitly with a Counter: every request whose
+// `res.timings.connecting > 0` had to establish a fresh TCP socket. With
+// connection reuse on (the default without `--cps`) this ≈ vus_max for the
+// run; with `noConnectionReuse`/`--cps` it equals total requests.
+const mockforge_connections_opened = new Counter('mockforge_connections_opened');
+
 // Test configuration
 export const options = {
   {{#if skip_tls_verify}}
@@ -57,7 +65,13 @@ export const options = {
       maxVUs: {{max_vus}},
       {{else}}
       executor: 'ramping-vus',
-      startVUs: 0,
+      // Issue #79 round 6 follow-up — Srikanth saw `--vus 5 -d 600s --cps`
+      // take until the ~6-minute mark to reach 5 VUs because startVUs was
+      // always 0 and `ramping-vus` linearly interpolates between current and
+      // target. For `--scenario constant` we now seed startVUs at the target
+      // so the test runs at full concurrency from t=0; ramp scenarios still
+      // start at 0 and let their stages drive the curve.
+      startVUs: {{start_vus}},
       stages: [
         {{#each stages}}
         { duration: '{{this.duration}}', target: {{this.target}} },
@@ -76,8 +90,14 @@ export const options = {
 // Inspect MockForge response headers and feed the chaos-signal trends/counter.
 // Called after every http.* invocation in the body so server-injected latency
 // and faults surface in summary.json next to the standard k6 metrics.
+// Also tracks new TCP/TLS connection opens via res.timings.connecting > 0
+// (Issue #79 round 6 follow-up — client-side connection count for --rps runs).
 function recordMockForgeChaosHeaders(res) {
-  if (!res || !res.headers) return;
+  if (!res) return;
+  if (res.timings && res.timings.connecting > 0) {
+    mockforge_connections_opened.add(1);
+  }
+  if (!res.headers) return;
   const lat = res.headers['X-Mockforge-Injected-Latency-Ms'] || res.headers['x-mockforge-injected-latency-ms'];
   const jit = res.headers['X-Mockforge-Injected-Jitter-Ms'] || res.headers['x-mockforge-injected-jitter-ms'];
   const fault = res.headers['X-Mockforge-Fault'] || res.headers['x-mockforge-fault'];

--- a/tests/tests/e2e/protocols/http_e2e_tests.rs
+++ b/tests/tests/e2e/protocols/http_e2e_tests.rs
@@ -59,7 +59,7 @@ async fn test_http_basic_get() {
     // Create a stub via Admin API
     let client = Client::new();
     let stub_response = client
-        .post(&format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
+        .post(format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
         .json(&json!({
             "path": "/api/users",
             "method": "GET",
@@ -79,7 +79,7 @@ async fn test_http_basic_get() {
 
     // Make GET request
     let response = client
-        .get(&format!("http://localhost:{}/api/users", http_port))
+        .get(format!("http://localhost:{}/api/users", http_port))
         .send()
         .await
         .expect("Failed to make GET request");
@@ -111,7 +111,7 @@ async fn test_http_post_with_validation() {
     // Create POST stub
     let client = Client::new();
     let stub_response = client
-        .post(&format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
+        .post(format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
         .json(&json!({
             "path": "/api/users",
             "method": "POST",
@@ -132,7 +132,7 @@ async fn test_http_post_with_validation() {
 
     // Make POST request
     let response = client
-        .post(&format!("http://localhost:{}/api/users", http_port))
+        .post(format!("http://localhost:{}/api/users", http_port))
         .json(&json!({
             "name": "Alice",
             "email": "alice@example.com"
@@ -168,7 +168,7 @@ async fn test_http_dynamic_stub_creation() {
 
     // Create stub via Admin API
     let stub_response = client
-        .post(&format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
+        .post(format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
         .json(&json!({
             "path": "/api/test",
             "method": "GET",
@@ -185,7 +185,7 @@ async fn test_http_dynamic_stub_creation() {
 
     // Verify stub works
     let test_response = client
-        .get(&format!("http://localhost:{}/api/test", http_port))
+        .get(format!("http://localhost:{}/api/test", http_port))
         .send()
         .await
         .expect("Failed to test stub");
@@ -216,7 +216,7 @@ async fn test_http_stub_update() {
 
     // Create initial stub
     let create_response = client
-        .post(&format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
+        .post(format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
         .json(&json!({
             "path": "/api/update-test",
             "method": "GET",
@@ -236,7 +236,7 @@ async fn test_http_stub_update() {
 
     // Update stub
     let update_response = client
-        .put(&format!("http://localhost:{}/__mockforge/api/mocks/{}", admin_port, stub_id))
+        .put(format!("http://localhost:{}/__mockforge/api/mocks/{}", admin_port, stub_id))
         .json(&json!({
             "path": "/api/update-test",
             "method": "GET",
@@ -253,7 +253,7 @@ async fn test_http_stub_update() {
 
     // Verify updated stub
     let test_response = client
-        .get(&format!("http://localhost:{}/api/update-test", http_port))
+        .get(format!("http://localhost:{}/api/update-test", http_port))
         .send()
         .await
         .expect("Failed to test updated stub");
@@ -284,7 +284,7 @@ async fn test_http_stub_deletion() {
 
     // Create stub
     let create_response = client
-        .post(&format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
+        .post(format!("http://localhost:{}/__mockforge/api/mocks", admin_port))
         .json(&json!({
             "path": "/api/delete-test",
             "method": "GET",
@@ -304,7 +304,7 @@ async fn test_http_stub_deletion() {
 
     // Verify stub exists
     let test_response = client
-        .get(&format!("http://localhost:{}/api/delete-test", http_port))
+        .get(format!("http://localhost:{}/api/delete-test", http_port))
         .send()
         .await
         .expect("Failed to test stub");
@@ -313,7 +313,7 @@ async fn test_http_stub_deletion() {
 
     // Delete stub
     let delete_response = client
-        .delete(&format!("http://localhost:{}/__mockforge/api/mocks/{}", admin_port, stub_id))
+        .delete(format!("http://localhost:{}/__mockforge/api/mocks/{}", admin_port, stub_id))
         .send()
         .await
         .expect("Failed to delete stub");
@@ -322,7 +322,7 @@ async fn test_http_stub_deletion() {
 
     // Verify stub is gone (should return 404)
     let test_response = client
-        .get(&format!("http://localhost:{}/api/delete-test", http_port))
+        .get(format!("http://localhost:{}/api/delete-test", http_port))
         .send()
         .await
         .expect("Failed to test deleted stub");

--- a/tests/tests/sdk_integration.rs
+++ b/tests/tests/sdk_integration.rs
@@ -35,7 +35,6 @@ async fn test_rust_sdk_integration() {
         }
     };
 
-    let http_port = server.http_port();
     // The mockforge management API (`/__mockforge/api/*`) is mounted on the
     // HTTP server, not the admin UI server (which has RBAC middleware that
     // would reject our anonymous requests). Use http_port; the older


### PR DESCRIPTION
## Summary

Three round-6 follow-ups from Srikanth's testing on Issue #79.

1. **Connections-opened counter for `--rps` runs** — k6's `http_req_connecting` Trend doesn't emit `count` in `summary.json`, so the parser always saw 0 and the line never printed without `--cps`. Now using a dedicated `mockforge_connections_opened` Counter incremented when `res.timings.connecting > 0`.
2. **`--scenario constant` now runs at full VU concurrency from t=0** — the template always set `startVUs: 0`, so a single `{duration:'600s', target:5}` stage made `ramping-vus` linearly interpolate over the whole window. Constant now seeds startVUs at max_vus.
3. **Pre-flight warning for under-provisioned `--rps`** — warns when `vus × 10 < rps` (rule of thumb: 1 VU at ~100ms sustains ~10 req/s), preempting k6's `Insufficient VUs, reached N active VUs` message.

Drive-by: cleared workspace-clippy regressions in two pre-existing test files that fall outside the precommit's scoped-clippy window and would only fail once `Cargo.lock` changes triggered a workspace-wide run.

## Test plan

- [x] `cargo test -p mockforge-bench --lib` (386 passed)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings`
- [x] End-to-end k6 run against the OpenAPI demo: confirmed `Connections opened: 5 (1.0 conn/s avg)` now appears with `--vus 5 --rps 100`
- [x] Generated script inspection: confirmed `startVUs: 5` under `--scenario constant --vus 5`
- [x] CLI confirmation: pre-flight warning fires for `--vus 5 --rps 1000`
- [x] New regression tests: `test_constant_scenario_starts_at_target_vus`, `test_connections_opened_counter_present`

Issue: https://github.com/SaaSy-Solutions/mockforge/issues/79