### PR TITLE
chore(release): 0.3.141 + fix mockforge-foundation::pillars doctests (release-gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixed
 
 - **[DevX]** `mockforge-foundation::pillars` doctests now reference the actual crate path (release-gate fix)
-  - All 9 doctests imported `use mockforge_core::pillars::...`, but the `Pillar` enum lives in `mockforge-foundation` itself. The mismatch caused `cargo test --doc -p mockforge-foundation` to fail with `cannot find module or crate \`mockforge_core\``, which gates the Release workflow's `cargo test --workspace --release` step — so the v0.3.140 tag's `Create Release` job failed and Publish-to-crates.io was skipped. Replaced `mockforge_core::pillars` → `mockforge_foundation::pillars` across all 9 doctests. 11 doctests now pass.
+  - All 9 doctests imported `use mockforge_core::pillars::...`, but the `Pillar` enum lives in `mockforge-foundation` itself. The mismatch caused `cargo test --doc -p mockforge-foundation` to fail with ``cannot find module or crate `mockforge_core` ``, which gates the Release workflow's `cargo test --workspace --release` step — so the v0.3.140 tag's `Create Release` job failed and Publish-to-crates.io was skipped. Replaced `mockforge_core::pillars` → `mockforge_foundation::pillars` across all 9 doctests. 11 doctests now pass.
   - **0.3.140 was never published to crates.io**; this release ships the round-9 bench fix originally intended for that version, plus this doctest fix on top.
 
 ## [0.3.140] - 2026-05-20
@@ -2096,4 +2096,3 @@ If you need to do a manual release:
 - [ ] Version bumped in all `Cargo.toml` files
 - [ ] Breaking changes documented (if any)
 - [ ] CI passes on all branches
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.3.141] - 2026-05-20
+
+### Fixed
+
+- **[DevX]** `mockforge-foundation::pillars` doctests now reference the actual crate path (release-gate fix)
+  - All 9 doctests imported `use mockforge_core::pillars::...`, but the `Pillar` enum lives in `mockforge-foundation` itself. The mismatch caused `cargo test --doc -p mockforge-foundation` to fail with `cannot find module or crate \`mockforge_core\``, which gates the Release workflow's `cargo test --workspace --release` step — so the v0.3.140 tag's `Create Release` job failed and Publish-to-crates.io was skipped. Replaced `mockforge_core::pillars` → `mockforge_foundation::pillars` across all 9 doctests. 11 doctests now pass.
+  - **0.3.140 was never published to crates.io**; this release ships the round-9 bench fix originally intended for that version, plus this doctest fix on top.
+
 ## [0.3.140] - 2026-05-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2096,3 +2096,4 @@ If you need to do a manual release:
 - [ ] Version bumped in all `Cargo.toml` files
 - [ ] Breaking changes documented (if any)
 - [ ] CI passes on all branches
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7693,7 +7693,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7751,7 +7751,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7887,7 +7887,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7932,7 +7932,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7942,7 +7942,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7963,7 +7963,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8035,7 +8035,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8068,7 +8068,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8124,7 +8124,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8147,7 +8147,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8173,7 +8173,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8254,7 +8254,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8333,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8380,7 +8380,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8409,7 +8409,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8431,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8458,7 +8458,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8483,7 +8483,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8530,7 +8530,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8576,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8625,7 +8625,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8654,7 +8654,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8669,7 +8669,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8693,7 +8693,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8733,7 +8733,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8751,7 +8751,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8795,7 +8795,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "axum 0.8.9",
  "mockforge-core",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8843,7 +8843,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8958,7 +8958,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9078,7 +9078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9108,7 +9108,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9159,14 +9159,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9193,7 +9193,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9267,7 +9267,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9298,7 +9298,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9350,7 +9350,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9385,7 +9385,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9396,7 +9396,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9413,7 +9413,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15162,7 +15162,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.140"
+version = "0.3.141"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.140"
+version = "0.3.141"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - **[DevX]** `mockforge-foundation::pillars` doctests now reference the actual crate path (release-gate fix)
-  - All 9 doctests imported `use mockforge_core::pillars::...`, but the `Pillar` enum lives in `mockforge-foundation` itself. The mismatch caused `cargo test --doc -p mockforge-foundation` to fail with `cannot find module or crate \`mockforge_core\``, which gates the Release workflow's `cargo test --workspace --release` step — so the v0.3.140 tag's `Create Release` job failed and Publish-to-crates.io was skipped. Replaced `mockforge_core::pillars` → `mockforge_foundation::pillars` across all 9 doctests. 11 doctests now pass.
+  - All 9 doctests imported `use mockforge_core::pillars::...`, but the `Pillar` enum lives in `mockforge-foundation` itself. The mismatch caused `cargo test --doc -p mockforge-foundation` to fail with ``cannot find module or crate `mockforge_core` ``, which gates the Release workflow's `cargo test --workspace --release` step — so the v0.3.140 tag's `Create Release` job failed and Publish-to-crates.io was skipped. Replaced `mockforge_core::pillars` → `mockforge_foundation::pillars` across all 9 doctests. 11 doctests now pass.
   - **0.3.140 was never published to crates.io**; this release ships the round-9 bench fix originally intended for that version, plus this doctest fix on top.
 
 ## [0.3.140] - 2026-05-20

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,13 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.141] - 2026-05-20
+
+### Fixed
+
+- **[DevX]** `mockforge-foundation::pillars` doctests now reference the actual crate path (release-gate fix)
+  - All 9 doctests imported `use mockforge_core::pillars::...`, but the `Pillar` enum lives in `mockforge-foundation` itself. The mismatch caused `cargo test --doc -p mockforge-foundation` to fail with `cannot find module or crate \`mockforge_core\``, which gates the Release workflow's `cargo test --workspace --release` step — so the v0.3.140 tag's `Create Release` job failed and Publish-to-crates.io was skipped. Replaced `mockforge_core::pillars` → `mockforge_foundation::pillars` across all 9 doctests. 11 doctests now pass.
+  - **0.3.140 was never published to crates.io**; this release ships the round-9 bench fix originally intended for that version, plus this doctest fix on top.
+
 ## [0.3.140] - 2026-05-20
 
 ### Fixed

--- a/crates/mockforge-foundation/src/pillars.rs
+++ b/crates/mockforge-foundation/src/pillars.rs
@@ -26,7 +26,7 @@
 //! Or use the `Pillar` enum programmatically:
 //!
 //! ```rust
-//! use mockforge_core::pillars::{Pillar, PillarMetadata};
+//! use mockforge_foundation::pillars::{Pillar, PillarMetadata};
 //!
 //! let metadata = PillarMetadata::new()
 //!     .with_pillar(Pillar::Reality)
@@ -104,7 +104,7 @@ impl Pillar {
     /// # Examples
     ///
     /// ```
-    /// use mockforge_core::pillars::Pillar;
+    /// use mockforge_foundation::pillars::Pillar;
     ///
     /// assert_eq!(Pillar::Reality.as_str(), "reality");
     /// assert_eq!(Pillar::Contracts.as_str(), "contracts");
@@ -127,7 +127,7 @@ impl Pillar {
     /// # Examples
     ///
     /// ```
-    /// use mockforge_core::pillars::Pillar;
+    /// use mockforge_foundation::pillars::Pillar;
     ///
     /// assert_eq!(Pillar::from_str("reality"), Some(Pillar::Reality));
     /// assert_eq!(Pillar::from_str("REALITY"), Some(Pillar::Reality));
@@ -152,7 +152,7 @@ impl Pillar {
     /// # Examples
     ///
     /// ```
-    /// use mockforge_core::pillars::Pillar;
+    /// use mockforge_foundation::pillars::Pillar;
     ///
     /// assert_eq!(Pillar::Reality.display_name(), "[Reality]");
     /// assert_eq!(Pillar::Contracts.display_name(), "[Contracts]");
@@ -172,7 +172,7 @@ impl Pillar {
     /// # Examples
     ///
     /// ```
-    /// use mockforge_core::pillars::Pillar;
+    /// use mockforge_foundation::pillars::Pillar;
     ///
     /// let all = Pillar::all();
     /// assert_eq!(all.len(), 5);
@@ -273,7 +273,7 @@ impl PillarMetadata {
     /// # Examples
     ///
     /// ```
-    /// use mockforge_core::pillars::{Pillar, PillarMetadata};
+    /// use mockforge_foundation::pillars::{Pillar, PillarMetadata};
     ///
     /// let doc = "//! Pillars: [Reality][AI]\n//! This module does something";
     /// let metadata = PillarMetadata::from_doc_comment(doc).unwrap();
@@ -324,7 +324,7 @@ impl Default for PillarMetadata {
 /// # Examples
 ///
 /// ```
-/// use mockforge_core::pillars::{Pillar, parse_pillar_tags_from_scenario_tags};
+/// use mockforge_foundation::pillars::{Pillar, parse_pillar_tags_from_scenario_tags};
 ///
 /// let tags = vec!["[Cloud]".to_string(), "auth".to_string(), "[Contracts][Reality]".to_string()];
 /// let pillars = parse_pillar_tags_from_scenario_tags(&tags);
@@ -366,7 +366,7 @@ pub fn parse_pillar_tags_from_scenario_tags(tags: &[String]) -> Vec<Pillar> {
 /// # Examples
 ///
 /// ```
-/// use mockforge_core::pillars::has_pillar_tags;
+/// use mockforge_foundation::pillars::has_pillar_tags;
 ///
 /// assert!(has_pillar_tags("[Cloud]"));
 /// assert!(has_pillar_tags("[Contracts][Reality]"));
@@ -397,7 +397,7 @@ pub fn has_pillar_tags(tag: &str) -> bool {
 /// # Examples
 ///
 /// ```
-/// use mockforge_core::pillars::{Pillar, pillar_metadata_from_scenario_tags};
+/// use mockforge_foundation::pillars::{Pillar, pillar_metadata_from_scenario_tags};
 ///
 /// let tags = vec!["[Cloud]".to_string(), "[Contracts]".to_string(), "auth".to_string()];
 /// let metadata = pillar_metadata_from_scenario_tags(&tags);


### PR DESCRIPTION
## Summary

v0.3.140 (#79 round 9) was tagged but its Release workflow's `Create Release` gate failed in `cargo test --workspace --release` with 9 doctests in `mockforge-foundation/src/pillars.rs` erroring:

```
error[E0433]: cannot find module or crate `mockforge_core` in this scope
```

The doctests imported `use mockforge_core::pillars::{Pillar, PillarMetadata};` but the `Pillar` enum lives in `mockforge-foundation` itself (the type was likely moved from `mockforge-core` in an earlier refactor without updating the doctests). `mockforge-foundation` has no dependency on `mockforge-core`, so the compile errors out.

Fix: replace `mockforge_core::pillars` → `mockforge_foundation::pillars` across all 9 doctests.

Bumped to **0.3.141** because 0.3.140 was never published to crates.io — the release gate failed before the Publish-to-crates.io job ran. This release ships:
- The round-9 bench pre-flight `× num_operations` fix originally intended for 0.3.140 (#79, #593)
- This doctest fix on top

## Test plan

- [x] `cargo test -p mockforge-foundation --doc` → 11 passed, 0 failed
- [x] All 9 imports updated (verified by grep count)