### PR TITLE
fix(fmt): rustfmt collapse fallout from #591 + #592

### DIFF
--- a/crates/mockforge-plugin-host/src/host.rs
+++ b/crates/mockforge-plugin-host/src/host.rs
@@ -767,10 +767,8 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let verifier = SignatureVerifier::new(
-                TrustStore::new(),
-                crate::signing::SignatureMode::Optional,
-            );
+            let verifier =
+                SignatureVerifier::new(TrustStore::new(), crate::signing::SignatureMode::Optional);
             let (host, actor, _bus) =
                 Host::new(loader_config(), verifier, Blocklist::new(), PlatformTrustStore::new());
             tokio::select! {
@@ -874,10 +872,8 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let verifier = SignatureVerifier::new(
-                TrustStore::new(),
-                crate::signing::SignatureMode::Required,
-            );
+            let verifier =
+                SignatureVerifier::new(TrustStore::new(), crate::signing::SignatureMode::Required);
             let (host, actor, _bus) =
                 Host::new(loader_config(), verifier, Blocklist::new(), PlatformTrustStore::new());
             tokio::select! {
@@ -939,10 +935,8 @@ mod tests {
     {
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         rt.block_on(async move {
-            let verifier = SignatureVerifier::new(
-                TrustStore::new(),
-                crate::signing::SignatureMode::Optional,
-            );
+            let verifier =
+                SignatureVerifier::new(TrustStore::new(), crate::signing::SignatureMode::Optional);
             let (host, actor, _bus) =
                 Host::new(loader_config(), verifier, blocklist, PlatformTrustStore::new());
             tokio::select! {

--- a/crates/mockforge-registry-server/tests/marketplace_e2e.rs
+++ b/crates/mockforge-registry-server/tests/marketplace_e2e.rs
@@ -145,10 +145,7 @@ async fn test_plugin_marketplace_workflow() {
     // Step 1: Register and authenticate
     let test_id = Uuid::new_v4().simple();
     helper
-        .register_user(
-            &format!("testuser_{}", test_id),
-            &format!("test_{}@example.com", test_id),
-        )
+        .register_user(&format!("testuser_{}", test_id), &format!("test_{}@example.com", test_id))
         .await
         .expect("Failed to register user");
 
@@ -266,10 +263,7 @@ async fn test_template_marketplace_workflow() {
     // Step 1: Register and authenticate
     let test_id = Uuid::new_v4().simple();
     helper
-        .register_user(
-            &format!("testuser_{}", test_id),
-            &format!("test_{}@example.com", test_id),
-        )
+        .register_user(&format!("testuser_{}", test_id), &format!("test_{}@example.com", test_id))
         .await
         .expect("Failed to register user");
 
@@ -356,10 +350,7 @@ async fn test_scenario_marketplace_workflow() {
     // Step 1: Register and authenticate
     let test_id = Uuid::new_v4().simple();
     helper
-        .register_user(
-            &format!("testuser_{}", test_id),
-            &format!("test_{}@example.com", test_id),
-        )
+        .register_user(&format!("testuser_{}", test_id), &format!("test_{}@example.com", test_id))
         .await
         .expect("Failed to register user");
 
@@ -458,10 +449,7 @@ async fn test_upload_validation_errors() {
     // Register and authenticate
     let test_id = Uuid::new_v4().simple();
     helper
-        .register_user(
-            &format!("testuser_{}", test_id),
-            &format!("test_{}@example.com", test_id),
-        )
+        .register_user(&format!("testuser_{}", test_id), &format!("test_{}@example.com", test_id))
         .await
         .expect("Failed to register user");
 
@@ -563,10 +551,7 @@ async fn test_template_star_flow() {
 
     let test_id = Uuid::new_v4().simple();
     helper
-        .register_user(
-            &format!("staruser_{}", test_id),
-            &format!("star_{}@example.com", test_id),
-        )
+        .register_user(&format!("staruser_{}", test_id), &format!("star_{}@example.com", test_id))
         .await
         .expect("Failed to register user");
     helper


### PR DESCRIPTION
## Summary

Two recent merges shortened identifiers enough that rustfmt now prefers single-line argument lists, but neither PR ran \`cargo fmt\` before push:

- \`mockforge-plugin-host/src/host.rs\` (3 sites): #592 shortened \`crate::signing::TrustStore::new()\` → \`TrustStore::new()\`, so the \`SignatureVerifier::new(...)\` constructor fits on one line.
- \`mockforge-registry-server/tests/marketplace_e2e.rs\` (3 sites): #591 shortened identifiers via \`Uuid::new_v4().simple()\`, so the \`helper.register_user(...)\` call fits on one line.

Result: \`cargo fmt --all --check\` was failing the **Check formatting** step in **Test (stable)** on every PR opened after #591/#592 landed (caught on #590's freshly-rebased CI run). This PR is just \`cargo fmt --all\`; no logic changes.

## Process note

This is the second time in a week a qualifier shortening has caused a rustfmt collapse (first was #585→#589). Process improvement for next time: always run \`cargo fmt --all --check\` before committing, even for one-line qualifier swaps — they can shrink wrapped expressions enough to trigger a rustfmt rewrite.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [ ] CI Test (stable) — Check formatting step green