### PR TITLE
fix(ci): check-changelog.sh works on PR merge commit checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- **[DevX]** `scripts/check-changelog.sh` now uses the PR-wide diff in CI instead of `git diff-tree -r HEAD` (which returns the empty combined diff on the synthetic `refs/pull/<N>/merge` commit `actions/checkout` uses). Previously every PR whose CHANGELOG.md edit landed in a commit that the merge didn't have to reconcile would fail the "Changelog Validation" gate even though the workflow's own outer condition correctly detected the edit (caught on #595's release PR). Now switches modes on `$GITHUB_BASE_REF`: PR-wide `git diff --name-only origin/$GITHUB_BASE_REF...HEAD` in CI, single-commit `diff-tree -r HEAD` locally for the cargo-release flow.
+
 ## [0.3.141] - 2026-05-20
 
 ### Fixed

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [Unreleased]
+
+### Fixed
+
+- **[DevX]** `scripts/check-changelog.sh` now uses the PR-wide diff in CI instead of `git diff-tree -r HEAD` (which returns the empty combined diff on the synthetic `refs/pull/<N>/merge` commit `actions/checkout` uses). Previously every PR whose CHANGELOG.md edit landed in a commit that the merge didn't have to reconcile would fail the "Changelog Validation" gate even though the workflow's own outer condition correctly detected the edit (caught on #595's release PR). Now switches modes on `$GITHUB_BASE_REF`: PR-wide `git diff --name-only origin/$GITHUB_BASE_REF...HEAD` in CI, single-commit `diff-tree -r HEAD` locally for the cargo-release flow.
+
 ## [0.3.141] - 2026-05-20
 
 ### Fixed

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -7,15 +7,37 @@ if git status --porcelain | grep -Eq '^[^?]'; then
   exit 1
 fi
 
-changed_files=$(git diff-tree --no-commit-id --name-only -r HEAD)
+# Pick a "what changed in this change-set" diff range that survives both call
+# sites. Two contexts:
+#
+#   1. CI on a pull_request event. `actions/checkout@v6` checks out the
+#      synthetic merge commit at `refs/pull/<N>/merge`. `git diff-tree -r HEAD`
+#      on a merge commit returns the *combined* diff (files where the two
+#      parents disagreed and the merge had to choose) — which is empty for any
+#      clean merge. So this script was previously failing CI runs whose
+#      CHANGELOG.md edit lived in a non-merge-touching commit (e.g. the most
+#      recent push amended *only* a different file), even though the PR
+#      clearly modified CHANGELOG.md across its full diff.
+#
+#   2. Local cargo-release via `scripts/release.sh`. HEAD is the actual
+#      version-bump commit on a regular branch; `diff-tree -r HEAD` returns
+#      its real file list.
+#
+# GitHub Actions exports $GITHUB_BASE_REF in pull_request contexts (and only
+# there), so we use it as the signal to switch modes.
+if [ -n "${GITHUB_BASE_REF:-}" ]; then
+  changed_files=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")
+else
+  changed_files=$(git diff-tree --no-commit-id --name-only -r HEAD)
+fi
 
 if ! grep -qx 'CHANGELOG.md' <<<"$changed_files"; then
-  echo "The latest commit does not update CHANGELOG.md. Add the changelog entry first." >&2
+  echo "CHANGELOG.md was not modified in this change. Add the changelog entry first." >&2
   exit 1
 fi
 
 if ! grep -qx 'book/src/reference/changelog.md' <<<"$changed_files"; then
-  echo "The latest commit does not update book/src/reference/changelog.md. Keep the docs in sync before releasing." >&2
+  echo "book/src/reference/changelog.md was not modified. Keep the docs in sync before releasing." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

`scripts/check-changelog.sh` was false-failing every PR whose CHANGELOG.md edit happened to live in a non-merge-touching commit — caught on #595's release PR.

**Root cause:** `actions/checkout@v6` on `pull_request` events checks out the synthetic `refs/pull/<N>/merge` commit. The script then ran:

```bash
changed_files=$(git diff-tree --no-commit-id --name-only -r HEAD)
```

For a merge commit, `git diff-tree -r HEAD` defaults to the **combined diff** — files where both parents disagreed and the merge had to choose. For any clean merge that's empty. So the script said "The latest commit does not update CHANGELOG.md" even when the workflow's own outer guard (`git diff --name-only origin/${GITHUB_BASE_REF}...HEAD | grep CHANGELOG.md`) had just confirmed it was modified.

**Fix:** switch the diff range on `$GITHUB_BASE_REF` (set by GH Actions only on `pull_request` runs).

- **CI:** `git diff --name-only origin/$GITHUB_BASE_REF...HEAD` — matches the outer workflow guard and surfaces the full PR diff.
- **Local (`scripts/release.sh` → cargo-release):** `git diff-tree -r HEAD` unchanged — keeps the "the version-bump commit must touch CHANGELOG.md" invariant.

## Verification

Reproduced the bug locally by synthesizing the same merge-commit shape `actions/checkout` produces, then confirmed the fix:

```
$ git merge --no-ff fix/check-changelog-merge-commit  # synthesize PR merge

# Old behavior: diff-tree -r HEAD returns empty → script fails
$ git diff-tree --no-commit-id --name-only -r HEAD
(empty)

# Fixed behavior: PR-wide diff sees CHANGELOG.md → script passes
$ git diff --name-only origin/main...HEAD
CHANGELOG.md
book/src/reference/changelog.md
scripts/check-changelog.sh

$ GITHUB_BASE_REF=main bash scripts/check-changelog.sh
✅ Changelog validation passed: pillar tags found in new version sections.
```

This PR's own `Changelog Validation` check is the live confirmation — without the fix, it would fail like #595's did.

## Test plan

- [x] Synthesized merge commit locally, confirmed old logic fails and new logic passes
- [x] Local mode (no `GITHUB_BASE_REF`) still uses `diff-tree -r HEAD` — `scripts/release.sh` flow unchanged
- [x] Added `[Unreleased]` entries to both `CHANGELOG.md` and `book/src/reference/changelog.md` with the `[DevX]` pillar tag so the pillar-validation portion of the script also exercises end-to-end
- [ ] **Live test on this PR:** Changelog Validation goes green where #595's went red