### PR TITLE
docs(intelligence,core): document why voice_workspace stays in core (#562 epilogue)

### DIFF
--- a/crates/mockforge-core/src/voice.rs
+++ b/crates/mockforge-core/src/voice.rs
@@ -9,6 +9,32 @@
 //! multi_tenant, scenarios, workspace, contract_drift, and reality_continuum —
 //! all still core-only.
 //!
+//! ## Why `voice_workspace` is not extracted (do not attempt)
+//!
+//! It is tempting to "finish the job" and move `voice_workspace` into
+//! `mockforge-intelligence` too. **Do not.** It would introduce a real
+//! dependency cycle:
+//!
+//! ```text
+//! mockforge_intelligence::voice::voice_workspace
+//!   → mockforge_core::multi_tenant::MultiTenantWorkspaceRegistry
+//!     → mockforge_core::workspace
+//!     → mockforge_core::contract_drift
+//!       → mockforge_intelligence::threat_modeling   (re-exported from core)
+//! ```
+//!
+//! The five blocker modules (`multi_tenant`, `workspace`, `contract_drift`,
+//! `reality_continuum::engine`, `scenarios`) are **domain primitives**, not
+//! AI features — they belong with the rest of core. Moving the live
+//! `MultiTenantWorkspaceRegistry` engine (not just its data types) is what
+//! `voice_workspace` actually needs, so promoting POD types to
+//! `mockforge-foundation` does not help either.
+//!
+//! `mockforge-intelligence` does **not** consume `voice_workspace` — only
+//! `mockforge-cli/voice_commands.rs` and `mockforge-ui/handlers/voice.rs` do.
+//! The cycle is already broken; this file's location is a feature, not a
+//! debt. Issue #562 is complete.
+//!
 //! This shim re-exports both halves so existing
 //! `mockforge_core::voice::{VoiceCommandParser, WorkspaceBuilder, ...}` call
 //! sites keep working unchanged.

--- a/crates/mockforge-core/src/voice_workspace.rs
+++ b/crates/mockforge-core/src/voice_workspace.rs
@@ -7,6 +7,16 @@
 //! - Behavioral scenario generation
 //! - Reality continuum configuration
 //! - Drift budget configuration
+//!
+//! ## Why this file lives in `mockforge-core`, not `mockforge-intelligence`
+//!
+//! It's the orchestration half of `voice`, and `voice`'s 6 leaf files moved
+//! to `mockforge-intelligence` during Issue #562 phase 7. This 7th file
+//! depends on 5 core-only domain primitives (`multi_tenant`, `workspace`,
+//! `contract_drift`, `reality_continuum`, `scenarios::types`) — moving it
+//! into intelligence would introduce a real dep cycle (intelligence →
+//! core → intelligence via `threat_modeling`). See
+//! `crates/mockforge-core/src/voice.rs` for the full diagram. Don't move it.
 
 use crate::contract_drift::{DriftBudget, DriftBudgetConfig};
 use crate::multi_tenant::MultiTenantWorkspaceRegistry;

--- a/crates/mockforge-intelligence/src/voice/mod.rs
+++ b/crates/mockforge-intelligence/src/voice/mod.rs
@@ -18,6 +18,17 @@
 //! depends on `multi_tenant`, `scenarios`, `workspace`, `contract_drift`, and
 //! `reality_continuum` — all still core-only. The `mockforge_core::voice::*`
 //! shim consolidates both halves so callers see one unified public API.
+//!
+//! ## Do not extract `voice_workspace` into this crate
+//!
+//! See the matching rationale in `mockforge_core::voice` (the shim) for the
+//! full cycle diagram. Short version: `voice_workspace` calls the live
+//! `MultiTenantWorkspaceRegistry` engine, and the 5 modules it depends on are
+//! domain primitives that belong in core. Importing them here would invert
+//! the established `core → intelligence` dep direction
+//! (already in use via `contract_drift` re-exporting `threat_modeling`) and
+//! reintroduce the cycle that Issue #562 phase 1 broke. Issue #562 is
+//! complete; the location of `voice_workspace` is a feature, not debt.
 
 pub mod command_parser;
 pub mod conversation;


### PR DESCRIPTION
Docs-only PR closing the #562 loop. The phase-7/8 docstrings called `voice_workspace` 'still core-only, needs follow-up' — but a future contributor who tries to move it would discover that doing so would **create** a dep cycle, not break one.

This PR makes the cycle risk explicit in three places:

1. **`crates/mockforge-core/src/voice.rs`** — full cycle diagram showing `intelligence::voice::voice_workspace → core::multi_tenant → core::workspace → core::contract_drift → intelligence::threat_modeling` (which core already re-exports). Plus the three reasons cheap tricks don't help: the 5 blockers are domain primitives not AI features; voice_workspace calls the live `MultiTenantWorkspaceRegistry` engine (not just data types); and `mockforge-intelligence` doesn't even consume `voice_workspace` (only CLI + UI do).

2. **`crates/mockforge-intelligence/src/voice/mod.rs`** — mirror note pointing at the core diagram.

3. **`crates/mockforge-core/src/voice_workspace.rs`** — short heads-up at the file docstring.

No code change. Closes the loop on Issue #562: not just 'AI cluster extracted' but 'and here's why this last file isn't part of that cluster'.

Stacked on #573.