### PR TITLE
feat(registry,security): HSM-backed platform signing-root rotation via AWS KMS (#550)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-kms"
+version = "1.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b682ef733ec24c300b11cec2df9bfea7ee4bf48ab2030c832e27db92b69c68"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.4.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.124.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,7 +2507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2492,7 +2516,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6082,7 +6106,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -8494,6 +8518,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockforge-platform-signing"
+version = "0.3.137"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "aws-smithy-types",
+ "base64 0.22.1",
+ "chrono",
+ "ring",
+ "serde",
+ "serde_jcs",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "mockforge-plugin-cli"
 version = "0.3.137"
 dependencies = [
@@ -8807,6 +8850,7 @@ dependencies = [
  "mockforge-core",
  "mockforge-federation",
  "mockforge-observability",
+ "mockforge-platform-signing",
  "mockforge-plugin-registry",
  "mockforge-registry-core",
  "mockforge-scenarios",
@@ -10475,7 +10519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11542,7 +11586,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11817,7 +11861,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11855,7 +11899,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -17210,7 +17254,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/mockforge-plugin-loader",
     "crates/mockforge-plugin-registry",
     "crates/mockforge-plugin-sdk",
+    "crates/mockforge-platform-signing",
 
     # Observability & tracing
     "crates/mockforge-observability",

--- a/crates/mockforge-platform-signing/Cargo.toml
+++ b/crates/mockforge-platform-signing/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "mockforge-platform-signing"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "HSM-backed platform signing-root for MockForge (RFC §8.2 / §9). Defines the PlatformSigner trait, AWS KMS backend, and dual-control rotation state machine used to authenticate first-party cloud plugins."
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme = "README.md"
+keywords = ["mockforge", "kms", "signing", "hsm", "rotation"]
+categories = ["cryptography", "development-tools"]
+publish = false
+
+[features]
+# AWS KMS backend. Off by default so OSS consumers (CLI, plugin-host
+# in self-hosted mode) don't pull the AWS SDK transitive tree. The
+# registry server turns it on via its `storage-s3` umbrella feature.
+aws-kms = ["dep:aws-sdk-kms", "dep:aws-config", "dep:aws-smithy-types"]
+
+[dependencies]
+# Sign/verify primitives. We accept ECDSA P-256 / P-384 signatures
+# from KMS in DER form and verify them with ring; for the legacy
+# Ed25519 publisher path see `mockforge-plugin-host::signing`.
+ring = { workspace = true }
+
+# AWS SDK (feature: `aws-kms`). Version-pinned to match
+# `mockforge-registry-server::storage` so cargo can resolve a single
+# AWS smithy stack across the workspace.
+aws-sdk-kms = { version = "1.50", optional = true }
+aws-config = { version = "1.1", optional = true }
+aws-smithy-types = { version = "1.2", optional = true }
+
+# Async
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_jcs = { workspace = true }
+
+# Errors / logging / time
+thiserror = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+base64 = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "test-util", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/mockforge-platform-signing/README.md
+++ b/crates/mockforge-platform-signing/README.md
@@ -1,0 +1,74 @@
+# mockforge-platform-signing
+
+HSM-backed platform signing-root for MockForge — implements RFC §8.2 and §9
+of [`cloud-trust-permissions-rfc.md`](../../docs/plugins/security/cloud-trust-permissions-rfc.md).
+
+The **platform signing root** is the key that authenticates first-party
+MockForge cloud plugins. The private bytes must never reach
+general-purpose compute; this crate keeps them behind an HSM boundary
+(AWS KMS for v1) and only exposes a `sign(...)` operation that round-trips
+through the KMS service.
+
+See [`docs/plugins/security/platform-signing-rotation-runbook.md`](../../docs/plugins/security/platform-signing-rotation-runbook.md)
+for the operator-facing rotation procedure.
+
+## Why a separate crate
+
+- The registry server needs the **signer** (to publish rotation events
+  and sign the plugin-blocklist).
+- Plugin-hosts (`mockforge-plugin-host`) need the **verifier** (to
+  trust newly-rotated platform keys).
+- Pulling the AWS SDK into either crate directly would bloat the
+  self-hosted build. This crate is feature-gated (`aws-kms`) so the
+  trait + verifier are always available; the AWS backend is opt-in.
+
+## Backend choice (v1 = AWS KMS)
+
+| Backend | FIPS level | Trade-off |
+| ------- | ---------- | --------- |
+| AWS KMS standard CMK | FIPS 140-2 L2 | Cheapest, fastest, no extra ops |
+| AWS KMS Custom Key Store (CloudHSM-backed) | FIPS 140-2 L3 | Documented upgrade path; same SDK call surface |
+| GCP KMS | FIPS 140-2 L3 | Future backend (trait-based) |
+| YubiHSM (on-prem) | FIPS 140-2 L3 | Future backend; for air-gapped installs |
+
+We picked AWS KMS for the first cut because AWS credentials are already
+present in the registry environment (via the `storage-s3` feature). The
+upgrade path to CloudHSM Custom Key Store does not change the trait
+surface — only the `KeyId` ARN changes.
+
+### Why ECDSA P-256 (not Ed25519)
+
+AWS KMS does not support Ed25519 signing keys as of writing. The platform
+signing root therefore uses `ECC_NIST_P256` with `ECDSA_SHA_256`. This is
+distinct from the per-publisher Ed25519 keys (see
+`mockforge-plugin-host::signing`) — those continue to live in the
+existing trust-store. The platform signer authenticates the **rotation
+event** that introduces a new publisher trust-root; it never replaces
+the per-publisher signature on the WASM bytes.
+
+## Rotation model (dual-control)
+
+1. Operator generates a new KMS CMK out-of-band (see runbook).
+2. New CMK's public bytes are fetched via `GetPublicKey`.
+3. The **current** CMK signs the new CMK's public bytes via `Sign` —
+   this is the cryptographic handover. The signature proves the new
+   key was authorized by the predecessor.
+4. The registry publishes a `RotationEvent { from_key_id, to_key_id,
+   to_public_key_der, handover_signature_der, transition_until }` —
+   plugin-hosts trust **both** keys during the transition window
+   (default 30 days, per RFC §9).
+5. After the transition window expires, the old CMK is disabled in
+   AWS via `DisableKey` (and eventually scheduled for deletion).
+
+Every step emits an `audit_logs` row tagged with the operator user-id.
+
+## Out of scope (filed as follow-ups)
+
+- **Plugin-host live reload** of the rotation event — depends on the
+  in-flight #549 trust-cache PR. Tracked separately.
+- **CloudHSM Custom Key Store** provisioning automation — runbook
+  covers the manual upgrade path.
+- **Two-of-three quorum** signing (RFC §9 long-term target). AWS KMS
+  alone is single-operator; quorum requires either CloudHSM with
+  multi-officer PIN, or a custodial multisig overlay. Out of scope
+  for v1.

--- a/crates/mockforge-platform-signing/src/aws_kms.rs
+++ b/crates/mockforge-platform-signing/src/aws_kms.rs
@@ -1,0 +1,172 @@
+//! AWS KMS-backed [`crate::signer::PlatformSigner`].
+//!
+//! Round-trips `Sign` and `GetPublicKey` through KMS. Private key bytes
+//! never leave the service boundary — only the resulting signature and
+//! the (already-public) `SubjectPublicKeyInfo` come back.
+//!
+//! # Key requirements (runbook also documents these)
+//!
+//! The KMS CMK MUST be:
+//!   - `KeyUsage = SIGN_VERIFY`
+//!   - `KeySpec = ECC_NIST_P256` (default) or `ECC_NIST_P384`
+//!   - `Origin = AWS_KMS` for first-cut deployments, or
+//!     `EXTERNAL`/`AWS_CLOUDHSM` for the FIPS 140-2 L3 upgrade path
+//!
+//! Ed25519 (`ECC_SECG_P256K1` / `ECC_NIST_P521` are *not* supported)
+//! because AWS KMS doesn't offer it — that's the trade-off documented
+//! in the crate-level README.
+//!
+//! # IAM permissions required
+//!
+//! The registry server's role needs:
+//!   - `kms:Sign`              (mandatory — every rotation handover)
+//!   - `kms:GetPublicKey`      (mandatory — every rotation handover)
+//!   - `kms:DescribeKey`       (recommended — diagnostics + audit-log
+//!     enrichment with the operator-facing alias)
+//!
+//! `kms:DisableKey` is NOT required by this crate — the runbook does
+//! that step manually via the AWS CLI, deliberately. Granting
+//! `DisableKey` to the registry role would make a registry compromise
+//! immediately destructive; keeping it out-of-band means the operator
+//! has to consciously perform the irreversible step.
+
+use async_trait::async_trait;
+use aws_config::BehaviorVersion;
+use aws_sdk_kms::{
+    primitives::Blob,
+    types::{KeySpec, MessageType, SigningAlgorithmSpec},
+    Client as KmsClient,
+};
+
+use crate::signer::{PlatformSigner, SignerError, SigningAlgorithm};
+
+/// Environment variable that names the active platform signing-root
+/// KMS key. Required by [`AwsKmsSigner::from_env`].
+pub const ENV_KEY_ID: &str = "MOCKFORGE_PLATFORM_SIGNING_KMS_KEY_ID";
+
+/// AWS KMS-backed signer.
+#[derive(Debug, Clone)]
+pub struct AwsKmsSigner {
+    client: KmsClient,
+    key_id: String,
+    algorithm: SigningAlgorithm,
+}
+
+impl AwsKmsSigner {
+    /// Build a signer using the standard AWS credential chain (env vars,
+    /// `~/.aws/credentials`, instance metadata) and the key id from
+    /// [`ENV_KEY_ID`].
+    pub async fn from_env() -> Result<Self, SignerError> {
+        let key_id = std::env::var(ENV_KEY_ID).map_err(|_| SignerError::MissingEnv(ENV_KEY_ID))?;
+        if key_id.trim().is_empty() {
+            return Err(SignerError::InvalidKeyId(format!("{ENV_KEY_ID} is empty")));
+        }
+        Self::from_key_id(key_id).await
+    }
+
+    /// Build a signer for an explicit key id (ARN, alias, or key UUID).
+    /// Probes the key spec via `GetPublicKey` so the configured algorithm
+    /// matches what KMS will actually use at `Sign` time.
+    pub async fn from_key_id(key_id: impl Into<String>) -> Result<Self, SignerError> {
+        let key_id = key_id.into();
+        let aws_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+        let client = KmsClient::new(&aws_config);
+        let algorithm = probe_algorithm(&client, &key_id).await?;
+        tracing::info!(
+            key_id = %key_id,
+            algorithm = ?algorithm,
+            "AwsKmsSigner ready"
+        );
+        Ok(Self {
+            client,
+            key_id,
+            algorithm,
+        })
+    }
+
+    /// Inject a pre-built client (used by integration tests with
+    /// `LocalStack` or a stubbed transport).
+    pub fn with_client(
+        client: KmsClient,
+        key_id: impl Into<String>,
+        algorithm: SigningAlgorithm,
+    ) -> Self {
+        Self {
+            client,
+            key_id: key_id.into(),
+            algorithm,
+        }
+    }
+}
+
+#[async_trait]
+impl PlatformSigner for AwsKmsSigner {
+    fn key_id(&self) -> &str {
+        &self.key_id
+    }
+
+    fn algorithm(&self) -> SigningAlgorithm {
+        self.algorithm
+    }
+
+    async fn public_key_der(&self) -> Result<Vec<u8>, SignerError> {
+        let out = self
+            .client
+            .get_public_key()
+            .key_id(&self.key_id)
+            .send()
+            .await
+            .map_err(|e| SignerError::Backend(format!("kms GetPublicKey: {e}")))?;
+        let bytes = out
+            .public_key()
+            .ok_or_else(|| SignerError::UnexpectedPublicKey("response had no public key".into()))?;
+        Ok(bytes.as_ref().to_vec())
+    }
+
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_alg = match self.algorithm {
+            SigningAlgorithm::EcdsaSha256P256 => SigningAlgorithmSpec::EcdsaSha256,
+            SigningAlgorithm::EcdsaSha384P384 => SigningAlgorithmSpec::EcdsaSha384,
+        };
+        let out = self
+            .client
+            .sign()
+            .key_id(&self.key_id)
+            .message(Blob::new(message.to_vec()))
+            .message_type(MessageType::Raw)
+            .signing_algorithm(signing_alg)
+            .send()
+            .await
+            .map_err(|e| SignerError::Backend(format!("kms Sign: {e}")))?;
+        let sig = out
+            .signature()
+            .ok_or_else(|| SignerError::Backend("kms Sign returned no signature".into()))?;
+        Ok(sig.as_ref().to_vec())
+    }
+}
+
+/// Look up the KMS key spec and translate it into our [`SigningAlgorithm`].
+/// Refuses any spec we don't have a signing algorithm pair for — better
+/// to fail at boot than to discover at first `sign()` that the key is
+/// unusable.
+async fn probe_algorithm(
+    client: &KmsClient,
+    key_id: &str,
+) -> Result<SigningAlgorithm, SignerError> {
+    let out = client
+        .get_public_key()
+        .key_id(key_id)
+        .send()
+        .await
+        .map_err(|e| SignerError::Backend(format!("kms GetPublicKey (probe): {e}")))?;
+    let spec = out
+        .key_spec()
+        .ok_or_else(|| SignerError::Backend("kms GetPublicKey returned no KeySpec".into()))?;
+    match spec {
+        KeySpec::EccNistP256 => Ok(SigningAlgorithm::EcdsaSha256P256),
+        KeySpec::EccNistP384 => Ok(SigningAlgorithm::EcdsaSha384P384),
+        other => Err(SignerError::Backend(format!(
+            "unsupported KMS KeySpec {other:?}; expected ECC_NIST_P256 or ECC_NIST_P384"
+        ))),
+    }
+}

--- a/crates/mockforge-platform-signing/src/lib.rs
+++ b/crates/mockforge-platform-signing/src/lib.rs
@@ -1,0 +1,58 @@
+//! HSM-backed platform signing-root for `MockForge`.
+//!
+//! Implements RFC §8.2 (kill-switch signing) and §9 (rotation procedure) of
+//! the cloud trust & permissions RFC.
+//!
+//! # Layout
+//!
+//! - [`signer`] — [`PlatformSigner`] trait + an in-memory [`MockSigner`]
+//!   for tests.
+//! - [`aws_kms`] (feature: `aws-kms`) — production [`AwsKmsSigner`] that
+//!   round-trips signatures through AWS KMS so private bytes never leave
+//!   the service boundary.
+//! - [`rotation`] — [`RotationStateMachine`] + [`RotationEvent`]; how the
+//!   operator drives a key handover and how the wire-format manifest is
+//!   built.
+//! - [`verifier`] — pure-Rust verifier for `RotationEvent` manifests, used
+//!   by plugin-hosts to decide whether to trust a newly-rotated platform
+//!   key. Does not need the AWS SDK.
+//!
+//! # Quick start (operator-facing)
+//!
+//! ```no_run
+//! # #[cfg(feature = "aws-kms")]
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! use mockforge_platform_signing::aws_kms::AwsKmsSigner;
+//! use mockforge_platform_signing::rotation::RotationStateMachine;
+//! use chrono::Duration;
+//!
+//! // Active key — `MOCKFORGE_PLATFORM_SIGNING_KMS_KEY_ID`.
+//! let current = AwsKmsSigner::from_env().await?;
+//! // New key — generated out-of-band via the runbook.
+//! let next = AwsKmsSigner::from_key_id("arn:aws:kms:us-east-1:...:key/new").await?;
+//!
+//! let mut sm = RotationStateMachine::new(current);
+//! let event = sm.begin_handover(&next, Duration::days(30)).await?;
+//! // `event` is the wire manifest the registry publishes; every host
+//! // verifies it before trusting `next.key_id()`.
+//! # Ok(()) }
+//! ```
+//!
+//! See `docs/plugins/security/platform-signing-rotation-runbook.md`
+//! for the end-to-end runbook (this crate is the machinery; the runbook
+//! is the process).
+
+#![warn(missing_docs)]
+
+pub mod rotation;
+pub mod signer;
+pub mod verifier;
+
+#[cfg(feature = "aws-kms")]
+pub mod aws_kms;
+
+pub use rotation::{
+    RotationError, RotationEvent, RotationEventPayload, RotationPhase, RotationStateMachine,
+};
+pub use signer::{MockSigner, PlatformSigner, SignerError, SigningAlgorithm};
+pub use verifier::{verify_rotation_event, VerifyError};

--- a/crates/mockforge-platform-signing/src/rotation.rs
+++ b/crates/mockforge-platform-signing/src/rotation.rs
@@ -1,0 +1,449 @@
+//! Dual-control rotation state machine + on-the-wire rotation event.
+//!
+//! See RFC §9 for the procedure this implements. The operator-facing
+//! runbook is in `docs/plugins/security/platform-signing-rotation-runbook.md`.
+//!
+//! # Phases
+//!
+//! ```text
+//!     Active        ── begin_handover ──▶    Transitioning
+//!     (cur)                                  (cur + next trusted)
+//!                                                   │
+//!                                                   │ retire_old
+//!                                                   ▼
+//!                                              Active(next)
+//! ```
+//!
+//! The state machine does not talk to AWS directly when retiring the
+//! old key (operators do that via the runbook + `aws kms disable-key`)
+//! — it just gates the on-the-wire event so plugin-hosts only see
+//! state changes that match the documented sequence.
+//!
+//! # Wire format
+//!
+//! [`RotationEvent`] is what the registry publishes; plugin-hosts pick
+//! it up (poll or push) and pass it to
+//! [`crate::verifier::verify_rotation_event`]. It contains:
+//!
+//!   - the **from** key id + DER public key (the current trust anchor)
+//!   - the **to**   key id + DER public key (the new trust anchor)
+//!   - a `transition_until` timestamp (both keys are trusted until this)
+//!   - a signature over the canonical JCS payload, produced by the
+//!     **from** key — this is the cryptographic handover that proves
+//!     the new key was authorized by the predecessor.
+//!
+//! Domain prefix: `mockforge-platform-rotation/v1\n` is prepended before
+//! signing, mirroring the prefix discipline in
+//! `mockforge-plugin-host::signing` (cross-protocol replay defense).
+
+use base64::Engine;
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use crate::signer::{PlatformSigner, SignerError, SigningAlgorithm};
+
+/// Domain-separation prefix for the rotation-event signed bytes.
+///
+/// Same discipline as `mockforge-plugin-host::signing` — prevents a
+/// signature over any other JSON document with a matching prefix from
+/// being replayed as a platform rotation event.
+pub const ROTATION_DOMAIN_PREFIX: &[u8] = b"mockforge-platform-rotation/v1\n";
+
+/// Default transition window. Matches RFC §9 ("≥ 30 days").
+pub const DEFAULT_TRANSITION_DAYS: i64 = 30;
+
+/// Where the rotation state machine currently sits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RotationPhase {
+    /// Single active key. Steady state.
+    Active,
+    /// Both old and new keys are trusted. Hosts accept signatures from
+    /// either. Lasts until `transition_until` passes.
+    Transitioning,
+}
+
+/// Inner payload of a [`RotationEvent`] — the bytes that get signed.
+///
+/// Serialized via [`serde_jcs`] (RFC 8785 canonical JSON) so the byte
+/// representation is stable across hosts. Any drift in field order or
+/// number encoding silently invalidates the signature, so canonical
+/// JSON is non-negotiable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct RotationEventPayload {
+    /// Schema version. Always `1` for this crate.
+    pub version: u32,
+    /// Algorithm of the **from** key — what signed this payload.
+    pub from_algorithm: SigningAlgorithm,
+    /// Opaque id of the previous key (e.g. KMS ARN).
+    pub from_key_id: String,
+    /// `SubjectPublicKeyInfo` (DER) of the previous key, base64-encoded.
+    pub from_public_key_b64: String,
+    /// Algorithm of the **to** key.
+    pub to_algorithm: SigningAlgorithm,
+    /// Opaque id of the new key.
+    pub to_key_id: String,
+    /// `SubjectPublicKeyInfo` (DER) of the new key, base64-encoded.
+    pub to_public_key_b64: String,
+    /// UTC instant at which the transition window opened.
+    pub issued_at: DateTime<Utc>,
+    /// UTC instant after which the previous key should no longer be
+    /// trusted. Plugin-hosts MUST evict the `from` key from their trust
+    /// cache once their wall clock passes this.
+    pub transition_until: DateTime<Utc>,
+}
+
+/// On-the-wire rotation event — published by the registry, consumed by
+/// every plugin-host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct RotationEvent {
+    /// The signed payload.
+    pub payload: RotationEventPayload,
+    /// DER-encoded ECDSA signature over
+    /// `ROTATION_DOMAIN_PREFIX || serde_jcs(payload)`, base64-encoded.
+    /// Signed by `payload.from_key_id`.
+    pub handover_signature_b64: String,
+}
+
+impl RotationEvent {
+    /// Canonical bytes that were signed to produce
+    /// `handover_signature_b64`. Used by the verifier; exposed so tests
+    /// and the audit log can show the operator exactly what was signed.
+    pub fn signed_bytes(payload: &RotationEventPayload) -> Result<Vec<u8>, RotationError> {
+        let canonical = serde_jcs::to_vec(payload)
+            .map_err(|e| RotationError::Encoding(format!("serde_jcs failed: {e}")))?;
+        let mut out = Vec::with_capacity(ROTATION_DOMAIN_PREFIX.len() + canonical.len());
+        out.extend_from_slice(ROTATION_DOMAIN_PREFIX);
+        out.extend_from_slice(&canonical);
+        Ok(out)
+    }
+}
+
+/// Drives the rotation procedure end-to-end.
+///
+/// One state machine corresponds to one platform deployment. Hold this
+/// behind an `Arc<Mutex<_>>` if multiple operators can drive it
+/// concurrently — the type itself is `!Sync` so the compiler enforces
+/// serialized access through the mutex.
+pub struct RotationStateMachine<S: PlatformSigner> {
+    current: S,
+    inner: Mutex<RotationInner>,
+}
+
+#[derive(Debug)]
+struct RotationInner {
+    phase: RotationPhase,
+    last_event: Option<RotationEvent>,
+}
+
+impl<S: PlatformSigner> RotationStateMachine<S> {
+    /// Build a fresh state machine seeded with the active key. Phase is
+    /// [`RotationPhase::Active`].
+    pub fn new(current: S) -> Self {
+        Self {
+            current,
+            inner: Mutex::new(RotationInner {
+                phase: RotationPhase::Active,
+                last_event: None,
+            }),
+        }
+    }
+
+    /// Current phase.
+    pub async fn phase(&self) -> RotationPhase {
+        self.inner.lock().await.phase
+    }
+
+    /// Most recent rotation event published, if any.
+    pub async fn last_event(&self) -> Option<RotationEvent> {
+        self.inner.lock().await.last_event.clone()
+    }
+
+    /// Step 1 of the runbook (after the operator has generated the new
+    /// KMS key out-of-band). Fetches both public keys, asks the current
+    /// signer to sign the handover, returns the wire event.
+    ///
+    /// Transitions the state machine from [`RotationPhase::Active`] to
+    /// [`RotationPhase::Transitioning`]. Refuses to re-fire if a
+    /// rotation is already in progress — emergency revocation is a
+    /// distinct call path (see [`Self::emergency_revoke_current`]).
+    ///
+    /// `transition_window`: how long both keys remain trusted. Default
+    /// per RFC is 30 days (see [`DEFAULT_TRANSITION_DAYS`]).
+    pub async fn begin_handover<N: PlatformSigner>(
+        &self,
+        next: &N,
+        transition_window: Duration,
+    ) -> Result<RotationEvent, RotationError> {
+        let mut inner = self.inner.lock().await;
+        if inner.phase != RotationPhase::Active {
+            return Err(RotationError::WrongPhase {
+                current: inner.phase,
+                expected: RotationPhase::Active,
+            });
+        }
+        if self.current.key_id() == next.key_id() {
+            return Err(RotationError::SameKey);
+        }
+        if transition_window <= Duration::zero() {
+            return Err(RotationError::InvalidTransitionWindow);
+        }
+
+        let now = Utc::now();
+        let payload = RotationEventPayload {
+            version: 1,
+            from_algorithm: self.current.algorithm(),
+            from_key_id: self.current.key_id().to_string(),
+            from_public_key_b64: b64_encode(&self.current.public_key_der().await?),
+            to_algorithm: next.algorithm(),
+            to_key_id: next.key_id().to_string(),
+            to_public_key_b64: b64_encode(&next.public_key_der().await?),
+            issued_at: now,
+            transition_until: now + transition_window,
+        };
+        let to_sign = RotationEvent::signed_bytes(&payload)?;
+        let sig_der = self.current.sign(&to_sign).await?;
+        let event = RotationEvent {
+            payload,
+            handover_signature_b64: b64_encode(&sig_der),
+        };
+        inner.phase = RotationPhase::Transitioning;
+        inner.last_event = Some(event.clone());
+        tracing::info!(
+            from_key_id = %self.current.key_id(),
+            to_key_id = %next.key_id(),
+            transition_window_days = transition_window.num_days(),
+            "platform signing-root rotation: handover signed"
+        );
+        Ok(event)
+    }
+
+    /// Step 2 of the runbook — operator calls this after the transition
+    /// window has elapsed and the runbook's manual `aws kms disable-key`
+    /// step is complete. Brings the state machine back to
+    /// [`RotationPhase::Active`].
+    ///
+    /// Note: the **state machine** does not switch its `current` signer
+    /// (this type is generic and immutable). The expectation is that
+    /// the registry process restarts with the new `MOCKFORGE_PLATFORM_SIGNING_KMS_KEY_ID`
+    /// pointing at the new ARN. This method exists for in-memory state
+    /// hygiene + audit completeness, and is the call site where the
+    /// `PlatformSigningKeyRetired` audit event fires.
+    pub async fn retire_old(&self) -> Result<(), RotationError> {
+        let mut inner = self.inner.lock().await;
+        if inner.phase != RotationPhase::Transitioning {
+            return Err(RotationError::WrongPhase {
+                current: inner.phase,
+                expected: RotationPhase::Transitioning,
+            });
+        }
+        // Clone the relevant fields out of the immutable borrow so we
+        // can subsequently mutate `inner.phase` without overlap.
+        let (from_id, to_id, transition_until) = {
+            let last = inner.last_event.as_ref().ok_or(RotationError::NoRotationInProgress)?;
+            (
+                last.payload.from_key_id.clone(),
+                last.payload.to_key_id.clone(),
+                last.payload.transition_until,
+            )
+        };
+        if Utc::now() < transition_until {
+            return Err(RotationError::TransitionStillOpen {
+                until: transition_until,
+            });
+        }
+        inner.phase = RotationPhase::Active;
+        tracing::info!(
+            from_key_id = %from_id,
+            to_key_id = %to_id,
+            "platform signing-root rotation: old key retired"
+        );
+        Ok(())
+    }
+
+    /// Emergency: revoke the current key without a successor. Used when
+    /// the active key is believed compromised and no new key has been
+    /// provisioned yet. After this returns, the registry refuses to
+    /// publish anything signed by the old key.
+    ///
+    /// This does NOT publish a rotation event — there's no new key to
+    /// hand over to. The runbook's "Emergency revocation" section
+    /// covers the operator-facing process (notify all hosted-mock
+    /// owners, then run [`Self::begin_handover`] with a fresh key once
+    /// it's available).
+    pub async fn emergency_revoke_current(&self) -> Result<(), RotationError> {
+        // We still take the lock so the state machine refuses
+        // concurrent handovers while the operator is responding to the
+        // incident. There's no phase transition — emergency revoke is
+        // a "shut everything down" signal handled by the caller.
+        let _inner = self.inner.lock().await;
+        tracing::error!(
+            key_id = %self.current.key_id(),
+            "platform signing-root: emergency revoke fired — registry refusing further signs"
+        );
+        Ok(())
+    }
+}
+
+fn b64_encode(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// Errors the state machine can produce.
+#[derive(Debug, Error)]
+pub enum RotationError {
+    /// Tried to do something in the wrong phase (e.g. retire while still
+    /// active). Hints at an operator misstep in the runbook.
+    #[error("rotation in phase {current:?}, but operation requires {expected:?}")]
+    WrongPhase {
+        /// What phase the state machine is in.
+        current: RotationPhase,
+        /// What phase the operation expected.
+        expected: RotationPhase,
+    },
+
+    /// `begin_handover` was called with the same key id as the current
+    /// signer. A no-op rotation would still publish an event that
+    /// every host would refuse.
+    #[error("from-key and to-key have the same key id; nothing to rotate")]
+    SameKey,
+
+    /// `begin_handover` was called with a non-positive transition
+    /// window. Hosts must have a real overlap window or rotation is
+    /// just an atomic swap from their perspective.
+    #[error("transition window must be a positive duration")]
+    InvalidTransitionWindow,
+
+    /// `retire_old` was called but the transition window hasn't elapsed
+    /// yet. Tells the operator to wait or override (override is a
+    /// separate code path).
+    #[error("transition window is still open until {until}")]
+    TransitionStillOpen {
+        /// When the window closes.
+        until: DateTime<Utc>,
+    },
+
+    /// `retire_old` was called but no rotation has been started yet.
+    #[error("no rotation in progress")]
+    NoRotationInProgress,
+
+    /// JCS encoding failed. Should be impossible for the fixed-shape
+    /// payload, but propagated rather than panicked.
+    #[error("rotation encoding error: {0}")]
+    Encoding(String),
+
+    /// The underlying signer failed.
+    #[error(transparent)]
+    Signer(#[from] SignerError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signer::MockSigner;
+    use crate::verifier::verify_rotation_event;
+
+    #[tokio::test]
+    async fn happy_path_handover_emits_verifiable_event() {
+        let current = MockSigner::generate("key-old").unwrap();
+        let next = MockSigner::generate("key-new").unwrap();
+        let sm = RotationStateMachine::new(current);
+        assert_eq!(sm.phase().await, RotationPhase::Active);
+
+        let event = sm.begin_handover(&next, Duration::days(30)).await.expect("handover succeeds");
+
+        assert_eq!(sm.phase().await, RotationPhase::Transitioning);
+        assert_eq!(event.payload.from_key_id, "key-old");
+        assert_eq!(event.payload.to_key_id, "key-new");
+        assert_eq!(event.payload.version, 1);
+        assert_eq!(event.payload.transition_until - event.payload.issued_at, Duration::days(30));
+
+        // Round-trip through the verifier — confirms the bytes the
+        // signer signed are exactly what the verifier reconstructs.
+        verify_rotation_event(&event).expect("rotation event verifies");
+    }
+
+    #[tokio::test]
+    async fn cannot_begin_handover_while_transitioning() {
+        let current = MockSigner::generate("k1").unwrap();
+        let next1 = MockSigner::generate("k2").unwrap();
+        let next2 = MockSigner::generate("k3").unwrap();
+        let sm = RotationStateMachine::new(current);
+        sm.begin_handover(&next1, Duration::days(30)).await.unwrap();
+        let err = sm.begin_handover(&next2, Duration::days(30)).await.unwrap_err();
+        assert!(matches!(err, RotationError::WrongPhase { .. }));
+    }
+
+    #[tokio::test]
+    async fn refuses_same_key_handover() {
+        // Two distinct signers with the same id — operator misconfig.
+        // Generating two `MockSigner::generate("k")` produces different
+        // keypairs, so we need to share the key id via direct
+        // construction — easiest path: same MockSigner is used twice.
+        let current = MockSigner::generate("same-id").unwrap();
+        let next = MockSigner::generate("same-id").unwrap();
+        let sm = RotationStateMachine::new(current);
+        let err = sm.begin_handover(&next, Duration::days(30)).await.unwrap_err();
+        assert!(matches!(err, RotationError::SameKey));
+    }
+
+    #[tokio::test]
+    async fn refuses_non_positive_transition_window() {
+        let current = MockSigner::generate("k1").unwrap();
+        let next = MockSigner::generate("k2").unwrap();
+        let sm = RotationStateMachine::new(current);
+        let err = sm.begin_handover(&next, Duration::zero()).await.unwrap_err();
+        assert!(matches!(err, RotationError::InvalidTransitionWindow));
+    }
+
+    #[tokio::test]
+    async fn retire_old_refuses_while_window_open() {
+        let current = MockSigner::generate("k1").unwrap();
+        let next = MockSigner::generate("k2").unwrap();
+        let sm = RotationStateMachine::new(current);
+        sm.begin_handover(&next, Duration::days(30)).await.unwrap();
+        let err = sm.retire_old().await.unwrap_err();
+        assert!(matches!(err, RotationError::TransitionStillOpen { .. }));
+    }
+
+    #[tokio::test]
+    async fn retire_old_succeeds_after_window() {
+        let current = MockSigner::generate("k1").unwrap();
+        let next = MockSigner::generate("k2").unwrap();
+        let sm = RotationStateMachine::new(current);
+        // Use a negative window via a small positive then manual
+        // overwrite — clearer to use a 1ms window and sleep.
+        sm.begin_handover(&next, Duration::milliseconds(1)).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        sm.retire_old().await.expect("retire_old after window closes");
+        assert_eq!(sm.phase().await, RotationPhase::Active);
+    }
+
+    #[tokio::test]
+    async fn rotation_event_jcs_is_deterministic() {
+        // Re-serializing the same payload must yield identical bytes —
+        // any non-determinism here silently invalidates signatures
+        // because the verifier reconstructs the bytes from the
+        // payload.
+        let payload = RotationEventPayload {
+            version: 1,
+            from_algorithm: SigningAlgorithm::EcdsaSha256P256,
+            from_key_id: "old".into(),
+            from_public_key_b64: "AAAA".into(),
+            to_algorithm: SigningAlgorithm::EcdsaSha256P256,
+            to_key_id: "new".into(),
+            to_public_key_b64: "BBBB".into(),
+            issued_at: Utc::now(),
+            transition_until: Utc::now() + Duration::days(30),
+        };
+        let a = RotationEvent::signed_bytes(&payload).unwrap();
+        let b = RotationEvent::signed_bytes(&payload).unwrap();
+        assert_eq!(a, b);
+        // And the bytes start with the domain prefix.
+        assert!(a.starts_with(ROTATION_DOMAIN_PREFIX));
+    }
+}

--- a/crates/mockforge-platform-signing/src/signer.rs
+++ b/crates/mockforge-platform-signing/src/signer.rs
@@ -1,0 +1,251 @@
+//! [`PlatformSigner`] — backend-agnostic trait for the platform signing
+//! root.
+//!
+//! Backends keep the private key behind an HSM boundary (AWS KMS today,
+//! GCP KMS or a `YubiHSM` tomorrow) and only expose a `sign(...)`
+//! round-trip. All test fixtures use [`MockSigner`], which holds a
+//! software keypair in memory and is **not safe for production**.
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// What signature algorithm a [`PlatformSigner`] produces.
+///
+/// AWS KMS does not support Ed25519, so the platform root uses ECDSA over
+/// NIST P-256 or P-384. P-256 is the default (smaller signatures, faster
+/// verify on the host fleet) — P-384 is available for higher-assurance
+/// deployments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SigningAlgorithm {
+    /// ECDSA over NIST P-256 with SHA-256. Default.
+    EcdsaSha256P256,
+    /// ECDSA over NIST P-384 with SHA-384. Higher-assurance opt-in.
+    EcdsaSha384P384,
+}
+
+impl SigningAlgorithm {
+    /// Stable wire-form for use inside [`crate::rotation::RotationEventPayload`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EcdsaSha256P256 => "ecdsa-sha256-p256",
+            Self::EcdsaSha384P384 => "ecdsa-sha384-p384",
+        }
+    }
+}
+
+/// The platform signer abstraction. One instance corresponds to one HSM-
+/// hosted key.
+///
+/// Implementations MUST guarantee that the private key bytes never leave
+/// the HSM. Only [`PlatformSigner::sign`] crosses the boundary, and only
+/// the resulting signature comes back.
+#[async_trait]
+pub trait PlatformSigner: Send + Sync {
+    /// Opaque identifier the operator uses to refer to this key (e.g. a
+    /// KMS key ARN). Stable across signer instances.
+    fn key_id(&self) -> &str;
+
+    /// Signature algorithm this key produces.
+    fn algorithm(&self) -> SigningAlgorithm;
+
+    /// `SubjectPublicKeyInfo` (DER) for the key. Plugin-hosts use this
+    /// to verify signatures the signer produces.
+    async fn public_key_der(&self) -> Result<Vec<u8>, SignerError>;
+
+    /// Sign the given message. The returned bytes are the DER-encoded
+    /// ECDSA signature (matches what AWS KMS `Sign` returns when called
+    /// with `MessageType=RAW`).
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>, SignerError>;
+}
+
+/// Errors a signer backend can produce.
+#[derive(Debug, Error)]
+pub enum SignerError {
+    /// The backend rejected the call (e.g. `AccessDenied`, `KeyDisabled`).
+    /// The string is the backend's own error message, surfaced as-is.
+    #[error("signer backend error: {0}")]
+    Backend(String),
+
+    /// The configured key id was empty or malformed.
+    #[error("invalid key id: {0}")]
+    InvalidKeyId(String),
+
+    /// Required environment variable missing.
+    #[error("missing environment variable: {0}")]
+    MissingEnv(&'static str),
+
+    /// The backend returned a public key in an unexpected encoding.
+    #[error("unexpected public-key encoding from backend: {0}")]
+    UnexpectedPublicKey(String),
+}
+
+/// Software-keypair signer for tests. **Never use in production** — the
+/// private bytes live in process memory, which defeats the entire point
+/// of this crate.
+///
+/// Uses ring's ECDSA implementation over NIST P-256 with SHA-256.
+pub struct MockSigner {
+    key_id: String,
+    keypair: ring::signature::EcdsaKeyPair,
+    public_key_der: Vec<u8>,
+    algorithm: SigningAlgorithm,
+}
+
+impl std::fmt::Debug for MockSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MockSigner")
+            .field("key_id", &self.key_id)
+            .field("algorithm", &self.algorithm)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MockSigner {
+    /// Generate a fresh P-256 keypair labelled with `key_id`.
+    pub fn generate(key_id: impl Into<String>) -> Result<Self, SignerError> {
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = ring::signature::EcdsaKeyPair::generate_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+            &rng,
+        )
+        .map_err(|e| SignerError::Backend(format!("ring pkcs8 generate failed: {e}")))?;
+        let keypair = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+            pkcs8.as_ref(),
+            &rng,
+        )
+        .map_err(|e| SignerError::Backend(format!("ring keypair load failed: {e}")))?;
+        // ring returns the raw subject-public-key (uncompressed point);
+        // wrap it in a SubjectPublicKeyInfo so the verifier can use the
+        // same DER shape as the AWS KMS path.
+        let raw_pub = ring::signature::KeyPair::public_key(&keypair).as_ref().to_vec();
+        let public_key_der = wrap_p256_spki(&raw_pub);
+        Ok(Self {
+            key_id: key_id.into(),
+            keypair,
+            public_key_der,
+            algorithm: SigningAlgorithm::EcdsaSha256P256,
+        })
+    }
+}
+
+#[async_trait]
+impl PlatformSigner for MockSigner {
+    fn key_id(&self) -> &str {
+        &self.key_id
+    }
+
+    fn algorithm(&self) -> SigningAlgorithm {
+        self.algorithm
+    }
+
+    async fn public_key_der(&self) -> Result<Vec<u8>, SignerError> {
+        Ok(self.public_key_der.clone())
+    }
+
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let rng = ring::rand::SystemRandom::new();
+        let sig = self
+            .keypair
+            .sign(&rng, message)
+            .map_err(|e| SignerError::Backend(format!("ring sign failed: {e}")))?;
+        Ok(sig.as_ref().to_vec())
+    }
+}
+
+/// Wrap a raw P-256 uncompressed public-key point (65 bytes, leading 0x04)
+/// in a minimal `SubjectPublicKeyInfo` so the verifier sees the same DER
+/// shape the AWS KMS backend returns.
+fn wrap_p256_spki(raw_uncompressed_point: &[u8]) -> Vec<u8> {
+    // Hand-rolled DER builder — this is fixed-shape ASN.1 (RFC 5480
+    // §2.1.1) so a bespoke encoding is simpler than pulling in a full
+    // DER library just for one record.
+    //
+    // SEQUENCE {
+    //   SEQUENCE {            // AlgorithmIdentifier
+    //     OID 1.2.840.10045.2.1     // id-ecPublicKey
+    //     OID 1.2.840.10045.3.1.7   // secp256r1
+    //   }
+    //   BIT STRING { <unused = 0> || raw_uncompressed_point }
+    // }
+    const ALG_PREFIX: &[u8] = &[
+        0x30, 0x13, // SEQUENCE (AlgorithmIdentifier), len 19
+        0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, // OID id-ecPublicKey
+        0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, // OID secp256r1
+    ];
+    let bitstring_len = 1 + raw_uncompressed_point.len(); // 1 = "unused bits" byte
+    let mut bitstring = Vec::with_capacity(2 + bitstring_len);
+    bitstring.push(0x03); // BIT STRING tag
+    bitstring.push(bitstring_len as u8);
+    bitstring.push(0x00); // 0 unused bits
+    bitstring.extend_from_slice(raw_uncompressed_point);
+    let body_len = ALG_PREFIX.len() + bitstring.len();
+    let mut out = Vec::with_capacity(2 + body_len);
+    out.push(0x30); // outer SEQUENCE
+    out.push(body_len as u8);
+    out.extend_from_slice(ALG_PREFIX);
+    out.extend_from_slice(&bitstring);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_signer_round_trips() {
+        let signer = MockSigner::generate("test-key-1").unwrap();
+        assert_eq!(signer.key_id(), "test-key-1");
+        assert_eq!(signer.algorithm(), SigningAlgorithm::EcdsaSha256P256);
+
+        let msg = b"hello mockforge";
+        let sig = signer.sign(msg).await.unwrap();
+        let pub_der = signer.public_key_der().await.unwrap();
+
+        // Verify with ring directly against the wrapped SPKI — the
+        // verifier module does the same thing for the rotation event.
+        // Strip the SPKI wrapping to get back the raw point ring expects.
+        let raw_point = extract_p256_point_from_spki(&pub_der).expect("valid spki");
+        let pubkey = ring::signature::UnparsedPublicKey::new(
+            &ring::signature::ECDSA_P256_SHA256_ASN1,
+            &raw_point,
+        );
+        pubkey.verify(msg, &sig).expect("signature should verify");
+    }
+
+    #[tokio::test]
+    async fn mock_signer_rejects_tampered_message() {
+        let signer = MockSigner::generate("test-key-2").unwrap();
+        let sig = signer.sign(b"original").await.unwrap();
+        let pub_der = signer.public_key_der().await.unwrap();
+        let raw_point = extract_p256_point_from_spki(&pub_der).unwrap();
+        let pubkey = ring::signature::UnparsedPublicKey::new(
+            &ring::signature::ECDSA_P256_SHA256_ASN1,
+            &raw_point,
+        );
+        assert!(pubkey.verify(b"tampered", &sig).is_err());
+    }
+
+    #[test]
+    fn signing_algorithm_wire_form_is_stable() {
+        // These strings ship over the wire inside RotationEventPayload;
+        // any change is a backwards-incompatible break of every
+        // plugin-host that's persisted a rotation event.
+        assert_eq!(SigningAlgorithm::EcdsaSha256P256.as_str(), "ecdsa-sha256-p256");
+        assert_eq!(SigningAlgorithm::EcdsaSha384P384.as_str(), "ecdsa-sha384-p384");
+    }
+
+    /// Pull the 65-byte uncompressed point back out of a minimal P-256
+    /// `SubjectPublicKeyInfo` so ring can verify against it.
+    fn extract_p256_point_from_spki(spki: &[u8]) -> Option<Vec<u8>> {
+        // The wrap_p256_spki layout is fixed; the raw point starts at
+        // a known offset. This is test-only — production verifier in
+        // `verifier.rs` does the same thing more carefully.
+        const HEADER_LEN: usize = 26; // outer SEQ(2) + AlgorithmIdentifier(21) + BIT STRING tag+len(2) + unused-bits(1)
+        if spki.len() <= HEADER_LEN {
+            return None;
+        }
+        Some(spki[HEADER_LEN..].to_vec())
+    }
+}

--- a/crates/mockforge-platform-signing/src/verifier.rs
+++ b/crates/mockforge-platform-signing/src/verifier.rs
@@ -1,0 +1,291 @@
+//! Pure-Rust verifier for [`crate::rotation::RotationEvent`] manifests.
+//!
+//! Lives outside `rotation.rs` so plugin-host code that only needs to
+//! **verify** rotation events doesn't have to pull in the
+//! [`crate::signer::PlatformSigner`] trait or anything that depends on
+//! the AWS SDK feature.
+
+use base64::Engine;
+use chrono::Utc;
+use thiserror::Error;
+
+use crate::rotation::RotationEvent;
+use crate::signer::SigningAlgorithm;
+
+/// Verify a rotation event end-to-end:
+///
+/// 1. Reconstruct the canonical signed bytes (domain prefix + JCS payload).
+/// 2. Decode `from_public_key_b64` as a `SubjectPublicKeyInfo` and pull
+///    out the algorithm OID + raw point.
+/// 3. Verify the DER signature against the from-key's public bytes.
+/// 4. Optional clock sanity: refuse if `issued_at > now + 5 min` (clock
+///    skew) or `transition_until < issued_at` (malformed).
+///
+/// Returns `Ok(())` on success; any failure path returns a descriptive
+/// `VerifyError`. The caller is responsible for the trust decision
+/// **after** verification (i.e. "do I currently trust `from_key_id` as
+/// my platform root?" — that's the cache lookup, separate from
+/// crypto verification).
+pub fn verify_rotation_event(event: &RotationEvent) -> Result<(), VerifyError> {
+    let payload = &event.payload;
+
+    if payload.version != 1 {
+        return Err(VerifyError::UnsupportedVersion(payload.version));
+    }
+    if payload.transition_until <= payload.issued_at {
+        return Err(VerifyError::MalformedTimestamps);
+    }
+    // 5-minute skew tolerance — enough for clock drift between regions
+    // without letting a backdated event sneak in.
+    let now = Utc::now();
+    if payload.issued_at > now + chrono::Duration::minutes(5) {
+        return Err(VerifyError::FutureIssuedAt);
+    }
+
+    let signed_bytes = RotationEvent::signed_bytes(payload)
+        .map_err(|e| VerifyError::Reencoding(format!("{e}")))?;
+
+    let sig_der = base64::engine::general_purpose::STANDARD
+        .decode(event.handover_signature_b64.as_bytes())
+        .map_err(|e| VerifyError::InvalidSignatureBase64(e.to_string()))?;
+
+    let from_spki = base64::engine::general_purpose::STANDARD
+        .decode(payload.from_public_key_b64.as_bytes())
+        .map_err(|e| VerifyError::InvalidPublicKeyBase64(e.to_string()))?;
+
+    let raw_point = extract_p256_or_p384_point(&from_spki)?;
+    let alg: &dyn ring::signature::VerificationAlgorithm = match payload.from_algorithm {
+        SigningAlgorithm::EcdsaSha256P256 => &ring::signature::ECDSA_P256_SHA256_ASN1,
+        SigningAlgorithm::EcdsaSha384P384 => &ring::signature::ECDSA_P384_SHA384_ASN1,
+    };
+    let pubkey = ring::signature::UnparsedPublicKey::new(alg, raw_point);
+    pubkey
+        .verify(&signed_bytes, &sig_der)
+        .map_err(|e| VerifyError::SignatureMismatch(format!("{e}")))?;
+
+    Ok(())
+}
+
+/// Strip a `SubjectPublicKeyInfo` to its raw uncompressed point.
+///
+/// Tolerates both the P-256 (65-byte point) and P-384 (97-byte point)
+/// shapes that AWS KMS and [`crate::signer::MockSigner`] both produce.
+/// Does NOT validate the OID — the algorithm choice comes from the
+/// signed `from_algorithm` field. (An attacker can't lie about the
+/// algorithm without invalidating the signature.)
+fn extract_p256_or_p384_point(spki: &[u8]) -> Result<Vec<u8>, VerifyError> {
+    // Pure structural scan — find the BIT STRING and return everything
+    // after its "unused bits" byte. We don't trust the absolute length
+    // because AWS KMS may emit either P-256 (91-byte SPKI) or P-384
+    // (120-byte SPKI), and there's no harm in accepting both.
+    //
+    // SubjectPublicKeyInfo ::= SEQUENCE {
+    //   algorithm AlgorithmIdentifier,
+    //   subjectPublicKey BIT STRING
+    // }
+    if spki.len() < 4 || spki[0] != 0x30 {
+        return Err(VerifyError::MalformedPublicKey("not a SEQUENCE"));
+    }
+    let (_seq_len, after_seq_hdr) = read_der_length(&spki[1..])?;
+    // First inner element: AlgorithmIdentifier (a SEQUENCE) — skip it.
+    if after_seq_hdr.is_empty() || after_seq_hdr[0] != 0x30 {
+        return Err(VerifyError::MalformedPublicKey("missing AlgorithmIdentifier"));
+    }
+    let (alg_len, after_alg_hdr) = read_der_length(&after_seq_hdr[1..])?;
+    if after_alg_hdr.len() < alg_len {
+        return Err(VerifyError::MalformedPublicKey("truncated AlgorithmIdentifier"));
+    }
+    let after_alg = &after_alg_hdr[alg_len..];
+    // Next: BIT STRING.
+    if after_alg.is_empty() || after_alg[0] != 0x03 {
+        return Err(VerifyError::MalformedPublicKey("missing BIT STRING"));
+    }
+    let (bs_len, after_bs_hdr) = read_der_length(&after_alg[1..])?;
+    if after_bs_hdr.len() < bs_len || bs_len == 0 {
+        return Err(VerifyError::MalformedPublicKey("truncated BIT STRING"));
+    }
+    // First byte of a BIT STRING is the number of unused bits — must
+    // be zero for a key.
+    if after_bs_hdr[0] != 0 {
+        return Err(VerifyError::MalformedPublicKey("BIT STRING has unused bits"));
+    }
+    Ok(after_bs_hdr[1..bs_len].to_vec())
+}
+
+/// Read a DER length octet stream. Returns `(length, rest_after_length_bytes)`.
+fn read_der_length(input: &[u8]) -> Result<(usize, &[u8]), VerifyError> {
+    if input.is_empty() {
+        return Err(VerifyError::MalformedPublicKey("missing length octet"));
+    }
+    let first = input[0];
+    if first & 0x80 == 0 {
+        return Ok((first as usize, &input[1..]));
+    }
+    let n_octets = (first & 0x7F) as usize;
+    if n_octets == 0 || n_octets > 4 || input.len() < 1 + n_octets {
+        return Err(VerifyError::MalformedPublicKey("bad long-form length"));
+    }
+    let mut len = 0usize;
+    for &byte in &input[1..=n_octets] {
+        len = (len << 8) | byte as usize;
+    }
+    Ok((len, &input[1 + n_octets..]))
+}
+
+/// Reasons rotation-event verification can fail.
+#[derive(Debug, Error)]
+pub enum VerifyError {
+    /// Event uses a `version` this build doesn't understand.
+    #[error("unsupported rotation-event version: {0}")]
+    UnsupportedVersion(u32),
+
+    /// `transition_until <= issued_at`.
+    #[error("malformed timestamps: transition_until must be after issued_at")]
+    MalformedTimestamps,
+
+    /// `issued_at` is more than 5 minutes in the future.
+    #[error("issued_at is in the future beyond clock-skew tolerance")]
+    FutureIssuedAt,
+
+    /// Could not re-serialize the payload to canonical bytes.
+    #[error("re-encoding failed: {0}")]
+    Reencoding(String),
+
+    /// `handover_signature_b64` was not valid base64.
+    #[error("handover signature is not valid base64: {0}")]
+    InvalidSignatureBase64(String),
+
+    /// `from_public_key_b64` was not valid base64.
+    #[error("from public key is not valid base64: {0}")]
+    InvalidPublicKeyBase64(String),
+
+    /// SPKI parsing failed.
+    #[error("from public key is not a valid SubjectPublicKeyInfo: {0}")]
+    MalformedPublicKey(&'static str),
+
+    /// Ring rejected the signature.
+    #[error("handover signature did not verify against from public key: {0}")]
+    SignatureMismatch(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rotation::{RotationEvent, RotationEventPayload, RotationStateMachine};
+    use crate::signer::MockSigner;
+    use chrono::Duration;
+
+    #[tokio::test]
+    async fn happy_path_verifies() {
+        let cur = MockSigner::generate("from").unwrap();
+        let next = MockSigner::generate("to").unwrap();
+        let sm = RotationStateMachine::new(cur);
+        let event = sm.begin_handover(&next, Duration::days(30)).await.unwrap();
+        verify_rotation_event(&event).expect("verifies");
+    }
+
+    #[tokio::test]
+    async fn tampered_to_key_id_fails() {
+        let cur = MockSigner::generate("from").unwrap();
+        let next = MockSigner::generate("to").unwrap();
+        let sm = RotationStateMachine::new(cur);
+        let mut event = sm.begin_handover(&next, Duration::days(30)).await.unwrap();
+        event.payload.to_key_id = "attacker-key".into();
+        let err = verify_rotation_event(&event).unwrap_err();
+        assert!(matches!(err, VerifyError::SignatureMismatch(_)));
+    }
+
+    #[tokio::test]
+    async fn tampered_transition_until_fails() {
+        let cur = MockSigner::generate("from").unwrap();
+        let next = MockSigner::generate("to").unwrap();
+        let sm = RotationStateMachine::new(cur);
+        let mut event = sm.begin_handover(&next, Duration::days(30)).await.unwrap();
+        event.payload.transition_until += Duration::days(365);
+        let err = verify_rotation_event(&event).unwrap_err();
+        assert!(matches!(err, VerifyError::SignatureMismatch(_)));
+    }
+
+    #[tokio::test]
+    async fn replayed_signature_against_different_payload_fails() {
+        // Take a valid signature, paste it onto a fresh payload — must
+        // not verify. Confirms the domain prefix + JCS payload binding.
+        let cur = MockSigner::generate("from").unwrap();
+        let next1 = MockSigner::generate("to1").unwrap();
+        let sm = RotationStateMachine::new(cur);
+        let event1 = sm.begin_handover(&next1, Duration::days(30)).await.unwrap();
+        // Build a parallel event using `next2` but reuse event1's
+        // signature. We can't call `begin_handover` again (state
+        // machine refuses) so we hand-craft a payload.
+        let mut event2 = event1.clone();
+        event2.payload.to_key_id = "to2".into();
+        // Crucially, leave the signature from event1 in place.
+        let err = verify_rotation_event(&event2).unwrap_err();
+        assert!(matches!(err, VerifyError::SignatureMismatch(_)));
+    }
+
+    #[test]
+    fn rejects_version_mismatch() {
+        let payload = RotationEventPayload {
+            version: 99,
+            from_algorithm: SigningAlgorithm::EcdsaSha256P256,
+            from_key_id: "a".into(),
+            from_public_key_b64: "AAAA".into(),
+            to_algorithm: SigningAlgorithm::EcdsaSha256P256,
+            to_key_id: "b".into(),
+            to_public_key_b64: "BBBB".into(),
+            issued_at: Utc::now(),
+            transition_until: Utc::now() + Duration::days(30),
+        };
+        let event = RotationEvent {
+            payload,
+            handover_signature_b64: "AAAA".into(),
+        };
+        let err = verify_rotation_event(&event).unwrap_err();
+        assert!(matches!(err, VerifyError::UnsupportedVersion(99)));
+    }
+
+    #[test]
+    fn rejects_inverted_timestamps() {
+        let now = Utc::now();
+        let payload = RotationEventPayload {
+            version: 1,
+            from_algorithm: SigningAlgorithm::EcdsaSha256P256,
+            from_key_id: "a".into(),
+            from_public_key_b64: "AAAA".into(),
+            to_algorithm: SigningAlgorithm::EcdsaSha256P256,
+            to_key_id: "b".into(),
+            to_public_key_b64: "BBBB".into(),
+            issued_at: now,
+            transition_until: now - Duration::days(1),
+        };
+        let event = RotationEvent {
+            payload,
+            handover_signature_b64: "AAAA".into(),
+        };
+        let err = verify_rotation_event(&event).unwrap_err();
+        assert!(matches!(err, VerifyError::MalformedTimestamps));
+    }
+
+    #[test]
+    fn rejects_future_issued_at() {
+        let now = Utc::now();
+        let payload = RotationEventPayload {
+            version: 1,
+            from_algorithm: SigningAlgorithm::EcdsaSha256P256,
+            from_key_id: "a".into(),
+            from_public_key_b64: "AAAA".into(),
+            to_algorithm: SigningAlgorithm::EcdsaSha256P256,
+            to_key_id: "b".into(),
+            to_public_key_b64: "BBBB".into(),
+            issued_at: now + Duration::hours(1),
+            transition_until: now + Duration::days(30),
+        };
+        let event = RotationEvent {
+            payload,
+            handover_signature_b64: "AAAA".into(),
+        };
+        let err = verify_rotation_event(&event).unwrap_err();
+        assert!(matches!(err, VerifyError::FutureIssuedAt));
+    }
+}

--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -83,6 +83,13 @@ pub enum AuditEventType {
     PluginBlocklistHit,
     OrgTrustRootCreated,
     OrgTrustRootRevoked,
+    // Platform signing-root rotation (RFC §8.2 / §9, Issue #550).
+    // Operator-scoped events — recorded with the operator's org_id (or
+    // the platform operator's tenant when SaaSy Solutions itself runs
+    // the rotation).
+    PlatformSigningRotationStarted,
+    PlatformSigningKeyRetired,
+    PlatformSigningKeyRevoked,
     // Admin actions
     AdminImpersonation,
 }
@@ -151,6 +158,9 @@ impl AuditEventType {
             "plugin_blocklist_hit" => Some(Self::PluginBlocklistHit),
             "org_trust_root_created" => Some(Self::OrgTrustRootCreated),
             "org_trust_root_revoked" => Some(Self::OrgTrustRootRevoked),
+            "platform_signing_rotation_started" => Some(Self::PlatformSigningRotationStarted),
+            "platform_signing_key_retired" => Some(Self::PlatformSigningKeyRetired),
+            "platform_signing_key_revoked" => Some(Self::PlatformSigningKeyRevoked),
             "admin_impersonation" => Some(Self::AdminImpersonation),
             _ => None,
         }
@@ -219,6 +229,9 @@ impl AuditEventType {
             Self::PluginBlocklistHit => "plugin_blocklist_hit",
             Self::OrgTrustRootCreated => "org_trust_root_created",
             Self::OrgTrustRootRevoked => "org_trust_root_revoked",
+            Self::PlatformSigningRotationStarted => "platform_signing_rotation_started",
+            Self::PlatformSigningKeyRetired => "platform_signing_key_retired",
+            Self::PlatformSigningKeyRevoked => "platform_signing_key_revoked",
             Self::AdminImpersonation => "admin_impersonation",
         }
     }
@@ -426,6 +439,9 @@ mod tests {
             AuditEventType::InvitationCreated,
             AuditEventType::InvitationRevoked,
             AuditEventType::InvitationAccepted,
+            AuditEventType::PlatformSigningRotationStarted,
+            AuditEventType::PlatformSigningKeyRetired,
+            AuditEventType::PlatformSigningKeyRevoked,
             AuditEventType::AdminImpersonation,
         ];
         for variant in variants {

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -29,7 +29,13 @@ saas = [
   "oauth",
   "saml",
   "cache-redis",
+  "platform-signing-aws-kms",
 ]
+
+# HSM-backed platform signing-root rotation via AWS KMS (Issue #550).
+# Off in OSS builds — the registry can still load + verify rotation
+# events emitted by the cloud control plane without minting them.
+platform-signing-aws-kms = ["mockforge-platform-signing/aws-kms"]
 
 # Storage backends. Exactly one should be enabled per consumer.
 postgres = ["sqlx/postgres"]
@@ -139,6 +145,7 @@ x509-parser = { version = "0.17", optional = true }
 rustls-pemfile = { version = "2.0", optional = true }
 
 # Internal dependencies
+mockforge-platform-signing = { path = "../mockforge-platform-signing" }
 mockforge-registry-core = { path = "../mockforge-registry-core", default-features = false, features = ["postgres"] }
 mockforge-analytics = { version = "0.3.70", path = "../mockforge-analytics" }
 mockforge-collab = { version = "0.3.70", path = "../mockforge-collab" }

--- a/crates/mockforge-registry-server/migrations/20250101000077_platform_signing_audit_events.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000077_platform_signing_audit_events.sql
@@ -1,0 +1,30 @@
+-- Platform signing-root rotation audit events (Issue #550, RFC §8.2 / §9).
+--
+-- New enum values consumed by the registry whenever the operator
+-- (SaaSy Solutions, not an org admin) drives the platform signing-key
+-- rotation procedure. These rows are written by code in
+-- `mockforge-platform-signing` via the existing `record_audit_event`
+-- helper.
+--
+-- The Rust mirror lives in
+-- `crates/mockforge-registry-core/src/models/audit_log.rs`
+-- (`AuditEventType::PlatformSigning*`). Round-trip test in that file
+-- guarantees every snake_case literal here also exists on the Rust
+-- side.
+
+-- Operator started a key handover. Payload (in `metadata`) includes
+-- `from_key_id`, `to_key_id`, `transition_until`, `algorithm`. The
+-- handover signature itself is NOT stored — it's published on the
+-- rotation-event endpoint that plugin-hosts poll.
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'platform_signing_rotation_started';
+
+-- Old key formally retired after the transition window. Operator
+-- runs `aws kms disable-key` manually; this row records that the
+-- registry observed the retirement and updated in-memory state.
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'platform_signing_key_retired';
+
+-- Emergency revocation — old key destroyed without a successor in
+-- place. Used when the active key is believed compromised. Operator
+-- must follow up with `platform_signing_rotation_started` once a new
+-- key is provisioned (see runbook).
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'platform_signing_key_revoked';

--- a/crates/mockforge-registry-server/src/lib.rs
+++ b/crates/mockforge-registry-server/src/lib.rs
@@ -35,6 +35,9 @@ pub mod middleware;
 /// cloud-core extraction.
 pub use mockforge_registry_core::models;
 pub mod pillar_tracking_init;
+/// HSM-backed platform signing-root rotation (Issue #550, RFC §8.2 / §9).
+/// Audit-aware wrapper around [`mockforge_platform_signing`].
+pub mod platform_signing;
 pub mod redis;
 pub mod routes;
 pub mod run_queue;

--- a/crates/mockforge-registry-server/src/platform_signing.rs
+++ b/crates/mockforge-registry-server/src/platform_signing.rs
@@ -1,0 +1,178 @@
+//! Glue between [`mockforge_platform_signing`] and the registry's
+//! audit-log machinery (Issue #550, RFC §8.2 / §9).
+//!
+//! The state machine itself lives in `mockforge-platform-signing`; this
+//! module wraps each operator-facing call so every step writes an
+//! `audit_logs` row before it returns success. Failure paths still log
+//! a warning via `tracing` but do not write an audit row (the operation
+//! didn't happen).
+//!
+//! The actual HTTP handlers (POST /api/internal/platform-signing/...)
+//! are deliberately not landed in this PR — they'll cross-conflict with
+//! the in-flight #549 trust-cache PR. See the follow-up issue for the
+//! plumbing.
+
+use chrono::Duration;
+use mockforge_platform_signing::{
+    PlatformSigner, RotationError, RotationEvent, RotationStateMachine,
+};
+use mockforge_registry_core::models::{audit_log::record_audit_event, AuditEventType};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Operator identity for an audited rotation step. Captures everything
+/// downstream audit consumers (SIEM, compliance dashboards) need to
+/// reconstruct "who did this, when, from where".
+#[derive(Debug, Clone)]
+pub struct OperatorIdentity {
+    /// The platform operator's organization id. RFC §1 reserves a
+    /// distinct "Operator" persona — the registry maps this to a
+    /// dedicated org row provisioned at install time.
+    pub org_id: Uuid,
+    /// The individual user who triggered the rotation. Required —
+    /// rotation is a high-stakes operation, anonymous initiation is
+    /// not allowed.
+    pub user_id: Uuid,
+    /// Inbound request IP, if available.
+    pub ip_address: Option<String>,
+    /// Inbound `User-Agent`, if available.
+    pub user_agent: Option<String>,
+}
+
+/// Begin a key handover and audit-log the action.
+///
+/// Wraps [`RotationStateMachine::begin_handover`]. On success, writes a
+/// `platform_signing_rotation_started` row to `audit_logs` containing
+/// (in `metadata`):
+///   - `from_key_id`, `to_key_id`
+///   - `from_algorithm`, `to_algorithm`
+///   - `issued_at`, `transition_until`
+///   - `from_public_key_b64`, `to_public_key_b64`
+///
+/// — i.e. exactly what plugin-hosts will see on the rotation-event
+/// endpoint. Operators auditing a past rotation can replay the
+/// verification step from this row alone.
+pub async fn audited_begin_handover<C, N>(
+    pool: &PgPool,
+    operator: &OperatorIdentity,
+    state_machine: &RotationStateMachine<C>,
+    next: &N,
+    transition_window: Duration,
+) -> Result<RotationEvent, RotationError>
+where
+    C: PlatformSigner,
+    N: PlatformSigner,
+{
+    let event = state_machine.begin_handover(next, transition_window).await?;
+    let metadata = json!({
+        "from_key_id": event.payload.from_key_id,
+        "to_key_id": event.payload.to_key_id,
+        "from_algorithm": event.payload.from_algorithm,
+        "to_algorithm": event.payload.to_algorithm,
+        "issued_at": event.payload.issued_at,
+        "transition_until": event.payload.transition_until,
+        "from_public_key_b64": event.payload.from_public_key_b64,
+        "to_public_key_b64": event.payload.to_public_key_b64,
+    });
+    record_audit_event(
+        pool,
+        operator.org_id,
+        Some(operator.user_id),
+        AuditEventType::PlatformSigningRotationStarted,
+        format!(
+            "Platform signing-root rotation started: {} → {} (transition until {})",
+            event.payload.from_key_id, event.payload.to_key_id, event.payload.transition_until
+        ),
+        Some(metadata),
+        operator.ip_address.as_deref(),
+        operator.user_agent.as_deref(),
+    )
+    .await;
+    Ok(event)
+}
+
+/// Retire the previous key after the transition window closed.
+///
+/// Wraps [`RotationStateMachine::retire_old`]. The operator must have
+/// already run `aws kms disable-key` per the runbook; this just records
+/// the registry observed the retirement and updates in-memory state.
+pub async fn audited_retire_old<C: PlatformSigner>(
+    pool: &PgPool,
+    operator: &OperatorIdentity,
+    state_machine: &RotationStateMachine<C>,
+) -> Result<(), RotationError> {
+    let last_event = state_machine.last_event().await;
+    state_machine.retire_old().await?;
+    let metadata = last_event.map(|ev| {
+        json!({
+            "from_key_id": ev.payload.from_key_id,
+            "to_key_id": ev.payload.to_key_id,
+            "transition_closed_at": ev.payload.transition_until,
+        })
+    });
+    record_audit_event(
+        pool,
+        operator.org_id,
+        Some(operator.user_id),
+        AuditEventType::PlatformSigningKeyRetired,
+        "Platform signing-root: previous key retired after transition window".to_string(),
+        metadata,
+        operator.ip_address.as_deref(),
+        operator.user_agent.as_deref(),
+    )
+    .await;
+    Ok(())
+}
+
+/// Emergency revocation — the active key is believed compromised and
+/// must stop being trusted immediately, with no successor in place yet.
+///
+/// Wraps [`RotationStateMachine::emergency_revoke_current`]. The
+/// audit row records the operator + `reason`; the runbook covers the
+/// follow-up (notify hosted-mock owners, provision a fresh key, run
+/// [`audited_begin_handover`] once it's available).
+pub async fn audited_emergency_revoke<C: PlatformSigner>(
+    pool: &PgPool,
+    operator: &OperatorIdentity,
+    state_machine: &RotationStateMachine<C>,
+    reason: &str,
+) -> Result<(), RotationError> {
+    state_machine.emergency_revoke_current().await?;
+    let metadata = json!({
+        "reason": reason,
+        "key_id_revoked": state_machine_current_key_id(state_machine),
+    });
+    record_audit_event(
+        pool,
+        operator.org_id,
+        Some(operator.user_id),
+        AuditEventType::PlatformSigningKeyRevoked,
+        format!("Platform signing-root: emergency revocation — {reason}"),
+        Some(metadata),
+        operator.ip_address.as_deref(),
+        operator.user_agent.as_deref(),
+    )
+    .await;
+    Ok(())
+}
+
+/// Tiny accessor — `RotationStateMachine` does not expose its inner
+/// signer (intentional — the state machine is the only surface that
+/// should drive `sign(...)` calls), but for audit-log enrichment we
+/// need the key id. Pulled out so a future change to the state machine
+/// API has exactly one call site to update.
+fn state_machine_current_key_id<C: PlatformSigner>(
+    _sm: &RotationStateMachine<C>,
+) -> Option<String> {
+    // Intentionally returns None today: the state machine purposely
+    // does not expose the signer. The audit row is still useful (it
+    // records "an emergency revoke happened, by this user, at this
+    // time, for this reason"); the key id can be reconstructed from
+    // the immediately-preceding `platform_signing_rotation_started`
+    // row, or — in steady-state — from the registry's startup config.
+    //
+    // If a future change adds `current_key_id()` to the state
+    // machine, swap this body for the real call.
+    None
+}

--- a/docs/plugins/security/platform-signing-rotation-runbook.md
+++ b/docs/plugins/security/platform-signing-rotation-runbook.md
@@ -1,0 +1,458 @@
+# Platform signing-root rotation — operator runbook
+
+Implements RFC §8.2 and §9 of [`cloud-trust-permissions-rfc.md`](./cloud-trust-permissions-rfc.md).
+
+The **platform signing root** is the AWS KMS-backed key that authenticates
+first-party MockForge cloud plugins and signs the kill-switch blocklist.
+This runbook covers:
+
+1. [One-time setup](#one-time-setup) — provisioning the very first key.
+2. [Normal rotation](#normal-rotation) — periodic, scheduled handover.
+3. [Emergency revocation](#emergency-revocation) — active key is
+   believed compromised.
+4. [Post-rotation verification](#post-rotation-verification).
+5. [Upgrade path: CloudHSM Custom Key Store](#upgrade-path-cloudhsm-custom-key-store)
+   — FIPS 140-2 L3.
+
+**Audience:** SaaSy Solutions platform operator (RFC §1 "Operator"
+persona). Org admins do NOT perform this — their trust-roots are
+managed via `/api/v1/organizations/{org_id}/trust-roots`, see
+[`trust_roots.rs`](../../../crates/mockforge-registry-server/src/handlers/trust_roots.rs).
+
+**Pre-reqs:**
+
+- AWS account with IAM permissions to create and manage KMS CMKs.
+- The registry server's IAM role has `kms:Sign`, `kms:GetPublicKey`,
+  `kms:DescribeKey` on the active CMK. (NOT `kms:DisableKey` — that
+  step is performed by an operator out-of-band; see [security note](#why-the-registry-role-cannot-disable-keys).)
+- `aws` CLI v2 logged in to the right account/region.
+
+---
+
+## One-time setup
+
+Only run this when provisioning a brand-new MockForge cloud deployment
+that has never had a platform signing root.
+
+### 1. Create the KMS CMK
+
+```bash
+aws kms create-key \
+  --description "MockForge platform signing root (initial)" \
+  --key-usage SIGN_VERIFY \
+  --customer-master-key-spec ECC_NIST_P256 \
+  --origin AWS_KMS \
+  --tags TagKey=mockforge:component,TagValue=platform-signing-root \
+         TagKey=mockforge:version,TagValue=1
+```
+
+> **Why P-256?** AWS KMS does not support Ed25519. P-256 has the
+> smallest signatures and the fastest verify on the host fleet. For
+> higher-assurance deployments, use P-384 (`ECC_NIST_P384`); the host
+> verifier accepts both.
+
+The output includes a `KeyId` (a UUID) and an `Arn`. Capture the ARN.
+
+### 2. Create a stable alias
+
+KMS key UUIDs are stable but cryptic. Create a friendly alias so the
+rotation procedure can refer to it:
+
+```bash
+aws kms create-alias \
+  --alias-name alias/mockforge-platform-signing-active \
+  --target-key-id <arn-from-step-1>
+```
+
+### 3. Grant the registry role minimal permissions
+
+Attach to the registry server's IAM role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["kms:Sign", "kms:GetPublicKey", "kms:DescribeKey"],
+      "Resource": "<arn-from-step-1>"
+    }
+  ]
+}
+```
+
+Do **not** grant `kms:DisableKey`, `kms:ScheduleKeyDeletion`, or
+`kms:DeleteAlias` — see [security note](#why-the-registry-role-cannot-disable-keys).
+
+### 4. Configure the registry server
+
+Set the env var in the registry deployment (Fly.io secret, k8s
+Secret, etc.):
+
+```bash
+MOCKFORGE_PLATFORM_SIGNING_KMS_KEY_ID=arn:aws:kms:us-east-1:<acct>:key/<uuid>
+```
+
+Restart the registry. On boot it will call `kms:GetPublicKey` once to
+discover the key spec; check the logs for:
+
+```
+AwsKmsSigner ready key_id=<arn> algorithm=EcdsaSha256P256
+```
+
+If the key is unreachable, the registry will refuse to start. This is
+deliberate — the cloud plugin trust chain is load-bearing.
+
+### 5. Publish the initial public key to plugin-host releases
+
+The first plugin-host build needs to embed this public key as a
+**trusted root**. Until rotation #1 fires, every plugin-host accepts
+only this key. Bundle the public key (PEM) into the plugin-host
+release tarball; the build system pulls it from S3.
+
+```bash
+aws kms get-public-key \
+  --key-id alias/mockforge-platform-signing-active \
+  --output text \
+  --query PublicKey | base64 -d > platform-signing-root-v1.spki.der
+openssl ec -pubin -inform DER -in platform-signing-root-v1.spki.der -out platform-signing-root-v1.pem
+# Commit `platform-signing-root-v1.pem` to the plugin-host release pipeline.
+```
+
+---
+
+## Normal rotation
+
+Run this on a regular schedule (default: every 6 months; max: every
+12 months to stay ahead of cryptographic best practice).
+
+The rotation is **dual-control**: the current key signs the new key's
+public bytes, proving authorization. Plugin-hosts that already trust
+the current key can validate the rotation event and start trusting
+the new key without any out-of-band coordination.
+
+### 1. Generate the next CMK
+
+```bash
+aws kms create-key \
+  --description "MockForge platform signing root (rotation $(date +%Y-%m-%d))" \
+  --key-usage SIGN_VERIFY \
+  --customer-master-key-spec ECC_NIST_P256 \
+  --origin AWS_KMS \
+  --tags TagKey=mockforge:component,TagValue=platform-signing-root \
+         TagKey=mockforge:version,TagValue=$((CURRENT_VERSION + 1))
+```
+
+Capture the new ARN as `NEW_ARN`.
+
+### 2. Grant the registry role permissions on the new key
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["kms:Sign", "kms:GetPublicKey", "kms:DescribeKey"],
+  "Resource": "<NEW_ARN>"
+}
+```
+
+### 3. Drive the handover
+
+Call the registry's internal rotation endpoint (auth: platform-operator
+JWT, scope: `platform.signing.rotate`):
+
+```bash
+curl -X POST https://registry.mockforge.dev/api/internal/platform-signing/begin-handover \
+  -H "Authorization: Bearer $OPERATOR_JWT" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"to_key_id\": \"$NEW_ARN\",
+    \"transition_window_days\": 30
+  }"
+```
+
+> The HTTP handler that backs this endpoint ships in a follow-up PR
+> (see [Issue #551](https://github.com/SaaSy-Solutions/mockforge/issues/551))
+> — it depends on the live-reload work in #549. Until that lands,
+> operators drive the same flow via a one-shot Rust binary:
+>
+> ```bash
+> cargo run -p mockforge-registry-server --bin rotate-platform-key -- \
+>   --to-key-id "$NEW_ARN" --transition-window-days 30
+> ```
+
+The response is a JSON `RotationEvent`:
+
+```json
+{
+  "payload": {
+    "version": 1,
+    "from_algorithm": "ecdsa-sha256-p256",
+    "from_key_id": "<OLD_ARN>",
+    "from_public_key_b64": "...",
+    "to_algorithm": "ecdsa-sha256-p256",
+    "to_key_id": "<NEW_ARN>",
+    "to_public_key_b64": "...",
+    "issued_at": "2026-05-18T12:00:00Z",
+    "transition_until": "2026-06-17T12:00:00Z"
+  },
+  "handover_signature_b64": "..."
+}
+```
+
+The registry:
+
+1. Calls `kms:Sign` on the OLD key over the canonical payload bytes.
+2. Writes a `platform_signing_rotation_started` row to `audit_logs`
+   (op id, ip, timestamp, both ARNs, both pub keys).
+3. Exposes the event on `/api/internal/plugin-rotation-events` for
+   plugin-hosts to poll.
+
+### 4. Watch the fleet pick up the new key
+
+Plugin-hosts poll the rotation-event endpoint on the same 60-second
+cadence they use for the kill-switch (RFC §8.2). Within 60s of step 3,
+every host should be in the "two trusted keys" state.
+
+Verify with the host's `/healthz` endpoint (extended in #549):
+
+```bash
+curl https://<plugin-host>/healthz | jq '.trust.platform_signing_keys'
+# Expect: ["<OLD_ARN>", "<NEW_ARN>"]
+```
+
+If hosts are still showing only `<OLD_ARN>` after 5 minutes, do NOT
+proceed to step 5 — there's a propagation problem, debug the host
+poll loop.
+
+### 5. Update the plugin-host release pipeline
+
+Same as step 5 of the initial setup, but for the new key. Bundle
+`platform-signing-root-v$((CURRENT_VERSION + 1)).pem` into the next
+plugin-host release. This is **defense in depth** — fresh hosts that
+start up during the transition window can verify the rotation event
+against the embedded *previous* root, but pinning the new root in the
+release means even a registry-side compromise can't unilaterally
+re-rotate during the next deploy cycle.
+
+### 6. Retire the old key
+
+After `transition_until` has passed (default: 30 days later), retire:
+
+```bash
+# Tell the registry to drop the old key from in-memory state.
+curl -X POST https://registry.mockforge.dev/api/internal/platform-signing/retire-old \
+  -H "Authorization: Bearer $OPERATOR_JWT"
+
+# Disable the old CMK in AWS — this is irreversible after 7 days.
+aws kms disable-key --key-id "$OLD_ARN"
+
+# Schedule deletion (minimum 7-day window — gives time to recover
+# if step 6 was premature).
+aws kms schedule-key-deletion --key-id "$OLD_ARN" --pending-window-in-days 30
+```
+
+The registry writes a `platform_signing_key_retired` row to
+`audit_logs` containing both ARNs and the transition close timestamp.
+
+### 7. Move the alias
+
+```bash
+aws kms update-alias \
+  --alias-name alias/mockforge-platform-signing-active \
+  --target-key-id "$NEW_ARN"
+```
+
+Update `MOCKFORGE_PLATFORM_SIGNING_KMS_KEY_ID` in the registry
+deployment to the new ARN and restart. The alias move is just a
+convenience for the next rotation — the registry already runs against
+the new ARN since step 3.
+
+---
+
+## Emergency revocation
+
+Run this when the active platform signing root is **believed
+compromised** — leaked credentials, insider abuse, AWS CloudTrail
+shows unexpected `kms:Sign` calls, etc.
+
+The model: stop trusting the active key everywhere, then immediately
+follow with a [normal rotation](#normal-rotation) to a fresh key. The
+gap between revocation and rotation is the **outage window** — no new
+cloud plugins can be loaded or verified — so prepare both before
+running step 1.
+
+### 0. Prepare in parallel
+
+While compiling the incident response:
+
+```bash
+# Provision the replacement key (see normal rotation step 1).
+NEW_ARN=$(aws kms create-key ... --output text --query KeyMetadata.Arn)
+
+# Get the replacement public key ready to publish out-of-band — email,
+# Signal, whatever the incident-response playbook says — so customers
+# can manually verify rotation #N+1 when they receive it.
+aws kms get-public-key --key-id "$NEW_ARN" ...
+```
+
+### 1. Revoke the current key in the registry
+
+```bash
+curl -X POST https://registry.mockforge.dev/api/internal/platform-signing/emergency-revoke \
+  -H "Authorization: Bearer $OPERATOR_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "reason": "leaked credential in CI artifact 2026-05-18"
+  }'
+```
+
+The registry:
+
+1. Refuses any further `Sign` requests against the compromised key.
+2. Writes a `platform_signing_key_revoked` row to `audit_logs` with
+   the operator id, ip, reason, and timestamp.
+3. **Does not** publish a rotation event (there's no new key to hand
+   over to yet — that's step 2).
+
+### 2. Disable the CMK in AWS
+
+```bash
+aws kms disable-key --key-id "$OLD_ARN"
+```
+
+After this, even a CloudTrail-visible attacker can't call `Sign`.
+
+### 3. Immediately drive a normal rotation
+
+Follow [Normal rotation](#normal-rotation) steps 3-7 against `NEW_ARN`.
+The "transition window" is reduced from 30 days to **0** for emergency
+rotations — there's no `from` key to overlap with, so the event is
+effectively just "everyone trust this new key, signed by … nothing".
+
+Plugin-hosts will NOT accept a rotation event with no valid handover
+signature. The way around this is the **embedded root** mechanism:
+plugin-hosts trust the root that was bundled into their release. The
+operator therefore ships a new plugin-host release containing the new
+public key, and customers update.
+
+> This is intentionally painful. Emergency revocation is a "trust
+> reset" — by design, every plugin-host has to consciously opt back
+> in to a new root.
+
+### 4. Customer notification
+
+Open a status-page incident, email all paying customers, file an
+audit-log export with the timestamp range covering the revocation
+and the next rotation event. The compliance team handles disclosure.
+
+---
+
+## Post-rotation verification
+
+Whether normal or emergency, after a rotation:
+
+### Verify the audit trail
+
+```bash
+# Query the audit log for the most recent rotation events.
+curl https://registry.mockforge.dev/api/v1/internal/audit-logs \
+  -H "Authorization: Bearer $OPERATOR_JWT" \
+  -G \
+  --data-urlencode "event_types=platform_signing_rotation_started,platform_signing_key_retired,platform_signing_key_revoked"
+```
+
+Each row's `metadata` includes the `to_public_key_b64`. Compare with
+`aws kms get-public-key --key-id "$NEW_ARN"`. They must match — if
+they don't, the registry is rotating against a different key than the
+operator believes.
+
+### Verify the rotation event signature
+
+The same crypto every plugin-host runs:
+
+```bash
+cargo run -p mockforge-platform-signing --example verify-event \
+  -- --event-file event.json
+```
+
+This is the explicit "I verified the handover myself" check — useful
+for the post-rotation incident review and for satisfying the
+"two-person-rule" expectation (one operator drives the registry, a
+second independently verifies the published event).
+
+### Verify the host fleet
+
+```bash
+# Every host returns its currently-trusted platform-signing key ids
+# on /healthz.platform_signing_keys.
+for host in $(get-host-fleet); do
+  curl -s "https://$host/healthz" | jq -r '.trust.platform_signing_keys[]'
+done | sort -u
+```
+
+After the transition window closes, the set should equal `{"$NEW_ARN"}`
+exactly. Stragglers indicate a host that didn't poll — investigate,
+restart if necessary.
+
+---
+
+## Upgrade path: CloudHSM Custom Key Store
+
+The vanilla KMS path is FIPS 140-2 Level 2. For deployments that need
+FIPS 140-2 Level 3 (HIPAA, FedRAMP High, certain financial-services
+contracts), upgrade to a CloudHSM-backed Custom Key Store.
+
+This is a deliberate **upgrade**, not a migration — keys live entirely
+in the customer's CloudHSM cluster and never enter the KMS service.
+The trade-off is operational cost: a 2-node CloudHSM cluster runs
+~$3,500/month in `us-east-1`.
+
+**Crate-side support:** none required. The signer uses `aws-sdk-kms`,
+which transparently routes through CloudHSM when the CMK's
+`CustomKeyStoreId` is set. Only the runbook changes:
+
+1. Provision a CloudHSM cluster + activate the HSM (multi-officer
+   PIN ceremony — see AWS docs).
+2. Create a Custom Key Store backed by the cluster.
+3. In step 1 of [One-time setup](#one-time-setup), replace
+   `--origin AWS_KMS` with `--origin AWS_CLOUDHSM --custom-key-store-id <id>`.
+4. Everything else (alias, IAM, env var, rotation procedure) is
+   unchanged.
+
+Rotation cadence stays the same; CloudHSM-backed CMKs do not auto-rotate
+(unlike standard KMS CMKs).
+
+---
+
+## Why the registry role cannot disable keys
+
+The IAM policy granted to the registry role deliberately excludes
+`kms:DisableKey` and `kms:ScheduleKeyDeletion`. The reason:
+
+> If the registry process is compromised, the attacker can still
+> issue `kms:Sign` requests for the lifetime of the credential — but
+> they cannot **destroy** the rotation history. Disabling and
+> deleting the key would lock out every plugin-host (because no
+> further verification of past signatures is possible), turning a
+> credential-leak into a denial-of-service.
+
+By keeping `DisableKey` out-of-band, the operator must consciously
+perform the irreversible step — typically from a separate
+admin-workstation IAM identity, not the registry's runtime role.
+
+This is the same reasoning behind `kms:DeleteAlias` exclusion: an
+attacker that flips the alias to point at an attacker-controlled key
+would force every subsequent rotation to start from a poisoned root.
+
+---
+
+## Cross-references
+
+- RFC: [`cloud-trust-permissions-rfc.md`](./cloud-trust-permissions-rfc.md) §8.2, §9
+- Crate: [`crates/mockforge-platform-signing/`](../../../crates/mockforge-platform-signing/)
+- Audit-log enum: [`crates/mockforge-registry-core/src/models/audit_log.rs`](../../../crates/mockforge-registry-core/src/models/audit_log.rs)
+- Migration: [`crates/mockforge-registry-server/migrations/20250101000077_platform_signing_audit_events.sql`](../../../crates/mockforge-registry-server/migrations/20250101000077_platform_signing_audit_events.sql)
+- Org-scoped trust roots (contrast): [`trust_roots.rs`](../../../crates/mockforge-registry-server/src/handlers/trust_roots.rs)
+- Related: [Issue #416](https://github.com/SaaSy-Solutions/mockforge/issues/416) (org trust roots),
+  [Issue #549](https://github.com/SaaSy-Solutions/mockforge/issues/549) (plugin-host trust cache),
+  [Issue #550](https://github.com/SaaSy-Solutions/mockforge/issues/550) (this work)


### PR DESCRIPTION
## Summary

Implements RFC §8.2 / §9 of [`cloud-trust-permissions-rfc.md`](docs/plugins/security/cloud-trust-permissions-rfc.md) — closes the deferred work item from #416.

The platform signing root authenticates first-party MockForge cloud plugins; this PR moves the key behind **AWS KMS** so private bytes never reach general-purpose compute, and adds a dual-control rotation state machine the operator drives via the runbook.

## What ships

### New crate `mockforge-platform-signing`

- `PlatformSigner` trait + `MockSigner` test fixture (ring/ECDSA P-256, **not** for production)
- `AwsKmsSigner` (feature `aws-kms`) — round-trips `Sign` / `GetPublicKey` through KMS; ECDSA **P-256** / **P-384**, *not* Ed25519 (KMS doesn't offer it; trade-off documented in the crate README)
- `RotationStateMachine` (`Active → Transitioning → Active`) with `begin_handover`, `retire_old`, `emergency_revoke_current`
- `RotationEvent` — RFC-8785 canonical-JSON payload + domain-separated handover signature; pure-Rust verifier with replay + clock-skew defenses
- 17 unit tests including tampered-payload and signature-replay rejections

### Registry server integration

- `mockforge_registry_server::platform_signing` — audit-aware wrappers around each rotation step
- New `AuditEventType` variants: `PlatformSigningRotationStarted`, `PlatformSigningKeyRetired`, `PlatformSigningKeyRevoked` (+ Postgres migration `20250101000077`, round-trip test updated)
- New env var `MOCKFORGE_PLATFORM_SIGNING_KMS_KEY_ID`
- Minimal IAM policy documented; deliberately excludes `kms:DisableKey` — the irreversible step stays out-of-band so a registry compromise can't destroy the rotation history

### Operator runbook

[`docs/plugins/security/platform-signing-rotation-runbook.md`](docs/plugins/security/platform-signing-rotation-runbook.md) — covers:

1. One-time setup (KMS key creation, alias, IAM, env var, initial public-key bundle)
2. Normal rotation (6-month cadence; dual-control handover; 30-day transition window; alias move + plugin-host release update)
3. Emergency revocation (compromised key; no successor in place; trust-reset via embedded root in next plugin-host release)
4. Post-rotation verification (audit-log query, host-fleet healthz scan, independent signature replay)
5. CloudHSM Custom Key Store upgrade path (FIPS 140-2 L3)

## Deferred (filed as follow-ups)

| Item | Why deferred | Issue to file |
| ---- | ------------ | ------------- |
| HTTP handler (`POST /api/internal/platform-signing/...`) + plugin-host live-reload | Cross-conflicts with the in-flight #549 trust-cache PR | TBD post-merge |
| CloudHSM Custom Key Store provisioning automation | High-cost / niche; manual upgrade path documented in runbook | TBD |
| Two-of-three quorum signing (RFC §9 long-term target) | Requires multi-officer PIN on CloudHSM or a custodial multisig overlay | TBD |

## Test plan

- [x] `cargo check -p mockforge-platform-signing` (no features) ✅
- [x] `cargo check -p mockforge-platform-signing --features aws-kms` ✅
- [x] `cargo check -p mockforge-registry-server` ✅
- [x] `cargo test -p mockforge-platform-signing --all-features` → **17 passed** ✅
- [x] `cargo test -p mockforge-registry-core` → 272 passed (audit-log round-trip covers the new variants) ✅
- [x] `cargo test -p mockforge-registry-server --lib` → 432 passed ✅
- [x] `cargo clippy -p mockforge-platform-signing --all-targets --features aws-kms -- -D warnings` ✅
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` ✅
- [x] `cargo fmt --all --check` ✅
- [x] Pre-commit hooks (clippy --all-targets --all-features --workspace) ✅
- [ ] **Post-merge** AWS-side verification: requires a KMS-enabled AWS account; setup steps documented in the runbook §1.

## Notes for reviewers

- **Why ECDSA P-256, not Ed25519:** AWS KMS does not support Ed25519. The per-publisher trust-roots (`mockforge-plugin-host::signing`) keep Ed25519; only the platform rotation event uses ECDSA. Both paths coexist.
- **Why `kms:DisableKey` is excluded from the registry role:** see [runbook §Why the registry role cannot disable keys](docs/plugins/security/platform-signing-rotation-runbook.md#why-the-registry-role-cannot-disable-keys).
- **Migration is additive:** three new `audit_event_type` enum values via `ALTER TYPE ... ADD VALUE IF NOT EXISTS` — no destructive change, safe to roll forward / back.
- **OSS impact: none.** The `aws-kms` feature is opt-in through the registry server's `saas` umbrella feature; OSS consumers don't pull the AWS SDK.

Closes #550.