### PR TITLE
deps: bump tower-http 0.6.11, dashmap 6.2.1, tar 0.4.46, tauri 2.11.2 (re-do of #572)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if 1.0.4",
  "crossbeam-utils",
@@ -5410,7 +5410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
 dependencies = [
  "cfg-if 1.0.4",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -6412,7 +6412,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "env_logger",
  "indexmap 2.14.0",
  "itoa",
@@ -7279,7 +7279,7 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "derive_more 2.1.1",
  "futures-util",
  "getrandom 0.3.4",
@@ -7902,7 +7902,7 @@ dependencies = [
  "blake3 1.8.3",
  "bytes",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "futures",
  "google-cloud-storage",
  "hyper 1.9.0",
@@ -7924,7 +7924,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tracing",
  "url",
  "uuid",
@@ -8060,7 +8060,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tracing",
  "url",
  "uuid",
@@ -8247,7 +8247,7 @@ dependencies = [
  "tonic-prost-build",
  "tonic-reflection",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tracing",
  "tracing-subscriber",
 ]
@@ -8262,7 +8262,7 @@ dependencies = [
  "axum-server",
  "base64 0.22.1",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "futures",
  "futures-util",
  "glob",
@@ -8324,7 +8324,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tracing",
  "url",
  "urlencoding",
@@ -8375,7 +8375,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.20.1",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
 ]
 
 [[package]]
@@ -8943,7 +8943,7 @@ dependencies = [
  "tonic 0.14.6",
  "totp-lite",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
@@ -9069,7 +9069,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tracing",
  "uuid",
 ]
@@ -9339,7 +9339,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tracing",
  "urlencoding",
  "uuid",
@@ -9374,7 +9374,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -12581,7 +12581,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -12624,7 +12624,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -14658,9 +14658,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -14681,9 +14681,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
+checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
 dependencies = [
  "anyhow",
  "bytes",
@@ -14732,9 +14732,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
+checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -14753,9 +14753,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
+checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -14780,9 +14780,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
+checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -14963,9 +14963,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
+checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
 dependencies = [
  "cookie",
  "dpi",
@@ -14988,9 +14988,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
+checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http 1.4.0",
@@ -15014,9 +15014,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
+checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
 dependencies = [
  "anyhow",
  "brotli",
@@ -15856,9 +15856,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.11.0",

--- a/crates/mockforge-collab/Cargo.toml
+++ b/crates/mockforge-collab/Cargo.toml
@@ -64,7 +64,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "postgre
 
 # Concurrency
 parking_lot = { workspace = true }
-dashmap = "6.1"
+dashmap = "6.2"
 
 # Conflict resolution
 similar = "2.6"

--- a/crates/mockforge-http/Cargo.toml
+++ b/crates/mockforge-http/Cargo.toml
@@ -77,7 +77,7 @@ rustls-pemfile = "2.0"
 tokio-rustls = "0.26"
 axum-server = { version = "0.8", features = ["tls-rustls-no-provider"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "migrate"], optional = true }
-dashmap = { version = "6.1", optional = true }
+dashmap = { version = "6.2", optional = true }
 mockforge-pipelines = { version = "0.3.70", path = "../mockforge-pipelines", optional = true }
 mockforge-runtime-daemon = { version = "0.3.95", path = "../mockforge-runtime-daemon", optional = true }
 mockforge-kafka = { version = "0.3.70", path = "../mockforge-kafka", optional = true }

--- a/crates/mockforge-registry-server/src/workers/incident_dispatcher.rs
+++ b/crates/mockforge-registry-server/src/workers/incident_dispatcher.rs
@@ -694,10 +694,8 @@ mod tests {
         // and asserting the failure is a network error (the request
         // was actually attempted), not a missing-key validation error.
         std::env::set_var("MOCKFORGE_PAGERDUTY_ENQUEUE_URL", "http://127.0.0.1:1/v2/enqueue");
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_millis(200))
-            .build()
-            .unwrap();
+        let client =
+            reqwest::Client::builder().timeout(Duration::from_millis(200)).build().unwrap();
         let channel = pagerduty_channel(serde_json::json!({ "integration_key": "abc123" }));
         let result = post_pagerduty(&client, &channel, &fake_incident()).await;
         match result {


### PR DESCRIPTION
## Summary

Manual re-do of the dependabot patch-and-minor group bumps that landed as PR #572. Dependabot auto-closed #572 on rebase (\"updatable in another way\") when the AI cluster refactor on main moved the manifest layout out from under its diff, but the bumps themselves are still wanted on main.

Bumps:
- `tower-http` 0.6.10 → 0.6.11 (Cargo.lock only — workspace dep already \`0.6\`, semver-compatible)
- `dashmap` 6.1.0 → 6.2.1 (manifest bumps in mockforge-collab + mockforge-http)
- `tar` 0.4.45 → 0.4.46 (Cargo.lock only)
- `tauri` 2.11.1 → 2.11.2 (Cargo.lock only, plus matching tauri-build/codegen/macros/runtime/runtime-wry/utils)

Also rolls in a one-line **rustfmt fix** in `incident_dispatcher.rs:694` — PR #585 shortened the qualifier on this builder chain enough that rustfmt now collapses it onto one line, but #585 didn't run cargo fmt and so left main with a failing fmt check. Folding the fix in here unblocks main's fmt CI without an extra PR.

## Test plan
- [x] \`cargo build -p mockforge-collab -p mockforge-http --all-features\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] CI green