### PR TITLE
fix(bench): pre-flight probe × ops/iteration (#79 round 9) + bump 0.3.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.3.140] - 2026-05-20
+
+### Fixed
+
+- **[DevX]** Pre-flight `--vus` probe now factors in operations-per-iteration (#79 round 9)
+  - The round-8 probe assumed 1 iteration = 1 request, but k6's `constant-arrival-rate` counts iterations and every iteration calls every operation in the spec. Srikanth's 12-op spec at `--rps 100` with 15ms latency reported "--vus 5 is sufficient" and then k6 still emitted "Insufficient VUs, reached 5 active VUs" mid-run because real iteration time was 15ms × 12 ops, not 15ms.
+  - Fix: `ProbeResult::required_vus(rps, num_operations)` now multiplies by spec operation count. Same call site change in `command.rs`. New tests `required_vus_scales_with_operation_count` and `required_vus_treats_zero_operations_as_one`. The pre-flight progress / warning lines now print the operation count so users see what the math used.
+
 ## [0.3.139] - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7693,7 +7693,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7751,7 +7751,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7887,7 +7887,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7932,7 +7932,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7942,7 +7942,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7963,7 +7963,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8035,7 +8035,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8068,7 +8068,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8124,7 +8124,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8147,7 +8147,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8173,7 +8173,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8254,7 +8254,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8333,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8380,7 +8380,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8409,7 +8409,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8431,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8458,7 +8458,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8483,7 +8483,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8530,7 +8530,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8576,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8625,7 +8625,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8654,7 +8654,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8669,7 +8669,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8693,7 +8693,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8733,7 +8733,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8751,7 +8751,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8795,7 +8795,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8843,7 +8843,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8958,7 +8958,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9078,7 +9078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9108,7 +9108,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9159,14 +9159,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9193,7 +9193,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9267,7 +9267,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9298,7 +9298,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9350,7 +9350,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9385,7 +9385,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9396,7 +9396,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9413,7 +9413,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15162,7 +15162,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.139"
+version = "0.3.140"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.139"
+version = "0.3.140"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,13 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.140] - 2026-05-20
+
+### Fixed
+
+- **[DevX]** Pre-flight `--vus` probe now factors in operations-per-iteration (#79 round 9)
+  - The round-8 probe assumed 1 iteration = 1 request, but k6's `constant-arrival-rate` counts iterations and every iteration calls every operation in the spec. Srikanth's 12-op spec at `--rps 100` with 15ms latency reported "--vus 5 is sufficient" and then k6 still emitted "Insufficient VUs, reached 5 active VUs" mid-run because real iteration time was 15ms × 12 ops, not 15ms.
+  - Fix: `ProbeResult::required_vus(rps, num_operations)` now multiplies by spec operation count. Same call site change in `command.rs`. New tests `required_vus_scales_with_operation_count` and `required_vus_treats_zero_operations_as_one`. The pre-flight progress / warning lines now print the operation count so users see what the math used.
+
 ## [0.3.139] - 2026-05-19
 
 ### Added

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -429,32 +429,49 @@ impl BenchCommand {
         // latency, then derive a more accurate sizing recommendation. Fall
         // back to the 100ms heuristic only when the probe can't reach the
         // target (auth-gated endpoints, strict WAFs, etc).
+        //
+        // Round 9 (#79): factor in operation count. k6's constant-arrival-rate
+        // counts ITERATIONS, not requests — and every iteration runs all N
+        // operations sequentially, so required VUs scale with N. Srikanth's
+        // 12-op spec at --rps 100 with 15ms latency needs ~19 VUs, not 3.
+        let num_ops = operations.len() as u32;
         if let Some(rps) = self.target_rps {
             let probe =
                 crate::preflight::probe_target_latency(&self.target, 3, self.skip_tls_verify).await;
 
             let (required_vus, basis) = match probe {
                 Some(p) => (
-                    p.required_vus(rps),
+                    p.required_vus(rps, num_ops),
                     format!("avg {:.1}ms (measured)", p.avg_latency.as_secs_f64() * 1000.0),
                 ),
-                None => (rps.div_ceil(10), "~100ms (default — probe failed)".to_string()),
+                None => {
+                    // Static fallback: ~100ms heuristic × num_ops per iteration.
+                    let fallback = (rps as u64)
+                        .saturating_mul(num_ops.max(1) as u64)
+                        .div_ceil(10)
+                        .min(u32::MAX as u64) as u32;
+                    (fallback, "~100ms (default — probe failed)".to_string())
+                }
             };
 
             if self.vus < required_vus {
                 TerminalReporter::print_warning(&format!(
-                    "--vus {} may be insufficient for --rps {} (baseline latency {}). \
-                     k6's constant-arrival-rate needs ≈ rps × latency_secs VUs to sustain \
-                     the rate; bump --vus to ~{} if you see \"Insufficient VUs\" warnings.",
+                    "--vus {} may be insufficient for --rps {} × {} ops/iteration \
+                     (baseline latency {}). k6's constant-arrival-rate counts ITERATIONS \
+                     and each runs every operation in the spec — required ≈ rps × ops × \
+                     latency_secs VUs. Bump --vus to ~{} if you see \"Insufficient VUs\" \
+                     warnings.",
                     self.vus,
                     rps,
+                    num_ops,
                     basis,
                     required_vus.max(self.vus + 1),
                 ));
             } else if probe.is_some() {
                 TerminalReporter::print_progress(&format!(
-                    "Pre-flight probe: target latency {} — --vus {} is sufficient for --rps {}",
-                    basis, self.vus, rps,
+                    "Pre-flight probe: target latency {}, {} ops/iteration — --vus {} \
+                     is sufficient for --rps {}",
+                    basis, num_ops, self.vus, rps,
                 ));
             }
         }

--- a/crates/mockforge-bench/src/preflight.rs
+++ b/crates/mockforge-bench/src/preflight.rs
@@ -23,12 +23,26 @@ pub struct ProbeResult {
 }
 
 impl ProbeResult {
-    /// Required VUs to sustain `target_rps` end-to-end, given the observed
-    /// latency. Formula: `rps × latency_secs`, with a small +1 safety margin.
+    /// Required VUs to sustain `target_rps` end-to-end with `num_operations`
+    /// per iteration.
+    ///
+    /// Why `num_operations` matters: k6's `constant-arrival-rate` executor
+    /// (set by `--rps`) targets ITERATIONS per second, not requests. Each
+    /// iteration runs every operation in the generated script sequentially.
+    /// So sustaining `--rps R` with a spec of `N` operations actually needs
+    /// `R × N × latency_secs` VUs, not `R × latency_secs`.
+    ///
+    /// Issue #79 round 9 — Srikanth saw "Pre-flight probe: --vus 5 is
+    /// sufficient" followed by k6 emitting "Insufficient VUs" mid-run.
+    /// Cause: he had a ~12-operation spec, so the real iteration time
+    /// was ~12 × measured latency, not 1 ×.
+    ///
+    /// Formula: `rps × num_operations × latency_secs + 1` (safety margin).
     /// Returns at least 1.
-    pub fn required_vus(&self, target_rps: u32) -> u32 {
+    pub fn required_vus(&self, target_rps: u32, num_operations: u32) -> u32 {
         let lat_secs = self.avg_latency.as_secs_f64().max(0.001);
-        let raw = (target_rps as f64 * lat_secs).ceil() as u32;
+        let ops = num_operations.max(1) as f64;
+        let raw = (target_rps as f64 * ops * lat_secs).ceil() as u32;
         raw.saturating_add(1).max(1)
     }
 }
@@ -93,15 +107,28 @@ mod tests {
             avg_latency: Duration::from_millis(2),
             samples: 3,
         };
-        // 1000 rps × 2ms = 2 VU + 1 margin = 3
-        assert_eq!(fast.required_vus(1000), 3);
+        // Single-op spec: 1000 rps × 1 op × 2ms = 2 VU + 1 margin = 3
+        assert_eq!(fast.required_vus(1000, 1), 3);
 
         let slow = ProbeResult {
             avg_latency: Duration::from_millis(100),
             samples: 3,
         };
-        // 100 rps × 100ms = 10 VU + 1 margin = 11
-        assert_eq!(slow.required_vus(100), 11);
+        // Single-op: 100 rps × 1 op × 100ms = 10 VU + 1 margin = 11
+        assert_eq!(slow.required_vus(100, 1), 11);
+    }
+
+    #[test]
+    fn required_vus_scales_with_operation_count() {
+        // Issue #79 round 9 — Srikanth saw "vus 5 is sufficient" then k6
+        // hit Insufficient VUs because his spec had ~12 operations per
+        // iteration. With 15ms baseline × 12 ops × 100 rps = 18 VUs.
+        let probe = ProbeResult {
+            avg_latency: Duration::from_millis(15),
+            samples: 3,
+        };
+        assert_eq!(probe.required_vus(100, 1), 3); // single op
+        assert_eq!(probe.required_vus(100, 12), 19); // 12 ops + 1 margin
     }
 
     #[test]
@@ -110,8 +137,19 @@ mod tests {
             avg_latency: Duration::from_micros(50),
             samples: 1,
         };
-        // (1 × 0.001s clamp) × 1 = 1, +1 margin = 2
-        assert!(fast.required_vus(1) >= 1);
+        // (1 × 0.001s clamp) × 1 op × 1 rps = 1, +1 margin = 2
+        assert!(fast.required_vus(1, 1) >= 1);
+    }
+
+    #[test]
+    fn required_vus_treats_zero_operations_as_one() {
+        let probe = ProbeResult {
+            avg_latency: Duration::from_millis(10),
+            samples: 1,
+        };
+        // num_operations=0 should clamp to 1 so we never divide-by-zero
+        // upstream or report an impossible "0 VUs" recommendation.
+        assert_eq!(probe.required_vus(100, 0), probe.required_vus(100, 1));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Srikanth's 0.3.139 testing: pre-flight reported "--vus 5 is sufficient for --rps 100" then k6 emitted "Insufficient VUs, reached 5 active VUs" mid-run.

Root cause: the round-8 probe treated 1 iteration = 1 request, but k6's `constant-arrival-rate` counts ITERATIONS, and each iteration runs every operation in the spec. With his 12-op spec at 15ms latency, real iteration time was 15ms × 12 = 180ms, requiring ~18 VUs for `--rps 100`, not 3.

Fix: `ProbeResult::required_vus(rps, num_operations)` now multiplies by spec operation count. Both the probe-success and probe-failure (static-100ms) branches respect it. Pre-flight progress / warning lines print the operation count so the math is transparent.

## Test plan

- [x] `cargo test -p mockforge-bench --lib preflight` — 5 pass (2 new tests for ops-count and zero-ops)
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings` — clean
- [x] End-to-end against `examples/openapi-demo.json` (3 ops):
  - `--vus 5 --rps 100` → `target latency avg 0.6ms, 3 ops/iteration — --vus 5 is sufficient`
  - `--vus 2 --rps 1000` → `--vus 2 may be insufficient for --rps 1000 × 3 ops/iteration ... Bump --vus to ~4`

Workspace bumped to 0.3.140. CHANGELOG + book mirror tagged `[DevX]`.