### PR TITLE
fix(bench): cap VU recommendation + iteration coverage (#79 round 10) + bump 0.3.142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## [Unreleased]
+## [0.3.142] - 2026-05-21
+
+### Changed
+
+- **[DevX]** Pre-flight `--vus` recommendation caps at 1000 for huge specs (#79 round 10)
+  - Srikanth's 11,422-operation spec at `--rps 100` (9.4ms baseline) produced a recommendation of **~10,740 VUs** — mathematically correct but practically absurd. The right answer for that workload isn't "spin up 10K VUs", it's "shrink the workload." 0.3.142 caps the printed recommendation at 1000 and, above the cap, steers users toward `--operations`/`--exclude-operations` filters or dropping `--rps` for closed-model loading.
+
+### Added
+
+- **[DevX]** Iteration coverage in bench summary (#79 round 10)
+  - New `Iterations: X complete × N ops = Y ops fully exercised` line appears whenever k6's `iterations.values.count` is non-zero. When the run ends mid-iteration (large spec, undersized VUs), a follow-up line surfaces the extra requests from the partial pass so users know the last iteration didn't cover every operation in the spec.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7693,7 +7693,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7751,7 +7751,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7888,7 +7888,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7933,7 +7933,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7943,7 +7943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7968,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8074,7 +8074,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8130,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8179,7 +8179,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8217,7 +8217,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8260,7 +8260,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8357,7 +8357,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8386,7 +8386,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8440,7 +8440,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8467,7 +8467,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8513,7 +8513,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8539,7 +8539,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8555,7 +8555,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8585,7 +8585,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8604,7 +8604,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8663,7 +8663,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8678,7 +8678,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8702,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8742,7 +8742,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8779,7 +8779,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8804,7 +8804,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8820,7 +8820,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8854,7 +8854,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8892,7 +8892,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8969,7 +8969,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8989,7 +8989,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9002,7 +9002,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9024,7 +9024,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9061,7 +9061,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9089,7 +9089,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9119,7 +9119,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9146,7 +9146,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9170,14 +9170,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9215,7 +9215,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9278,7 +9278,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9309,7 +9309,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9396,7 +9396,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9407,7 +9407,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15173,7 +15173,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.141"
+version = "0.3.142"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.141"
+version = "0.3.142"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,6 +1,16 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
-## [Unreleased]
+## [0.3.142] - 2026-05-21
+
+### Changed
+
+- **[DevX]** Pre-flight `--vus` recommendation caps at 1000 for huge specs (#79 round 10)
+  - Srikanth's 11,422-operation spec at `--rps 100` (9.4ms baseline) produced a recommendation of **~10,740 VUs** — mathematically correct but practically absurd. The right answer for that workload isn't "spin up 10K VUs", it's "shrink the workload." 0.3.142 caps the printed recommendation at 1000 and, above the cap, steers users toward `--operations`/`--exclude-operations` filters or dropping `--rps` for closed-model loading.
+
+### Added
+
+- **[DevX]** Iteration coverage in bench summary (#79 round 10)
+  - New `Iterations: X complete × N ops = Y ops fully exercised` line appears whenever k6's `iterations.values.count` is non-zero. When the run ends mid-iteration (large spec, undersized VUs), a follow-up line surfaces the extra requests from the partial pass so users know the last iteration didn't cover every operation in the spec.
 
 ### Fixed
 

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -853,6 +853,9 @@ fn parse_k6_summary(bytes: &[u8]) -> Result<K6Results> {
         },
         tls_handshake_avg_ms: tls_handshake["avg"].as_f64().unwrap_or(0.0),
         tls_handshake_max_ms: tls_handshake["max"].as_f64().unwrap_or(0.0),
+        iterations_completed: json["metrics"]["iterations"]["values"]["count"]
+            .as_u64()
+            .unwrap_or(0),
     })
 }
 

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -455,18 +455,43 @@ impl BenchCommand {
             };
 
             if self.vus < required_vus {
-                TerminalReporter::print_warning(&format!(
-                    "--vus {} may be insufficient for --rps {} × {} ops/iteration \
-                     (baseline latency {}). k6's constant-arrival-rate counts ITERATIONS \
-                     and each runs every operation in the spec — required ≈ rps × ops × \
-                     latency_secs VUs. Bump --vus to ~{} if you see \"Insufficient VUs\" \
-                     warnings.",
-                    self.vus,
-                    rps,
-                    num_ops,
-                    basis,
-                    required_vus.max(self.vus + 1),
-                ));
+                // Round 10 (#79): Srikanth's 11422-op spec at --rps 100 produced
+                // a recommendation of ~10,740 VUs, which is absurd in practice.
+                // When the recommendation goes super-linear, the real fix is to
+                // reduce the workload (use --operations filter), not bump VUs.
+                // Cap the suggestion at 1000 and steer the user toward filtering.
+                const VU_RECOMMENDATION_CAP: u32 = 1000;
+                let recommendation = required_vus.max(self.vus + 1);
+                if recommendation > VU_RECOMMENDATION_CAP {
+                    TerminalReporter::print_warning(&format!(
+                        "Workload is very large: --rps {} × {} ops/iteration × {} \
+                         baseline ⇒ ~{} VUs needed end-to-end, far beyond what's \
+                         practical to drive. Two ways to fix:\n  1. Reduce \
+                         operations per iteration with `--operations 'pattern,…'` \
+                         (or `--exclude-operations`) to focus the bench on a \
+                         representative subset.\n  2. Drop `--rps` and use \
+                         `--vus {}` alone — closed-model load runs as fast as \
+                         the VU pool allows, bounded by latency, with no per-\
+                         iteration deadline. Expect 1-iteration coverage of ~{} \
+                         operations in {}s.",
+                        rps,
+                        num_ops,
+                        basis,
+                        recommendation,
+                        self.vus.max(5),
+                        num_ops,
+                        Self::parse_duration(&self.duration).unwrap_or(0),
+                    ));
+                } else {
+                    TerminalReporter::print_warning(&format!(
+                        "--vus {} may be insufficient for --rps {} × {} ops/iteration \
+                         (baseline latency {}). k6's constant-arrival-rate counts ITERATIONS \
+                         and each runs every operation in the spec — required ≈ rps × ops × \
+                         latency_secs VUs. Bump --vus to ~{} if you see \"Insufficient VUs\" \
+                         warnings.",
+                        self.vus, rps, num_ops, basis, recommendation,
+                    ));
+                }
             } else if probe.is_some() {
                 TerminalReporter::print_progress(&format!(
                     "Pre-flight probe: target latency {}, {} ops/iteration — --vus {} \
@@ -573,7 +598,12 @@ impl BenchCommand {
 
         // Print results
         let duration_secs = Self::parse_duration(&self.duration)?;
-        TerminalReporter::print_summary_with_mode(&results, duration_secs, self.no_keep_alive);
+        TerminalReporter::print_summary_full(
+            &results,
+            duration_secs,
+            self.no_keep_alive,
+            Some(num_ops),
+        );
 
         println!("\nResults saved to: {}", self.output.display());
 

--- a/crates/mockforge-bench/src/executor.rs
+++ b/crates/mockforge-bench/src/executor.rs
@@ -363,6 +363,9 @@ impl K6Executor {
             },
             tls_handshake_avg_ms: tls_handshake["avg"].as_f64().unwrap_or(0.0),
             tls_handshake_max_ms: tls_handshake["max"].as_f64().unwrap_or(0.0),
+            iterations_completed: json["metrics"]["iterations"]["values"]["count"]
+                .as_u64()
+                .unwrap_or(0),
         })
     }
 }
@@ -423,6 +426,13 @@ pub struct K6Results {
     pub tls_handshake_avg_ms: f64,
     #[serde(default)]
     pub tls_handshake_max_ms: f64,
+    /// Issue #79 round 10 — k6 iteration counter from `iterations.values.count`.
+    /// For `constant-arrival-rate` (`--rps`), this is the number of full
+    /// iterations completed within the duration. When `iterations × num_ops`
+    /// is much less than `total_requests`, mid-iteration cancellation truncated
+    /// the run and not every operation in the spec was exercised.
+    #[serde(default)]
+    pub iterations_completed: u64,
 }
 
 impl K6Results {

--- a/crates/mockforge-bench/src/reporter.rs
+++ b/crates/mockforge-bench/src/reporter.rs
@@ -28,6 +28,23 @@ impl TerminalReporter {
     /// equals "distinct connections opened", which is what Srikanth wanted
     /// alongside RPS.
     pub fn print_summary_with_mode(results: &K6Results, duration_secs: u64, cps_mode: bool) {
+        Self::print_summary_full(results, duration_secs, cps_mode, None);
+    }
+
+    /// Like [`print_summary_with_mode`] but accepts `num_operations` (the count
+    /// of operations the bench generated from the spec). When supplied, the
+    /// summary surfaces iteration coverage: how many iterations completed and
+    /// what fraction of the spec's operations got exercised end-to-end.
+    ///
+    /// Issue #79 round 10 — Srikanth's 11422-op spec ran for 600s with only
+    /// `--vus 5`; many iterations were cancelled mid-way and the final
+    /// summary didn't reveal which slice of the spec was actually covered.
+    pub fn print_summary_full(
+        results: &K6Results,
+        duration_secs: u64,
+        cps_mode: bool,
+        num_operations: Option<u32>,
+    ) {
         println!("\n{}", "=".repeat(60).bright_green());
         println!("{}", "Load Test Complete! ✓".bright_green().bold());
         println!("{}\n", "=".repeat(60).bright_green());
@@ -151,6 +168,38 @@ impl TerminalReporter {
                 "  Peak concurrent VUs:  {} (max open conns from client side)",
                 results.vus_max.to_string().cyan(),
             );
+        }
+
+        // Issue #79 round 10 — iteration coverage. When --rps is supplied and
+        // the spec has many operations per iteration, k6 may cancel iterations
+        // mid-walk if the duration ends before a full pass completes. Surface
+        // "iterations completed" alongside operation count so users see what
+        // fraction of the spec was actually exercised.
+        if results.iterations_completed > 0 {
+            if let Some(num_ops) = num_operations {
+                let expected_reqs_per_iter = num_ops as u64;
+                let full_iter_reqs =
+                    results.iterations_completed.saturating_mul(expected_reqs_per_iter);
+                let partial_iter_reqs = results.total_requests.saturating_sub(full_iter_reqs);
+                println!(
+                    "  Iterations:           {} complete × {} ops = {} ops fully exercised",
+                    results.iterations_completed.to_string().cyan(),
+                    num_ops.to_string().cyan(),
+                    full_iter_reqs.to_string().cyan(),
+                );
+                if partial_iter_reqs > 0 && num_ops > 1 {
+                    println!(
+                        "                        {} extra request(s) from a partially-completed \
+                         iteration — duration ended mid-walk; not every op was hit on the last pass.",
+                        partial_iter_reqs.to_string().yellow(),
+                    );
+                }
+            } else {
+                println!(
+                    "  Iterations:           {} complete",
+                    results.iterations_completed.to_string().cyan(),
+                );
+            }
         }
 
         // Issue #79 — server-injected chaos signals (latency / jitter / faults)


### PR DESCRIPTION
## Summary

Srikanth's 0.3.141 testing on an 11,422-operation spec exposed two gaps in the round-9 fix:

1. **Pre-flight VU recommendation was absurd.** `--rps 100` at 9.4ms baseline produced "Bump --vus to ~10740" — mathematically correct (`100 × 11422 × 0.0094 ≈ 10740`) but no one runs 10K VUs. The real fix for that workload is to shrink it: use `--operations`/`--exclude-operations`, or drop `--rps` for closed-model loading.

   This PR caps the printed recommendation at 1000. Above the cap, a different warning surfaces that steers users toward filtering / closed-model:

   ```
   ⚠ Workload is very large: --rps 100000 × 3 ops/iteration × avg 3.4ms baseline
     ⇒ ~1015 VUs needed end-to-end, far beyond what's practical to drive. Two
     ways to fix:
       1. Reduce operations per iteration with `--operations 'pattern,…'`
       2. Drop `--rps` and use `--vus N` alone — closed-model load runs as fast
          as the VU pool allows…
   ```

2. **Final summary didn't reveal iteration coverage.** With a huge spec and undersized VUs, k6 cancels iterations mid-walk and only a fraction of the spec gets exercised. Srikanth asked: "It would be good if we print X operations executed out of N in the final output." Done — new line:

   ```
   Iterations:           276 complete × 3 ops = 828 ops fully exercised
   ```

   And when `total_requests > iterations × num_ops`, a follow-up line about the partial iteration so users know the last pass was cut short.

## Test plan

- [x] `cargo test -p mockforge-bench --lib` — 391 pass
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings` — clean
- [x] End-to-end against `examples/openapi-demo.json` (3 ops):
  - `--vus 5 --rps 100`: confirmation prints; new "Iterations: 276 complete × 3 ops = 828 ops fully exercised" line appears.
  - `--vus 1 --rps 100000`: cap warning triggers, recommends `--operations` filter or closed-model `--vus N`.

Workspace 0.3.141 → 0.3.142. Folds the [Unreleased] check-changelog.sh fix into the same release.