### PR TITLE
fix(registry-tests): align marketplace_e2e with current server contract

### DIFF
--- a/crates/mockforge-registry-server/tests/marketplace_e2e.rs
+++ b/crates/mockforge-registry-server/tests/marketplace_e2e.rs
@@ -192,11 +192,18 @@ async fn test_plugin_marketplace_workflow() {
     let plugin_name = format!("test-plugin-{}", test_id);
 
     // Step 4: Search for the plugin
+    //
+    // `SearchQuery` in `mockforge-plugin-registry` uses camelCase and requires
+    // `tags` and `sort` to be present (no `#[serde(default)]`). Sending only
+    // `query`/`page`/`perPage` makes axum reject the body with 422 before the
+    // handler runs.
     let search_response = helper
         .client
         .post(format!("{}/api/v1/plugins/search", helper.base_url))
         .json(&json!({
             "query": plugin_name.clone(),
+            "tags": json!([]),
+            "sort": "downloads",
             "page": 0,
             "perPage": 10
         }))
@@ -204,7 +211,11 @@ async fn test_plugin_marketplace_workflow() {
         .await
         .expect("Failed to search plugins");
 
-    assert!(search_response.status().is_success());
+    assert!(
+        search_response.status().is_success(),
+        "Plugin search failed: {:?}",
+        search_response.text().await
+    );
     let search_body: serde_json::Value =
         search_response.json().await.expect("Failed to parse response");
     assert!(!search_body["plugins"].as_array().unwrap().is_empty());
@@ -278,10 +289,13 @@ async fn test_template_marketplace_workflow() {
     let checksum = MarketplaceTestHelper::calculate_checksum(&package_data);
     let package_base64 = base64::engine::general_purpose::STANDARD.encode(&package_data);
 
+    // Templates publish under the `/marketplace/` prefix. `PublishTemplateRequest`
+    // uses `content_json` (not `content`) and `TemplateCategory` is a kebab-case
+    // enum — `"chaos"` is not a valid variant; use `"network-chaos"`.
     let template_name = format!("test-template-{}", test_id);
     let publish_response = helper
         .client
-        .post(format!("{}/api/v1/templates/publish", helper.base_url))
+        .post(format!("{}/api/v1/marketplace/templates/publish", helper.base_url))
         .header("Authorization", helper.auth_header().unwrap())
         .header("X-Org-Id", helper.org_id.unwrap().to_string())
         .json(&json!({
@@ -289,9 +303,8 @@ async fn test_template_marketplace_workflow() {
             "slug": template_name.clone(),
             "description": "Test template for E2E testing",
             "version": "1.0.0",
-            "category": "chaos",
-            "tags": vec!["test", "e2e"],
-            "content": json!({
+            "category": "network-chaos",
+            "content_json": json!({
                 "name": template_name,
                 "version": "1.0.0",
                 "description": "Test template"
@@ -311,19 +324,27 @@ async fn test_template_marketplace_workflow() {
     );
 
     // Step 4: Search for the template
+    //
+    // `TemplateSearchQuery` lives under `/marketplace/templates/search` and uses
+    // snake_case fields; `tags` is required (no `#[serde(default)]`).
     let search_response = helper
         .client
-        .post(format!("{}/api/v1/templates/search", helper.base_url))
+        .post(format!("{}/api/v1/marketplace/templates/search", helper.base_url))
         .json(&json!({
             "query": template_name.clone(),
+            "tags": json!([]),
             "page": 0,
-            "perPage": 10
+            "per_page": 10
         }))
         .send()
         .await
         .expect("Failed to search templates");
 
-    assert!(search_response.status().is_success());
+    assert!(
+        search_response.status().is_success(),
+        "Template search failed: {:?}",
+        search_response.text().await
+    );
     let search_body: serde_json::Value =
         search_response.json().await.expect("Failed to parse response");
     assert!(!search_body["templates"].as_array().unwrap().is_empty());
@@ -372,9 +393,12 @@ async fn test_scenario_marketplace_workflow() {
         "description": "Test scenario for E2E testing"
     });
 
+    // Scenarios publish/search live under the `/marketplace/` prefix.
+    // The bare `/api/v1/scenarios/*` paths are reserved for org-level listing
+    // (GET /api/v1/scenarios, GET /api/v1/scenarios/{id}) and return 405 for POST.
     let publish_response = helper
         .client
-        .post(format!("{}/api/v1/scenarios/publish", helper.base_url))
+        .post(format!("{}/api/v1/marketplace/scenarios/publish", helper.base_url))
         .header("Authorization", helper.auth_header().unwrap())
         .header("X-Org-Id", helper.org_id.unwrap().to_string())
         .json(&json!({
@@ -394,19 +418,27 @@ async fn test_scenario_marketplace_workflow() {
     );
 
     // Step 4: Search for the scenario
+    //
+    // `ScenarioSearchQuery` uses snake_case; `tags` is required (no
+    // `#[serde(default)]`).
     let search_response = helper
         .client
-        .post(format!("{}/api/v1/scenarios/search", helper.base_url))
+        .post(format!("{}/api/v1/marketplace/scenarios/search", helper.base_url))
         .json(&json!({
             "query": scenario_name.clone(),
+            "tags": json!([]),
             "page": 0,
-            "perPage": 10
+            "per_page": 10
         }))
         .send()
         .await
         .expect("Failed to search scenarios");
 
-    assert!(search_response.status().is_success());
+    assert!(
+        search_response.status().is_success(),
+        "Scenario search failed: {:?}",
+        search_response.text().await
+    );
     let search_body: serde_json::Value =
         search_response.json().await.expect("Failed to parse response");
     assert!(!search_body["scenarios"].as_array().unwrap().is_empty());
@@ -576,8 +608,7 @@ async fn test_template_star_flow() {
             "slug": template_name.clone(),
             "description": "Star-flow regression template",
             "version": version,
-            "category": "chaos",
-            "tags": vec!["test"],
+            "category": "network-chaos",
             "content_json": json!({ "name": template_name, "version": version }),
             "checksum": checksum,
             "file_size": package_data.len() as i64,


### PR DESCRIPTION
## Summary

\`marketplace_e2e.rs\` has been failing on every Registry E2E run since at least 2026-04-25 (the earliest run still in the GH Actions retention window). Four independent contract drifts between the tests and the registry server caused four panics. \`cargo build --tests\` can't catch any of them — the tests only assert on \`response.status().is_success()\`, which is opaque to the compiler.

Confirmed by reading the registry-server log uploaded by job 77483696712:

| Test | Request | Status | Cause |
|---|---|---|---|
| \`test_plugin_marketplace_workflow\` | \`POST /api/v1/plugins/search\` | 422 | \`SearchQuery\` requires \`tags\` + \`sort\` (no \`#[serde(default)]\`) |
| \`test_template_marketplace_workflow\` | \`POST /api/v1/templates/publish\` | 404 | publish lives at \`/api/v1/marketplace/templates/publish\` |
| \`test_template_marketplace_workflow\` | \`POST /api/v1/templates/search\` | 404 | search lives at \`/api/v1/marketplace/templates/search\` |
| \`test_scenario_marketplace_workflow\` | \`POST /api/v1/scenarios/publish\` | 405 | publish lives at \`/api/v1/marketplace/scenarios/publish\`; the bare path is GET-only org listing |
| \`test_template_star_flow\` | \`POST /api/v1/marketplace/templates/publish\` | 422 | \`category: \"chaos\"\` not a valid \`TemplateCategory\` (kebab-case enum: \`network-chaos\`, \`service-failure\`, …) |

Additional bugs surfaced once the URLs were corrected:
- \`PublishTemplateRequest.content_json\` was being sent as \`content\`.
- \`TemplateSearchQuery\` / \`ScenarioSearchQuery\` use snake_case and require \`tags\`; the tests were sending \`perPage\` (silently ignored) and omitting \`tags\`.

## Why not loosen the server contract instead

The 405/404 cases are wrong URLs in the test — no sensible server-side fix. The 422 cases reflect required fields in public API types (\`SearchQuery\` in \`mockforge-plugin-registry\`, \`TemplateSearchQuery\` / \`ScenarioSearchQuery\` / \`PublishTemplateRequest\` in \`mockforge-registry-server\`); making them \`#[serde(default)]\` would be a wider behaviour change touching the SDK, the UI, and the plugin-registry crate's public API. The tests are the faulty party and were the only thing that needed to move.

## Verification

- ✅ \`cargo check -p mockforge-registry-server --tests\` clean
- ✅ \`cargo clippy -p mockforge-registry-server --tests -- -D warnings\` clean
- ✅ \`cargo fmt --all --check\` clean
- ✅ Pre-commit hooks all passed (clippy, typos, rustfmt)
- ⏳ Registry E2E in CI — proof of the test-side fix depends on a green run; this is the whole point of the PR.

## What this does NOT fix

- Disk-space pressure on the self-hosted runner during \`Test (stable)\` and \`Standard Load Test\` (separate infrastructure issue).
- The post-#607 \`unused-qualifications\` regression in \`mockforge-proxy\` (fixed in #620).

## Test plan

- [x] Local clippy + fmt + check all clean
- [ ] Registry E2E goes green in CI — that's the load-bearing test