### PR TITLE
fix(ci/docker): explicit cosign login so signature push to GHCR succeeds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -141,7 +141,18 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
           IMAGE_DIGEST: ${{ steps.build-and-push.outputs.digest }}
           IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          REGISTRY: ${{ env.REGISTRY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # cosign uses its own auth chain when pushing signature manifests
+          # to the OCI registry — the `docker/login-action` step earlier
+          # only authenticates `docker` itself. Without an explicit
+          # `cosign login`, the signature push to
+          # ghcr.io/saasy-solutions/mockforge fails with
+          # `DENIED: permission_denied: write_package` even though the job
+          # has `packages: write` (cosign can't read the workflow's
+          # permission grants; it needs creds in its own keyring).
+          cosign login "$REGISTRY" --username "$GITHUB_ACTOR" --password "$GITHUB_TOKEN"
           cosign sign --yes "${IMAGE_REF}@${IMAGE_DIGEST}"
 
       # Self-hosted runner keeps its disk between jobs, so prune old


### PR DESCRIPTION
## Summary

Docker builds have been completing with the image push succeeding but the post-push cosign step failing with:

\`\`\`
Pushing signature to: ghcr.io/saasy-solutions/mockforge
Error: signing [...]@sha256:...: signing digest:
  POST https://ghcr.io/v2/saasy-solutions/mockforge/blobs/uploads/:
  DENIED: permission_denied: write_package
\`\`\`

The job permissions block already declares \`packages: write\`, and the preceding \`docker/login-action\` step authenticates docker — that's how the image push succeeds. But cosign uses its own auth resolver and doesn't inherit the docker keyring or the workflow's permission grant automatically; it needs explicit credentials.

This adds a \`cosign login ghcr.io\` step right before \`cosign sign\`, using the same \`GITHUB_ACTOR\` + \`secrets.GITHUB_TOKEN\` pair the docker login uses.

## Why now

Surfaced during #468 end-to-end verification — docker-build kept reporting red even after the image push worked, masking real failures. Not on the critical path (image deploys fine, signatures are decorative until admission control), but ends the recurring red status.

## Test plan

- [x] YAML syntactically valid
- [ ] Verify post-merge: next docker-build run on main exits 0 cleanly (signature push lands)