### PR TITLE
fix(ui/rbac): exempt /api/resilience/ from auth so cloud proxy can reach it (#468)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,8 +118,10 @@ ENV MOCKFORGE_RESPONSE_TEMPLATE_EXPAND=true
 ENV MOCKFORGE_RESPONSE_VALIDATION=1
 # Mark that we're running in Docker (for Admin UI host detection)
 ENV DOCKER_CONTAINER=true
-# Default Admin UI to be accessible from outside container
-ENV MOCKFORGE_ADMIN_HOST=0.0.0.0
+# Dual-stack admin bind (IPv4 + IPv6). On Linux with bindv6only=0 (default), a
+# `::` listener accepts both IPv4-mapped and native IPv6 — making the admin
+# port reachable on Fly 6PN where private traffic is IPv6-only (#468).
+ENV MOCKFORGE_ADMIN_HOST=::
 
 # Default command
 # Use full path to ensure binary is found regardless of PATH

--- a/crates/mockforge-cli/src/progress.rs
+++ b/crates/mockforge-cli/src/progress.rs
@@ -187,8 +187,31 @@ pub fn parse_address(addr_str: &str, context: &str) -> Result<SocketAddr, CliErr
             format!("Invalid {} address '{}': {}", context, addr_str, e),
             ExitCode::ConfigurationError,
         )
-        .with_suggestion("Ensure the address is in the correct format (e.g., '127.0.0.1:8080' or '0.0.0.0:3000')".to_string())
+        .with_suggestion("Ensure the address is in the correct format (e.g., '127.0.0.1:8080', '0.0.0.0:3000', or '[::]:8080' for IPv6)".to_string())
     })
+}
+
+/// Build a `host:port` string that handles bare IPv6 hosts correctly.
+///
+/// `SocketAddr::from_str` requires IPv6 literals to be wrapped in `[...]`,
+/// so naively `format!("{host}:{port}")` with `host = "::"` yields the
+/// ambiguous `":::9080"` and fails to parse. This helper detects unbracketed
+/// IPv6 hosts (anything containing `:` that doesn't already start with `[`)
+/// and adds the brackets. IPv4 hosts and already-bracketed IPv6 hosts pass
+/// through unchanged.
+///
+/// Examples:
+/// * `("0.0.0.0", 80)` → `"0.0.0.0:80"`
+/// * `("127.0.0.1", 80)` → `"127.0.0.1:80"`
+/// * `("::", 80)` → `"[::]:80"`
+/// * `("::1", 80)` → `"[::1]:80"`
+/// * `("[::]", 80)` → `"[::]:80"`
+pub fn format_bind_address(host: &str, port: u16) -> String {
+    if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
 }
 
 /// Helper function to require a config value with a meaningful error
@@ -690,5 +713,44 @@ mod tests {
         let result = utils::validate_output_dir(&file_path);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().exit_code, ExitCode::InvalidArguments);
+    }
+
+    // format_bind_address tests — covers the IPv6 bracketing bug that
+    // surfaced as `:::9080` parse failures during the #468 cloud rollout.
+
+    #[test]
+    fn format_bind_address_ipv4_passes_through() {
+        assert_eq!(format_bind_address("0.0.0.0", 80), "0.0.0.0:80");
+        assert_eq!(format_bind_address("127.0.0.1", 3000), "127.0.0.1:3000");
+    }
+
+    #[test]
+    fn format_bind_address_ipv6_unbracketed_gets_brackets() {
+        // Bare IPv6 literals. SocketAddr::parse needs them wrapped — this
+        // is the actual bug the helper exists to fix.
+        assert_eq!(format_bind_address("::", 9080), "[::]:9080");
+        assert_eq!(format_bind_address("::1", 9080), "[::1]:9080");
+        assert_eq!(format_bind_address("fe80::1", 9080), "[fe80::1]:9080");
+    }
+
+    #[test]
+    fn format_bind_address_ipv6_already_bracketed_passes_through() {
+        assert_eq!(format_bind_address("[::]", 9080), "[::]:9080");
+        assert_eq!(format_bind_address("[::1]", 9080), "[::1]:9080");
+    }
+
+    #[test]
+    fn format_bind_address_then_parse_round_trips() {
+        // The whole point of the helper: feed its output to parse_address
+        // and get a valid SocketAddr.
+        for (host, port) in [
+            ("0.0.0.0", 80),
+            ("127.0.0.1", 3000),
+            ("::", 9080),
+            ("::1", 9080),
+        ] {
+            let s = format_bind_address(host, port);
+            parse_address(&s, "test").unwrap_or_else(|e| panic!("failed on {s:?}: {e:?}"));
+        }
     }
 }

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -2818,20 +2818,25 @@ pub async fn handle_serve(
             }
         });
         Some(tokio::spawn(async move {
-            // Parse addresses with proper error handling
-            use crate::progress::parse_address;
-            let addr = match parse_address(&format!("{}:{}", admin_host, admin_port), "admin UI") {
-                Ok(addr) => addr,
-                Err(e) => {
-                    return Err(format!(
-                        "Failed to bind Admin UI to {}:{}: {}",
-                        admin_host, admin_port, e.message
-                    ))
-                }
-            };
+            // Parse addresses with proper error handling. `format_bind_address`
+            // wraps bare IPv6 literals (e.g. `::`) in brackets so SocketAddr
+            // parses cleanly — without it, `format!("{host}:{port}")` with
+            // host=`::` produces the ambiguous `":::9080"` and fails (this is
+            // what blocked Fly 6PN reachability for #468 Phase 3).
+            use crate::progress::{format_bind_address, parse_address};
+            let addr =
+                match parse_address(&format_bind_address(&admin_host, admin_port), "admin UI") {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        return Err(format!(
+                            "Failed to bind Admin UI to {}:{}: {}",
+                            admin_host, admin_port, e.message
+                        ))
+                    }
+                };
 
             let http_addr =
-                match parse_address(&format!("{}:{}", http_host, http_port), "HTTP server") {
+                match parse_address(&format_bind_address(&http_host, http_port), "HTTP server") {
                     Ok(addr) => Some(addr),
                     Err(e) => {
                         return Err(format!(
@@ -2841,7 +2846,7 @@ pub async fn handle_serve(
                     }
                 };
             let ws_addr =
-                match parse_address(&format!("{}:{}", ws_host, ws_port), "WebSocket server") {
+                match parse_address(&format_bind_address(&ws_host, ws_port), "WebSocket server") {
                     Ok(addr) => Some(addr),
                     Err(e) => {
                         return Err(format!(
@@ -2851,7 +2856,7 @@ pub async fn handle_serve(
                     }
                 };
             let grpc_addr =
-                match parse_address(&format!("{}:{}", grpc_host, grpc_port), "gRPC server") {
+                match parse_address(&format_bind_address(&grpc_host, grpc_port), "gRPC server") {
                     Ok(addr) => Some(addr),
                     Err(e) => {
                         return Err(format!(

--- a/crates/mockforge-core/src/config/protocol.rs
+++ b/crates/mockforge-core/src/config/protocol.rs
@@ -720,13 +720,21 @@ pub struct AdminConfig {
 
 impl Default for AdminConfig {
     fn default() -> Self {
-        // Default to 0.0.0.0 if running in Docker (detected via common Docker env vars)
-        // This makes Admin UI accessible from outside the container by default
+        // Bind dual-stack (`::`) when we detect we're in a container so the
+        // admin port is reachable on both IPv4 and IPv6. The IPv6 side is what
+        // Fly.io 6PN uses (`fdaa::/16` private network) to reach the admin
+        // endpoint from sibling apps — bare `0.0.0.0` is IPv4-only on Linux
+        // and breaks the cloud Resilience proxy (#468).
+        //
+        // On Linux the kernel's default `net.ipv6.bindv6only=0` means a `::`
+        // listener also accepts IPv4 connections via IPv4-mapped IPv6
+        // addresses (`::ffff:x.y.z.w`), so this single bind covers both.
+        // Outside the container the default stays loopback for safety.
         let default_host = if std::env::var("DOCKER_CONTAINER").is_ok()
             || std::env::var("container").is_ok()
             || Path::new("/.dockerenv").exists()
         {
-            "0.0.0.0".to_string()
+            "::".to_string()
         } else {
             "127.0.0.1".to_string()
         };

--- a/crates/mockforge-ui/src/rbac.rs
+++ b/crates/mockforge-ui/src/rbac.rs
@@ -297,6 +297,16 @@ pub async fn rbac_middleware(mut request: Request, next: Next) -> Result<Respons
     // (crates/mockforge-ui/src/registry_admin.rs) which carries its own
     // JWT-based auth layer — the rbac middleware would reject every request
     // before it reached the registry_admin handlers. Bypass it wholesale.
+    //
+    // /api/resilience/* is the chaos circuit-breaker / bulkhead dashboard
+    // (mockforge_chaos::create_resilience_router). In cloud mode the
+    // registry's reqwest proxy reaches this over Fly 6PN private network
+    // (#468 Phase 3) without an admin token — port 9080 isn't exposed via
+    // any Fly public `[[services]]` entry, so the network boundary IS the
+    // auth boundary. Locally the admin server is opt-in via --admin, same
+    // as /__mockforge/*. Both GET (read state) and POST (reset) are exempt
+    // for the same reason: anyone who can reach 9080 is already on a
+    // trust boundary controlled by the operator.
     let is_public_route = path == "/"
         || path.starts_with("/assets/")
         || path == "/__mockforge/auth/login"
@@ -308,6 +318,7 @@ pub async fn rbac_middleware(mut request: Request, next: Next) -> Result<Respons
         || path == "/sw.js"
         || path == "/api-docs"
         || path.starts_with("/api/admin/registry/")
+        || path.starts_with("/api/resilience/")
         || (method == "GET" && path.starts_with("/__mockforge/"));
 
     if is_public_route {


### PR DESCRIPTION
## Summary

#542 fixed the dual-stack admin bind so Fly 6PN can reach the admin port, but the next layer rejects the registry's reqwest proxy with **401**: rbac middleware demands an admin token, and the registry doesn't have one when calling sibling apps over private 6PN.

This PR adds `/api/resilience/` to the existing public-route exemption list, matching the same rationale as `/__mockforge/*`:

- The admin server is opt-in via \`--admin\` and isn't exposed via any Fly public \`[[services]]\` entry. In cloud mode port 9080 is reachable only on \`{app}.internal:9080\` over 6PN, and 6PN traffic is constrained to apps in the same Fly org. **The network boundary IS the auth boundary.**
- Locally, the admin port is on a separate process the operator explicitly turned on. Same trust model as \`/__mockforge/*\`.

Both GETs (read state) and POSTs (resets) are exempt for the same reason — anyone who can reach 9080 has already passed the operator's trust check.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p mockforge-ui --all-targets -- -D warnings\` clean
- [ ] Live verification post-merge: deploy hosted-mock, expect \`runtime_state: \"live\"\` (was 401 after #542, expecting 200 with empty state now)