### PR TITLE
chore(deps): rand::thread_rng → rand::rng sweep across rand 0.9 crates

### DIFF
--- a/crates/mockforge-core/src/ab_testing/middleware.rs
+++ b/crates/mockforge-core/src/ab_testing/middleware.rs
@@ -81,7 +81,7 @@ pub async fn select_variant(
 fn select_variant_random(
     allocations: &[crate::ab_testing::types::VariantAllocation],
 ) -> Result<String> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let random_value = rng.gen_range(0.0..100.0);
     let mut cumulative = 0.0;
 

--- a/crates/mockforge-core/src/behavioral_cloning/probabilistic_model.rs
+++ b/crates/mockforge-core/src/behavioral_cloning/probabilistic_model.rs
@@ -252,7 +252,7 @@ impl ProbabilisticModel {
     /// Sample a status code based on learned distribution
     pub fn sample_status_code(model: &EndpointProbabilityModel) -> u16 {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let random: f64 = rng.gen_range(0.0..1.0);
 
         let mut cumulative = 0.0;
@@ -275,7 +275,7 @@ impl ProbabilisticModel {
     /// Sample latency based on learned distribution
     pub fn sample_latency(model: &EndpointProbabilityModel) -> u64 {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Use normal distribution approximation based on mean and std_dev
         let mean = model.latency_distribution.mean;
@@ -299,7 +299,7 @@ impl ProbabilisticModel {
         _conditions: Option<&HashMap<String, String>>,
     ) -> Option<&'a ErrorPattern> {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let random: f64 = rng.gen_range(0.0..1.0);
 
         let mut cumulative = 0.0;

--- a/crates/mockforge-core/src/deceptive_canary.rs
+++ b/crates/mockforge-core/src/deceptive_canary.rs
@@ -262,7 +262,7 @@ impl DeceptiveCanaryRouter {
     /// Random routing
     fn random_route(&self) -> bool {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let random_value: f64 = rng.gen();
         random_value < self.config.traffic_percentage
     }

--- a/crates/mockforge-core/src/encryption.rs
+++ b/crates/mockforge-core/src/encryption.rs
@@ -27,7 +27,7 @@ use argon2::{
 use base64::{engine::general_purpose, Engine as _};
 use chacha20poly1305::{ChaCha20Poly1305, Key as ChaChaKey};
 use pbkdf2::pbkdf2_hmac;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::fmt;
@@ -123,9 +123,7 @@ impl EncryptionKey {
         salt: Option<&[u8]>,
         algorithm: EncryptionAlgorithm,
     ) -> Result<Self> {
-        let salt = salt
-            .map(|s| s.to_vec())
-            .unwrap_or_else(|| thread_rng().random::<[u8; 32]>().to_vec());
+        let salt = salt.map(|s| s.to_vec()).unwrap_or_else(|| rng().random::<[u8; 32]>().to_vec());
 
         let mut key = vec![0u8; 32];
         pbkdf2_hmac::<Sha256>(password.as_bytes(), &salt, 100_000, &mut key);
@@ -146,7 +144,7 @@ impl EncryptionKey {
         } else {
             // Generate a random salt
             let mut salt_bytes = [0u8; 32];
-            thread_rng().fill(&mut salt_bytes);
+            rng().fill(&mut salt_bytes);
             SaltString::encode_b64(&salt_bytes).map_err(|e| {
                 EncryptionError::KeyDerivationFailed {
                     message: e.to_string(),
@@ -207,7 +205,7 @@ impl EncryptionKey {
                 message: "Key length must be 32 bytes".to_string(),
             })?;
         let cipher = Aes256Gcm::new(&key_array.into());
-        let nonce: [u8; 12] = thread_rng().random(); // 96-bit nonce
+        let nonce: [u8; 12] = rng().random(); // 96-bit nonce
         let nonce = Nonce::from(nonce);
 
         let ciphertext = cipher.encrypt(&nonce, plaintext.as_bytes()).map_err(|e| {
@@ -290,7 +288,7 @@ impl EncryptionKey {
     ) -> Result<String> {
         let key = ChaChaKey::from_slice(&self.key_data);
         let cipher = ChaCha20Poly1305::new(key);
-        let nonce: [u8; 12] = thread_rng().random(); // 96-bit nonce for ChaCha20-Poly1305
+        let nonce: [u8; 12] = rng().random(); // 96-bit nonce for ChaCha20-Poly1305
         let nonce = chacha20poly1305::Nonce::from_slice(&nonce);
 
         let ciphertext = cipher.encrypt(nonce, plaintext.as_bytes()).map_err(|e| {

--- a/crates/mockforge-core/src/encryption/algorithms.rs
+++ b/crates/mockforge-core/src/encryption/algorithms.rs
@@ -10,7 +10,7 @@ use aes_gcm::{
 };
 use base64::{engine::general_purpose, Engine as _};
 use chacha20poly1305::{ChaCha20Poly1305, Key as ChaChaKey};
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, fmt};
 
@@ -69,7 +69,7 @@ impl EncryptionKey {
         };
 
         let mut key = vec![0u8; key_len];
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut key[..]);
 
         Self::new(key, algorithm)
@@ -214,7 +214,7 @@ impl EncryptionEngine {
     ) -> EncryptionResult<EncryptedData> {
         // Generate random nonce
         let mut nonce_bytes = [0u8; 12]; // 96 bits
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut nonce_bytes);
 
         let nonce = Nonce::from_slice(&nonce_bytes);
@@ -317,7 +317,7 @@ impl EncryptionEngine {
     ) -> EncryptionResult<EncryptedData> {
         // Generate random nonce
         let mut nonce_bytes = [0u8; 12]; // 96 bits
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut nonce_bytes);
 
         let nonce = chacha20poly1305::Nonce::from_slice(&nonce_bytes);
@@ -459,7 +459,7 @@ pub mod utils {
         };
 
         let mut nonce = vec![0u8; nonce_len];
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut nonce[..]);
 
         Ok(nonce)

--- a/crates/mockforge-core/src/encryption/derivation.rs
+++ b/crates/mockforge-core/src/encryption/derivation.rs
@@ -10,7 +10,7 @@ use argon2::{
     Algorithm, Argon2, Params, Version,
 };
 use pbkdf2::pbkdf2_hmac;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use sha2::Sha256;
 
 /// Key derivation method
@@ -250,7 +250,7 @@ impl KeyDerivationManager {
     #[allow(dead_code)]
     pub fn generate_salt() -> String {
         let mut salt = [0u8; 16];
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut salt);
         base64::Engine::encode(&base64::engine::general_purpose::STANDARD, salt)
     }

--- a/crates/mockforge-core/src/request_scripting.rs
+++ b/crates/mockforge-core/src/request_scripting.rs
@@ -475,7 +475,7 @@ fn add_global_functions<'js>(
 
     let random_bytes_func = Function::new(ctx.clone(), |length: usize| -> String {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let bytes: Vec<u8> = (0..length).map(|_| rng.random()).collect();
         hex::encode(bytes)
     })?;

--- a/crates/mockforge-core/src/templating.rs
+++ b/crates/mockforge-core/src/templating.rs
@@ -13,7 +13,7 @@ use crate::time_travel::VirtualClock;
 use crate::Config;
 use chrono::{Duration as ChronoDuration, Utc};
 use once_cell::sync::{Lazy, OnceCell};
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use regex::Regex;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -302,11 +302,11 @@ pub fn expand_str_with_context(input: &str, context: &TemplatingContext) -> Stri
 
     // Randoms - only process if tokens are present
     if out.contains("{{rand.int}}") {
-        let n: i64 = thread_rng().random_range(0..=1_000_000);
+        let n: i64 = rng().random_range(0..=1_000_000);
         out = out.replace("{{rand.int}}", &n.to_string());
     }
     if out.contains("{{rand.float}}") {
-        let n: f64 = thread_rng().random();
+        let n: f64 = rng().random();
         out = out.replace("{{rand.float}}", &format!("{:.6}", n));
     }
     if RANDINT_RE.is_match(&out) {
@@ -368,7 +368,7 @@ pub trait FakerProvider {
     }
     /// Generate a fake email address
     fn email(&self) -> String {
-        format!("user{}@example.com", thread_rng().random_range(1000..=9999))
+        format!("user{}@example.com", rng().random_range(1000..=9999))
     }
     /// Generate a fake person name
     fn name(&self) -> String {
@@ -432,7 +432,7 @@ fn replace_randint_ranges(input: &str) -> String {
             let a: i64 = caps.get(1).map(|m| m.as_str().parse().unwrap_or(0)).unwrap_or(0);
             let b: i64 = caps.get(2).map(|m| m.as_str().parse().unwrap_or(100)).unwrap_or(100);
             let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
-            let n: i64 = thread_rng().random_range(lo..=hi);
+            let n: i64 = rng().random_range(lo..=hi);
             s = RANDINT_RE.replace(&s, n.to_string()).to_string();
         } else {
             break;
@@ -715,17 +715,15 @@ fn replace_with_fallback(input: &str) -> String {
         out = out.replace("{{faker.uuid}}", &uuid::Uuid::new_v4().to_string());
     }
     if out.contains("{{faker.email}}") {
-        let user: String =
-            (0..8).map(|_| (b'a' + (thread_rng().random::<u8>() % 26)) as char).collect();
-        let dom: String =
-            (0..6).map(|_| (b'a' + (thread_rng().random::<u8>() % 26)) as char).collect();
+        let user: String = (0..8).map(|_| (b'a' + (rng().random::<u8>() % 26)) as char).collect();
+        let dom: String = (0..6).map(|_| (b'a' + (rng().random::<u8>() % 26)) as char).collect();
         out = out.replace("{{faker.email}}", &format!("{}@{}.example", user, dom));
     }
     if out.contains("{{faker.name}}") {
         let firsts = ["Alex", "Sam", "Taylor", "Jordan", "Casey", "Riley"];
         let lasts = ["Smith", "Lee", "Patel", "Garcia", "Kim", "Brown"];
-        let fi = thread_rng().random::<u8>() as usize % firsts.len();
-        let li = thread_rng().random::<u8>() as usize % lasts.len();
+        let fi = rng().random::<u8>() as usize % firsts.len();
+        let li = rng().random::<u8>() as usize % lasts.len();
         out = out.replace("{{faker.name}}", &format!("{} {}", firsts[fi], lasts[li]));
     }
     out

--- a/crates/mockforge-core/src/traffic_shaping.rs
+++ b/crates/mockforge-core/src/traffic_shaping.rs
@@ -249,7 +249,7 @@ impl BurstLossState {
                     false // Don't drop this packet
                 } else {
                     // Still in burst - apply loss rate
-                    let mut rng = rand::thread_rng();
+                    let mut rng = rand::rng();
                     rng.random_bool(config.loss_rate_during_burst)
                 }
             }
@@ -265,7 +265,7 @@ impl BurstLossState {
                     // End recovery
                     self.recovery_start = None;
                     // Check if we should start a new burst
-                    let mut rng = rand::thread_rng();
+                    let mut rng = rand::rng();
                     if rng.random_bool(config.burst_probability) {
                         self.in_burst = true;
                         self.burst_start = Some(now);
@@ -280,7 +280,7 @@ impl BurstLossState {
             }
             (false, _, None) => {
                 // Not in burst or recovery - check if we should start a burst
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 if rng.random_bool(config.burst_probability) {
                     self.in_burst = true;
                     self.burst_start = Some(now);

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -1899,8 +1899,8 @@ pub async fn build_router_with_chains_and_multi_tenant(
             // Register route using `any()` since we need full Request access for template expansion
             let expected_method = method.to_uppercase();
             // Clone Arc for the closure - Arc is Send-safe
-            // Note: RouteChaosInjector is marked as Send+Sync via unsafe impl, but the compiler
-            // is conservative because rng() is available in the rand crate, even though we use thread_rng()
+            // Note: RouteChaosInjector is marked as Send+Sync via unsafe impl, so we have to
+            // clone the Arc rather than move the inner injector into the route handler.
             let injector_clone = injector.clone();
             app = app.route(
                 &path,

--- a/crates/mockforge-intelligence/src/behavioral_cloning/probabilistic_model.rs
+++ b/crates/mockforge-intelligence/src/behavioral_cloning/probabilistic_model.rs
@@ -252,7 +252,7 @@ impl ProbabilisticModel {
     /// Sample a status code based on learned distribution
     pub fn sample_status_code(model: &EndpointProbabilityModel) -> u16 {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let random: f64 = rng.gen_range(0.0..1.0);
 
         let mut cumulative = 0.0;
@@ -275,7 +275,7 @@ impl ProbabilisticModel {
     /// Sample latency based on learned distribution
     pub fn sample_latency(model: &EndpointProbabilityModel) -> u64 {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Use normal distribution approximation based on mean and std_dev
         let mean = model.latency_distribution.mean;
@@ -299,7 +299,7 @@ impl ProbabilisticModel {
         _conditions: Option<&HashMap<String, String>>,
     ) -> Option<&'a ErrorPattern> {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let random: f64 = rng.gen_range(0.0..1.0);
 
         let mut cumulative = 0.0;

--- a/crates/mockforge-plugin-cli/src/commands/key.rs
+++ b/crates/mockforge-plugin-cli/src/commands/key.rs
@@ -190,15 +190,11 @@ pub async fn generate_key(out: &Path, force: bool) -> Result<()> {
     // Fill 32 bytes from the OS entropy source. We go through rand's
     // default RNG rather than depending on a specific `rand_core`
     // version — `fill_bytes` has been stable across the rand 0.7 → 0.9
-    // drift we see in the workspace. `thread_rng` was renamed to `rng`
-    // in rand 0.9, so we keep the deprecated call behind an allow so
-    // clippy `-D warnings` still passes on both versions. Once the
-    // workspace settles on 0.9+ exclusively this can become `rand::rng()`.
-    #[allow(deprecated)]
-    let mut thread_rng = rand::thread_rng();
+    // drift we see in the workspace.
+    let mut rng = rand::rng();
     use rand::RngCore;
     let mut secret = [0u8; 32];
-    thread_rng.fill_bytes(&mut secret);
+    rng.fill_bytes(&mut secret);
     let signing = SigningKey::from_bytes(&secret);
     let public_b64 =
         base64::engine::general_purpose::STANDARD.encode(signing.verifying_key().to_bytes());

--- a/crates/mockforge-security-core/src/encryption/algorithms.rs
+++ b/crates/mockforge-security-core/src/encryption/algorithms.rs
@@ -10,7 +10,7 @@ use aes_gcm::{
 };
 use base64::{engine::general_purpose, Engine as _};
 use chacha20poly1305::{ChaCha20Poly1305, Key as ChaChaKey};
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, fmt};
 
@@ -69,7 +69,7 @@ impl EncryptionKey {
         };
 
         let mut key = vec![0u8; key_len];
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut key[..]);
 
         Self::new(key, algorithm)
@@ -214,7 +214,7 @@ impl EncryptionEngine {
     ) -> EncryptionResult<EncryptedData> {
         // Generate random nonce
         let mut nonce_bytes = [0u8; 12]; // 96 bits
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut nonce_bytes);
 
         let nonce = Nonce::from_slice(&nonce_bytes);
@@ -317,7 +317,7 @@ impl EncryptionEngine {
     ) -> EncryptionResult<EncryptedData> {
         // Generate random nonce
         let mut nonce_bytes = [0u8; 12]; // 96 bits
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut nonce_bytes);
 
         let nonce = chacha20poly1305::Nonce::from_slice(&nonce_bytes);
@@ -459,7 +459,7 @@ pub mod utils {
         };
 
         let mut nonce = vec![0u8; nonce_len];
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut nonce[..]);
 
         Ok(nonce)

--- a/crates/mockforge-security-core/src/encryption/derivation.rs
+++ b/crates/mockforge-security-core/src/encryption/derivation.rs
@@ -10,7 +10,7 @@ use argon2::{
     Algorithm, Argon2, Params, Version,
 };
 use pbkdf2::pbkdf2_hmac;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use sha2::Sha256;
 
 /// Key derivation method
@@ -253,7 +253,7 @@ impl KeyDerivationManager {
     #[allow(dead_code)]
     pub fn generate_salt() -> String {
         let mut salt = [0u8; 16];
-        let mut rng = thread_rng();
+        let mut rng = rng();
         rng.fill(&mut salt);
         base64::Engine::encode(&base64::engine::general_purpose::STANDARD, salt)
     }


### PR DESCRIPTION
## Summary

Closes #588.

Sweeps the remaining `rand::thread_rng()` call sites in workspace crates that depend on `rand = "0.9"` (where the symbol is deprecated and surfaces under the pre-commit fallback `cargo clippy --workspace --all-targets -- -D warnings`). The rename is mechanical — `rand::rng()` has the same return type and same semantics as `rand::thread_rng()`.

**14 files across 5 crates** changed:

- `mockforge-core` (9 files)
- `mockforge-http` (1 file — stale comment update only)
- `mockforge-intelligence` (1 file)
- `mockforge-plugin-cli` (1 file — also drops the `#[allow(deprecated)]` wrapper and the comment explaining it)
- `mockforge-security-core` (2 files)

## Scope adjustment vs. the issue

Issue #588 listed 21 files in 9 crates. **Three of those crates pin `rand = "0.8"` independently** rather than inheriting the workspace's `rand = "0.9"`:

- `mockforge-registry-core/Cargo.toml`: `rand = "0.8"`
- `mockforge-registry-server/Cargo.toml`: `rand = "0.8" # Random number generation for tokens`
- `mockforge-ui/Cargo.toml`: `rand = "0.8"`

On rand 0.8, `rand::rng()` doesn't exist as a public function (`rng` is a private module), and the surrounding code uses the rand 0.8 API (`rng.gen()`, `rng.gen_range()`) that was renamed to `random()` / `random_range()` in 0.9. Touching those crates would either break the build or pull in a multi-step rand upgrade that's larger than this chore.

Crucially, **rand 0.8 doesn't deprecate `thread_rng`** — so leaving those crates alone still satisfies the acceptance criterion that `cargo clippy --workspace --all-targets -- -D warnings` passes without the `rand::thread_rng` deprecation showing.

A follow-up to bump those three crates to rand 0.9 (with the necessary `gen` → `random` rename) would let us drop the version pin and finish the workspace-wide convergence; out of scope here.

## Test plan
- [x] `cargo fmt --all --check` passes (rustfmt collapses some now-shorter call sites — applied)
- [x] `cargo clippy -p mockforge-core -p mockforge-http -p mockforge-intelligence -p mockforge-plugin-cli -p mockforge-security-core --all-targets -- -D warnings` passes
- [x] `cargo test -p mockforge-core -p mockforge-http -p mockforge-intelligence -p mockforge-plugin-cli -p mockforge-security-core --lib` passes
- [x] No remaining `thread_rng` references in `crates/` of the rand-0.9 set