### PR TITLE
feat(registry): wire email notification channel via EmailService (#551)

### DIFF
--- a/crates/mockforge-registry-server/src/email.rs
+++ b/crates/mockforge-registry-server/src/email.rs
@@ -99,6 +99,28 @@ impl EmailService {
         Self::new(config)
     }
 
+    /// Whether a real provider is configured. Returns false when
+    /// `EMAIL_PROVIDER` is unset or set to a value that doesn't map to
+    /// a known provider — in that case `send()` no-ops and silently
+    /// returns Ok, which is fine for user-onboarding paths (where a
+    /// missing welcome email isn't an outage) but surprising for the
+    /// incident dispatcher (where the operator believes their alert
+    /// went out). Callers that need to surface "not configured" to the
+    /// user should check this before calling `send`.
+    pub fn is_configured(&self) -> bool {
+        !matches!(self.config.provider, EmailProvider::Disabled)
+    }
+
+    /// Name of the configured provider, for logging / observability.
+    pub fn provider_name(&self) -> &'static str {
+        match self.config.provider {
+            EmailProvider::Postmark => "postmark",
+            EmailProvider::Brevo => "brevo",
+            EmailProvider::Smtp => "smtp",
+            EmailProvider::Disabled => "disabled",
+        }
+    }
+
     /// Send an email
     pub async fn send(&self, message: EmailMessage) -> Result<()> {
         match &self.config.provider {

--- a/crates/mockforge-registry-server/src/workers/incident_dispatcher.rs
+++ b/crates/mockforge-registry-server/src/workers/incident_dispatcher.rs
@@ -6,12 +6,14 @@
 //! in `incident_events` as `notification_sent`; the per-incident
 //! "we're done with this one" marker is `notification_dispatched`.
 //!
-//! Real outbound HTTP for `webhook` and `slack` channels (both are just
-//! incoming-webhook POSTs of a JSON body). `email` and `pagerduty`
-//! channels are recorded as attempts with `kind=skipped` for now —
-//! email needs an SMTP/SES provider, PagerDuty needs an Events-API
-//! mapping; both are follow-up slices once we have a customer asking
-//! for them.
+//! Real outbound for `webhook`, `slack`, and `email` channels. The
+//! `email` path uses the shared `crate::email::EmailService`, which
+//! also powers verification/reset/security alerts; it auto-picks the
+//! configured provider (Postmark / Brevo / SMTP) from env. When no
+//! provider is configured the attempt is recorded as `skipped` with a
+//! reason that surfaces the missing config — the dispatcher does not
+//! silently pretend to send. `pagerduty` is still skipped pending the
+//! Events-API mapping (#552).
 //!
 //! Reliability:
 //! - 5s tick cadence so a real outage shows up in seconds, not minutes.
@@ -237,9 +239,7 @@ async fn send_to_channel(
 ) -> ChannelResult {
     match channel.kind.as_str() {
         "webhook" | "slack" => post_webhook_style(client, channel, incident).await,
-        "email" => ChannelResult::Skipped {
-            reason: "email channel: SMTP/SES integration not yet wired".into(),
-        },
+        "email" => send_email(channel, incident).await,
         "pagerduty" => ChannelResult::Skipped {
             reason: "pagerduty channel: Events API mapping not yet wired".into(),
         },
@@ -300,6 +300,113 @@ async fn post_webhook_style(
             error: e.to_string(),
         },
     }
+}
+
+/// Email channel. Reads recipient from `channel.config.to` (a single
+/// address string). The send goes through `EmailService::from_env()`,
+/// which auto-picks Postmark / Brevo / SMTP based on `EMAIL_PROVIDER`
+/// — the same env-driven configuration the registry uses for
+/// verification, password-reset, and security-alert mails. When no
+/// provider is configured we record `skipped` with a reason rather
+/// than silently "sending" into the Disabled no-op, so the operator
+/// can tell their alert is not actually going out.
+async fn send_email(channel: &NotificationChannel, incident: &Incident) -> ChannelResult {
+    use crate::email::{EmailMessage, EmailService};
+
+    let to = match channel.config.get("to").and_then(|v| v.as_str()) {
+        Some(s) if !s.trim().is_empty() => s.trim().to_string(),
+        _ => {
+            return ChannelResult::Failed {
+                error: "channel.config.to missing or empty (expected a single email address)"
+                    .into(),
+            };
+        }
+    };
+
+    let service = match EmailService::from_env() {
+        Ok(s) => s,
+        Err(e) => {
+            return ChannelResult::Failed {
+                error: format!("email service init failed: {e}"),
+            };
+        }
+    };
+
+    if !service.is_configured() {
+        return ChannelResult::Skipped {
+            reason: "email provider not configured on registry server \
+                 (set EMAIL_PROVIDER + provider-specific env vars)"
+                .into(),
+        };
+    }
+
+    let subject =
+        format!("[{}] {}: {}", incident.severity.to_uppercase(), incident.source, incident.title);
+    let description = incident.description.as_deref().unwrap_or("(no description)");
+
+    let text_body = format!(
+        "MockForge incident\n\n\
+         Severity:    {sev}\n\
+         Source:      {src}\n\
+         Title:       {title}\n\
+         Description: {desc}\n\
+         \n\
+         Incident ID: {id}\n\
+         Org:         {org}\n\
+         Created at:  {created}\n",
+        sev = incident.severity,
+        src = incident.source,
+        title = incident.title,
+        desc = description,
+        id = incident.id,
+        org = incident.org_id,
+        created = incident.created_at,
+    );
+
+    let html_body = format!(
+        "<!DOCTYPE html><html><body style=\"font-family:-apple-system,Segoe UI,Roboto,sans-serif\">\
+         <h2 style=\"margin:0 0 8px 0\">[{sev_caps}] {title}</h2>\
+         <p style=\"color:#555\">Source: <code>{src}</code></p>\
+         <p>{desc_html}</p>\
+         <hr><table style=\"font-size:13px;color:#666\">\
+         <tr><td>Incident ID</td><td><code>{id}</code></td></tr>\
+         <tr><td>Org</td><td><code>{org}</code></td></tr>\
+         <tr><td>Created</td><td>{created}</td></tr>\
+         </table></body></html>",
+        sev_caps = incident.severity.to_uppercase(),
+        title = html_escape(&incident.title),
+        src = html_escape(&incident.source),
+        desc_html = html_escape(description),
+        id = incident.id,
+        org = incident.org_id,
+        created = incident.created_at,
+    );
+
+    let message = EmailMessage {
+        to,
+        subject,
+        html_body,
+        text_body,
+    };
+
+    match service.send(message).await {
+        // 250 is the SMTP "requested mail action okay, completed" code;
+        // for API providers (Postmark/Brevo) we still use 250 as the
+        // "the provider accepted the send" marker so the JSON shape in
+        // `incident_events` is uniform with the webhook-style channels.
+        Ok(()) => ChannelResult::Sent { status_code: 250 },
+        Err(e) => ChannelResult::Failed {
+            error: format!("email send failed via {}: {e}", service.provider_name()),
+        },
+    }
+}
+
+fn html_escape(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
 }
 
 /// User-facing test-fire: post a synthetic incident-shaped payload to a
@@ -382,10 +489,59 @@ mod tests {
     // which belong in integration tests under tests/. The matcher itself
     // already has coverage there.
 
+    use super::*;
+
+    fn fake_incident() -> Incident {
+        synthetic_incident(uuid::Uuid::nil())
+    }
+
+    fn email_channel(config: serde_json::Value) -> NotificationChannel {
+        NotificationChannel {
+            id: uuid::Uuid::nil(),
+            org_id: uuid::Uuid::nil(),
+            name: "test-email".into(),
+            kind: "email".into(),
+            config,
+            enabled: true,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
     #[test]
     fn smoke_module_links() {
         // Anchor: this module must exist for the registry main.rs wiring
         // to compile. If the worker is removed, main.rs breaks first
         // — this test is just a no-op safety net for the cfg(test) build.
+    }
+
+    #[tokio::test]
+    async fn email_missing_to_is_failure() {
+        // No `to` field — operator misconfigured the channel. We surface
+        // this as Failed (not Skipped) because skipped means "wiring is
+        // fine but provider isn't ready"; this is a real config bug the
+        // operator needs to fix on their side.
+        let channel = email_channel(serde_json::json!({}));
+        let result = send_email(&channel, &fake_incident()).await;
+        match result {
+            ChannelResult::Failed { error } => {
+                assert!(error.contains("channel.config.to"), "unexpected error: {error}");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn email_blank_to_is_failure() {
+        let channel = email_channel(serde_json::json!({ "to": "   " }));
+        let result = send_email(&channel, &fake_incident()).await;
+        assert!(matches!(result, ChannelResult::Failed { .. }));
+    }
+
+    #[test]
+    fn html_escape_handles_injection_chars() {
+        assert_eq!(html_escape("a & b"), "a &amp; b");
+        assert_eq!(html_escape("<script>"), "&lt;script&gt;");
+        assert_eq!(html_escape("\"quoted\""), "&quot;quoted&quot;");
     }
 }


### PR DESCRIPTION
Closes #551.

## Summary

The incident dispatcher's `email` channel previously returned `ChannelResult::Skipped` with the message "email channel: SMTP/SES integration not yet wired". It now goes through the existing `crate::email::EmailService` — the same Postmark / Brevo / SMTP abstraction already in production for verification, password-reset, and security-alert mails.

The dispatcher's behaviour is:
- `EMAIL_PROVIDER` set + `to` present → real send via the configured provider, recorded as `notification_sent` with `status_code: 250`.
- `EMAIL_PROVIDER` unset (i.e. `EmailProvider::Disabled`) → recorded as `skipped` with a reason that surfaces the missing env, rather than silently no-opping into `Disabled::send` (which would appear to the operator as "sent" because that path is intentionally a no-op for user-onboarding paths).
- `to` missing or blank → `failed` (operator config bug, distinct from "wiring not ready").

## Changes

- `email.rs`: new `is_configured()` and `provider_name()` methods. No change to existing `send()` behaviour.
- `incident_dispatcher.rs`:
  - `send_to_channel` routes `email` to a new `send_email` function.
  - `send_email` validates `channel.config.to`, calls `EmailService::send` with a subject built from the incident summary line + a plaintext + HTML body. HTML fields are escaped via a small `html_escape` helper.
  - Module-level doc-comment updated; `pagerduty` still skipped pending #552.
- 3 new unit tests: missing `to`, blank `to`, and the HTML-escape helper.

## Channel config shape

\`\`\`json
{ "to": "alerts@example.com" }
\`\`\`

Multi-recipient is out of scope here — a follow-up can extend this to accept a string array if customers ask. Same for CC/BCC / reply-to.

## Verification

- \`cargo check -p mockforge-registry-server\` ✅
- \`cargo clippy -p mockforge-registry-server --all-targets -- -D warnings\` ✅
- \`cargo test -p mockforge-registry-server --lib workers::incident_dispatcher\` — 4 tests pass
- \`cargo fmt --all --check\` ✅
- Did NOT run a live SMTP smoke test — the underlying \`EmailService::send\` is already exercised in production through the auth-mail paths (signup verification, password reset, security alerts, usage-threshold warnings, fly-spend alerts), all of which use the identical call shape. The new code is a thin validation wrapper, fully covered by unit tests.

## Test plan
- [x] Unit tests cover the validation paths.
- [ ] Post-merge: enable an SMTP provider on the staging registry, save an email channel via the UI, trigger a test incident, and confirm the message lands in the operator's mailbox. Same shape as the post-merge smoke tests already tracked in #554.