### PR TITLE
fix(registry-tests): relax max_projects in cloud_verification e2e fixture

### DIFF
--- a/crates/mockforge-registry-server/tests/cloud_verification_e2e.rs
+++ b/crates/mockforge-registry-server/tests/cloud_verification_e2e.rs
@@ -98,6 +98,29 @@ async fn register_and_setup(base_url: &str, pool: &PgPool) -> E2e {
     assert!(status.is_success(), "create org {}: {}", status, body);
     let org_id = body["id"].as_str().expect("no org id").to_string();
 
+    // Lift the free-plan max_projects=1 cap so tests can create more than
+    // one workspace under the same org (workspace_isolation needs two).
+    // Mirrors the gate in handlers::cloud_workspaces::create_workspace,
+    // which reads `org.limits_json.max_projects` and falls back to 1.
+    // -1 means unlimited.
+    let org_uuid_for_limits = Uuid::parse_str(&org_id).expect("org id not UUID");
+    sqlx::query(
+        r#"
+        UPDATE organizations
+        SET limits_json = jsonb_set(
+            COALESCE(limits_json, '{}'::jsonb),
+            '{max_projects}',
+            '-1'::jsonb,
+            true
+        )
+        WHERE id = $1
+        "#,
+    )
+    .bind(org_uuid_for_limits)
+    .execute(pool)
+    .await
+    .expect("relax org limits failed");
+
     // Workspace
     let res = client
         .post(format!("{}/api/v1/workspaces", base_url))


### PR DESCRIPTION
## Summary

`cloud_verification_workspace_isolation` panics on `body[\"id\"].as_str().expect(...)` at `crates/mockforge-registry-server/tests/cloud_verification_e2e.rs:439`.

**Why**: the second `POST /api/v1/workspaces` returns a JSON error body (no `id` field), not a workspace. The error is the plan-limit gate added in #449 — `handlers::cloud_workspaces::create_workspace` reads `org.limits_json.max_projects` and falls back to **1** when the value is absent. The test fixture creates a fresh org with `limits_json='{}'`, so the gate caps it at one workspace. First create (in `register_and_setup`) succeeds, second create (in the test) trips the gate.

**Pre-existing on main**: latest `registry-e2e` run on main (`25963661194`, 2026-05-16 13:52 UTC) hits the same panic. Same root cause. This is the regression that's been blocking #527 and #529 from auto-merging.

## Fix

One-file change. After org creation in `register_and_setup`, run a single SQL UPDATE that sets `limits_json.max_projects = -1` (unlimited) on the test org. Mirrors the gate's read path (`org.limits_json.max_projects`) so the relationship is obvious from reading the test.

```sql
UPDATE organizations
SET limits_json = jsonb_set(COALESCE(limits_json, '{}'::jsonb), '{max_projects}', '-1'::jsonb, true)
WHERE id = $1
```

## What does NOT change

- Production gating in `create_workspace` is unchanged.
- Other e2e fixtures (`paid_flow_e2e`, `marketplace_e2e`, `signup_flow_e2e`, …) are unchanged — each has its own setup. Only `cloud_verification_e2e.rs` is touched.
- All other tests in this file already use `register_and_setup`, and they only need one workspace each — no behavior change for them.

## Test plan

- [x] `cargo check -p mockforge-registry-server --tests` clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets` clean (pre-commit hook)
- [x] Pre-commit suite green
- [ ] Registry E2E job goes green on this PR (then #527 + #529 unblock)
- [ ] Auto-merge once green