### PR TITLE
refactor(intelligence,core): extract incidents AI-coupled pieces (#562 phase 9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8386,6 +8386,8 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
+ "hex",
+ "hmac 0.12.1",
  "indexmap 2.14.0",
  "mockforge-foundation",
  "mockforge-openapi",

--- a/crates/mockforge-core/src/incidents/mod.rs
+++ b/crates/mockforge-core/src/incidents/mod.rs
@@ -2,22 +2,30 @@
 //!
 //! This module provides functionality for creating, storing, and managing incidents
 //! related to contract drift and breaking changes.
+//!
+//! Issue #562 phase 9 moved the AI-coupled pieces (`semantic_manager`,
+//! `integrations` config + Slack/Jira formatters) into
+//! `mockforge_intelligence::incidents`. The structural pieces below
+//! (`manager`, `store`) and the shared types (re-exported from
+//! `mockforge_foundation::incidents_types` via `types.rs`) stay in core —
+//! they have no AI dependencies.
 
-pub mod integrations;
 pub mod manager;
-pub mod semantic_manager;
 pub mod store;
 pub mod types;
 
-// Integration formatters (always available, not behind feature flag for simplicity)
-#[path = "integrations/slack.rs"]
-pub mod slack_formatter;
+// The AI-coupled pieces now live in `mockforge-intelligence`; these
+// re-exports keep existing `mockforge_core::incidents::{...}` callers
+// resolving unchanged.
+pub use mockforge_intelligence::incidents::{integrations, semantic_manager};
 
-#[path = "integrations/jira.rs"]
-pub mod jira_formatter;
+// Integration formatters (always available, not behind feature flag for simplicity).
+// Same `#[path]` aliasing the legacy module used, but now pointing at the
+// intelligence-side mod aliases of the same name.
+pub use mockforge_intelligence::incidents::{jira_formatter, slack_formatter};
 
 pub use manager::IncidentManager;
-pub use semantic_manager::{SemanticIncident, SemanticIncidentManager};
+pub use mockforge_intelligence::incidents::{SemanticIncident, SemanticIncidentManager};
 pub use store::IncidentStore;
 pub use types::{
     DriftIncident, ExternalTicket, IncidentQuery, IncidentSeverity, IncidentStatus, IncidentType,

--- a/crates/mockforge-intelligence/Cargo.toml
+++ b/crates/mockforge-intelligence/Cargo.toml
@@ -25,6 +25,12 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
 dirs = "5.0"
+# `incidents::integrations::WebhookIntegration` signs outgoing webhook
+# payloads with HMAC-SHA256 (Issue #562 phase 9 — moved from
+# `mockforge-core`); both hex and hmac were already on the workspace's
+# pinned versions for the core crate.
+hex = { workspace = true }
+hmac = { workspace = true }
 indexmap = "2.14"
 once_cell = { workspace = true }
 openapiv3 = { workspace = true }

--- a/crates/mockforge-intelligence/src/incidents/integrations.rs
+++ b/crates/mockforge-intelligence/src/incidents/integrations.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides integrations with external systems like Jira, Linear, etc.
 
-use crate::incidents::types::{DriftIncident, ExternalTicket};
+use mockforge_foundation::incidents_types::{DriftIncident, ExternalTicket};
 use serde::{Deserialize, Serialize};
 
 /// Configuration for external integrations

--- a/crates/mockforge-intelligence/src/incidents/integrations/jira.rs
+++ b/crates/mockforge-intelligence/src/incidents/integrations/jira.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides formatting for Jira issue creation when drift incidents are detected.
 
-use crate::incidents::types::{DriftIncident, IncidentSeverity};
+use mockforge_foundation::incidents_types::{DriftIncident, IncidentSeverity};
 use serde_json::{json, Value};
 
 /// Format a drift incident as a Jira issue creation payload

--- a/crates/mockforge-intelligence/src/incidents/integrations/slack.rs
+++ b/crates/mockforge-intelligence/src/incidents/integrations/slack.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides formatting for Slack webhook messages when drift incidents are created.
 
-use crate::incidents::types::{DriftIncident, IncidentSeverity, IncidentType};
+use mockforge_foundation::incidents_types::{DriftIncident, IncidentSeverity, IncidentType};
 use serde_json::{json, Value};
 
 /// Format a drift incident as a Slack message

--- a/crates/mockforge-intelligence/src/incidents/mod.rs
+++ b/crates/mockforge-intelligence/src/incidents/mod.rs
@@ -1,0 +1,35 @@
+//! Drift-incident management — semantic side.
+//!
+//! Issue #562 phase 9: the AI-coupled pieces of `mockforge_core::incidents` moved
+//! here. The structural incident manager (`IncidentManager`), in-memory store
+//! (`IncidentStore`), and shared types (`IncidentSeverity`, `IncidentStatus`,
+//! etc., which live in `mockforge_foundation::incidents_types`) stay in core /
+//! foundation respectively — they don't depend on AI primitives.
+//!
+//! What's here:
+//!
+//! - [`semantic_manager`]: tracks **semantic** drift incidents (cross-linked
+//!   with structural incidents in core but built on top of the LLM-driven
+//!   semantic-change taxonomy from `crate::ai_contract_diff::semantic_analyzer`).
+//! - [`integrations`]: Jira / Linear / generic-webhook configuration types
+//!   used to push incident notifications to external systems.
+//! - [`slack_formatter`] (`integrations/slack.rs`) and [`jira_formatter`]
+//!   (`integrations/jira.rs`): payload-formatting helpers for the two
+//!   built-in integrations. Aliased under the same names as in the legacy
+//!   `mockforge_core::incidents` layout so existing call sites that go
+//!   through the core re-export shim resolve unchanged.
+
+pub mod integrations;
+pub mod semantic_manager;
+
+// Match the legacy core layout exactly — the two formatter aliases share
+// the same files as their parent `integrations` submodules. Existing
+// `mockforge_core::incidents::{slack_formatter, jira_formatter}` callers
+// pick these up via the core re-export shim.
+#[path = "integrations/slack.rs"]
+pub mod slack_formatter;
+
+#[path = "integrations/jira.rs"]
+pub mod jira_formatter;
+
+pub use semantic_manager::{SemanticIncident, SemanticIncidentManager};

--- a/crates/mockforge-intelligence/src/incidents/semantic_manager.rs
+++ b/crates/mockforge-intelligence/src/incidents/semantic_manager.rs
@@ -5,8 +5,8 @@
 //! cross-linked for unified contract health tracking.
 
 use crate::ai_contract_diff::semantic_analyzer::{SemanticChangeType, SemanticDriftResult};
-use crate::incidents::types::{IncidentSeverity, IncidentStatus};
 use chrono::Utc;
+use mockforge_foundation::incidents_types::{IncidentSeverity, IncidentStatus};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;

--- a/crates/mockforge-intelligence/src/lib.rs
+++ b/crates/mockforge-intelligence/src/lib.rs
@@ -35,6 +35,14 @@
 //!   mocks react to pressure, load, pricing, fraud, and customer segments
 //!   (Issue #562 phase 8). Self-contained — the only core-side dep was
 //!   `crate::Result`, now sourced from `mockforge-foundation` directly.
+//! - `incidents`: AI-coupled pieces of drift-incident management — semantic
+//!   incident manager (built on `ai_contract_diff::semantic_analyzer`) and
+//!   Jira/Slack/webhook integrations (Issue #562 phase 9). The structural
+//!   `IncidentManager` and in-memory `IncidentStore` stay in `mockforge-core`;
+//!   the shared types (`DriftIncident`, `IncidentSeverity`, ...) live in
+//!   `mockforge_foundation::incidents_types`. Core re-exports this module so
+//!   the legacy `mockforge_core::incidents::{semantic_manager, integrations,
+//!   slack_formatter, jira_formatter}` paths keep resolving.
 
 pub mod ai_contract_diff;
 pub mod ai_response;
@@ -43,6 +51,7 @@ pub mod behavioral_cloning;
 pub mod behavioral_economics;
 pub mod contract_validation;
 pub mod failure_analysis;
+pub mod incidents;
 pub mod intelligent_behavior;
 pub mod pr_generation;
 pub mod reality;


### PR DESCRIPTION
## Summary

Issue #562 phase 9. Moves the remaining AI-coupled drift-incident code from `mockforge_core::incidents` into `mockforge_intelligence::incidents`. The structural pieces (`IncidentManager`, `IncidentStore`) and shared types (re-exported from `mockforge_foundation::incidents_types`) stay in core — they have no AI dependencies.

## What moved (4 files)

- `incidents::semantic_manager` — semantic-drift incident manager, built on `ai_contract_diff::semantic_analyzer`
- `incidents::integrations` — Jira/Linear/Webhook config + sender (incl. HMAC-SHA256 webhook signer)
- `incidents::integrations::slack` — Slack message formatter
- `incidents::integrations::jira` — Jira issue formatter

## What stayed in core

- `incidents::manager` (structural `IncidentManager`)
- `incidents::store` (in-memory `IncidentStore`)
- `incidents::types` (thin re-export of `mockforge_foundation::incidents_types`)

## Backwards compatibility

`mockforge-core/src/incidents/mod.rs` re-exports the moved modules from intelligence, so every existing caller keeps resolving:

```rust
pub use mockforge_intelligence::incidents::{
    integrations, semantic_manager, jira_formatter, slack_formatter,
    SemanticIncident, SemanticIncidentManager,
};
```

External callers (`mockforge-cli`, `mockforge-http` handlers, `core::config::contracts`) keep their `mockforge_core::incidents::{...}` imports unchanged.

## Why this was safe

Both moved files had zero coupling to core internals. The only foreign imports were:
- `crate::ai_contract_diff::semantic_analyzer::*` — already in intelligence, so the import stays `crate::`-relative.
- `crate::incidents::types::*` — these are just re-exports of `mockforge_foundation::incidents_types::*`; rewrote the imports to point at foundation directly so intelligence doesn't depend on core.

## New deps on `mockforge-intelligence`

Both already in the workspace at the versions core pinned:
- `hex` 0.4 — `WebhookIntegration` hex-encodes its HMAC signature
- `hmac` 0.12 — same

## Test plan

- [x] `cargo check -p mockforge-intelligence -p mockforge-core -p mockforge-http -p mockforge-cli` — all clean
- [x] `cargo test -p mockforge-intelligence --lib` — 311 pass
- [x] `cargo test -p mockforge-core --lib` — 1261 pass
- [x] `cargo clippy -p mockforge-intelligence -p mockforge-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

## What remains of #562

With phase 9 in, the only originally-listed target left unaddressed is `mockforge_core::consistency` (issue says move to `mockforge-proxy`, not intelligence — different crate-direction story). `reality_continuum` shipped as `reality` in phase 6. Suggest closing #562 after this lands and filing a follow-up issue for the `consistency` → `mockforge-proxy` move if it's still worth doing.