### PR TITLE
fix(proxy): drop unused axum:: qualification on http:: paths

### DIFF
--- a/crates/mockforge-proxy/src/config.rs
+++ b/crates/mockforge-proxy/src/config.rs
@@ -147,7 +147,7 @@ impl ProxyConfig {
     /// Check if a request should be proxied
     /// Respects migration mode: mock forces mock, real forces proxy, shadow forces proxy, auto uses existing logic
     /// This is a legacy method that doesn't evaluate conditions - use should_proxy_with_condition for conditional proxying
-    pub fn should_proxy(&self, _method: &axum::http::Method, path: &str) -> bool {
+    pub fn should_proxy(&self, _method: &http::Method, path: &str) -> bool {
         if !self.enabled {
             return false;
         }
@@ -188,9 +188,9 @@ impl ProxyConfig {
     /// This method evaluates conditions in proxy rules using request context
     pub fn should_proxy_with_condition(
         &self,
-        method: &axum::http::Method,
-        uri: &axum::http::Uri,
-        headers: &axum::http::HeaderMap,
+        method: &http::Method,
+        uri: &http::Uri,
+        headers: &http::HeaderMap,
         body: Option<&[u8]>,
     ) -> bool {
         use crate::conditional::find_matching_rule;

--- a/crates/mockforge-proxy/src/handler.rs
+++ b/crates/mockforge-proxy/src/handler.rs
@@ -54,7 +54,7 @@ impl ProxyHandler {
         // Convert response back to ProxyResponse
         let mut response_headers = HeaderMap::new();
         for (key, value) in response.headers() {
-            if let Ok(header_name) = axum::http::HeaderName::try_from(key.as_str()) {
+            if let Ok(header_name) = http::HeaderName::try_from(key.as_str()) {
                 response_headers.insert(header_name, value.clone());
             }
         }
@@ -125,7 +125,7 @@ impl ProxyHandler {
         // Convert response back to ProxyResponse
         let mut response_headers = HeaderMap::new();
         for (key, value) in response.headers() {
-            if let Ok(header_name) = axum::http::HeaderName::try_from(key.as_str()) {
+            if let Ok(header_name) = http::HeaderName::try_from(key.as_str()) {
                 response_headers.insert(header_name, value.clone());
             }
         }


### PR DESCRIPTION
## Summary

- Drops `axum::` qualifier from 6 inline `axum::http::*` paths in `mockforge-proxy/src/{config.rs,handler.rs}`.
- `axum::http` is a re-export of the `http` crate, which this crate already lists as a direct dep (`http = \"1.3\"`). Bare `http::*` resolves to the same types and matches clippy's own suggested fix.

## Why now

The Incremental Warning Gate (which runs clippy with `-D unused-qualifications`) has been red on every PR since the `proxy_server` extraction landed in main (#607). PR #619 surfaced it because that PR's diff is unrelated (gitignore + SQL migration), making it obvious the warnings are pre-existing fallout, not new code.

Direct quote from the gate's failure log:
```
error: unnecessary qualification
   --> crates/mockforge-proxy/src/config.rs:150:42
    |
150 |     pub fn should_proxy(&self, _method: &axum::http::Method, path: &str) -> bool {
    |                                          ^^^^^^^^^^^^^^^^^^
    = note: requested on the command line with `-D unused-qualifications`
help: remove the unnecessary path segments
```
…and 5 sibling errors.

## Verification

- ✅ `cargo clippy -p mockforge-proxy --all-targets -- -D warnings -D unused-qualifications` — clean
- ✅ `cargo test -p mockforge-proxy --lib` — 17/17 pass
- ✅ `cargo fmt --all --check` — clean (signatures stay multi-line; no rustfmt-collapse fallout, per the lesson from #591/#592 → #594)
- ✅ Pre-commit hooks all passed (clippy, typos, rustfmt)

## Test plan

- [x] mockforge-proxy clippy passes locally
- [x] mockforge-proxy tests pass locally
- [x] cargo fmt clean
- [ ] Incremental Warning Gate green in CI (the whole point)