### PR TITLE
fix(ui): correct import path in CloudTestGeneratorView (stores/useWorkspaceStore)

### DIFF
--- a/crates/mockforge-ui/ui/src/pages/CloudTestGeneratorView.tsx
+++ b/crates/mockforge-ui/ui/src/pages/CloudTestGeneratorView.tsx
@@ -22,7 +22,7 @@ import { Badge } from '../components/ui/Badge';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { RefreshCw, Play, X, ChevronDown, ChevronRight } from 'lucide-react';
-import { useWorkspaceStore } from '../store/workspaceStore';
+import { useWorkspaceStore } from '../stores/useWorkspaceStore';
 import {
   cloudTestGeneratorApi,
   subscribeToJobStream,


### PR DESCRIPTION
## Summary

\`CloudTestGeneratorView.tsx\` imports from \`../store/workspaceStore\`, but the actual module lives at \`../stores/useWorkspaceStore\` (plural directory, different filename). Rollup's production build refuses unresolved imports:

\`\`\`
Could not resolve \"../store/workspaceStore\" from \"src/pages/CloudTestGeneratorView.tsx\"
\`\`\`

This has made docker-build red on every main push since the file landed, masking the cosign signing fix in #546. Other call sites (\`ServicesPage.tsx\`, \`OrchestrationBuilder.tsx\`) already use the correct path; this brings the new file in line.

## Test plan

- [x] \`pnpm type-check\` clean in \`crates/mockforge-ui/ui\`
- [ ] Verify post-merge: next docker-build run completes \`pnpm build\` cleanly, signature push lands (combined with #546)