### PR TITLE
chore(release): add mockforge-platform-signing to publish-crates.sh

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -71,6 +71,7 @@ CRATES=(
   mockforge-plugin-registry
   mockforge-registry-core
   mockforge-security-core
+  mockforge-platform-signing
   mockforge-template-expansion
   mockforge-tracing
   mockforge-tui


### PR DESCRIPTION
## Summary

#550 introduced `mockforge-platform-signing` (HSM-backed signing root via AWS KMS) but didn't add it to `scripts/publish-crates.sh`. v0.3.138 release hit this — the publish job failed for `mockforge-registry-server` (and the 7 cli/http crates downstream of core) with:

```
no matching package named \`mockforge-platform-signing\` found
required by package \`mockforge-registry-server v0.3.138\`
```

Recovered with a local `./scripts/publish-crates.sh --only mockforge-platform-signing,...` re-run; **53/53 crates now at 0.3.138 on crates.io**.

This patch makes the list self-sufficient for the next release.

## Test plan
- [x] `--dry-run` on v0.3.138 main shows 53/53 crates tracked (was 52/52 before)
- [x] Confirmed all 53 crates publish at 0.3.138 on crates.io
- [ ] CI green