### PR TITLE
chore(release): bump workspace to 0.3.138

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,49 @@
+## [0.3.138] - 2026-05-19
+
+### Added
+
+- **[Cloud][Reality]** Cloud-mode **Time Travel** — controllable virtual clock on hosted-mock deployments (#466, #527)
+  - 7 clock-control endpoints proxied (`status`, `enable`, `disable`, `advance`, `set`, `scale`, `reset`) over Fly 6PN. Wire format mirrors cloudResilience and cloudWorldState: `{ runtime_state: "live" | "unreachable", data }`. The runtime-unreachable branch disables the control fieldset so users don't fire mutations that'll bounce back.
+  - New `CloudTimeTravelView` reuses the local TimeTravelPage shape. Cron jobs + mutation rules stay local-only — they manage scenario state, not a hosted mock's single-process clock.
+  - **Note:** these entries were originally written into the 0.3.137 changelog block — the PRs landed after the v0.3.137 tag (efa43d20) was published to crates.io, so they actually ship in 0.3.138.
+- **[Cloud][AI]** Cloud-mode **Test Generator** — async LLM jobs over runtime_captures (#469, #529)
+  - New `cloud_test_generation_jobs` table + 4 CRUD endpoints + SSE stream (`GET .../jobs/{id}/stream`) for live progress.
+  - Background tokio worker drains the queue with `FOR UPDATE SKIP LOCKED` claims, processes up to `TEST_GENERATION_WORKER_CONCURRENCY` (default 4) jobs in parallel per tick, dispatched via the same `ai::client` + `ai::quota` pipeline `ai_studio` uses. BYOK skips the platform token quota; paid plans without BYOK succeed via the platform key.
+  - Worker is forgiving: best-effort JSON parse strips ```` ```json ```` fences, recovers from prose wrappers, falls back to a `{ raw_content }` wrapper. Cancellation race is safe — terminal writes are gated on `WHERE status = 'running'`.
+  - New `CloudTestGeneratorView` with job timeline, create form, expandable detail rows, and SSE-driven sub-second updates on expanded non-terminal rows.
+- **[Cloud][Reality]** Real-time runtime-logs SSE via Fly NATS subscription (#556, #559)
+  - The registry now subscribes to Fly's NATS log stream and re-broadcasts deployment logs over SSE so the cloud UI can render live logs without polling. Replaces the previous pull-based log endpoint.
+- **[Cloud][Reality]** OTLP gRPC trace receiver alongside HTTP/JSON (#548, #566)
+  - Registry exposes a standard `:4317` OTLP gRPC endpoint in addition to the existing HTTP/JSON path. Hosted mocks can now use OpenTelemetry SDKs configured for either transport.
+- **[Cloud][Reality]** Per-capture cloud forwarder with backpressure + retry (#553, #564)
+  - `mockforge-recorder` gained a registry-bound forwarder that streams individual captures to the cloud control plane with exponential-backoff retries and a bounded in-memory buffer for backpressure. Replaces the old end-of-recording bulk upload.
+- **[Cloud][Reality]** Trust-root boot — plugin host fetches + refreshes active trust roots from registry (#549, #565)
+  - The plugin host fetches the active set of plugin trust roots from the registry on boot and refreshes them on a schedule, so signed manifests written against rotated trust roots verify without a host redeploy.
+- **[Cloud][Reality]** HSM-backed platform signing-root rotation via AWS KMS (#550, #567)
+  - Platform signing roots can now be rotated end-to-end via AWS KMS without exposing private key material to host code. Replaces the file-backed signing root used in earlier versions.
+- **[Cloud][Reality]** Email notification channel via EmailService (#551, #557)
+  - Registry's notification dispatcher gained an Email transport alongside Slack, so cloud incidents/alerts can fan out to email recipients configured per-organization.
+- **[Cloud][Reality]** PagerDuty notification channel via Events API v2 (#552, #558)
+  - Same dispatcher gained a PagerDuty Events API v2 transport. Incidents created in cloud can now page on-call rotations directly.
+- **[CI][Reality]** Nightly hosted-mocks smoke workflow (#554, #563)
+  - New `hosted-mocks-smoke.yml` runs nightly against the production Fly deployments to catch regressions that pass per-PR CI but break in cloud. Outputs feed the runtime daemon's smoke incidents tab.
+
+### Changed
+
+- **[DevX]** `pr_generation` moved out of `mockforge-core` into `mockforge-intelligence`; the intelligence → core dependency cycle was broken (#562 phase 1, #571)
+  - `mockforge-intelligence` dropped its `mockforge-core` dep, freeing `mockforge-core` to take a `mockforge-intelligence` dep without Cargo rejecting it. The two real uses (`mockforge_core::Result` and `mockforge_core::scenarios::ScenarioDefinition`) moved to `mockforge_foundation::Result` and `mockforge-http::handlers::behavioral_cloning`.
+  - Backwards compat: `mockforge_core::pr_generation` is preserved as `pub use mockforge_intelligence::pr_generation;` — existing call sites compile unchanged. External callers (`mockforge-recorder`, `mockforge-pipelines`, `mockforge-http`, `mockforge-collab`) updated to import from the new home.
+- **[DevX]** ADR auditing `mockforge-http` for intelligence/proxy extraction (#555, #561)
+  - Documentation-only ADR (`docs/adr/0001-mockforge-http-extraction.md`) recording the dependency analysis and migration plan that #562 phase 1 acts on.
+
+### Fixed
+
+- **[DevX]** CI rust-cache no longer poisons builds with dangling `target/*.d` paths (#446, #570)
+  - Root cause: every workflow set `CARGO_HOME=/tmp/cargo-mockforge-${{ github.run_id }}` (unique per run) so the next run's `Swatinem/rust-cache@v2` restored a `target/` whose `.d` files referenced the *previous* run's CARGO_HOME — long since deleted. Surfaced as `error: could not compile <crate> ... (never executed) No such file or directory (os error 2)` on chronically red jobs.
+  - Fix: switched every `CARGO_HOME` to `runner.name` (stable per machine) and added `with: env-vars: "CARGO_HOME"` to all 13 `Swatinem/rust-cache@v2` invocations so the cache key partitions by runner.
+- **[UI][Cloud]** CloudTestGeneratorView import path corrected (`stores/useWorkspaceStore`) (#547)
+  - Minor follow-up to #529; runtime error on cloud mode without it.
+
 ## [0.3.137] - 2026-05-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7693,7 +7693,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7751,7 +7751,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7887,7 +7887,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7932,7 +7932,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7942,7 +7942,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7963,7 +7963,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8035,7 +8035,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8068,7 +8068,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8124,7 +8124,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8145,7 +8145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8171,7 +8171,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8209,7 +8209,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8252,7 +8252,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8349,7 +8349,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8378,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8397,7 +8397,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8419,7 +8419,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8471,7 +8471,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8518,7 +8518,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8534,7 +8534,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8564,7 +8564,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8583,7 +8583,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8642,7 +8642,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8657,7 +8657,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8680,7 +8680,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8720,7 +8720,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8757,7 +8757,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8782,7 +8782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8796,7 +8796,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8868,7 +8868,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8964,7 +8964,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8999,7 +8999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9064,7 +9064,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9121,7 +9121,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9145,14 +9145,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9190,7 +9190,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9212,7 +9212,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9230,7 +9230,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9253,7 +9253,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9336,7 +9336,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9371,7 +9371,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9382,7 +9382,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9399,7 +9399,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15148,7 +15148,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.137"
+version = "0.3.138"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.137"
+version = "0.3.138"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,32 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.138] - 2026-05-19
+
+### Added
+
+- **[Cloud][Reality]** Cloud-mode **Time Travel** — controllable virtual clock on hosted-mock deployments (#466, #527)
+- **[Cloud][AI]** Cloud-mode **Test Generator** — async LLM jobs over runtime_captures (#469, #529)
+- **[Cloud][Reality]** Real-time runtime-logs SSE via Fly NATS subscription (#556, #559)
+- **[Cloud][Reality]** OTLP gRPC trace receiver alongside HTTP/JSON (#548, #566)
+- **[Cloud][Reality]** Per-capture cloud forwarder with backpressure + retry (#553, #564)
+- **[Cloud][Reality]** Trust-root boot — plugin host fetches + refreshes active trust roots from registry (#549, #565)
+- **[Cloud][Reality]** HSM-backed platform signing-root rotation via AWS KMS (#550, #567)
+- **[Cloud][Reality]** Email notification channel via EmailService (#551, #557)
+- **[Cloud][Reality]** PagerDuty notification channel via Events API v2 (#552, #558)
+- **[CI][Reality]** Nightly hosted-mocks smoke workflow (#554, #563)
+
+### Changed
+
+- **[DevX]** `pr_generation` moved out of `mockforge-core` into `mockforge-intelligence`; intelligence → core dep cycle broken (#562 phase 1, #571)
+- **[DevX]** ADR auditing `mockforge-http` for intelligence/proxy extraction (#555, #561)
+
+### Fixed
+
+- **[DevX]** CI rust-cache no longer poisons builds with dangling `target/*.d` paths (#446, #570)
+- **[UI][Cloud]** CloudTestGeneratorView import path corrected (#547)
+
+> **Note:** Time Travel (#527) and Test Generator (#529) were initially attributed to 0.3.137 in the historical changelog block below. Both PRs landed after the v0.3.137 tag (efa43d20) had already been published, so they actually ship in 0.3.138.
+
 ## [0.3.137] - 2026-05-18
 
 ### Added


### PR DESCRIPTION
## Summary

Bumps workspace to **0.3.138** to ship the cloud-parity work + post-v0.3.137 cloud/infra additions that landed after `v0.3.137` was auto-tagged from #543.

**Why a new version:** `v0.3.137` was tagged at `efa43d20` (the #543 bench-fix merge) and immediately published to crates.io / Fly / Helm on 2026-05-18 03:23 UTC. Time Travel (#527) and Test Generator (#529) landed AFTER that tag — they were misattributed to 0.3.137 in the historical changelog but never actually shipped in the 0.3.137 artifact.

## What ships in 0.3.138

**Added (cloud parity + cloud infra)**
- Cloud Time Travel (#466, #527)
- Cloud Test Generator (#469, #529)
- NATS-backed runtime logs SSE (#556, #559)
- OTLP gRPC trace receiver (#548, #566)
- Per-capture cloud forwarder with backpressure + retry (#553, #564)
- Trust-root boot for plugin host (#549, #565)
- HSM-backed signing-root rotation via AWS KMS (#550, #567)
- Email notification channel (#551, #557)
- PagerDuty Events API v2 channel (#552, #558)
- Nightly hosted-mocks smoke workflow (#554, #563)

**Changed**
- `pr_generation` moved into `mockforge-intelligence`; intel→core dep cycle broken (#562 phase 1, #571)
- ADR for `mockforge-http` extraction (#555, #561)

**Fixed**
- CI rust-cache poisoning via stable per-runner `CARGO_HOME` (#446, #570)
- CloudTestGeneratorView import path (#547)

## Test plan
- [x] `Cargo.toml` + `Cargo.lock` bumped to 0.3.138 (62 workspace crates)
- [x] CHANGELOG.md + book/src/reference/changelog.md updated with 0.3.138 section
- [x] `scripts/check-changelog.sh` passes locally
- [ ] CI green
- [ ] Auto-merge → release.yml fires on `v0.3.138` tag → Fly + crates.io + Helm

Closes [#459](https://github.com/SaaSy-Solutions/mockforge/issues/459) cloud-parity meta tracker at 14 / 14.