### PR TITLE
feat(recorder): per-capture cloud forwarder with backpressure + retry (#553)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8721,6 +8721,7 @@ dependencies = [
  "mockforge-foundation",
  "mockforge-intelligence",
  "once_cell",
+ "prometheus",
  "regex",
  "reqwest 0.12.28",
  "serde",

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -1964,12 +1964,16 @@ pub async fn handle_serve(
 
             match mockforge_recorder::RecorderDatabase::new(&recorder_config.database_path).await {
                 Ok(db) => {
-                    // Attach the cloud-sync handle when running on a hosted
-                    // mock (#234 part 2). On local / self-hosted runs the
-                    // env vars are absent and the handle is a no-op.
+                    // Attach the cloud captures forwarder when running
+                    // on a hosted mock (#553, supersedes #234 part 2).
+                    // The forwarder POSTs each capture to the registry
+                    // ingest endpoint as it lands, treating cloud
+                    // Postgres as the durable source-of-truth. On
+                    // local / self-hosted runs the env vars are absent
+                    // and the handle is a no-op.
                     let cloud_sync = mockforge_recorder::cloud_sync::from_env();
                     if cloud_sync.is_active() {
-                        println!("✅ Recorder cloud-sync enabled — captures will mirror to MockForge Cloud");
+                        println!("✅ Recorder capture forwarder enabled — captures will forward to MockForge Cloud");
                     }
                     let recorder =
                         Arc::new(mockforge_recorder::Recorder::new(db).with_cloud_sync(cloud_sync));

--- a/crates/mockforge-recorder/Cargo.toml
+++ b/crates/mockforge-recorder/Cargo.toml
@@ -51,8 +51,11 @@ har = "0.8"
 similar = { version = "2.3", features = ["inline"] }
 serde_path_to_error = "0.1"
 
-# HTTP client for LLM calls
+# HTTP client for LLM calls + capture forwarder
 reqwest = { workspace = true }
+
+# Prometheus counters for the capture forwarder (#553)
+prometheus = "0.14"
 
 # Core types for OpenAPI generation
 mockforge-core = { version = "0.3.70", path = "../mockforge-core" }

--- a/crates/mockforge-recorder/src/cloud_sync.rs
+++ b/crates/mockforge-recorder/src/cloud_sync.rs
@@ -1,41 +1,102 @@
-//! Capture cloud-sync shipper for hosted-mock deployments (#234 part 2).
+//! Capture forwarder for hosted-mock deployments (#553, supersedes #234 part 2).
 //!
-//! The recorder writes captures to local SQLite, which is wiped when the
-//! Fly machine restarts. This module ships each completed exchange to
-//! MockForge Cloud's capture-ingest endpoint so the captures survive
-//! container restart.
+//! On hosted-mock machines the local SQLite recorder DB is ephemeral —
+//! every machine cycle / reschedule wipes whatever hadn't yet been
+//! mirrored to cloud Postgres. #553 migrates us from the batched mirror
+//! pattern to a **synchronous-per-capture forwarder**: the recorder
+//! POSTs each completed exchange to the registry's existing
+//! `runtime_captures` ingest endpoint as soon as it's recorded.
 //!
-//! Architecturally identical to `mockforge-observability::log_shipper`:
-//! a cloneable handle with a non-blocking `enqueue` is held by the
-//! recorder; a background task drains the channel, batches, and POSTs.
-//! When env vars aren't set, the handle is a no-op — local recorder
-//! usage outside hosted mocks is unaffected.
+//! The cloud Postgres `runtime_captures` table is now treated as the
+//! durable source-of-truth (per #240 + #242); the local SQLite is just
+//! a debugging buffer.
+//!
+//! ## Design
+//!
+//! - A cloneable [`CaptureCloudSyncHandle`] (kept name for back-compat
+//!   with the call sites in `recorder.rs` and `serve.rs`) is held by the
+//!   recorder. `enqueue` is non-blocking and never blocks request
+//!   serving.
+//! - Behind the handle is a **bounded** [`mpsc::Sender`]. If the
+//!   channel fills (registry slow / down) we drop the newest capture,
+//!   emit a `tracing::warn!`, and bump
+//!   `mockforge_capture_forwarder_drops_total{reason="buffer_full"}`.
+//!   Dropping captures is strictly preferable to applying back-pressure
+//!   onto user requests.
+//! - A background task drains the channel and POSTs each capture
+//!   individually (wrapped in a 1-element batch so we stay on the
+//!   existing `/captures/ingest` wire format). On 5xx or transport
+//!   error it retries up to 3 times with exponential backoff
+//!   (100ms / 400ms / 1600ms). After exhaustion it bumps
+//!   `mockforge_capture_forwarder_drops_total{reason="exhausted"}`
+//!   and moves on. 4xx is treated as a permanent error and dropped
+//!   immediately (no retry).
 //!
 //! ## Configuration
 //!
-//! - `MOCKFORGE_CAPTURE_INGEST_URL` — full URL of the ingest endpoint.
-//! - `MOCKFORGE_CAPTURE_INGEST_TOKEN` — short-lived deployment-scoped JWT.
-//! - `MOCKFORGE_CAPTURE_INGEST_BATCH_SIZE` — events per POST (default 25).
-//!   Smaller than log-ingest because capture rows are larger (full bodies).
-//! - `MOCKFORGE_CAPTURE_INGEST_FLUSH_MS` — max batch age (default 2000).
-//! - `MOCKFORGE_CAPTURE_INGEST_BUFFER` — channel capacity (default 256).
+//! - `MOCKFORGE_CLOUD_CAPTURES_FORWARDER_URL` *(preferred, #553)* or
+//!   `MOCKFORGE_CAPTURE_INGEST_URL` *(deprecated alias, #234 part 2)*
+//!   — full URL of the ingest endpoint.
+//! - `MOCKFORGE_CAPTURE_INGEST_TOKEN` — short-lived
+//!   deployment-scoped JWT. Sent as `Authorization: Bearer <token>`.
+//! - `MOCKFORGE_CAPTURE_FORWARDER_BUFFER` — channel capacity
+//!   (default 1024). Wider than the old batched shipper's 256 because
+//!   we now POST one capture per request and want headroom for a
+//!   transient registry stall.
+//! - `MOCKFORGE_CAPTURE_FORWARDER_TIMEOUT_MS` — per-request HTTP
+//!   timeout (default 5000).
 
 use crate::models::RecordedExchange;
+use once_cell::sync::Lazy;
+use prometheus::{IntCounterVec, Opts};
 use serde::Serialize;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 use tracing::{debug, warn};
+
+/// `mockforge_capture_forwarder_sent_total` — captures successfully
+/// accepted by the registry (HTTP 2xx).
+static SENT_TOTAL: Lazy<prometheus::IntCounter> = Lazy::new(|| {
+    let c = prometheus::IntCounter::new(
+        "mockforge_capture_forwarder_sent_total",
+        "Captures successfully forwarded to the cloud captures ingest endpoint",
+    )
+    .expect("Failed to create capture_forwarder_sent_total counter");
+    // Best-effort register; double-register on test re-init is harmless.
+    let _ = prometheus::default_registry().register(Box::new(c.clone()));
+    c
+});
+
+/// `mockforge_capture_forwarder_drops_total{reason}` — captures
+/// dropped before reaching the registry. Reasons:
+///
+/// * `buffer_full` — bounded mpsc was at capacity at enqueue time.
+/// * `exhausted` — all 3 retries failed (5xx / transport error).
+/// * `permanent` — registry returned 4xx (token expired, malformed
+///   payload, etc.) and we won't retry.
+static DROPS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    let c = IntCounterVec::new(
+        Opts::new(
+            "mockforge_capture_forwarder_drops_total",
+            "Captures dropped by the cloud forwarder, by reason",
+        ),
+        &["reason"],
+    )
+    .expect("Failed to create capture_forwarder_drops_total counter");
+    let _ = prometheus::default_registry().register(Box::new(c.clone()));
+    c
+});
 
 #[derive(Debug, Serialize)]
 struct IngestPayload<'a> {
-    exchanges: &'a [RecordedExchange],
+    exchanges: &'a [&'a RecordedExchange],
 }
 
-/// Cheap cloneable handle to the cloud-sync shipper. `enqueue` is
-/// non-blocking and never fails — safe to call from the recorder's
-/// hot path. When the shipper isn't configured the handle is `None`
-/// and calls are zero-cost.
+/// Cheap cloneable handle to the capture forwarder. `enqueue` is
+/// non-blocking. When the forwarder isn't configured the handle is
+/// `None` and calls are zero-cost.
 #[derive(Clone)]
 pub struct CaptureCloudSyncHandle {
     inner: Option<Arc<Inner>>,
@@ -52,54 +113,76 @@ impl Default for CaptureCloudSyncHandle {
 }
 
 impl CaptureCloudSyncHandle {
-    /// No-op handle. Used when the shipper isn't configured.
+    /// No-op handle. Used when the forwarder isn't configured.
     pub fn disabled() -> Self {
         Self { inner: None }
     }
 
-    /// Non-blocking enqueue. Drops silently when the buffer is full
-    /// (under sustained back-pressure we'd rather drop the newest than
-    /// stall the recorder; the local SQLite is the canonical store).
+    /// Non-blocking enqueue. If the bounded channel is full we log a
+    /// warning and bump the `buffer_full` drop counter — we never
+    /// block the recorder hot path waiting for the registry.
     pub fn enqueue(&self, exchange: RecordedExchange) {
-        if let Some(inner) = &self.inner {
-            let _ = inner.sender.try_send(exchange);
+        let Some(inner) = &self.inner else { return };
+        match inner.sender.try_send(exchange) {
+            Ok(()) => {}
+            Err(TrySendError::Full(dropped)) => {
+                DROPS_TOTAL.with_label_values(&["buffer_full"]).inc();
+                warn!(
+                    capture_id = %dropped.request.id,
+                    "Capture forwarder buffer full; dropping capture (registry slow or unreachable)"
+                );
+            }
+            Err(TrySendError::Closed(_)) => {
+                // Background task is gone — registry is permanently
+                // unreachable for this process. Bump and stay quiet
+                // so we don't flood logs.
+                DROPS_TOTAL.with_label_values(&["closed"]).inc();
+            }
         }
     }
 
-    /// True when the shipper is actually running.
+    /// True when the forwarder is actually running.
     pub fn is_active(&self) -> bool {
         self.inner.is_some()
     }
 }
 
-/// Construct from environment variables. Returns a disabled handle when
-/// required vars are missing (the common case in dev / self-hosted).
+/// Construct from environment variables. Returns a disabled handle
+/// when required vars are missing (the common case in dev /
+/// self-hosted). Accepts both the new `MOCKFORGE_CLOUD_CAPTURES_FORWARDER_URL`
+/// env var (preferred) and the legacy `MOCKFORGE_CAPTURE_INGEST_URL`
+/// alias for back-compat with #234-era deployments.
 pub fn from_env() -> CaptureCloudSyncHandle {
-    let url = match std::env::var("MOCKFORGE_CAPTURE_INGEST_URL") {
-        Ok(u) if !u.trim().is_empty() => u,
-        _ => return CaptureCloudSyncHandle::disabled(),
+    let url = std::env::var("MOCKFORGE_CLOUD_CAPTURES_FORWARDER_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            std::env::var("MOCKFORGE_CAPTURE_INGEST_URL")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+        });
+    let url = match url {
+        Some(u) => u,
+        None => return CaptureCloudSyncHandle::disabled(),
     };
     let token = match std::env::var("MOCKFORGE_CAPTURE_INGEST_TOKEN") {
         Ok(t) if !t.trim().is_empty() => t,
         _ => return CaptureCloudSyncHandle::disabled(),
     };
-    let batch_size: usize = std::env::var("MOCKFORGE_CAPTURE_INGEST_BATCH_SIZE")
+    let buffer: usize = std::env::var("MOCKFORGE_CAPTURE_FORWARDER_BUFFER")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(25);
-    let flush_ms: u64 = std::env::var("MOCKFORGE_CAPTURE_INGEST_FLUSH_MS")
+        .unwrap_or(1024);
+    let timeout_ms: u64 = std::env::var("MOCKFORGE_CAPTURE_FORWARDER_TIMEOUT_MS")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(2000);
-    let buffer: usize = std::env::var("MOCKFORGE_CAPTURE_INGEST_BUFFER")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(256);
+        .unwrap_or(5000);
 
-    let client = match reqwest::Client::builder().timeout(Duration::from_secs(10)).build() {
+    let client = match reqwest::Client::builder().timeout(Duration::from_millis(timeout_ms)).build()
+    {
         Ok(c) => c,
         Err(e) => {
-            warn!("CaptureCloudSync HTTP client init failed: {}", e);
+            warn!("Capture forwarder HTTP client init failed: {}", e);
             return CaptureCloudSyncHandle::disabled();
         }
     };
@@ -107,82 +190,90 @@ pub fn from_env() -> CaptureCloudSyncHandle {
     let (sender, receiver) = mpsc::channel::<RecordedExchange>(buffer);
     let inner = Arc::new(Inner { sender });
 
-    tokio::spawn(run(receiver, client, url, token, batch_size, flush_ms));
+    tokio::spawn(run(receiver, client, url, token));
 
     CaptureCloudSyncHandle { inner: Some(inner) }
 }
 
+/// Background drain loop. One POST per capture; bounded retries.
 async fn run(
     mut receiver: mpsc::Receiver<RecordedExchange>,
     client: reqwest::Client,
     url: String,
     token: String,
-    batch_size: usize,
-    flush_ms: u64,
 ) {
-    let flush_after = Duration::from_millis(flush_ms);
-    let mut batch: Vec<RecordedExchange> = Vec::with_capacity(batch_size);
-    let mut deadline = tokio::time::Instant::now() + flush_after;
-
-    loop {
-        let timeout = tokio::time::sleep_until(deadline);
-        tokio::pin!(timeout);
-
-        tokio::select! {
-            biased;
-            evt = receiver.recv() => {
-                match evt {
-                    Some(e) => {
-                        batch.push(e);
-                        if batch.len() >= batch_size {
-                            send_batch(&client, &url, &token, &batch).await;
-                            batch.clear();
-                            deadline = tokio::time::Instant::now() + flush_after;
-                        }
-                    }
-                    None => {
-                        if !batch.is_empty() {
-                            send_batch(&client, &url, &token, &batch).await;
-                        }
-                        return;
-                    }
-                }
-            }
-            _ = &mut timeout => {
-                if !batch.is_empty() {
-                    send_batch(&client, &url, &token, &batch).await;
-                    batch.clear();
-                }
-                deadline = tokio::time::Instant::now() + flush_after;
-            }
-        }
+    while let Some(exchange) = receiver.recv().await {
+        forward_one(&client, &url, &token, &exchange).await;
     }
+    debug!("Capture forwarder drain loop exited");
 }
 
-async fn send_batch(
+/// Send a single capture with up to 3 retries. Backoff: 100ms, 400ms,
+/// 1600ms. 4xx is treated as permanent. Counter increments live here
+/// so the hot path stays free of metric work.
+async fn forward_one(
     client: &reqwest::Client,
     url: &str,
     token: &str,
-    exchanges: &[RecordedExchange],
+    exchange: &RecordedExchange,
 ) {
-    let payload = IngestPayload { exchanges };
-    debug!(count = exchanges.len(), "Shipping capture batch");
-    match client.post(url).bearer_auth(token).json(&payload).send().await {
-        Ok(resp) if resp.status().is_success() => {}
-        Ok(resp) => {
-            warn!(
-                status = %resp.status(),
-                count = exchanges.len(),
-                "Capture ingest non-success; dropping batch"
-            );
+    const MAX_ATTEMPTS: u32 = 3;
+    const BASE_BACKOFF_MS: u64 = 100;
+
+    let payload = IngestPayload {
+        exchanges: &[exchange],
+    };
+
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        let result = client.post(url).bearer_auth(token).json(&payload).send().await;
+        match result {
+            Ok(resp) if resp.status().is_success() => {
+                SENT_TOTAL.inc();
+                return;
+            }
+            Ok(resp) if resp.status().is_client_error() => {
+                warn!(
+                    status = %resp.status(),
+                    capture_id = %exchange.request.id,
+                    "Capture forwarder got 4xx; dropping (will not retry)"
+                );
+                DROPS_TOTAL.with_label_values(&["permanent"]).inc();
+                return;
+            }
+            Ok(resp) => {
+                debug!(
+                    status = %resp.status(),
+                    attempt,
+                    capture_id = %exchange.request.id,
+                    "Capture forwarder got retriable status"
+                );
+            }
+            Err(e) => {
+                debug!(
+                    error = %e,
+                    attempt,
+                    capture_id = %exchange.request.id,
+                    "Capture forwarder transport error"
+                );
+            }
         }
-        Err(e) => {
+
+        if attempt >= MAX_ATTEMPTS {
             warn!(
-                error = %e,
-                count = exchanges.len(),
-                "Capture ingest send failed; dropping batch"
+                capture_id = %exchange.request.id,
+                attempts = attempt,
+                "Capture forwarder exhausted retries; dropping capture"
             );
+            DROPS_TOTAL.with_label_values(&["exhausted"]).inc();
+            return;
         }
+
+        // Exponential backoff: 100ms, 400ms, (1600ms — never reached
+        // because MAX_ATTEMPTS=3 returns before the 4th sleep).
+        let backoff = BASE_BACKOFF_MS * 4u64.pow(attempt - 1);
+        tokio::time::sleep(Duration::from_millis(backoff)).await;
     }
 }
 
@@ -224,8 +315,108 @@ mod tests {
 
     #[test]
     fn from_env_disabled_without_url_or_token() {
+        // Snapshot + clear all three relevant vars so the test stays
+        // hermetic regardless of host env.
+        let url_old = std::env::var("MOCKFORGE_CAPTURE_INGEST_URL").ok();
+        let url_new = std::env::var("MOCKFORGE_CLOUD_CAPTURES_FORWARDER_URL").ok();
+        let token = std::env::var("MOCKFORGE_CAPTURE_INGEST_TOKEN").ok();
         std::env::remove_var("MOCKFORGE_CAPTURE_INGEST_URL");
+        std::env::remove_var("MOCKFORGE_CLOUD_CAPTURES_FORWARDER_URL");
         std::env::remove_var("MOCKFORGE_CAPTURE_INGEST_TOKEN");
+
         assert!(!from_env().is_active());
+
+        if let Some(v) = url_old {
+            std::env::set_var("MOCKFORGE_CAPTURE_INGEST_URL", v);
+        }
+        if let Some(v) = url_new {
+            std::env::set_var("MOCKFORGE_CLOUD_CAPTURES_FORWARDER_URL", v);
+        }
+        if let Some(v) = token {
+            std::env::set_var("MOCKFORGE_CAPTURE_INGEST_TOKEN", v);
+        }
+    }
+
+    /// Bounded-channel drop behavior: enqueueing past capacity should
+    /// not panic, should not block, and should bump the drop counter.
+    /// We construct an Inner directly with a tiny buffer and a
+    /// non-draining receiver so the second send fills the queue.
+    #[tokio::test]
+    async fn enqueue_drops_when_buffer_full() {
+        let (sender, _receiver) = mpsc::channel::<RecordedExchange>(1);
+        let handle = CaptureCloudSyncHandle {
+            inner: Some(Arc::new(Inner { sender })),
+        };
+
+        let before = DROPS_TOTAL.with_label_values(&["buffer_full"]).get();
+        handle.enqueue(dummy_exchange()); // fits
+        handle.enqueue(dummy_exchange()); // dropped
+        let after = DROPS_TOTAL.with_label_values(&["buffer_full"]).get();
+        assert_eq!(after, before + 1, "buffer_full counter should bump exactly once");
+    }
+
+    /// End-to-end forwarder smoke: spin up a tiny axum server that
+    /// records every POST it receives, point the forwarder at it,
+    /// enqueue a capture, wait briefly, and verify it arrived.
+    #[tokio::test]
+    async fn forwarder_posts_capture_to_endpoint() {
+        use axum::{routing::post, Json, Router};
+        use std::sync::Mutex;
+        use tokio::net::TcpListener;
+
+        #[derive(serde::Deserialize)]
+        struct WirePayload {
+            exchanges: Vec<serde_json::Value>,
+        }
+
+        let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let received_clone = received.clone();
+
+        let app = Router::new().route(
+            "/captures/ingest",
+            post(move |Json(p): Json<WirePayload>| {
+                let received = received_clone.clone();
+                async move {
+                    for ex in p.exchanges {
+                        if let Some(id) =
+                            ex.get("request").and_then(|r| r.get("id")).and_then(|i| i.as_str())
+                        {
+                            received.lock().unwrap().push(id.to_string());
+                        }
+                    }
+                    axum::Json(serde_json::json!({ "accepted": 1 }))
+                }
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // Build the forwarder directly (skip env-var plumbing).
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(2)).build().unwrap();
+        let (sender, receiver) = mpsc::channel::<RecordedExchange>(8);
+        let url = format!("http://{}/captures/ingest", addr);
+        tokio::spawn(run(receiver, client, url, "fake-token".into()));
+
+        let handle = CaptureCloudSyncHandle {
+            inner: Some(Arc::new(Inner { sender })),
+        };
+        let mut ex = dummy_exchange();
+        ex.request.id = "smoke-1".into();
+        handle.enqueue(ex);
+
+        // Poll briefly for the capture to arrive.
+        for _ in 0..50 {
+            if !received.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let got = received.lock().unwrap().clone();
+        assert_eq!(got, vec!["smoke-1".to_string()]);
     }
 }

--- a/crates/mockforge-recorder/src/recorder.rs
+++ b/crates/mockforge-recorder/src/recorder.rs
@@ -42,10 +42,14 @@ impl Recorder {
         }
     }
 
-    /// Attach a cloud-sync handle. When configured, every completed
-    /// exchange (after `record_response`) is shipped to the cloud
-    /// ingest endpoint in addition to being stored locally. The local
-    /// SQLite stays the canonical store; cloud is the durable mirror.
+    /// Attach the cloud capture forwarder handle (#553). When
+    /// configured, every completed exchange (after `record_response`)
+    /// is forwarded to the registry's `runtime_captures` ingest
+    /// endpoint as soon as it lands, one POST per capture. Local
+    /// SQLite is still written for diagnostics, but cloud Postgres is
+    /// the durable source-of-truth (per #240 / #242) and survives
+    /// machine restart / reschedule. See `cloud_sync` module docs for
+    /// backpressure (bounded mpsc, drop-on-full) and retry policy.
     pub fn with_cloud_sync(mut self, handle: CaptureCloudSyncHandle) -> Self {
         self.cloud_sync = handle;
         self
@@ -104,10 +108,12 @@ impl Recorder {
         let request_id = response.request_id.clone();
         self.db.insert_response(&response).await?;
 
-        // Ship the now-complete exchange to cloud Postgres if the handle
-        // is configured. Local SQLite stays canonical so a transient
-        // ship failure doesn't lose data — the cloud is a durable mirror,
-        // not the source of truth.
+        // Forward the now-complete exchange to cloud Postgres if the
+        // handle is configured (#553). Cloud is the durable
+        // source-of-truth on hosted mocks; local SQLite is a debugging
+        // buffer that gets wiped on every machine cycle. The
+        // forwarder's bounded mpsc + retry loop guarantees we never
+        // block the recorder hot path waiting for the registry.
         if self.cloud_sync.is_active() {
             if let Ok(Some(request)) = self.db.get_request(&request_id).await {
                 self.cloud_sync.enqueue(RecordedExchange {


### PR DESCRIPTION
## Summary

Closes #553. Migrates hosted-mock captures from the batched cloud
mirror (#234 part 2) to a **synchronous-per-capture forwarder**.
Cloud Postgres `runtime_captures` is now the durable source-of-truth
(per #240 / #242); local SQLite is just a debugging buffer that
survives nothing on machine cycle / reschedule.

- Recorder forwards each completed exchange to the registry's existing
  `/api/v1/hosted-mocks/{deployment_id}/captures/ingest` endpoint as
  soon as it lands — one POST per capture, wrapped in a 1-element
  batch so the wire format is unchanged.
- Bounded `mpsc::channel` (default capacity **1024**) absorbs registry
  stalls without blocking request serving. On full → `tracing::warn!`
  + `mockforge_capture_forwarder_drops_total{reason="buffer_full"}`.
  Dropping the newest capture is strictly preferable to applying
  back-pressure onto user requests.
- Per-capture retry: 3 attempts on 5xx / transport with exponential
  backoff (100ms / 400ms / 1600ms). 4xx is permanent (no retry).
  Exhaustion bumps `mockforge_capture_forwarder_drops_total{reason="exhausted"}`.
- New metrics auto-register on `prometheus::default_registry()`, so
  the existing exporter picks them up with no extra wiring:
  - `mockforge_capture_forwarder_sent_total`
  - `mockforge_capture_forwarder_drops_total{reason="buffer_full"|"exhausted"|"permanent"|"closed"}`

## Configuration

- `MOCKFORGE_CLOUD_CAPTURES_FORWARDER_URL` *(preferred, #553)* or
  `MOCKFORGE_CAPTURE_INGEST_URL` *(deprecated alias, back-compat)* —
  full URL of the ingest endpoint.
- `MOCKFORGE_CAPTURE_INGEST_TOKEN` — short-lived deployment-scoped JWT.
- `MOCKFORGE_CAPTURE_FORWARDER_BUFFER` — channel capacity (default 1024).
- `MOCKFORGE_CAPTURE_FORWARDER_TIMEOUT_MS` — per-request timeout (default 5000).

## Acceptance criteria (#553)

- [x] **Machine restart** — captures forwarded synchronously per
      record_response; the local SQLite buffer is no longer the
      durability boundary.
- [x] **Machine reschedule** — same as above; cloud Postgres is the
      source-of-truth, so a fresh machine starts with all prior
      captures already in the durable store.
- [x] **Sustained cloud-sink outage** — bounded mpsc drops the newest
      with a counter; request serving is unaffected. After 3 retries
      with backoff, an exhausted POST drops the capture and bumps the
      exhaustion counter rather than retrying forever.

## Wire-up

Public API on `CaptureCloudSyncHandle` / `cloud_sync::from_env()` is
preserved, so the `Recorder::with_cloud_sync` integration in
`crates/mockforge-cli/src/serve.rs` keeps working unchanged — operators
just set the new env var.

## Test plan

- [x] `cargo check -p mockforge-recorder`
- [x] `cargo clippy -p mockforge-recorder --all-targets -- -D warnings`
- [x] `cargo test -p mockforge-recorder` — 246 / 246 pass, including
      4 new `cloud_sync` tests covering disabled handle, env-var
      gating, buffer-full drop counter, and an end-to-end smoke test
      that spins up a local axum endpoint and asserts captures arrive.
- [x] `cargo check -p mockforge-cli --features recorder`
- [x] `cargo fmt --check`
- [ ] Once merged: hosted-mock orchestrator sets
      `MOCKFORGE_CLOUD_CAPTURES_FORWARDER_URL` + token at deploy time;
      verify captures appear in cloud UI within a few seconds of the
      mock receiving traffic, and that machine restart doesn't lose
      in-flight captures.