### PR TITLE
fix(plugin-host): drop unused crate::signing:: qualifier on TrustStore in host.rs

### DIFF
--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -768,7 +768,7 @@ mod tests {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
             let verifier = SignatureVerifier::new(
-                crate::signing::TrustStore::new(),
+                TrustStore::new(),
                 crate::signing::SignatureMode::Optional,
             );
             let (host, actor, _bus) =
@@ -875,7 +875,7 @@ mod tests {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
             let verifier = SignatureVerifier::new(
-                crate::signing::TrustStore::new(),
+                TrustStore::new(),
                 crate::signing::SignatureMode::Required,
             );
             let (host, actor, _bus) =
@@ -940,7 +940,7 @@ mod tests {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
             let verifier = SignatureVerifier::new(
-                crate::signing::TrustStore::new(),
+                TrustStore::new(),
                 crate::signing::SignatureMode::Optional,
             );
             let (host, actor, _bus) =


### PR DESCRIPTION
## Summary

\`TrustStore\` is already imported at \`crates/mockforge-plugin-host/src/host.rs:35\` via:

\`\`\`rust
use crate::signing::{SignatureVerifier, TrustStore, VerificationError};
\`\`\`

so the three \`crate::signing::TrustStore::new()\` call sites at lines 771, 878, 943 trip the workspace-wide \`-Dunused_qualifications\` ratchet enforced by \`scripts/lint-warning-gate.sh\`.

Introduced by PR #586 (signing-root live-reload); the Incremental Warning Gate started failing on this immediately after merge and is now blocking every new PR (#590, #591) plus main itself.

## Why these and not the SignatureMode qualifiers

The next lines (\`crate::signing::SignatureMode::Optional\` / \`Required\`) look identical but are *not* flagged — \`SignatureMode\` isn't in the \`use\` import list, so those qualifiers are necessary. Leaving them as-is.

## Test plan
- [x] \`RUSTFLAGS=\"-Awarnings -Dunused_qualifications\" cargo check --workspace --all-targets --all-features\` clean
- [ ] CI Incremental Warning Gate green