### PR TITLE
fix(core): re-export voice_workspace as voice::workspace_builder (#562 phase 7 follow-up)

### DIFF
--- a/crates/mockforge-core/src/voice.rs
+++ b/crates/mockforge-core/src/voice.rs
@@ -50,3 +50,10 @@ pub use mockforge_intelligence::voice::*;
 pub use mockforge_intelligence::voice::{
     command_parser, conversation, hook_transpiler, spec_generator, workspace_scenario_generator,
 };
+
+// `voice_workspace` was previously a sub-module of `voice` (path:
+// `mockforge_core::voice::workspace_builder`). Phase 7 promoted it to a
+// top-level core module, but the integration test
+// `tests/tests/voice_workspace_creation.rs` still imports via the old
+// path. Alias for caller backwards compat.
+pub use crate::voice_workspace as workspace_builder;


### PR DESCRIPTION
## Summary

- Adds `pub use crate::voice_workspace as workspace_builder;` to `mockforge_core::voice` so the old pre-phase-7 path `mockforge_core::voice::workspace_builder` keeps resolving.
- Unblocks the Integration Tests CI job on PR #573, which currently fails with `error[E0432]: unresolved import \`mockforge_core::voice::workspace_builder\`` in `tests/tests/voice_workspace_creation.rs:12`.

## Context

Issue #562 phase 7 (PR #578) promoted `voice::workspace_builder` to a top-level core module (`voice_workspace`). The integration test was missed in the import-sweep and the test wasn't run as part of phase 7's local verification (it lives outside the affected crates). Re-export shim restores backwards compatibility without touching the test file.

## Test plan
- [x] `cargo build -p mockforge-core` clean
- [x] `cargo build -p mockforge-integration-tests` clean (the previously-failing crate)
- [ ] Integration Tests CI green on this PR (then auto-rolls into PR #573 once squash-merged)