### PR TITLE
refactor(intelligence,http): move pr_generation handler to mockforge-intelligence (#555 phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8389,6 +8389,7 @@ name = "mockforge-intelligence"
 version = "0.3.141"
 dependencies = [
  "async-trait",
+ "axum 0.8.9",
  "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",

--- a/audit.toml
+++ b/audit.toml
@@ -29,6 +29,7 @@ ignore = [
     { id = "RUSTSEC-2026-0095", reason = "wasmtime Winch sandbox-escaping memory access — blocked by wasmtime major bump" },
     { id = "RUSTSEC-2026-0096", reason = "wasmtime aarch64 Cranelift sandbox escape — blocked by wasmtime major bump" },
     { id = "RUSTSEC-2026-0114", reason = "wasmtime oversize-table allocation panic (DoS) — fixed in 36.0.8 but pinned at 36.0.6 by plugin-loader; clears with same wasmtime major bump" },
+    { id = "RUSTSEC-2026-0149", reason = "wasmtime-wasi path_open(TRUNCATE) bypasses FilePerms::WRITE — same wasmtime 36.x pin as the rest of this group; clears with the wasmtime major bump in plugin-loader" },
 
     # rustls-webpki pinned at multiple versions by transitive deps
     # (aws-sdk via rustls 0.21, rumqttc via rustls 0.22, axum-server via

--- a/crates/mockforge-http/src/handlers/pr_generation.rs
+++ b/crates/mockforge-http/src/handlers/pr_generation.rs
@@ -1,146 +1,17 @@
-//! PR generation handlers
+//! PR generation handlers — re-export shim.
 //!
-//! This module provides HTTP handlers for triggering PR generation when contract changes are detected.
+//! Issue #555 phase 2 moved this module to
+//! [`mockforge_intelligence::handlers::pr_generation`]. The handler's only
+//! foreign import was `mockforge_intelligence::pr_generation::*` (the
+//! underlying `pr_generation` module had already moved to intelligence in
+//! Issue #562 phase 1), so the handler followed once intelligence grew an
+//! `axum` dep.
+//!
+//! This shim keeps existing
+//! `mockforge_http::handlers::pr_generation::{PRGenerationState,
+//! GeneratePRRequest, pr_generation_router, ...}` callers (notably the
+//! router wired up in `mockforge_http::lib`) resolving unchanged. Future
+//! phases of #555 may drop this shim; until then, prefer importing from
+//! `mockforge_intelligence::handlers::pr_generation` directly in new code.
 
-use axum::extract::State;
-use axum::http::StatusCode;
-use axum::response::Json;
-use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-
-use mockforge_intelligence::pr_generation::{
-    PRFileChange, PRFileChangeType, PRGenerator, PRTemplateContext,
-};
-
-/// State for PR generation handlers
-#[derive(Clone)]
-pub struct PRGenerationState {
-    /// PR generator
-    pub generator: Option<Arc<PRGenerator>>,
-}
-
-/// Request to generate a PR
-#[derive(Debug, Deserialize, Serialize)]
-pub struct GeneratePRRequest {
-    /// Endpoint path
-    pub endpoint: String,
-    /// HTTP method
-    pub method: String,
-    /// Number of breaking changes
-    pub breaking_changes: u32,
-    /// Number of non-breaking changes
-    pub non_breaking_changes: u32,
-    /// Change summary
-    pub change_summary: String,
-    /// Affected files
-    pub affected_files: Vec<String>,
-    /// File changes
-    pub file_changes: Vec<PRFileChangeRequest>,
-    /// Labels to add
-    pub labels: Option<Vec<String>>,
-    /// Reviewers to request
-    pub reviewers: Option<Vec<String>>,
-}
-
-/// Request for a file change
-#[derive(Debug, Deserialize, Serialize)]
-pub struct PRFileChangeRequest {
-    /// File path
-    pub path: String,
-    /// File content
-    pub content: String,
-    /// Change type
-    pub change_type: String,
-}
-
-/// Response for PR generation
-#[derive(Debug, Serialize)]
-pub struct GeneratePRResponse {
-    /// PR number
-    pub pr_number: Option<u64>,
-    /// PR URL
-    pub pr_url: Option<String>,
-    /// Branch name
-    pub branch: Option<String>,
-    /// Success status
-    pub success: bool,
-    /// Error message (if any)
-    pub error: Option<String>,
-}
-
-/// Generate a PR from contract changes
-///
-/// POST /api/v1/pr/generate
-pub async fn generate_pr(
-    State(state): State<PRGenerationState>,
-    Json(request): Json<GeneratePRRequest>,
-) -> Result<Json<GeneratePRResponse>, StatusCode> {
-    let generator = state.generator.as_ref().ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-
-    // Convert file change requests to PR file changes
-    let file_changes: Vec<PRFileChange> = request
-        .file_changes
-        .into_iter()
-        .map(|fc| {
-            let change_type = match fc.change_type.as_str() {
-                "create" => PRFileChangeType::Create,
-                "update" => PRFileChangeType::Update,
-                "delete" => PRFileChangeType::Delete,
-                _ => PRFileChangeType::Update,
-            };
-
-            PRFileChange {
-                path: fc.path,
-                content: fc.content,
-                change_type,
-            }
-        })
-        .collect();
-
-    // Create template context
-    let context = PRTemplateContext {
-        endpoint: request.endpoint,
-        method: request.method,
-        breaking_changes: request.breaking_changes,
-        non_breaking_changes: request.non_breaking_changes,
-        affected_files: request.affected_files,
-        change_summary: request.change_summary,
-        is_breaking: request.breaking_changes > 0,
-        metadata: std::collections::HashMap::new(),
-    };
-
-    // Generate PR
-    match generator
-        .create_pr_from_context(
-            context,
-            file_changes,
-            request.labels.unwrap_or_default(),
-            request.reviewers.unwrap_or_default(),
-        )
-        .await
-    {
-        Ok(pr_result) => Ok(Json(GeneratePRResponse {
-            pr_number: Some(pr_result.number),
-            pr_url: Some(pr_result.url),
-            branch: Some(pr_result.branch),
-            success: true,
-            error: None,
-        })),
-        Err(e) => Ok(Json(GeneratePRResponse {
-            pr_number: None,
-            pr_url: None,
-            branch: None,
-            success: false,
-            error: Some(e.to_string()),
-        })),
-    }
-}
-
-/// Create PR generation router
-pub fn pr_generation_router(state: PRGenerationState) -> axum::Router {
-    use axum::routing::post;
-
-    axum::Router::new()
-        .route("/api/v1/pr/generate", post(generate_pr))
-        .with_state(state)
-}
+pub use mockforge_intelligence::handlers::pr_generation::*;

--- a/crates/mockforge-intelligence/Cargo.toml
+++ b/crates/mockforge-intelligence/Cargo.toml
@@ -22,6 +22,10 @@ mockforge-foundation = { path = "../mockforge-foundation", default-features = fa
 # dep is cycle-safe — it does NOT pull `mockforge-core` back in.
 mockforge-openapi = { path = "../mockforge-openapi" }
 async-trait = { workspace = true }
+# `handlers::*` (HTTP-handler files migrated out of `mockforge-http` under
+# Issue #555) need axum. Cycle-safe: `mockforge-http` already depends on
+# `mockforge-intelligence`, never the reverse.
+axum = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
 dirs = "5.0"

--- a/crates/mockforge-intelligence/src/handlers/mod.rs
+++ b/crates/mockforge-intelligence/src/handlers/mod.rs
@@ -1,0 +1,15 @@
+//! HTTP handlers for AI-coupled features.
+//!
+//! Issue #555 carves the AI-touching handler files out of
+//! `mockforge-http/src/handlers/` and re-homes them next to the
+//! intelligence logic they wrap. The HTTP crate keeps thin
+//! re-export shims at the legacy paths for one minor version so
+//! router-construction code in `mockforge_http::lib` keeps resolving
+//! unchanged.
+//!
+//! Currently migrated:
+//! - [`pr_generation`]: PR generation HTTP surface (#555 phase 2). The
+//!   underlying `pr_generation` module moved in #562 phase 1; the
+//!   handler followed once intelligence grew an axum dep.
+
+pub mod pr_generation;

--- a/crates/mockforge-intelligence/src/handlers/pr_generation.rs
+++ b/crates/mockforge-intelligence/src/handlers/pr_generation.rs
@@ -1,0 +1,144 @@
+//! PR generation handlers
+//!
+//! This module provides HTTP handlers for triggering PR generation when contract changes are detected.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::pr_generation::{PRFileChange, PRFileChangeType, PRGenerator, PRTemplateContext};
+
+/// State for PR generation handlers
+#[derive(Clone)]
+pub struct PRGenerationState {
+    /// PR generator
+    pub generator: Option<Arc<PRGenerator>>,
+}
+
+/// Request to generate a PR
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GeneratePRRequest {
+    /// Endpoint path
+    pub endpoint: String,
+    /// HTTP method
+    pub method: String,
+    /// Number of breaking changes
+    pub breaking_changes: u32,
+    /// Number of non-breaking changes
+    pub non_breaking_changes: u32,
+    /// Change summary
+    pub change_summary: String,
+    /// Affected files
+    pub affected_files: Vec<String>,
+    /// File changes
+    pub file_changes: Vec<PRFileChangeRequest>,
+    /// Labels to add
+    pub labels: Option<Vec<String>>,
+    /// Reviewers to request
+    pub reviewers: Option<Vec<String>>,
+}
+
+/// Request for a file change
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PRFileChangeRequest {
+    /// File path
+    pub path: String,
+    /// File content
+    pub content: String,
+    /// Change type
+    pub change_type: String,
+}
+
+/// Response for PR generation
+#[derive(Debug, Serialize)]
+pub struct GeneratePRResponse {
+    /// PR number
+    pub pr_number: Option<u64>,
+    /// PR URL
+    pub pr_url: Option<String>,
+    /// Branch name
+    pub branch: Option<String>,
+    /// Success status
+    pub success: bool,
+    /// Error message (if any)
+    pub error: Option<String>,
+}
+
+/// Generate a PR from contract changes
+///
+/// POST /api/v1/pr/generate
+pub async fn generate_pr(
+    State(state): State<PRGenerationState>,
+    Json(request): Json<GeneratePRRequest>,
+) -> Result<Json<GeneratePRResponse>, StatusCode> {
+    let generator = state.generator.as_ref().ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    // Convert file change requests to PR file changes
+    let file_changes: Vec<PRFileChange> = request
+        .file_changes
+        .into_iter()
+        .map(|fc| {
+            let change_type = match fc.change_type.as_str() {
+                "create" => PRFileChangeType::Create,
+                "update" => PRFileChangeType::Update,
+                "delete" => PRFileChangeType::Delete,
+                _ => PRFileChangeType::Update,
+            };
+
+            PRFileChange {
+                path: fc.path,
+                content: fc.content,
+                change_type,
+            }
+        })
+        .collect();
+
+    // Create template context
+    let context = PRTemplateContext {
+        endpoint: request.endpoint,
+        method: request.method,
+        breaking_changes: request.breaking_changes,
+        non_breaking_changes: request.non_breaking_changes,
+        affected_files: request.affected_files,
+        change_summary: request.change_summary,
+        is_breaking: request.breaking_changes > 0,
+        metadata: std::collections::HashMap::new(),
+    };
+
+    // Generate PR
+    match generator
+        .create_pr_from_context(
+            context,
+            file_changes,
+            request.labels.unwrap_or_default(),
+            request.reviewers.unwrap_or_default(),
+        )
+        .await
+    {
+        Ok(pr_result) => Ok(Json(GeneratePRResponse {
+            pr_number: Some(pr_result.number),
+            pr_url: Some(pr_result.url),
+            branch: Some(pr_result.branch),
+            success: true,
+            error: None,
+        })),
+        Err(e) => Ok(Json(GeneratePRResponse {
+            pr_number: None,
+            pr_url: None,
+            branch: None,
+            success: false,
+            error: Some(e.to_string()),
+        })),
+    }
+}
+
+/// Create PR generation router
+pub fn pr_generation_router(state: PRGenerationState) -> axum::Router {
+    use axum::routing::post;
+
+    axum::Router::new()
+        .route("/api/v1/pr/generate", post(generate_pr))
+        .with_state(state)
+}

--- a/crates/mockforge-intelligence/src/lib.rs
+++ b/crates/mockforge-intelligence/src/lib.rs
@@ -51,6 +51,9 @@ pub mod behavioral_cloning;
 pub mod behavioral_economics;
 pub mod contract_validation;
 pub mod failure_analysis;
+/// HTTP handlers for AI-coupled features. New in #555 phase 2 — see
+/// `handlers/mod.rs` for migration progress.
+pub mod handlers;
 pub mod incidents;
 pub mod intelligent_behavior;
 pub mod pr_generation;


### PR DESCRIPTION
## Summary

Second phase of #555. ADR 0001 (`docs/adr/0001-mockforge-http-extraction.md`) marks `pr_generation.rs` as the smallest INTELLIGENCE-bucket handler (146 LOC) and the cleanest first axum-into-intelligence move:

- Its only foreign import was `mockforge_intelligence::pr_generation::*`, which #562 phase 1 had already moved into intelligence.
- Single workspace caller: the router-construction code in `mockforge-http/src/lib.rs`, which goes through the shim.

## What changed

- `git mv crates/mockforge-http/src/handlers/pr_generation.rs → crates/mockforge-intelligence/src/handlers/pr_generation.rs`.
- Rewrote the file's `mockforge_intelligence::pr_generation::*` import to `crate::pr_generation::*`.
- New `crates/mockforge-intelligence/src/handlers/mod.rs` with `pub mod pr_generation;` + docstring explaining the migration pattern.
- `pub mod handlers;` added to `mockforge-intelligence/src/lib.rs`.
- `mockforge-intelligence/Cargo.toml` gains `axum` as a workspace dep. **Cycle-safe**: `mockforge-http` already depends on `mockforge-intelligence`, never the reverse. This is the first axum dep on the intelligence side; subsequent handler moves are now unblocked.
- `mockforge-http/src/handlers/pr_generation.rs` is now a one-line re-export shim so router code keeps resolving unchanged.

### Drive-by

Extend `audit.toml` to ignore `RUSTSEC-2026-0149` (wasmtime-wasi `path_open(TRUNCATE)` permission bypass). This is a new advisory in the same wasmtime-36.x pin family the file already documents as blocked by the plugin-loader's wasmtime major bump. Pre-commit cargo-audit started failing on it today because rustsec-advisory-db updated; not introduced by this PR.

## Why this is safe

- Zero behavior change in the handler — `git mv` + 1-line import update.
- Single workspace caller (`mockforge_http::lib`'s router wiring) keeps resolving via the shim.
- Cycle direction preserved: http→intelligence remains; nothing in intelligence reaches back into http or core.

## Phase context

Per ADR 0001, 17 INTELLIGENCE-bucket handlers remain in `mockforge-http/src/handlers/`. With axum now on the intelligence side, the rest are unblocked from a Cargo-deps perspective. Per-handler audits required by the ADR (checking each handler's incidental core/recorder deps) will drive subsequent #555 phases.

## Test plan

- [x] `cargo check -p mockforge-intelligence -p mockforge-http` — clean
- [x] `cargo test -p mockforge-intelligence -p mockforge-http --lib` — 926 pass (615 http, 311 intelligence)
- [x] `cargo clippy -p mockforge-intelligence -p mockforge-http --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Pre-commit cargo-audit — clean