### PR TITLE
docs(changelog): 0.3.137 cloud-parity + post-#543 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
-## [0.3.137] - 2026-05-17
+## [0.3.137] - 2026-05-18
+
+### Added
+
+- **[Cloud][Reality]** Cloud-mode **World State** — per-deployment graph + snapshot + layers + slice-query surface (#464, #528)
+  - Registry proxies 5 HTTP endpoints (`snapshot`, `snapshot/{id}`, `graph?layers=…`, `layers`, `query`) over Fly 6PN to `{fly-app}.internal:3000/api/world-state/*`. Wire format mirrors cloudResilience and cloudTimeTravel: `{ runtime_state: "live" | "unreachable", data }`. `unreachable` carries `data: null` so the UI renders an honest empty state.
+  - New `CloudWorldStateView` reuses the existing `StateLayerPanel`, `WorldStateGraph`, and `StateNodeInspector` components so the visualization is identical to local mode. Deployment selector auto-picks the first active hosted-mock; multi-deployment orgs get a dropdown. 5-second polling matches the local TanStack Query `refetchInterval`.
+  - `'world-state'` added to `cloudNavItemIds`. WebSocket `/stream` upstream is intentionally not proxied — polling parity is functionally equivalent for the cadence the local UI uses, and ws-tunneling through 6PN is a follow-up.
+- **[Cloud][Reality]** Cloud-mode **Time Travel** — controllable virtual clock on hosted-mock deployments (#466, #527)
+  - 7 clock-control endpoints proxied (`status`, `enable`, `disable`, `advance`, `set`, `scale`, `reset`). Targets the hosted mock's main HTTP port (3000) — not the admin port — because the time-travel router mounts there for reachability when admin isn't publicly exposed.
+  - New `CloudTimeTravelView` with a runtime-unreachable banner that disables the control fieldset so users don't fire mutations that'll bounce back. Cron jobs + mutation rules stay local-only — they manage scenario state, not a hosted mock's single-process clock.
+  - `'time-travel'` added to `cloudNavItemIds`.
+- **[Cloud][AI]** Cloud-mode **Test Generator** — async LLM jobs over runtime_captures (#469, #529)
+  - New `cloud_test_generation_jobs` table + 4 CRUD endpoints + SSE stream (`GET .../jobs/{id}/stream`) for live progress.
+  - Background tokio worker drains the queue with `FOR UPDATE SKIP LOCKED` claims, processes up to `TEST_GENERATION_WORKER_CONCURRENCY` (default 4) jobs in parallel per tick, and dispatches via the same `ai::client` + `ai::quota` pipeline `ai_studio` uses — so quota and billing semantics stay consistent. BYOK skips the platform token quota; paid plans without BYOK succeed via the platform key (`MOCKFORGE_PLATFORM_LLM_API_KEY` + provider/model/endpoint env vars).
+  - Worker is forgiving: best-effort JSON parse strips ```` ```json ```` fences, recovers from prose wrappers, falls back to a `{ raw_content }` wrapper. Cancellation race is safe — terminal writes are gated on `WHERE status = 'running'` so a user-cancel mid-flight wins.
+  - New `CloudTestGeneratorView` with job timeline + create form + expandable detail rows + SSE-driven sub-second updates on expanded non-terminal rows. `'test-generator'` added to `cloudNavItemIds`.
+- **[DevX]** Pre-flight warning when `--vus` is too low for `--rps` (#79 round 6 follow-up, #543)
+  - `mockforge bench --rps N --vus M` now warns before launch when `M × 10 < N` (rule of thumb: 1 VU at ~100ms latency sustains ~10 req/s). The warning suggests a higher `--vus` value (`ceil(rps / 10)`), so users hit by k6's "Insufficient VUs, reached M active VUs and cannot initialize more" message know what to change.
 
 ### Changed
 
-- **[Architecture]** `pr_generation` moved out of `mockforge-core` into `mockforge-intelligence` and the intelligence → core cycle was broken (Issue #562 phase 1)
+- **[CI][Reality]** `release.yml` gates Fly deploy + crates.io publish + Helm chart push on the `release` job's `cargo test --workspace --release` (#447, #526)
+  - All three downstream jobs (`deploy-registry`, `publish`, `helm`) now `needs: release`. A tag with red tests no longer ships to Fly / crates.io / the Helm repo. Cost is a few minutes of latency on a green deploy; benefit is no more "release auto-deploys broken code" surprises.
+- **[DevX]** `pr_generation` moved out of `mockforge-core` into `mockforge-intelligence` and the intelligence → core cycle was broken (Issue #562 phase 1, #571)
   - Why this matters: the ADR for #555 (`docs/adr/0001-mockforge-http-extraction.md`) and the `mockforge-intelligence/src/lib.rs` docstring both identified the bidirectional `mockforge-core` ↔ `mockforge-intelligence` dependency as the blocker behind every other AI submodule extraction. With the cycle broken, future moves (`behavioral_economics`, `ai_contract_diff`, `ai_studio`, etc.) become mechanical — they no longer have to fight the dep graph.
   - How the cycle was broken: `mockforge-intelligence` dropped its `mockforge-core` dep entirely. The two real uses (`mockforge_core::Result` and `mockforge_core::scenarios::ScenarioDefinition`) became `mockforge_foundation::Result` (zero-cost swap — `core::Result` already re-exports `foundation::Result`) and a one-method move of `SequenceLearner::generate_sequence_scenario` into `mockforge-http::handlers::behavioral_cloning` (its only caller). That freed `mockforge-core` to take a `mockforge-intelligence` dep without Cargo rejecting it.
   - Backwards compat: `mockforge_core::pr_generation` is preserved as `pub use mockforge_intelligence::pr_generation;`. Every existing `crate::pr_generation::*` import inside core (e.g., `config::mod` and `drift_gitops::handler`) keeps compiling unchanged. External callers (`mockforge-recorder`, `mockforge-pipelines`, `mockforge-http`, `mockforge-collab`) updated to import from the new home; the `mockforge_core::pr_generation` path remains valid for any out-of-tree consumers.
@@ -10,23 +30,30 @@
 
 ### Fixed
 
-- **[Build]** CI rust-cache no longer poisons builds with dangling `target/*.d` paths (Issue #446)
+- **[DevX]** CI rust-cache no longer poisons builds with dangling `target/*.d` paths (Issue #446, #570)
   - Root cause: every workflow set `CARGO_HOME=/tmp/cargo-mockforge-${{ github.run_id }}` (unique per run) so the next run's `Swatinem/rust-cache@v2` restored a `target/` whose `.d` files referenced the *previous* run's CARGO_HOME — long since deleted. Surfaced as `error: could not compile <crate> ... (never executed) No such file or directory (os error 2)` on chronically red jobs (Test stable, Incremental Warning Gate, Code Coverage).
-  - Fix: switched every `CARGO_HOME` to `runner.name` (stable per machine, still unique across the 7 sibling runners that share the host) so cached dep-info paths remain valid across runs on the same runner. Added `with: env-vars: "CARGO_HOME"` to all 13 `Swatinem/rust-cache@v2` invocations so the cache key partitions by runner — different runners can't restore each other's caches and re-introduce the same staleness across the runner pool. Five workflow files updated for `CARGO_HOME` (ci, integration-tests, benchmarks, contract-diff, registry-e2e) plus env-vars added across ci, integration-tests, registry-e2e, chaos-testing, jcs-fuzz, mutation-testing, and release.
-
-- **[Reality]** Client-side "Connections opened" counter now appears for `--rps`-only runs (Issue #79 round 6 follow-up)
+  - Fix: switched every `CARGO_HOME` to `runner.name` (stable per machine, still unique across the 7 sibling runners that share the host) so cached dep-info paths remain valid across runs on the same runner. Added `with: env-vars: "CARGO_HOME"` to all 13 `Swatinem/rust-cache@v2` invocations so the cache key partitions by runner — different runners can't restore each other's caches and re-introduce the same staleness across the runner pool.
+- **[Reality]** Client-side "Connections opened" counter now appears for `--rps`-only runs (#79 round 6 follow-up, #543)
   - Root cause: the parser was reading `http_req_connecting.values.count` from k6's `summary.json`, but k6's Trend metric never emits a `count` field — only `avg/min/med/max/p(90)/p(95)`. The field was always absent, so `tcp_connect_samples` was always 0 and the connection-count line never printed for non-`--cps` runs.
   - Fix: the generated k6 script now declares a dedicated `mockforge_connections_opened` Counter and increments it whenever `res.timings.connecting > 0` (i.e. a fresh TCP socket was opened). The Rust parser reads this Counter's `count` directly. Works for both `--cps` runs (≈ total requests) and pooled-reuse runs (≈ `vus_max`).
   - Also: TCP-connect / TLS-handshake timing lines now print whenever the Trend has a non-zero `avg`, not when `count > 0` (which was unreliable). New `test_connections_opened_counter_present` regression test guards both the Counter declaration and the per-request increment.
-
-- **[Reality]** `--scenario constant` now runs at full VU concurrency from t=0 (Issue #79 round 6 follow-up)
+- **[Reality]** `--scenario constant` now runs at full VU concurrency from t=0 (#79 round 6 follow-up, #543)
   - Root cause: Srikanth reported that `--vus 5 -d 600s` took until the ~6-minute mark to reach 5 VUs and then ramped DOWN. The k6 template always wrote `startVUs: 0`, so even `--scenario constant`'s single `{duration: '600s', target: 5}` stage made `ramping-vus` linearly interpolate from 0 → 5 across the whole window.
   - Fix: for `Constant`, `startVUs` is seeded at `max_vus` so concurrency is at full from the start. Ramping scenarios (`RampUp`/`Spike`/`Stress`/`Soak`) still start at 0 and let their stages drive the curve. Guarded by `test_constant_scenario_starts_at_target_vus`.
+- **[Cloud][Reality]** Cloud Resilience dashboard could not reach hosted mocks over Fly 6PN (#468 follow-up, #542, #544)
+  - `mockforge serve --admin` was binding the admin port to `127.0.0.1`, so the registry proxy's `{fly-app}.internal:9080` reach failed silently (#542 — bind dual-stack). UI's `/api/resilience/*` paths also sat behind auth middleware that doesn't run in proxied cloud mode, so the proxy's outbound calls 401'd (#544 — explicit exempt prefix). Both fixes were needed for the cloud Resilience tab to render live state instead of perpetual `runtime_state: unreachable`.
+- **[UI][Build]** Allow `esbuild` / `vue-demi` build scripts under pnpm 11's managed-builds policy (#525, #533)
+  - `pnpm-workspace.yaml` declares the two packages in `onlyBuiltDependencies` so production docker builds succeed. Fix split across two commits because the first round (#525) put the allowlist in the wrong file.
+- **[UI][Build]** Pin pnpm to 10.15.0 in the docker stages (#525 follow-up, #536)
+  - 10.15.0 predates the managed-builds policy that triggered #525 in the first place. Single-pin keeps build behaviour consistent across local + CI + cloud regardless of pnpm's release cadence.
+- **[UI][Cloud]** Hide `api-explorer` from cloud sidebar (#459 follow-up, #537)
+  - API Explorer is still reachable from the HostedMocksPage "Open" action, so it doesn't need a standalone cloud sidebar slot.
+- **[CI][Docker]** Explicit cosign login so signature push to GHCR succeeds (#546)
+  - GHCR rejected the unsigned cosign push with 401 after PAT-vs-GITHUB_TOKEN cleanup; cosign now logs in explicitly before push.
 
-### Added
+## [0.3.137] cloud-parity meta tracker
 
-- **[DevX]** Pre-flight warning when `--vus` is too low for `--rps` (Issue #79 round 6 follow-up)
-  - `mockforge bench --rps N --vus M` now warns before launch when `M × 10 < N` (rule of thumb: 1 VU at ~100ms latency sustains ~10 req/s). The warning suggests a higher `--vus` value (`ceil(rps / 10)`), so users hit by k6's "Insufficient VUs, reached M active VUs and cannot initialize more" message know what to change.
+This release closes [#459](https://github.com/SaaSy-Solutions/mockforge/issues/459) — the cloud-parity meta tracker for the 14 "Local only" nav items. **14 / 14** addressed: 8 shipped end-to-end across prior releases (Graph #460, Virtual Backends #461, Logs #462, Metrics-folded #463, World State #464, Observability #465, Performance-folded #467, Resilience #468), 4 explicitly kept local-only (Proxy Inspector #470, SMTP Mailbox #471, MQTT Broker #472, Kafka Broker #473), 2 land in this release (Time Travel #466, Test Generator #469).
 
 ## [0.3.136] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - **[CI][Docker]** Explicit cosign login so signature push to GHCR succeeds (#546)
   - GHCR rejected the unsigned cosign push with 401 after PAT-vs-GITHUB_TOKEN cleanup; cosign now logs in explicitly before push.
 
-## [0.3.137] cloud-parity meta tracker
+### Cloud-parity meta tracker
 
 This release closes [#459](https://github.com/SaaSy-Solutions/mockforge/issues/459) — the cloud-parity meta tracker for the 14 "Local only" nav items. **14 / 14** addressed: 8 shipped end-to-end across prior releases (Graph #460, Virtual Backends #461, Logs #462, Metrics-folded #463, World State #464, Observability #465, Performance-folded #467, Resilience #468), 4 explicitly kept local-only (Proxy Inspector #470, SMTP Mailbox #471, MQTT Broker #472, Kafka Broker #473), 2 land in this release (Time Travel #466, Test Generator #469).
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,22 +1,56 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
-## [0.3.137] - 2026-05-17
+## [0.3.137] - 2026-05-18
+
+### Added
+
+- **[Cloud][Reality]** Cloud-mode **World State** — per-deployment graph + snapshot + layers + slice-query surface (#464, #528)
+  - Registry proxies 5 HTTP endpoints (`snapshot`, `snapshot/{id}`, `graph?layers=…`, `layers`, `query`) over Fly 6PN to `{fly-app}.internal:3000/api/world-state/*`. Wire format mirrors cloudResilience and cloudTimeTravel: `{ runtime_state: "live" | "unreachable", data }`. `unreachable` carries `data: null` so the UI renders an honest empty state.
+  - New `CloudWorldStateView` reuses the existing `StateLayerPanel`, `WorldStateGraph`, and `StateNodeInspector` components so the visualization is identical to local mode. Deployment selector auto-picks the first active hosted-mock; multi-deployment orgs get a dropdown. 5-second polling matches the local TanStack Query `refetchInterval`.
+  - `'world-state'` added to `cloudNavItemIds`. WebSocket `/stream` upstream is intentionally not proxied — polling parity is functionally equivalent for the cadence the local UI uses, and ws-tunneling through 6PN is a follow-up.
+- **[Cloud][Reality]** Cloud-mode **Time Travel** — controllable virtual clock on hosted-mock deployments (#466, #527)
+  - 7 clock-control endpoints proxied (`status`, `enable`, `disable`, `advance`, `set`, `scale`, `reset`). Targets the hosted mock's main HTTP port (3000) — not the admin port — because the time-travel router mounts there for reachability when admin isn't publicly exposed.
+  - New `CloudTimeTravelView` with a runtime-unreachable banner that disables the control fieldset so users don't fire mutations that'll bounce back. Cron jobs + mutation rules stay local-only — they manage scenario state, not a hosted mock's single-process clock.
+  - `'time-travel'` added to `cloudNavItemIds`.
+- **[Cloud][AI]** Cloud-mode **Test Generator** — async LLM jobs over runtime_captures (#469, #529)
+  - New `cloud_test_generation_jobs` table + 4 CRUD endpoints + SSE stream (`GET .../jobs/{id}/stream`) for live progress.
+  - Background tokio worker drains the queue with `FOR UPDATE SKIP LOCKED` claims, processes up to `TEST_GENERATION_WORKER_CONCURRENCY` (default 4) jobs in parallel per tick, and dispatches via the same `ai::client` + `ai::quota` pipeline `ai_studio` uses — so quota and billing semantics stay consistent. BYOK skips the platform token quota; paid plans without BYOK succeed via the platform key (`MOCKFORGE_PLATFORM_LLM_API_KEY` + provider/model/endpoint env vars).
+  - Worker is forgiving: best-effort JSON parse strips ```` ```json ```` fences, recovers from prose wrappers, falls back to a `{ raw_content }` wrapper. Cancellation race is safe — terminal writes are gated on `WHERE status = 'running'` so a user-cancel mid-flight wins.
+  - New `CloudTestGeneratorView` with job timeline + create form + expandable detail rows + SSE-driven sub-second updates on expanded non-terminal rows. `'test-generator'` added to `cloudNavItemIds`.
+- **[DevX]** Pre-flight warning when `--vus` is too low for `--rps` (#79 round 6 follow-up, #543)
+  - `mockforge bench --rps N --vus M` now warns before launch when `M × 10 < N` (rule of thumb: 1 VU at ~100ms latency sustains ~10 req/s). The warning suggests a higher `--vus` value (`ceil(rps / 10)`), so users hit by k6's "Insufficient VUs, reached M active VUs and cannot initialize more" message know what to change.
+
+### Changed
+
+- **[CI][Reality]** `release.yml` gates Fly deploy + crates.io publish + Helm chart push on the `release` job's `cargo test --workspace --release` (#447, #526)
+  - All three downstream jobs (`deploy-registry`, `publish`, `helm`) now `needs: release`. A tag with red tests no longer ships to Fly / crates.io / the Helm repo.
+- **[DevX]** `pr_generation` moved out of `mockforge-core` into `mockforge-intelligence` and the intelligence → core cycle was broken (#562 phase 1, #571)
+  - `mockforge-intelligence` dropped its `mockforge-core` dep, freeing `mockforge-core` to take a `mockforge-intelligence` dep. `mockforge_core::pr_generation` is preserved as a `pub use` re-export for backwards compat.
 
 ### Fixed
 
-- **[Reality]** Client-side "Connections opened" counter now appears for `--rps`-only runs (Issue #79 round 6 follow-up)
+- **[DevX]** CI rust-cache no longer poisons builds with dangling `target/*.d` paths (#446, #570)
+  - `CARGO_HOME` switched from per-run to per-runner-name so cached dep-info paths remain valid across runs on the same runner. `Swatinem/rust-cache@v2` invocations now partition the cache key by runner.
+- **[Reality]** Client-side "Connections opened" counter now appears for `--rps`-only runs (#79 round 6 follow-up, #543)
   - Root cause: the parser was reading `http_req_connecting.values.count` from k6's `summary.json`, but k6's Trend metric never emits a `count` field — only `avg/min/med/max/p(90)/p(95)`. The field was always absent, so `tcp_connect_samples` was always 0 and the connection-count line never printed for non-`--cps` runs.
   - Fix: the generated k6 script now declares a dedicated `mockforge_connections_opened` Counter and increments it whenever `res.timings.connecting > 0` (i.e. a fresh TCP socket was opened). The Rust parser reads this Counter's `count` directly. Works for both `--cps` runs (≈ total requests) and pooled-reuse runs (≈ `vus_max`).
   - Also: TCP-connect / TLS-handshake timing lines now print whenever the Trend has a non-zero `avg`, not when `count > 0` (which was unreliable). New `test_connections_opened_counter_present` regression test guards both the Counter declaration and the per-request increment.
 
-- **[Reality]** `--scenario constant` now runs at full VU concurrency from t=0 (Issue #79 round 6 follow-up)
+- **[Reality]** `--scenario constant` now runs at full VU concurrency from t=0 (#79 round 6 follow-up, #543)
   - Root cause: Srikanth reported that `--vus 5 -d 600s` took until the ~6-minute mark to reach 5 VUs and then ramped DOWN. The k6 template always wrote `startVUs: 0`, so even `--scenario constant`'s single `{duration: '600s', target: 5}` stage made `ramping-vus` linearly interpolate from 0 → 5 across the whole window.
   - Fix: for `Constant`, `startVUs` is seeded at `max_vus` so concurrency is at full from the start. Ramping scenarios (`RampUp`/`Spike`/`Stress`/`Soak`) still start at 0 and let their stages drive the curve. Guarded by `test_constant_scenario_starts_at_target_vus`.
+- **[Cloud][Reality]** Cloud Resilience dashboard could not reach hosted mocks over Fly 6PN (#468 follow-up, #542, #544)
+  - `mockforge serve --admin` was binding the admin port to `127.0.0.1`, so the registry proxy's `{fly-app}.internal:9080` reach failed silently (#542 — bind dual-stack). UI's `/api/resilience/*` paths also sat behind auth middleware that doesn't run in proxied cloud mode, so the proxy's outbound calls 401'd (#544 — explicit exempt prefix). Both fixes were needed for the cloud Resilience tab to render live state instead of perpetual `runtime_state: unreachable`.
+- **[UI][Build]** Allow `esbuild` / `vue-demi` build scripts under pnpm 11's managed-builds policy (#525, #533)
+  - `pnpm-workspace.yaml` declares the two packages in `onlyBuiltDependencies` so production docker builds succeed.
+- **[UI][Build]** Pin pnpm to 10.15.0 in the docker stages (#525 follow-up, #536)
+  - 10.15.0 predates the managed-builds policy that triggered #525 in the first place.
+- **[UI][Cloud]** Hide `api-explorer` from cloud sidebar (#459 follow-up, #537)
+- **[CI][Docker]** Explicit cosign login so signature push to GHCR succeeds (#546)
 
-### Added
+## [0.3.137] cloud-parity meta tracker
 
-- **[DevX]** Pre-flight warning when `--vus` is too low for `--rps` (Issue #79 round 6 follow-up)
-  - `mockforge bench --rps N --vus M` now warns before launch when `M × 10 < N` (rule of thumb: 1 VU at ~100ms latency sustains ~10 req/s). The warning suggests a higher `--vus` value (`ceil(rps / 10)`), so users hit by k6's "Insufficient VUs, reached M active VUs and cannot initialize more" message know what to change.
+This release closes [#459](https://github.com/SaaSy-Solutions/mockforge/issues/459) — the cloud-parity meta tracker for the 14 "Local only" nav items. **14 / 14** addressed: 8 shipped end-to-end across prior releases (Graph #460, Virtual Backends #461, Logs #462, Metrics-folded #463, World State #464, Observability #465, Performance-folded #467, Resilience #468), 4 explicitly kept local-only (Proxy Inspector #470, SMTP Mailbox #471, MQTT Broker #472, Kafka Broker #473), 2 land in this release (Time Travel #466, Test Generator #469).
 
 ## [0.3.132] - 2026-05-12
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -48,7 +48,7 @@
 - **[UI][Cloud]** Hide `api-explorer` from cloud sidebar (#459 follow-up, #537)
 - **[CI][Docker]** Explicit cosign login so signature push to GHCR succeeds (#546)
 
-## [0.3.137] cloud-parity meta tracker
+### Cloud-parity meta tracker
 
 This release closes [#459](https://github.com/SaaSy-Solutions/mockforge/issues/459) — the cloud-parity meta tracker for the 14 "Local only" nav items. **14 / 14** addressed: 8 shipped end-to-end across prior releases (Graph #460, Virtual Backends #461, Logs #462, Metrics-folded #463, World State #464, Observability #465, Performance-folded #467, Resilience #468), 4 explicitly kept local-only (Proxy Inspector #470, SMTP Mailbox #471, MQTT Broker #472, Kafka Broker #473), 2 land in this release (Time Travel #466, Test Generator #469).
 


### PR DESCRIPTION
## Summary

CHANGELOG-only PR folding the cloud-parity work and post-bump fixes into the existing **0.3.137** release entry. The workspace version bump itself already shipped in #543 (it was tacked onto the bench round-6 fix instead of a standalone bump PR).

This release closes [#459](https://github.com/SaaSy-Solutions/mockforge/issues/459) — the cloud-parity meta tracker — at **14 / 14** addressed:

- 8 already shipped (#460, #461, #462, #463, #464, #465, #467, #468)
- 4 kept local-only with rationale (#470, #471, #472, #473)
- **2 land in 0.3.137**: Time Travel (#466 → #527) and Test Generator (#469 → #529)

## Changes folded into 0.3.137

**Added**
- Cloud World State (#464, #528)
- Cloud Time Travel (#466, #527)
- Cloud Test Generator (#469, #529)
- Bench `--vus` / `--rps` pre-flight warning (#79, #543)

**Changed**
- `release.yml` gates Fly / crates / Helm on the `release` test job (#447, #526)

**Fixed**
- Bench connections-opened counter for `--rps`-only runs (#79, #543)
- Bench `--scenario constant` startVUs (#79, #543)
- Cloud Resilience over Fly 6PN — admin dual-stack bind + auth exempt (#468, #542, #544)
- pnpm 11 build scripts + 10.15.0 pin (#525, #533, #536)
- Cloud sidebar polish: hide api-explorer (#459, #537)
- cosign GHCR push (#546)

## Test plan
- [x] CHANGELOG conflict resolved cleanly (no merge markers remain)
- [x] No `Cargo.toml` / `Cargo.lock` changes — version bump already on `main` via #543
- [x] Cloud-parity meta tracker note matches reality (14 / 14)
- [ ] CI green
- [ ] Auto-merge → tag `v0.3.137` → release job ships to Fly / crates.io / Helm