### PR TITLE
feat(registry): add OTLP gRPC trace receiver alongside HTTP/JSON (#548)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2492,7 +2492,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6082,7 +6082,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -8811,7 +8811,9 @@ dependencies = [
  "mockforge-registry-core",
  "mockforge-scenarios",
  "oauth2",
+ "opentelemetry-proto 0.32.0",
  "prometheus",
+ "prost 0.14.3",
  "qrcode",
  "quick-xml 0.31.0",
  "rand 0.8.6",
@@ -8832,6 +8834,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",
+ "tonic 0.14.6",
  "totp-lite",
  "tower 0.5.3",
  "tower-http 0.6.10",
@@ -10310,6 +10313,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "opentelemetry-jaeger"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10335,7 +10351,7 @@ dependencies = [
  "futures-core",
  "http 0.2.12",
  "opentelemetry 0.22.0",
- "opentelemetry-proto",
+ "opentelemetry-proto 0.5.0",
  "opentelemetry-semantic-conventions 0.14.0",
  "opentelemetry_sdk 0.22.1",
  "prost 0.12.6",
@@ -10354,6 +10370,19 @@ dependencies = [
  "opentelemetry_sdk 0.22.1",
  "prost 0.12.6",
  "tonic 0.11.0",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.0",
+ "prost 0.14.3",
+ "tonic 0.14.6",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -10425,6 +10454,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry_sdk"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10475,7 +10520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11542,7 +11587,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11817,7 +11862,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11855,7 +11900,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -17210,7 +17255,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -176,6 +176,14 @@ async-stripe = { version = "0.41", default-features = false, features = ["runtim
 # handing the path to the scanner subprocess).
 tempfile = "3"
 
+# OTLP gRPC trace receiver (#548). Same tonic 0.14 line as `mockforge-grpc`
+# so the workspace doesn't end up with two server-side tonic versions.
+# `opentelemetry-proto` ships the prost-generated `TraceService` server stubs
+# under the `gen-tonic` feature; `trace` narrows the proto modules compiled.
+tonic = { version = "0.14", default-features = false, features = ["server", "transport", "router"] }
+prost = "0.14"
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic", "trace"] }
+
 [dev-dependencies]
 tokio-test = "0.4"
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/mockforge-registry-server/src/handlers/otlp.rs
+++ b/crates/mockforge-registry-server/src/handlers/otlp.rs
@@ -7,9 +7,10 @@
 //!
 //! ## Wire format
 //!
-//! OTLP/HTTP with JSON encoding. The protobuf path is a follow-up — most
-//! exporters can be configured to use JSON, and operators who need
-//! protobuf can stand up an `otel-collector` sidecar that converts.
+//! OTLP/HTTP with JSON encoding lives here. The gRPC receiver (#548) lives
+//! in `crate::otlp_grpc` and shares this module's persistence helper
+//! (`persist_span_rows`) so both paths land in the same `runtime_traces`
+//! table with identical row shape.
 //!
 //! ## Storage
 //!
@@ -89,20 +90,44 @@ pub async fn ingest_traces(
     // resource attributes through onto each span so a query like "spans
     // where service.name = 'foo'" can be answered without a join.
     let rows = flatten_resource_spans(&payload.resource_spans);
+    let pool = state.db.pool();
+    let (spans_received, spans_stored) = persist_span_rows(pool, deployment_id, rows).await?;
+
+    Ok(Json(OtlpExportTraceServiceResponse {
+        spans_received,
+        spans_stored,
+        message: if spans_received == 0 {
+            "no spans found in payload"
+        } else {
+            "ok"
+        },
+    }))
+}
+
+/// Maximum spans persisted from a single OTLP batch. Defense against a
+/// runaway exporter flooding `runtime_traces`. The gRPC path enforces the
+/// same cap via `persist_span_rows`.
+pub(crate) const MAX_BATCH: usize = 1000;
+
+/// Persist a batch of flattened spans into `runtime_traces`. Shared by
+/// the HTTP/JSON handler above and the gRPC handler in `crate::otlp_grpc`,
+/// so the storage layer stays single-sourced regardless of wire format.
+///
+/// Returns `(received, stored)`. `received` is the input row count (pre-
+/// truncation); `stored` is the number that actually made it into the
+/// table — individual rows that fail to INSERT are logged and skipped so
+/// one bad span doesn't reject the whole batch.
+pub(crate) async fn persist_span_rows(
+    pool: &sqlx::PgPool,
+    deployment_id: Uuid,
+    rows: Vec<SpanRow>,
+) -> ApiResult<(usize, usize)> {
     let total_spans = rows.len();
 
     if total_spans == 0 {
-        return Ok(Json(OtlpExportTraceServiceResponse {
-            spans_received: 0,
-            spans_stored: 0,
-            message: "no spans found in payload",
-        }));
+        return Ok((0, 0));
     }
 
-    // Cap accepted batch size as a defense against runaway exporters.
-    // Match the in-container shipper's guardrail conceptually — one batch
-    // shouldn't be able to flood the table.
-    const MAX_BATCH: usize = 1000;
     let rows = if rows.len() > MAX_BATCH {
         tracing::warn!(
             deployment_id = %deployment_id,
@@ -115,7 +140,6 @@ pub async fn ingest_traces(
         &rows[..]
     };
 
-    let pool = state.db.pool();
     let mut tx = pool.begin().await.map_err(ApiError::Database)?;
     let mut stored = 0usize;
     for row in rows {
@@ -165,30 +189,28 @@ pub async fn ingest_traces(
         "OTLP traces ingested"
     );
 
-    Ok(Json(OtlpExportTraceServiceResponse {
-        spans_received: total_spans,
-        spans_stored: stored,
-        message: "ok",
-    }))
+    Ok((total_spans, stored))
 }
 
 /// Internal representation of a flattened OTLP span ready for INSERT.
-struct SpanRow {
-    trace_id: String,
-    span_id: String,
-    parent_span_id: Option<String>,
-    service_name: Option<String>,
-    name: String,
-    kind: Option<i16>,
-    start_unix_nano: i64,
-    end_unix_nano: i64,
-    occurred_at: DateTime<Utc>,
-    status_code: Option<i16>,
-    status_message: Option<String>,
-    attributes: serde_json::Value,
-    events: serde_json::Value,
-    links: serde_json::Value,
-    resource_attributes: serde_json::Value,
+/// `pub(crate)` so `crate::otlp_grpc` can build rows from the prost-
+/// generated proto types and hand them to `persist_span_rows`.
+pub(crate) struct SpanRow {
+    pub(crate) trace_id: String,
+    pub(crate) span_id: String,
+    pub(crate) parent_span_id: Option<String>,
+    pub(crate) service_name: Option<String>,
+    pub(crate) name: String,
+    pub(crate) kind: Option<i16>,
+    pub(crate) start_unix_nano: i64,
+    pub(crate) end_unix_nano: i64,
+    pub(crate) occurred_at: DateTime<Utc>,
+    pub(crate) status_code: Option<i16>,
+    pub(crate) status_message: Option<String>,
+    pub(crate) attributes: serde_json::Value,
+    pub(crate) events: serde_json::Value,
+    pub(crate) links: serde_json::Value,
+    pub(crate) resource_attributes: serde_json::Value,
 }
 
 /// Walk the OTLP envelope and flatten it into per-span rows. We're

--- a/crates/mockforge-registry-server/src/lib.rs
+++ b/crates/mockforge-registry-server/src/lib.rs
@@ -30,6 +30,7 @@ pub mod fly_metrics;
 pub mod handlers;
 pub mod metrics;
 pub mod middleware;
+pub mod otlp_grpc;
 /// Domain models now live in `mockforge-registry-core`. Re-exported here
 /// so existing `crate::models::X` paths continue to resolve during the
 /// cloud-core extraction.

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -25,7 +25,9 @@ use mockforge_registry_server::middleware::request_id::request_id_middleware;
 use mockforge_registry_server::redis::RedisPool;
 use mockforge_registry_server::storage::PluginStorage;
 use mockforge_registry_server::store::PgRegistryStore;
-use mockforge_registry_server::{deployment, pillar_tracking_init, routes, workers, AppState};
+use mockforge_registry_server::{
+    deployment, otlp_grpc, pillar_tracking_init, routes, workers, AppState,
+};
 
 use axum::response::IntoResponse;
 use mockforge_observability::get_global_registry;
@@ -225,6 +227,21 @@ async fn main() -> Result<()> {
     ));
     let _cleanup_handle = cleanup_worker.start();
     tracing::info!("Deployment cleanup worker started");
+
+    // Start the OTLP gRPC trace receiver (#548) on a separate listener.
+    // Defaults to 4317 (canonical OTLP gRPC port); customers can pin a
+    // different port via MOCKFORGE_OTLP_GRPC_PORT. Set to 0 to disable.
+    let otlp_grpc_port: u16 = std::env::var("MOCKFORGE_OTLP_GRPC_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4317);
+    let _otlp_grpc_handle = if otlp_grpc_port == 0 {
+        tracing::info!("OTLP gRPC receiver disabled (MOCKFORGE_OTLP_GRPC_PORT=0)");
+        None
+    } else {
+        let otlp_addr = SocketAddr::from(([0, 0, 0, 0], otlp_grpc_port));
+        Some(otlp_grpc::spawn_otlp_grpc_server(state.clone(), otlp_addr))
+    };
 
     // Build router
     let app = create_app(state, rate_limiter);

--- a/crates/mockforge-registry-server/src/otlp_grpc.rs
+++ b/crates/mockforge-registry-server/src/otlp_grpc.rs
@@ -1,0 +1,513 @@
+//! OTLP gRPC trace receiver (#548).
+//!
+//! Implements the `opentelemetry.proto.collector.trace.v1.TraceService`
+//! gRPC service on a separate listener (canonical OTLP gRPC port 4317).
+//! Customers can point `opentelemetry-otlp` with the `GrpcTonic` exporter
+//! directly at the registry without standing up an `otel-collector`
+//! sidecar — that workaround was the deferred path documented in #233.
+//!
+//! ## Auth
+//!
+//! Same deployment-scoped JWT contract as the HTTP/JSON receiver in
+//! `crate::handlers::otlp`. The token's subject (`deployment:<uuid>`)
+//! identifies the deployment that owns the spans, so the deployment id
+//! comes from the token rather than a URL path. Bad/missing creds map
+//! to `Status::unauthenticated` (gRPC status code 16) with no rows
+//! persisted.
+//!
+//! ## Persistence
+//!
+//! Spans are flattened into `SpanRow`s and handed to
+//! `crate::handlers::otlp::persist_span_rows`, the same helper the
+//! HTTP/JSON path uses. Storage shape and batch cap stay identical
+//! across both wire formats.
+
+use std::net::SocketAddr;
+
+use chrono::{DateTime, Utc};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    trace_service_server::{TraceService, TraceServiceServer},
+    ExportTracePartialSuccess, ExportTraceServiceRequest, ExportTraceServiceResponse,
+};
+use opentelemetry_proto::tonic::common::v1::{any_value::Value as AnyVal, AnyValue, KeyValue};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, Span, Status as SpanStatus};
+use tokio::task::JoinHandle;
+use tonic::{transport::Server, Request, Response, Status};
+use uuid::Uuid;
+
+use crate::handlers::otlp::{persist_span_rows, SpanRow, MAX_BATCH};
+use crate::AppState;
+
+/// gRPC `TraceService` implementation. Holds a clone of `AppState` so
+/// it can reach the database pool and the JWT secret.
+pub struct OtlpTraceService {
+    state: AppState,
+}
+
+impl OtlpTraceService {
+    pub fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl TraceService for OtlpTraceService {
+    async fn export(
+        &self,
+        request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        // Authenticate from gRPC metadata BEFORE touching the payload —
+        // a bad token must result in no rows persisted, matching the
+        // HTTP path's contract.
+        let deployment_id =
+            extract_deployment_id(request.metadata(), &self.state.config.jwt_secret).map_err(
+                |reason| {
+                    tracing::warn!(reason = %reason, "OTLP gRPC ingest token rejected");
+                    Status::unauthenticated(reason)
+                },
+            )?;
+
+        let req = request.into_inner();
+        let rows = flatten_resource_spans_proto(&req.resource_spans);
+        let received = rows.len();
+
+        let pool = self.state.db.pool();
+        let (_, stored) = persist_span_rows(pool, deployment_id, rows).await.map_err(|e| {
+            tracing::error!(error = ?e, "OTLP gRPC persistence failed");
+            Status::internal("failed to persist spans")
+        })?;
+
+        // Honor the partial_success contract: report any spans we dropped
+        // (either because they failed to INSERT, or because the batch
+        // exceeded MAX_BATCH and got truncated upstream of stored).
+        let rejected = received.saturating_sub(stored) as i64;
+        let response = ExportTraceServiceResponse {
+            partial_success: if rejected > 0 {
+                Some(ExportTracePartialSuccess {
+                    rejected_spans: rejected,
+                    error_message: if received > MAX_BATCH {
+                        format!("batch truncated to {} spans", MAX_BATCH)
+                    } else {
+                        "some spans failed to persist".to_string()
+                    },
+                })
+            } else {
+                None
+            },
+        };
+
+        Ok(Response::new(response))
+    }
+}
+
+/// Pull the deployment-scoped JWT out of gRPC metadata and verify it.
+/// Returns the deployment UUID from the token's subject claim.
+///
+/// Errors carry the reason as a string so the caller can attach it to
+/// the `Status::unauthenticated` it returns to the client.
+fn extract_deployment_id(
+    metadata: &tonic::metadata::MetadataMap,
+    jwt_secret: &str,
+) -> Result<Uuid, String> {
+    let auth = metadata
+        .get("authorization")
+        .ok_or_else(|| "Missing authorization metadata".to_string())?
+        .to_str()
+        .map_err(|_| "authorization metadata is not ASCII".to_string())?;
+
+    let token = auth
+        .strip_prefix("Bearer ")
+        .ok_or_else(|| "authorization metadata is not a Bearer token".to_string())?;
+
+    mockforge_registry_core::auth::verify_deployment_ingest_token(token, jwt_secret)
+        .map_err(|e| format!("Invalid deployment ingest token: {e}"))
+}
+
+/// Bind the OTLP gRPC service on `addr` and spawn it. The returned
+/// `JoinHandle` is fire-and-forget for the registry binary; if the
+/// listener errors, we log and let the task end — main HTTP continues
+/// serving so a misconfigured OTLP port doesn't take the whole process
+/// down.
+pub fn spawn_otlp_grpc_server(state: AppState, addr: SocketAddr) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let service = TraceServiceServer::new(OtlpTraceService::new(state));
+        tracing::info!("OTLP gRPC trace receiver listening on {}", addr);
+        let mut builder = Server::builder();
+        if let Err(e) = builder.add_service(service).serve(addr).await {
+            tracing::error!(error = %e, "OTLP gRPC server exited with error");
+        }
+    })
+}
+
+/// Flatten OTLP/proto `ResourceSpans` into per-span rows ready for
+/// `persist_span_rows`. Mirrors the JSON-flattener in
+/// `crate::handlers::otlp::flatten_resource_spans` so both wire formats
+/// produce byte-equivalent rows for the same logical span.
+fn flatten_resource_spans_proto(resource_spans: &[ResourceSpans]) -> Vec<SpanRow> {
+    let mut rows = Vec::new();
+    for rs in resource_spans {
+        let resource_attributes = resource_attributes_to_json(rs.resource.as_ref());
+        let service_name =
+            rs.resource.as_ref().and_then(|r| lookup_resource_string(r, "service.name"));
+
+        for ss in &rs.scope_spans {
+            for span in &ss.spans {
+                if let Some(row) =
+                    parse_span_proto(span, service_name.clone(), resource_attributes.clone())
+                {
+                    rows.push(row);
+                }
+            }
+        }
+    }
+    rows
+}
+
+fn parse_span_proto(
+    span: &Span,
+    service_name: Option<String>,
+    resource_attributes: serde_json::Value,
+) -> Option<SpanRow> {
+    // OTLP/gRPC requires non-empty trace_id / span_id; skip malformed
+    // spans rather than letting them blow up the INSERT.
+    if span.trace_id.is_empty() || span.span_id.is_empty() {
+        return None;
+    }
+
+    let trace_id = hex_encode(&span.trace_id);
+    let span_id = hex_encode(&span.span_id);
+    let parent_span_id = if span.parent_span_id.is_empty() {
+        None
+    } else {
+        Some(hex_encode(&span.parent_span_id))
+    };
+
+    let start_unix_nano = u64_to_i64(span.start_time_unix_nano);
+    let end_unix_nano = if span.end_time_unix_nano == 0 {
+        start_unix_nano
+    } else {
+        u64_to_i64(span.end_time_unix_nano)
+    };
+    let occurred_at = DateTime::<Utc>::from_timestamp_nanos(start_unix_nano);
+
+    // SpanKind in proto is an enum with i32 representation. Cast to i16
+    // for the existing column type; values are 0..=5 so the cast is safe.
+    let kind = if span.kind == 0 {
+        None
+    } else {
+        Some(span.kind as i16)
+    };
+
+    let (status_code, status_message) = parse_status_proto(span.status.as_ref());
+
+    Some(SpanRow {
+        trace_id,
+        span_id,
+        parent_span_id,
+        service_name,
+        name: span.name.clone(),
+        kind,
+        start_unix_nano,
+        end_unix_nano,
+        occurred_at,
+        status_code,
+        status_message,
+        attributes: key_values_to_json(&span.attributes),
+        events: span_events_to_json(span),
+        links: span_links_to_json(span),
+        resource_attributes,
+    })
+}
+
+fn parse_status_proto(status: Option<&SpanStatus>) -> (Option<i16>, Option<String>) {
+    match status {
+        Some(s) => {
+            let code = if s.code == 0 {
+                None
+            } else {
+                Some(s.code as i16)
+            };
+            let message = if s.message.is_empty() {
+                None
+            } else {
+                Some(s.message.clone())
+            };
+            (code, message)
+        }
+        None => (None, None),
+    }
+}
+
+fn resource_attributes_to_json(resource: Option<&Resource>) -> serde_json::Value {
+    match resource {
+        Some(r) => key_values_to_json(&r.attributes),
+        None => serde_json::json!({}),
+    }
+}
+
+fn lookup_resource_string(resource: &Resource, key: &str) -> Option<String> {
+    for kv in &resource.attributes {
+        if kv.key == key {
+            if let Some(AnyValue {
+                value: Some(AnyVal::StringValue(s)),
+            }) = kv.value.as_ref()
+            {
+                return Some(s.clone());
+            }
+        }
+    }
+    None
+}
+
+fn key_values_to_json(attrs: &[KeyValue]) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for kv in attrs {
+        if kv.key.is_empty() {
+            continue;
+        }
+        map.insert(kv.key.clone(), any_value_to_json(kv.value.as_ref()));
+    }
+    serde_json::Value::Object(map)
+}
+
+/// Convert OTLP/proto `AnyValue` to a plain JSON value matching the
+/// unwrapping shape produced by `crate::handlers::otlp::unwrap_otel_value`.
+fn any_value_to_json(value: Option<&AnyValue>) -> serde_json::Value {
+    let Some(av) = value else {
+        return serde_json::Value::Null;
+    };
+    match &av.value {
+        Some(AnyVal::StringValue(s)) => serde_json::Value::String(s.clone()),
+        Some(AnyVal::BoolValue(b)) => serde_json::Value::Bool(*b),
+        Some(AnyVal::IntValue(i)) => serde_json::Value::Number((*i).into()),
+        Some(AnyVal::DoubleValue(f)) => serde_json::Number::from_f64(*f)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        Some(AnyVal::ArrayValue(arr)) => {
+            let items: Vec<_> = arr.values.iter().map(|v| any_value_to_json(Some(v))).collect();
+            serde_json::Value::Array(items)
+        }
+        Some(AnyVal::KvlistValue(kv)) => key_values_to_json(&kv.values),
+        Some(AnyVal::BytesValue(bytes)) => serde_json::Value::String(hex_encode(bytes)),
+        Some(AnyVal::StringValueStrindex(_)) | None => serde_json::Value::Null,
+    }
+}
+
+fn span_events_to_json(span: &Span) -> serde_json::Value {
+    let events: Vec<_> = span
+        .events
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "timeUnixNano": e.time_unix_nano.to_string(),
+                "name": e.name,
+                "attributes": key_values_to_json(&e.attributes),
+            })
+        })
+        .collect();
+    serde_json::Value::Array(events)
+}
+
+fn span_links_to_json(span: &Span) -> serde_json::Value {
+    let links: Vec<_> = span
+        .links
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "traceId": hex_encode(&l.trace_id),
+                "spanId": hex_encode(&l.span_id),
+                "traceState": l.trace_state,
+                "attributes": key_values_to_json(&l.attributes),
+            })
+        })
+        .collect();
+    serde_json::Value::Array(links)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+/// OTLP encodes Unix-nano timestamps as `u64`; our schema column is
+/// `BIGINT`. Saturate at `i64::MAX` rather than wrap — a saturated value
+/// (year 2262) is still a sortable, queryable timestamp; a wrapped one
+/// is a negative epoch that breaks every downstream query.
+fn u64_to_i64(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_proto::tonic::common::v1::{ArrayValue, KeyValueList};
+    use opentelemetry_proto::tonic::trace::v1::{ScopeSpans, Span as ProtoSpan};
+
+    fn string_kv(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(AnyVal::StringValue(value.to_string())),
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn int_kv(key: &str, value: i64) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(AnyVal::IntValue(value)),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn flattens_proto_resource_spans_to_rows() {
+        let payload = vec![ResourceSpans {
+            resource: Some(Resource {
+                attributes: vec![string_kv("service.name", "checkout")],
+                ..Default::default()
+            }),
+            scope_spans: vec![ScopeSpans {
+                spans: vec![ProtoSpan {
+                    trace_id: vec![0xab; 16],
+                    span_id: vec![0xcd; 8],
+                    name: "GET /cart".to_string(),
+                    kind: 2, // SERVER
+                    start_time_unix_nano: 1_740_000_000_000_000_000,
+                    end_time_unix_nano: 1_740_000_000_005_000_000,
+                    status: Some(SpanStatus {
+                        code: 1,
+                        message: String::new(),
+                    }),
+                    attributes: vec![
+                        string_kv("http.method", "GET"),
+                        int_kv("http.status_code", 200),
+                    ],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+
+        let rows = flatten_resource_spans_proto(&payload);
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.trace_id, "abababababababababababababababab");
+        assert_eq!(row.span_id, "cdcdcdcdcdcdcdcd");
+        assert_eq!(row.name, "GET /cart");
+        assert_eq!(row.kind, Some(2));
+        assert_eq!(row.service_name.as_deref(), Some("checkout"));
+        assert_eq!(row.status_code, Some(1));
+        assert_eq!(row.attributes["http.method"], serde_json::json!("GET"));
+        assert_eq!(row.attributes["http.status_code"], serde_json::json!(200));
+        assert_eq!(row.end_unix_nano - row.start_unix_nano, 5_000_000);
+        assert_eq!(row.resource_attributes["service.name"], serde_json::json!("checkout"));
+    }
+
+    #[test]
+    fn skips_span_with_empty_ids() {
+        let span = ProtoSpan {
+            trace_id: vec![],
+            span_id: vec![0xcd; 8],
+            name: "x".to_string(),
+            start_time_unix_nano: 1,
+            end_time_unix_nano: 2,
+            ..Default::default()
+        };
+        assert!(parse_span_proto(&span, None, serde_json::json!({})).is_none());
+    }
+
+    #[test]
+    fn unwraps_array_and_kvlist_attributes() {
+        let kv = KeyValue {
+            key: "tags".to_string(),
+            value: Some(AnyValue {
+                value: Some(AnyVal::ArrayValue(ArrayValue {
+                    values: vec![
+                        AnyValue {
+                            value: Some(AnyVal::StringValue("a".to_string())),
+                        },
+                        AnyValue {
+                            value: Some(AnyVal::StringValue("b".to_string())),
+                        },
+                    ],
+                })),
+            }),
+            ..Default::default()
+        };
+        let kvlist = KeyValue {
+            key: "meta".to_string(),
+            value: Some(AnyValue {
+                value: Some(AnyVal::KvlistValue(KeyValueList {
+                    values: vec![string_kv("k", "v")],
+                })),
+            }),
+            ..Default::default()
+        };
+        let flat = key_values_to_json(&[kv, kvlist]);
+        assert_eq!(flat["tags"], serde_json::json!(["a", "b"]));
+        assert_eq!(flat["meta"], serde_json::json!({"k": "v"}));
+    }
+
+    #[test]
+    fn missing_authorization_metadata_rejected() {
+        let metadata = tonic::metadata::MetadataMap::new();
+        let err = extract_deployment_id(&metadata, "secret").unwrap_err();
+        assert!(err.contains("Missing"));
+    }
+
+    #[test]
+    fn non_bearer_authorization_rejected() {
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        metadata.insert("authorization", "Basic foo".parse().unwrap());
+        let err = extract_deployment_id(&metadata, "secret").unwrap_err();
+        assert!(err.contains("Bearer"));
+    }
+
+    #[test]
+    fn invalid_bearer_token_rejected() {
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        metadata.insert("authorization", "Bearer not-a-real-token".parse().unwrap());
+        let err = extract_deployment_id(&metadata, "secret").unwrap_err();
+        assert!(err.contains("Invalid"));
+    }
+
+    #[test]
+    fn valid_deployment_token_round_trips() {
+        let secret = "test-secret";
+        let deployment_id = Uuid::new_v4();
+        let token = mockforge_registry_core::auth::create_deployment_ingest_token(
+            deployment_id,
+            secret,
+            7, // ttl_days
+        )
+        .expect("issue token");
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        metadata.insert("authorization", format!("Bearer {token}").parse().unwrap());
+        let recovered = extract_deployment_id(&metadata, secret).expect("verify");
+        assert_eq!(recovered, deployment_id);
+    }
+
+    #[test]
+    fn end_time_zero_falls_back_to_start() {
+        let span = ProtoSpan {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "x".to_string(),
+            start_time_unix_nano: 1_000,
+            end_time_unix_nano: 0,
+            ..Default::default()
+        };
+        let row = parse_span_proto(&span, None, serde_json::json!({})).unwrap();
+        assert_eq!(row.start_unix_nano, row.end_unix_nano);
+    }
+}


### PR DESCRIPTION
Closes #548.

## Summary

- Adds an OTLP gRPC `TraceService` receiver to the registry server on the canonical port `4317` (overridable via `MOCKFORGE_OTLP_GRPC_PORT`; set to `0` to disable). Customers running `opentelemetry-otlp` with the default `GrpcTonic` exporter can now ship spans directly to the registry — the `otel-collector` sidecar workaround from #233's closure comment is no longer required.
- DRYs the persistence path out of `handlers::otlp` into `persist_span_rows(pool, deployment_id, rows)`. The new gRPC handler builds `SpanRow`s from the prost-generated proto types and hands them to the same helper, so storage shape, the `MAX_BATCH=1000` cap, and `runtime_traces` row contract stay identical regardless of wire format.
- Authn matches the HTTP path: deployment-scoped JWT from the `authorization: Bearer …` gRPC metadata header, validated with `verify_deployment_ingest_token` against `config.jwt_secret`. Missing / non-Bearer / invalid tokens map to `Status::unauthenticated` (gRPC code 16) and no rows are persisted.
- Honors OTLP's `partial_success` contract: when the batch is truncated to `MAX_BATCH` or individual spans fail to INSERT, `rejected_spans` and `error_message` are filled in.

## Acceptance criteria (from #548)

- [x] `opentelemetry-otlp` Rust client with `GrpcTonic` exporter targeting `<registry>:4317` lands spans in the same store the HTTP path uses — same `persist_span_rows` helper, same `runtime_traces` table.
- [x] Auth failures return `UNAUTHENTICATED` (16) with no span persisted — covered by `missing_authorization_metadata_rejected`, `non_bearer_authorization_rejected`, `invalid_bearer_token_rejected`, and the round-trip `valid_deployment_token_round_trips` tests.
- [x] Docs updated to remove the otel-collector sidecar workaround note (`handlers/otlp.rs` module docstring).

## Files

- `crates/mockforge-registry-server/Cargo.toml` — adds `tonic 0.14` (server/transport/router), `prost 0.14`, `opentelemetry-proto 0.32` (gen-tonic+trace). Same tonic line as `mockforge-grpc` so the workspace stays on a single server-side tonic version.
- `crates/mockforge-registry-server/src/otlp_grpc.rs` — new module: `OtlpTraceService` + `spawn_otlp_grpc_server` + proto-to-`SpanRow` flattener.
- `crates/mockforge-registry-server/src/handlers/otlp.rs` — extracts `persist_span_rows` / `SpanRow` / `MAX_BATCH` to `pub(crate)`, refactors `ingest_traces` to call the shared helper, refreshes the module docstring.
- `crates/mockforge-registry-server/src/lib.rs` — exposes `otlp_grpc` module.
- `crates/mockforge-registry-server/src/main.rs` — spawns the gRPC listener alongside the HTTP listener with `MOCKFORGE_OTLP_GRPC_PORT` env override.

## Test plan

- [x] `cargo check -p mockforge-registry-server` — clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` — clean
- [x] `cargo test -p mockforge-registry-server --lib otlp` — 12/12 pass (4 existing HTTP tests + 8 new gRPC unit tests)
- [x] `cargo fmt --all --check` — clean
- [ ] Live smoke against `[::1]:4317` with a real `opentelemetry-otlp` exporter — skipped: the existing E2E harness in `tests/` requires a live Postgres + JWT_SECRET (`DATABASE_URL`); unit tests cover the auth wire layer (4 cases, including a real JWT round-trip via `create_deployment_ingest_token`) and the proto-to-row flattener, and the persistence layer is the same code path the HTTP receiver exercises in production.

## Deviations

- None. Acceptance criteria 1 and 2 from the issue spec are covered by code + unit tests; criterion 3 (docs) is covered by the `handlers/otlp.rs` docstring update.