### PR TITLE
feat(registry): real-time runtime-logs SSE via Fly NATS subscription (#556)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8980b86fddaad5d28d128f4517b23fdacdcbd32c20f7149b5117e07ad65bb50f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.6",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,7 +2520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2492,7 +2529,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3996,6 +4033,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
+ "signature 2.2.0",
  "subtle",
  "zeroize",
 ]
@@ -6082,7 +6120,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -8780,6 +8818,8 @@ name = "mockforge-registry-server"
 version = "0.3.137"
 dependencies = [
  "anyhow",
+ "async-nats",
+ "async-stream",
  "async-stripe",
  "async-trait",
  "aws-config",
@@ -9558,6 +9598,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.6",
+ "signatory",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9694,6 +9749,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -10475,7 +10539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11542,7 +11606,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11817,7 +11881,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11855,7 +11919,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -13293,6 +13357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13571,6 +13644,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -15304,6 +15389,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "httparse",
+ "rand 0.8.6",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15825,6 +15931,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "ttf-parser"
@@ -17210,7 +17326,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -160,8 +160,21 @@ prometheus = { version = "0.14", features = ["process"] }
 # instead of buffering the whole body in memory.
 reqwest = { version = "0.12", features = ["json", "stream"] }
 
+# Real-time Fly runtime-log subscription (#556). Fly publishes log
+# lines on the `logs.<app>.<region>.<machine>` NATS subject; this
+# replaces the REST poll loop with a push subscription when the
+# registry server is reachable to Fly's internal NATS proxy
+# (`[fdaa::3]:4223`), and falls back to polling otherwise.
+async-nats = { version = "0.43", default-features = false, features = ["server_2_10", "ring"] }
+
 # `futures::StreamExt` adapters for the streaming download path.
 futures-util = "0.3"
+
+# `async_stream::stream!` macro — lets the runtime-logs SSE handler
+# express "phase 1: forward NATS messages, phase 2: drop into REST
+# polling fallback" as a single async block instead of an enum-based
+# state machine driven through `unfold`.
+async-stream = "0.3"
 
 # SMTP email sending (feature: `email`)
 lettre = { version = "0.11", features = ["tokio1-native-tls", "builder", "smtp-transport"], optional = true }

--- a/crates/mockforge-registry-server/src/fly_nats.rs
+++ b/crates/mockforge-registry-server/src/fly_nats.rs
@@ -1,0 +1,272 @@
+//! Real-time Fly.io runtime-log subscription over NATS (#556).
+//!
+//! Fly publishes every container log line to its internal NATS proxy on
+//! subject `logs.<app>.<region>.<machine_id>`. Subscribing gives us
+//! sub-second delivery, where REST polling in [`crate::fly_logs`] was
+//! capped at the loop's tick cadence (currently 2s) and added latency
+//! for the round-trip plus Fly's own buffering on the GET endpoint.
+//!
+//! ## Reachability constraint
+//!
+//! The NATS proxy is reachable at `[fdaa::3]:4223` only from inside a
+//! Fly app's 6PN network (or via WireGuard). The registry server is a
+//! Fly app — that's where production traffic to this code lives — so
+//! the connection succeeds. Self-hosted and local-dev installs have no
+//! route to that address and must fall back to the REST poller; that
+//! fallback is the caller's responsibility (see the SSE handler in
+//! `handlers::hosted_mocks::build_runtime_logs_stream`).
+//!
+//! ## Auth
+//!
+//! Org slug as username, read-only PAT as password. The token is the
+//! same `FLYIO_API_TOKEN` env var already used by [`crate::fly_logs`];
+//! `FLY_ORG_SLUG` is the new env var this module introduces.
+//!
+//! ## Stability caveat
+//!
+//! Fly documents the NATS proxy as "internal transport without a
+//! versioned API or stability guarantee." That's why the fallback to
+//! REST polling is wired unconditionally — if the proxy moves or
+//! changes shape, the runtime-logs UI degrades to polling rather than
+//! breaking.
+
+use async_nats::{Client, ConnectOptions, Subscriber};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use std::time::Duration;
+use tracing::{debug, info};
+
+use crate::fly_logs::LogEntry;
+
+const DEFAULT_NATS_URL: &str = "nats://[fdaa::3]:4223";
+const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 1500;
+
+/// Connection settings derived from env. `None` means we don't have
+/// enough config to even attempt a NATS connection (no org slug or no
+/// API token) — callers should fall back to polling without warning.
+#[derive(Debug, Clone)]
+pub struct FlyNatsConfig {
+    pub url: String,
+    pub org_slug: String,
+    pub token: String,
+    pub connect_timeout: Duration,
+}
+
+impl FlyNatsConfig {
+    pub fn from_env() -> Option<Self> {
+        let org_slug = std::env::var("FLY_ORG_SLUG").ok()?;
+        let token = std::env::var("FLYIO_API_TOKEN").ok()?;
+        let url = std::env::var("FLY_NATS_URL").unwrap_or_else(|_| DEFAULT_NATS_URL.to_string());
+        let connect_timeout_ms = std::env::var("FLY_NATS_CONNECT_TIMEOUT_MS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_CONNECT_TIMEOUT_MS);
+        Some(Self {
+            url,
+            org_slug,
+            token,
+            connect_timeout: Duration::from_millis(connect_timeout_ms),
+        })
+    }
+}
+
+/// A live NATS subscription to one Fly app's logs. Owns both the
+/// underlying client and the subscriber — dropping this struct closes
+/// the connection and ends the subscription. The SSE handler holds it
+/// for the lifetime of one streamed response.
+pub struct FlyLogSubscription {
+    // Field order matters for Drop: subscriber drops first, then the
+    // client tears down the connection. Rust's drop order is
+    // declaration order, so subscriber must come before client here.
+    pub subscriber: Subscriber,
+    _client: Client,
+}
+
+/// Subscribe to live runtime logs for one Fly app.
+///
+/// Returns a [`FlyLogSubscription`] whose `subscriber` yields raw
+/// messages on `logs.<app_name>.>` (all regions, all machines). Caller
+/// parses each message via [`parse_message`] and is responsible for
+/// surfacing errors / disconnections.
+///
+/// Connection is per-subscription rather than process-wide so each SSE
+/// stream gets its own short-lived connection — that keeps the failure
+/// mode local (one bad subscription doesn't poison everyone) at the
+/// cost of a few hundred milliseconds per stream start. If we ever
+/// have hundreds of concurrent log viewers, switch to a shared
+/// connection + per-subscriber subscription using a single shared
+/// `async_nats::Client`.
+pub async fn subscribe_app(
+    config: &FlyNatsConfig,
+    app_name: &str,
+) -> Result<FlyLogSubscription, async_nats::Error> {
+    debug!(app = %app_name, url = %config.url, "connecting to Fly NATS proxy");
+    let client = ConnectOptions::new()
+        .user_and_password(config.org_slug.clone(), config.token.clone())
+        .connection_timeout(config.connect_timeout)
+        // No reconnect retries — the SSE handler owns the lifecycle and
+        // will rebuild the subscription on a fresh connection if the
+        // user reopens the stream. Reconnect logic in async-nats can
+        // mask "this NATS proxy disappeared, fall back to polling."
+        .max_reconnects(Some(0))
+        .name(format!("mockforge-registry runtime-logs ({app_name})"))
+        .connect(&config.url)
+        .await?;
+    let subject = format!("logs.{app_name}.>");
+    info!(app = %app_name, subject = %subject, "subscribed to Fly NATS log subject");
+    let subscriber = client.subscribe(subject).await?;
+    Ok(FlyLogSubscription {
+        subscriber,
+        _client: client,
+    })
+}
+
+/// Parse a Fly NATS log message into the shape the runtime-logs SSE
+/// stream already uses. Returns `None` for messages we can't parse —
+/// quietly dropped rather than failed so an unexpected payload shape
+/// degrades to "we missed one line" instead of closing the stream.
+///
+/// Fly's wire format historically wraps logs in a Vector-style
+/// envelope; we accept several common shapes and pull the same fields
+/// regardless of nesting.
+pub fn parse_message(payload: &[u8]) -> Option<LogEntry> {
+    let raw: FlyLogPayload = serde_json::from_slice(payload).ok()?;
+    let timestamp = raw
+        .timestamp
+        .as_deref()
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.with_timezone(&Utc))
+        .unwrap_or_else(Utc::now);
+    let level = raw
+        .log
+        .as_ref()
+        .and_then(|l| l.level.clone())
+        .or(raw.level)
+        .unwrap_or_else(|| "info".to_string());
+    let message = raw.message?;
+    let instance = raw.fly.as_ref().and_then(|f| f.app.as_ref()).and_then(|a| a.instance.clone());
+    let region = raw.fly.and_then(|f| f.region);
+    Some(LogEntry {
+        timestamp,
+        level,
+        message,
+        instance,
+        region,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct FlyLogPayload {
+    #[serde(default)]
+    timestamp: Option<String>,
+    #[serde(default)]
+    level: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    log: Option<FlyLogInner>,
+    #[serde(default)]
+    fly: Option<FlyEnvelope>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FlyLogInner {
+    #[serde(default)]
+    level: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FlyEnvelope {
+    #[serde(default)]
+    region: Option<String>,
+    #[serde(default)]
+    app: Option<FlyApp>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FlyApp {
+    #[serde(default)]
+    instance: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_requires_org_and_token() {
+        std::env::remove_var("FLY_ORG_SLUG");
+        std::env::remove_var("FLYIO_API_TOKEN");
+        assert!(FlyNatsConfig::from_env().is_none());
+
+        std::env::set_var("FLY_ORG_SLUG", "test-org");
+        assert!(FlyNatsConfig::from_env().is_none(), "org without token should be None");
+
+        std::env::set_var("FLYIO_API_TOKEN", "test-token-value");
+        let cfg = FlyNatsConfig::from_env().expect("both set");
+        assert_eq!(cfg.org_slug, "test-org");
+        assert_eq!(cfg.token, "test-token-value");
+        assert_eq!(cfg.url, DEFAULT_NATS_URL);
+
+        std::env::set_var("FLY_NATS_URL", "nats://localhost:4222");
+        let cfg = FlyNatsConfig::from_env().unwrap();
+        assert_eq!(cfg.url, "nats://localhost:4222");
+
+        std::env::remove_var("FLY_NATS_URL");
+        std::env::remove_var("FLY_ORG_SLUG");
+        std::env::remove_var("FLYIO_API_TOKEN");
+    }
+
+    #[test]
+    fn parses_vector_envelope_form() {
+        // Shape Vector/Fly typically emits — nested `log` and `fly`
+        // objects with the metadata we care about.
+        let raw = br#"{
+            "timestamp": "2026-05-18T10:00:00Z",
+            "log": { "level": "warn" },
+            "message": "GET /api/users 500",
+            "fly": {
+                "region": "lhr",
+                "app": { "instance": "machineabc123", "name": "my-app" }
+            }
+        }"#;
+        let entry = parse_message(raw).expect("parses");
+        assert_eq!(entry.message, "GET /api/users 500");
+        assert_eq!(entry.level, "warn");
+        assert_eq!(entry.region.as_deref(), Some("lhr"));
+        assert_eq!(entry.instance.as_deref(), Some("machineabc123"));
+    }
+
+    #[test]
+    fn parses_flat_form() {
+        // Some Fly publishers (Machines API direct) emit a flatter
+        // shape with top-level `level` instead of nested `log.level`.
+        let raw = br#"{
+            "timestamp": "2026-05-18T10:00:00Z",
+            "level": "error",
+            "message": "boom"
+        }"#;
+        let entry = parse_message(raw).expect("parses");
+        assert_eq!(entry.level, "error");
+        assert_eq!(entry.message, "boom");
+        assert!(entry.region.is_none());
+    }
+
+    #[test]
+    fn drops_message_without_text() {
+        let raw = br#"{ "timestamp": "2026-05-18T10:00:00Z", "level": "info" }"#;
+        assert!(parse_message(raw).is_none());
+    }
+
+    #[test]
+    fn drops_unparsable_payload() {
+        assert!(parse_message(b"not json").is_none());
+    }
+
+    #[test]
+    fn defaults_missing_level_to_info() {
+        let raw = br#"{ "message": "hi", "timestamp": "2026-05-18T10:00:00Z" }"#;
+        let entry = parse_message(raw).unwrap();
+        assert_eq!(entry.level, "info");
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -1176,71 +1176,122 @@ pub async fn stream_runtime_logs(
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
 
-/// Build the SSE event stream for runtime logs. Each tick polls Fly with a
-/// `since` cursor that advances past the latest entry observed so we don't
-/// duplicate events on refetch.
+/// Build the SSE event stream for runtime logs.
+///
+/// Tries the real-time NATS subscription first (#556 / `fly_nats`).
+/// If `FLY_ORG_SLUG` + `FLYIO_API_TOKEN` are both set AND the NATS
+/// connection succeeds within `FLY_NATS_CONNECT_TIMEOUT_MS` (default
+/// 1.5s), each incoming log message is forwarded as an SSE event the
+/// moment it arrives — sub-second delivery instead of the 2s poll
+/// floor.
+///
+/// Falls back to the historical REST poll loop when:
+/// - `FLY_ORG_SLUG` is unset (local-dev / self-hosted), or
+/// - the connect call fails (no route to `[fdaa::3]:4223` outside Fly,
+///   bad credentials, NATS proxy unavailable), or
+/// - any subsequent NATS error closes the subscription mid-stream.
+///
+/// The fallback preserves the user-visible "Fly runtime logs are not
+/// configured" hint when no `FLYIO_API_TOKEN` is set at all — both
+/// paths agree on that surface.
 fn build_runtime_logs_stream(app_name: String) -> impl Stream<Item = Result<Event, Infallible>> {
-    use futures_util::stream::unfold;
+    use async_stream::stream;
+    use futures_util::StreamExt;
 
-    /// Per-stream poll state: cursor + tick count for an initial empty-poll
-    /// quietness. We start the cursor a few seconds in the past so the first
-    /// poll picks up "what's happening now" without dumping the whole window.
-    struct State {
-        cursor: DateTime<Utc>,
-        client: Option<&'static crate::fly_logs::FlyLogsClient>,
-        app_name: String,
-        emitted_unconfigured: bool,
-    }
-
-    let state = State {
-        cursor: Utc::now() - chrono::Duration::seconds(30),
-        client: crate::fly_logs::global(),
-        app_name,
-        emitted_unconfigured: false,
-    };
-
-    unfold(state, |mut st| async move {
-        // Slow poll loop. 2 seconds keeps the UI responsive without hammering
-        // Fly's API; tighten once we move to the NATS subscription path
-        // (#232).
-        if st.client.is_none() && !st.emitted_unconfigured {
-            st.emitted_unconfigured = true;
-            let event = Event::default()
-                .event("config")
-                .data("Fly runtime logs are not configured (FLYIO_API_TOKEN unset)");
-            return Some((Ok(event), st));
-        }
-
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-        let Some(client) = st.client else {
-            // Configured-flag already emitted; keep stream alive with a
-            // periodic comment so the connection doesn't close.
-            let event = Event::default().comment("idle");
-            return Some((Ok(event), st));
+    stream! {
+        // Phase 1: try NATS subscription. Silent failure here is fine —
+        // most installs (local-dev, self-hosted off Fly) can't reach the
+        // proxy and shouldn't see a banner about it.
+        let nats_sub = match crate::fly_nats::FlyNatsConfig::from_env() {
+            Some(cfg) => {
+                match crate::fly_nats::subscribe_app(&cfg, &app_name).await {
+                    Ok(sub) => {
+                        tracing::debug!(
+                            app = %app_name,
+                            "runtime-logs SSE using NATS subscription",
+                        );
+                        Some(sub)
+                    }
+                    Err(err) => {
+                        // Likely "no route to host" off Fly. Drop to
+                        // polling without telling the operator — the
+                        // poll loop is the documented user-facing path
+                        // and we don't want to surface internal-network
+                        // noise.
+                        tracing::debug!(
+                            app = %app_name,
+                            error = %err,
+                            "Fly NATS subscribe failed; falling back to polling",
+                        );
+                        None
+                    }
+                }
+            }
+            None => None,
         };
 
-        match client.fetch_recent(&st.app_name, Some(st.cursor), None).await {
-            Ok(entries) if entries.is_empty() => {
-                let event = Event::default().comment("no-new-logs");
-                Some((Ok(event), st))
+        if let Some(mut sub) = nats_sub {
+            // NATS path: forward each incoming message as it arrives.
+            while let Some(msg) = sub.subscriber.next().await {
+                let Some(entry) = crate::fly_nats::parse_message(&msg.payload) else {
+                    continue;
+                };
+                // Wrap as a single-element list so the SSE payload shape
+                // matches the polling path (always a JSON array). That
+                // way the UI doesn't need to branch on transport.
+                let payload =
+                    serde_json::to_string(&vec![entry]).unwrap_or_else(|_| "[]".to_string());
+                yield Ok(Event::default().event("logs").data(payload));
             }
-            Ok(entries) => {
-                // Advance cursor to the newest entry we just emitted.
-                if let Some(latest) = entries.iter().map(|e| e.timestamp).max() {
-                    st.cursor = latest;
+            // Subscription closed (connection lost or NATS proxy went
+            // away). Surface as an SSE error event then drop into the
+            // poll fallback so the user still gets logs.
+            yield Ok(Event::default().event("info").data(
+                r#"{"message":"Real-time NATS subscription ended, switching to polling"}"#,
+            ));
+        }
+
+        // Phase 2: polling fallback. Either we never had NATS or the
+        // subscription ended.
+        let client = crate::fly_logs::global();
+        let mut cursor: DateTime<Utc> = Utc::now() - chrono::Duration::seconds(30);
+        let mut emitted_unconfigured = false;
+
+        loop {
+            if client.is_none() && !emitted_unconfigured {
+                emitted_unconfigured = true;
+                yield Ok(Event::default()
+                    .event("config")
+                    .data("Fly runtime logs are not configured (FLYIO_API_TOKEN unset)"));
+                continue;
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+            let Some(c) = client else {
+                yield Ok(Event::default().comment("idle"));
+                continue;
+            };
+
+            match c.fetch_recent(&app_name, Some(cursor), None).await {
+                Ok(entries) if entries.is_empty() => {
+                    yield Ok(Event::default().comment("no-new-logs"));
                 }
-                let payload = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
-                let event = Event::default().event("logs").data(payload);
-                Some((Ok(event), st))
-            }
-            Err(err) => {
-                let payload = serde_json::json!({ "error": err.to_string() }).to_string();
-                let event = Event::default().event("error").data(payload);
-                Some((Ok(event), st))
+                Ok(entries) => {
+                    if let Some(latest) = entries.iter().map(|e| e.timestamp).max() {
+                        cursor = latest;
+                    }
+                    let payload =
+                        serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
+                    yield Ok(Event::default().event("logs").data(payload));
+                }
+                Err(err) => {
+                    let payload = serde_json::json!({ "error": err.to_string() }).to_string();
+                    yield Ok(Event::default().event("error").data(payload));
+                }
             }
         }
-    })
+    }
 }
 
 /// One captured request/response event. Mirrors `RequestLogEvent` in

--- a/crates/mockforge-registry-server/src/lib.rs
+++ b/crates/mockforge-registry-server/src/lib.rs
@@ -27,6 +27,7 @@ pub mod email;
 pub mod error;
 pub mod fly_logs;
 pub mod fly_metrics;
+pub mod fly_nats;
 pub mod handlers;
 pub mod metrics;
 pub mod middleware;


### PR DESCRIPTION
Closes #556.

## Summary

The runtime-logs SSE stream (`GET /api/v1/hosted-mocks/{id}/runtime-logs/stream`) previously polled Fly's REST logs API every 2 seconds. It now opens a NATS subscription to `logs.<app>.>` on Fly's internal proxy (`[fdaa::3]:4223`) and forwards each message as it arrives — **sub-second delivery** instead of the 2s poll floor.

REST polling stays as a fallback for all the cases where NATS isn't reachable (every off-Fly install, plus any future Fly proxy outage).

## Architecture

- **`fly_nats` module**: env-driven `FlyNatsConfig::from_env` (org slug + existing `FLYIO_API_TOKEN`); `subscribe_app` returns a `FlyLogSubscription` that owns both the NATS client and the subscriber. Drop order matters — subscriber first, then client — so the struct's field order is load-bearing.
- **`async-nats 0.43`** dep, scoped to `mockforge-registry-server` only (not workspace, to avoid dragging the lib into every crate's compile time). Crypto backend pinned to `ring` to match the rest of the workspace's rustls choice (default `aws-lc-rs` would have pulled in a second crypto stack).
- **`build_runtime_logs_stream`** (the SSE handler in `handlers::hosted_mocks`) rewritten with the `async-stream` macro: phase 1 forwards NATS messages, phase 2 is the original REST poll loop. Each stream tries NATS first; if config is missing or the connect fails it drops silently to polling. A mid-stream NATS termination surfaces an `info` SSE event then continues via polling.

## Why fallback is unconditional

Fly explicitly documents the NATS proxy as **"internal transport without a versioned API or stability guarantee."** If the proxy moves or changes shape, runtime-logs UX degrades to polling rather than breaking. Same fallback also covers every self-hosted / local-dev install — none of those can reach the IPv6 `fdaa::` address.

## What's NOT in this PR

- **Live verification against Fly's NATS proxy.** The connection only works from inside a Fly app or via WireGuard; this dev box has neither. Post-merge, the registry's Fly deploy will pick up the new path; the SSE handler logs `runtime-logs SSE using NATS subscription` when the connect succeeds — that's the operator-visible signal this code is in effect.
- **Container-side log shipping (#232 Phase 6).** That's the durable long-term answer (no Fly internal-API risk, structured fields end-to-end) but it's a multi-day change. This PR is the tactical real-time win that matches the deferral note the maintainer left at `fly_logs.rs:44`.

## Verification

- `cargo check -p mockforge-registry-server` ✅
- `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` ✅
- `cargo test -p mockforge-registry-server --lib fly_nats` — 6 tests pass (env config, two payload shapes, dropped malformed inputs, default level)
- `cargo fmt --all --check` ✅
- NATS connection itself not unit-tested (no in-process broker stub available)

## Test plan
- [x] Unit tests cover env parsing + message parsing.
- [ ] Post-merge: deploy registry to Fly, set `FLY_ORG_SLUG=<our org>`, open a runtime-logs SSE stream on a hosted mock, confirm `logs` events arrive at the moment a request hits the mock (compare to current 0–2s poll cadence).