### PR TITLE
fix(registry-server): drop unused std::time:: qualifier in incident_dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [0.3.139] - 2026-05-19
 
+### Fixed
+
+- **[Cloud]** Drop unnecessary `std::time::` qualifier in `incident_dispatcher` PagerDuty timeout
+  - `Duration` is already imported at the top of `crates/mockforge-registry-server/src/workers/incident_dispatcher.rs`, so the fully-qualified `std::time::Duration::from_millis(200)` at line 698 was tripping the workspace-wide `-Dunused_qualifications` ratchet. The Incremental Warning Gate started failing on this when PR #573 landed; this clears it without touching behaviour.
+
 ### Added
 
 - **[DevX]** Adaptive pre-flight latency probe for `--vus` sizing (#79 round 8)

--- a/crates/mockforge-registry-server/src/workers/incident_dispatcher.rs
+++ b/crates/mockforge-registry-server/src/workers/incident_dispatcher.rs
@@ -695,7 +695,7 @@ mod tests {
         // was actually attempted), not a missing-key validation error.
         std::env::set_var("MOCKFORGE_PAGERDUTY_ENQUEUE_URL", "http://127.0.0.1:1/v2/enqueue");
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_millis(200))
+            .timeout(Duration::from_millis(200))
             .build()
             .unwrap();
         let channel = pagerduty_channel(serde_json::json!({ "integration_key": "abc123" }));


### PR DESCRIPTION
## Summary

`Duration` is already imported at `crates/mockforge-registry-server/src/workers/incident_dispatcher.rs:31`, so the fully-qualified `std::time::Duration::from_millis(200)` at line 698 trips the workspace-wide `-Dunused_qualifications` ratchet enforced by `scripts/lint-warning-gate.sh`. CI's Incremental Warning Gate started failing on this when PR #573 landed; this clears it without behaviour changes.

## Why this exists on main

Diagnosed while reviewing PR #573's failed checks. PR #573 had local clippy verification per-affected-crate, but the workspace-wide `unused_qualifications` gate runs only in CI and isn't part of the standard per-crate `cargo clippy -p <crate>` checklist. The qualifier was likely written before `Duration` was added to the file's imports.

## Test plan
- [x] `RUSTFLAGS="-Awarnings -Dunused_qualifications" cargo check --workspace --all-targets --all-features` → clean
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D unused-qualifications -Awarnings` → clean
- [ ] CI Incremental Warning Gate green on this PR