### PR TITLE
fix(ci): stable per-runner CARGO_HOME + scope rust-cache by runner (#446)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,7 +31,7 @@ env:
   CARGO_BUILD_JOBS: "4"
   # Isolate cargo state from `/home/actions/.cargo` (shared with 7
   # sibling runners). See integration-tests.yml for the full rationale.
-  CARGO_HOME: /tmp/cargo-mockforge-${{ github.run_id }}
+  CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
   RUSTUP_TOOLCHAIN: stable
 
 jobs:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,13 +35,18 @@ jobs:
   benchmark:
     name: Run Benchmarks
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     permissions:
       contents: write
       pull-requests: write
 
     steps:
+      - name: Set per-runner CARGO_HOME
+        # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+        # (GH Actions context: `runner.*` is step-scoped). Writing to
+        # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+        # including the rust-toolchain composite action and rust-cache.
+        run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,15 +29,14 @@ env:
   CARGO_TERM_COLOR: always
   REGRESSION_THRESHOLD: 5.0
   CARGO_BUILD_JOBS: "4"
-  # Isolate cargo state from `/home/actions/.cargo` (shared with 7
-  # sibling runners). See integration-tests.yml for the full rationale.
-  CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
   RUSTUP_TOOLCHAIN: stable
 
 jobs:
   benchmark:
     name: Run Benchmarks
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/chaos-testing.yml
+++ b/.github/workflows/chaos-testing.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: "CARGO_HOME"
 
       - name: Build release binary
         id: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,12 @@ env:
   RUST_BACKTRACE: 1
   # Isolate cargo state from `/home/actions/.cargo` (shared with 7
   # sibling runners). See integration-tests.yml for the full rationale.
-  CARGO_HOME: /tmp/cargo-mockforge-${{ github.run_id }}
+  # Keyed by runner.name (stable per machine, unique across siblings) so the
+  # path is stable across runs on the same runner — Swatinem/rust-cache
+  # restores target/*.d files whose paths reference CARGO_HOME, and run_id
+  # changed those paths every run, leaving dangling refs that surfaced as
+  # `(never executed) No such file or directory` rustc spawn failures.
+  CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
   CARGO_BUILD_JOBS: "4"
   RUSTUP_TOOLCHAIN: stable
   # Reality level for mock testing (1-5, default: 3)
@@ -66,6 +71,8 @@ jobs:
     # Swatinem/rust-cache@v2 below covers the same use case (target/ caching).
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        env-vars: "CARGO_HOME"
 
     - name: Check formatting
       run: cargo fmt --all -- --check
@@ -158,6 +165,8 @@ jobs:
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        env-vars: "CARGO_HOME"
 
     - name: Run warning gate
       run: bash scripts/lint-warning-gate.sh
@@ -180,6 +189,8 @@ jobs:
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        env-vars: "CARGO_HOME"
 
     - name: Run ratchet preview
       run: bash scripts/lint-warning-ratchet-preview.sh
@@ -276,6 +287,8 @@ jobs:
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        env-vars: "CARGO_HOME"
 
     - name: Generate coverage report
       run: cargo llvm-cov --workspace --exclude mockforge-desktop --lcov --output-path lcov.info
@@ -305,6 +318,8 @@ jobs:
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        env-vars: "CARGO_HOME"
 
     - name: Check MSRV compatibility
       run: |
@@ -441,6 +456,7 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        env-vars: "CARGO_HOME"
         key: ${{ matrix.target }}
 
     - name: Build binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
     name: Test
     runs-on: [self-hosted, linux, x64, rust]
     env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
     strategy:
       fail-fast: false
@@ -45,6 +44,13 @@ jobs:
           - stable
 
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -93,10 +99,15 @@ jobs:
   ui-test:
     name: UI Tests
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
 
     steps:
+      - name: Set per-runner CARGO_HOME
+        # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+        # (GH Actions context: `runner.*` is step-scoped). Writing to
+        # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+        # including the rust-toolchain composite action and rust-cache.
+        run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -147,9 +158,15 @@ jobs:
     name: Incremental Warning Gate
     runs-on: [self-hosted, linux, x64, rust]
     env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -172,9 +189,15 @@ jobs:
     runs-on: [self-hosted, linux, x64, rust]
     continue-on-error: true
     env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -195,9 +218,14 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -265,14 +293,19 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     # Coverage only runs on main pushes — per-PR runs took a full workspace
     # rebuild with llvm-cov instrumentation (~15 min on a warm runner) for a
     # signal that was never acted on at PR-review time. Codecov tracks the
     # trend on main; if a PR needs per-branch coverage, use workflow_dispatch.
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -304,9 +337,15 @@ jobs:
     name: Minimum Supported Rust Version
     runs-on: [self-hosted, linux, x64, rust]
     env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -331,9 +370,14 @@ jobs:
   typos:
     name: Spell Check
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -343,10 +387,15 @@ jobs:
   changelog-validation:
     name: Changelog Validation
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     if: github.event_name == 'pull_request'
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
       with:
@@ -376,7 +425,6 @@ jobs:
     needs: [test, warning-gate, security-audit, typos]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: "2G"
       # Set reproducible build flag
@@ -402,6 +450,13 @@ jobs:
             name: windows-x64
 
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
       with:
@@ -500,13 +555,18 @@ jobs:
   release:
     name: Create Release
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     needs: build-binaries
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     steps:
+    - name: Set per-runner CARGO_HOME
+      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+      # (GH Actions context: `runner.*` is step-scoped). Writing to
+      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+      # including the rust-toolchain composite action and rust-cache.
+      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Isolate cargo state from `/home/actions/.cargo` (shared with 7
-  # sibling runners). See integration-tests.yml for the full rationale.
-  # Keyed by runner.name (stable per machine, unique across siblings) so the
-  # path is stable across runs on the same runner — Swatinem/rust-cache
-  # restores target/*.d files whose paths reference CARGO_HOME, and run_id
-  # changed those paths every run, leaving dangling refs that surfaced as
-  # `(never executed) No such file or directory` rustc spawn failures.
-  CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
   CARGO_BUILD_JOBS: "4"
   RUSTUP_TOOLCHAIN: stable
   # Reality level for mock testing (1-5, default: 3)
@@ -44,6 +36,7 @@ jobs:
     name: Test
     runs-on: [self-hosted, linux, x64, rust]
     env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
     strategy:
       fail-fast: false
@@ -100,6 +93,8 @@ jobs:
   ui-test:
     name: UI Tests
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
 
     steps:
       - name: Checkout code
@@ -152,6 +147,7 @@ jobs:
     name: Incremental Warning Gate
     runs-on: [self-hosted, linux, x64, rust]
     env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
     steps:
     - name: Checkout repository
@@ -176,6 +172,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, rust]
     continue-on-error: true
     env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
     steps:
     - name: Checkout repository
@@ -198,6 +195,8 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -266,6 +265,8 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     # Coverage only runs on main pushes — per-PR runs took a full workspace
     # rebuild with llvm-cov instrumentation (~15 min on a warm runner) for a
     # signal that was never acted on at PR-review time. Codecov tracks the
@@ -303,6 +304,7 @@ jobs:
     name: Minimum Supported Rust Version
     runs-on: [self-hosted, linux, x64, rust]
     env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
     steps:
     - name: Checkout repository
@@ -329,6 +331,8 @@ jobs:
   typos:
     name: Spell Check
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -339,6 +343,8 @@ jobs:
   changelog-validation:
     name: Changelog Validation
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     if: github.event_name == 'pull_request'
     steps:
     - name: Checkout repository
@@ -370,6 +376,7 @@ jobs:
     needs: [test, warning-gate, security-audit, typos]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: "2G"
       # Set reproducible build flag
@@ -493,6 +500,8 @@ jobs:
   release:
     name: Create Release
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     needs: build-binaries
     if: startsWith(github.ref, 'refs/tags/')
     permissions:

--- a/.github/workflows/contract-diff.yml
+++ b/.github/workflows/contract-diff.yml
@@ -39,15 +39,14 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_BUILD_JOBS: "4"
-  # Isolate cargo state from `/home/actions/.cargo` (shared with 7
-  # sibling runners). See integration-tests.yml for the full rationale.
-  CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
   RUSTUP_TOOLCHAIN: stable
 
 jobs:
   contract-diff:
     name: Contract Diff Analysis
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/contract-diff.yml
+++ b/.github/workflows/contract-diff.yml
@@ -45,13 +45,18 @@ jobs:
   contract-diff:
     name: Contract Diff Analysis
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     permissions:
       contents: read
       pull-requests: write
 
     steps:
+      - name: Set per-runner CARGO_HOME
+        # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+        # (GH Actions context: `runner.*` is step-scoped). Writing to
+        # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+        # including the rust-toolchain composite action and rust-cache.
+        run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/contract-diff.yml
+++ b/.github/workflows/contract-diff.yml
@@ -41,7 +41,7 @@ env:
   CARGO_BUILD_JOBS: "4"
   # Isolate cargo state from `/home/actions/.cargo` (shared with 7
   # sibling runners). See integration-tests.yml for the full rationale.
-  CARGO_HOME: /tmp/cargo-mockforge-${{ github.run_id }}
+  CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
   RUSTUP_TOOLCHAIN: stable
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,18 +26,6 @@ env:
   # consistent with rustc being killed under CPU/memory pressure
   # without triggering the OOM-killer log).
   CARGO_BUILD_JOBS: "4"
-  # Isolate cargo state from `/home/actions/.cargo` (shared with 7
-  # sibling runners). When saas-platform / apiary / aca runners run
-  # `cargo install ...`, they churn the shared registry and lock files,
-  # which surfaces in mockforge jobs as "(never executed) No such file
-  # or directory" rustc spawn failures. Keyed by `runner.name` so the
-  # path is unique per runner instance (no cross-runner collision) AND
-  # stable across runs on the same runner — switching from `github.run_id`
-  # to `runner.name` because `Swatinem/rust-cache` restores target/*.d
-  # files whose absolute paths reference CARGO_HOME; a path that changed
-  # every run produced the same "No such file or directory" symptom from
-  # within mockforge's own state, defeating the isolation. See #446.
-  CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
   # Force rustup to use stable regardless of whatever a sibling repo
   # pinned as the user-level default. `dtolnay/rust-toolchain@stable`
   # installs stable but does not change the default; RUSTUP_TOOLCHAIN
@@ -55,6 +43,8 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     # 30 min was tight even on a warm target/. After the target/ size
     # guard wipes at >30GB, cold rebuilds take ~25 min plus test time,
     # which overran the prior limit. 60 min leaves headroom for the
@@ -159,6 +149,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: [self-hosted, linux, x64, rust]
+    env:
+      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     # Serialize after integration-tests. Both jobs build the workspace
     # in release mode and share the self-hosted runner's target/ and
     # ~/.cargo dirs. When they ran in parallel the rustc process could

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,8 +43,6 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     # 30 min was tight even on a warm target/. After the target/ size
     # guard wipes at >30GB, cold rebuilds take ~25 min plus test time,
     # which overran the prior limit. 60 min leaves headroom for the
@@ -52,6 +50,13 @@ jobs:
     timeout-minutes: 60
 
     steps:
+      - name: Set per-runner CARGO_HOME
+        # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+        # (GH Actions context: `runner.*` is step-scoped). Writing to
+        # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+        # including the rust-toolchain composite action and rust-cache.
+        run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -149,8 +154,6 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: [self-hosted, linux, x64, rust]
-    env:
-      CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
     # Serialize after integration-tests. Both jobs build the workspace
     # in release mode and share the self-hosted runner's target/ and
     # ~/.cargo dirs. When they ran in parallel the rustc process could
@@ -163,6 +166,13 @@ jobs:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
 
     steps:
+      - name: Set per-runner CARGO_HOME
+        # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+        # (GH Actions context: `runner.*` is step-scoped). Writing to
+        # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+        # including the rust-toolchain composite action and rust-cache.
+        run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,10 +30,14 @@ env:
   # sibling runners). When saas-platform / apiary / aca runners run
   # `cargo install ...`, they churn the shared registry and lock files,
   # which surfaces in mockforge jobs as "(never executed) No such file
-  # or directory" rustc spawn failures. `github.run_id` (not
-  # `runner.temp`, which is only valid at job level) gives a per-run
-  # path that's fresh, disposable, and untouched by siblings.
-  CARGO_HOME: /tmp/cargo-mockforge-${{ github.run_id }}
+  # or directory" rustc spawn failures. Keyed by `runner.name` so the
+  # path is unique per runner instance (no cross-runner collision) AND
+  # stable across runs on the same runner — switching from `github.run_id`
+  # to `runner.name` because `Swatinem/rust-cache` restores target/*.d
+  # files whose absolute paths reference CARGO_HOME; a path that changed
+  # every run produced the same "No such file or directory" symptom from
+  # within mockforge's own state, defeating the isolation. See #446.
+  CARGO_HOME: /tmp/cargo-mockforge-${{ runner.name }}
   # Force rustup to use stable regardless of whatever a sibling repo
   # pinned as the user-level default. `dtolnay/rust-toolchain@stable`
   # installs stable but does not change the default; RUSTUP_TOOLCHAIN
@@ -91,6 +95,8 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: "CARGO_HOME"
 
       - name: Build MockForge binary (needed for integration tests)
         # Retry once on transient "No such file or directory" / SIGKILL

--- a/.github/workflows/jcs-fuzz.yml
+++ b/.github/workflows/jcs-fuzz.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: "CARGO_HOME"
           key: jcs-fuzz
 
       # Compile separately so that infrastructure failures (linker

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: "CARGO_HOME"
           key: mutation-${{ matrix.crate }}
 
       - name: Run mutation testing on ${{ matrix.crate }}

--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -20,10 +20,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Shared self-hosted runner: cap parallelism + isolate CARGO_HOME per run to avoid
-  # registry/lockfile churn from sibling runners. Same pattern as integration-tests.yml.
+  # Shared self-hosted runner: cap parallelism + isolate CARGO_HOME per runner instance
+  # to avoid registry/lockfile churn from sibling runners. Same pattern as integration-tests.yml.
   CARGO_BUILD_JOBS: "4"
-  CARGO_HOME: /tmp/cargo-mockforge-e2e-${{ github.run_id }}
+  CARGO_HOME: /tmp/cargo-mockforge-e2e-${{ runner.name }}
   RUSTUP_TOOLCHAIN: stable
 
 concurrency:
@@ -86,6 +86,8 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: "CARGO_HOME"
 
       - name: Build registry-server
         # Retry once under shared-runner resource pressure, same as the sibling workflow.

--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -38,7 +38,6 @@ jobs:
     timeout-minutes: 45
 
     env:
-      CARGO_HOME: /tmp/cargo-mockforge-e2e-${{ runner.name }}
       # Bound ports on the compose file. Kept non-default so multiple runners on the
       # same host could in principle parallelize by overriding these.
       PG_PORT: "55432"
@@ -65,6 +64,13 @@ jobs:
       STRIPE_WEBHOOK_SECRET: "whsec_e2e_test_secret"
 
     steps:
+      - name: Set per-runner CARGO_HOME
+        # `runner.name` is unavailable in workflow- or job-level `env:` blocks
+        # (GH Actions context: `runner.*` is step-scoped). Writing to
+        # `$GITHUB_ENV` here exports it to every subsequent step in this job,
+        # including the rust-toolchain composite action and rust-cache.
+        run: echo "CARGO_HOME=/tmp/cargo-mockforge-e2e-${{ runner.name }}" >> "$GITHUB_ENV"
+
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -20,10 +20,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Shared self-hosted runner: cap parallelism + isolate CARGO_HOME per runner instance
-  # to avoid registry/lockfile churn from sibling runners. Same pattern as integration-tests.yml.
+  # Cap cargo parallelism. The self-hosted runner is 8 vCPU shared with
+  # 7 other runners; unrestricted `-j` produces flakes under contention.
+  # `CARGO_HOME` is set per-job (not here) — it must reference `runner.name`,
+  # which the workflow parser only resolves once a runner is assigned.
   CARGO_BUILD_JOBS: "4"
-  CARGO_HOME: /tmp/cargo-mockforge-e2e-${{ runner.name }}
   RUSTUP_TOOLCHAIN: stable
 
 concurrency:
@@ -37,6 +38,7 @@ jobs:
     timeout-minutes: 45
 
     env:
+      CARGO_HOME: /tmp/cargo-mockforge-e2e-${{ runner.name }}
       # Bound ports on the compose file. Kept non-default so multiple runners on the
       # same host could in principle parallelize by overriding these.
       PG_PORT: "55432"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,8 @@ jobs:
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        env-vars: "CARGO_HOME"
 
     # mockforge-cli's default features do NOT include `ws`/`grpc`/`mqtt` (see
     # crates/mockforge-cli/Cargo.toml). The mockforge-integration-tests crate
@@ -130,6 +132,8 @@ jobs:
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        env-vars: "CARGO_HOME"
 
     - name: Publish crates
       # Delegates to scripts/publish-crates.sh, which:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Fixed
 
+- **[Build]** CI rust-cache no longer poisons builds with dangling `target/*.d` paths (Issue #446)
+  - Root cause: every workflow set `CARGO_HOME=/tmp/cargo-mockforge-${{ github.run_id }}` (unique per run) so the next run's `Swatinem/rust-cache@v2` restored a `target/` whose `.d` files referenced the *previous* run's CARGO_HOME — long since deleted. Surfaced as `error: could not compile <crate> ... (never executed) No such file or directory (os error 2)` on chronically red jobs (Test stable, Incremental Warning Gate, Code Coverage).
+  - Fix: switched every `CARGO_HOME` to `runner.name` (stable per machine, still unique across the 7 sibling runners that share the host) so cached dep-info paths remain valid across runs on the same runner. Added `with: env-vars: "CARGO_HOME"` to all 13 `Swatinem/rust-cache@v2` invocations so the cache key partitions by runner — different runners can't restore each other's caches and re-introduce the same staleness across the runner pool. Five workflow files updated for `CARGO_HOME` (ci, integration-tests, benchmarks, contract-diff, registry-e2e) plus env-vars added across ci, integration-tests, registry-e2e, chaos-testing, jcs-fuzz, mutation-testing, and release.
+
 - **[Reality]** Client-side "Connections opened" counter now appears for `--rps`-only runs (Issue #79 round 6 follow-up)
   - Root cause: the parser was reading `http_req_connecting.values.count` from k6's `summary.json`, but k6's Trend metric never emits a `count` field — only `avg/min/med/max/p(90)/p(95)`. The field was always absent, so `tcp_connect_samples` was always 0 and the connection-count line never printed for non-`--cps` runs.
   - Fix: the generated k6 script now declares a dedicated `mockforge_connections_opened` Counter and increments it whenever `res.timings.connecting > 0` (i.e. a fresh TCP socket was opened). The Rust parser reads this Counter's `count` directly. Works for both `--cps` runs (≈ total requests) and pooled-reuse runs (≈ `vus_max`).


### PR DESCRIPTION
## Summary

- Switch every \`CARGO_HOME\` from \`\${{ github.run_id }}\` to \`\${{ runner.name }}\` across all 5 workflows that set it (ci, integration-tests, benchmarks, contract-diff, registry-e2e).
- Add \`with: env-vars: \"CARGO_HOME\"\` to all 13 \`Swatinem/rust-cache@v2\` invocations so cache keys partition by runner.

## Why

Every CI run set \`CARGO_HOME=/tmp/cargo-mockforge-<run_id>\`. \`Swatinem/rust-cache@v2\` restored a \`target/\` from a prior run whose \`.d\` files referenced the *previous* run's CARGO_HOME — long since deleted. Result: chronic \`error: could not compile <crate> ... (never executed) No such file or directory (os error 2)\` on Test (stable), Incremental Warning Gate, and Code Coverage.

\`runner.name\` is stable per machine *and* unique across the 7 sibling runners on the host, so it preserves the original isolation rationale (dodging sibling repos that churn \`/home/actions/.cargo\`) while keeping dep-info paths valid across runs.

Adding \`env-vars: CARGO_HOME\` to each rust-cache invocation ensures the cache key partitions by runner. Without it, runner A could restore runner B's cache (paths still wouldn't match) and re-introduce the same staleness whenever a job rebalanced across the pool.

## Test plan

- [ ] CI passes on this PR (the smoke test — if it goes green here, the fix works).
- [ ] After merge, the next 2-3 push runs on main should be green for Test (stable), Incremental Warning Gate, and Code Coverage.
- [ ] If a run still fails with the same \"No such file or directory\" symptom, capture which runner ran it and inspect \`/tmp/cargo-mockforge-<runner.name>\` for path drift.

## Reference

- Closes #446
- Earlier comments on #446 documented the .profile pollution + apt-lock cascade fixes (already shipped). This addresses the third class — stale rust-cache restoration — that was the only one still red on the latest main run (sha \`70bede38\`).