### PR TITLE
chore(release): 0.3.143 hotfix — fix broken cargo install on 0.3.142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.3.143] - 2026-05-23
+
+### Fixed
+
+- **[DevX]** Republish of 0.3.142 — fixes broken `mockforge-http@0.3.142` install (#79 round 10 hotfix)
+  - `cargo install mockforge-cli@0.3.142` failed with `error[E0432]: unresolved import \`crate::database::Database\`` in `mockforge-http/src/handlers/threat_modeling.rs:29` and `lib.rs:2387`. The `database` module was moved to `mockforge-intelligence` in #611, but two `use crate::database::Database;` statements weren't gated behind `#[cfg(feature = "database")]`, so default-feature builds (which is what `cargo install` uses) failed to compile. Fix landed on `main` in #616/#618 but was not in the 0.3.142 tag.
+  - 0.3.142 of the broken crates (cli, http, import, pipelines, proxy, workspace, core, bench, chaos, collab, recorder, registry-server, k8s-operator, vbr, sdk, test, reporting, ui) yanked from crates.io. 0.3.143 republishes the same #79 round-10 changes from a known-good main commit.
+
 ## [0.3.142] - 2026-05-21
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7693,7 +7693,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7751,7 +7751,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7888,7 +7888,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7933,7 +7933,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7943,7 +7943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7968,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8074,7 +8074,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8130,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8179,7 +8179,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8217,7 +8217,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8260,7 +8260,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8357,7 +8357,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8386,7 +8386,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8419,7 +8419,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8441,7 +8441,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8468,7 +8468,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8493,7 +8493,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8540,7 +8540,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8556,7 +8556,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8605,7 +8605,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8664,7 +8664,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8703,7 +8703,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8743,7 +8743,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8761,7 +8761,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8780,7 +8780,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8805,7 +8805,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8821,7 +8821,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8893,7 +8893,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8970,7 +8970,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8990,7 +8990,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9003,7 +9003,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9025,7 +9025,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9062,7 +9062,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9090,7 +9090,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9147,7 +9147,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9170,14 +9170,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9215,7 +9215,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9278,7 +9278,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9309,7 +9309,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9396,7 +9396,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9407,7 +9407,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15130,7 +15130,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.142"
+version = "0.3.143"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.142"
+version = "0.3.143"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,13 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.143] - 2026-05-23
+
+### Fixed
+
+- **[DevX]** Republish of 0.3.142 — fixes broken `mockforge-http@0.3.142` install (#79 round 10 hotfix)
+  - `cargo install mockforge-cli@0.3.142` failed with `error[E0432]: unresolved import \`crate::database::Database\`` in `mockforge-http/src/handlers/threat_modeling.rs:29` and `lib.rs:2387`. The `database` module was moved to `mockforge-intelligence` in #611, but two `use crate::database::Database;` statements weren't gated behind `#[cfg(feature = "database")]`, so default-feature builds (which is what `cargo install` uses) failed to compile. Fix landed on `main` in #616/#618 but was not in the 0.3.142 tag.
+  - 0.3.142 of the broken crates (cli, http, import, pipelines, proxy, workspace, core, bench, chaos, collab, recorder, registry-server, k8s-operator, vbr, sdk, test, reporting, ui) yanked from crates.io. 0.3.143 republishes the same #79 round-10 changes from a known-good main commit.
+
 ## [0.3.142] - 2026-05-21
 
 ### Changed


### PR DESCRIPTION
## Summary

`cargo install mockforge-cli@0.3.142` fails on default features:

```
error[E0432]: unresolved import `crate::database::Database`
  --> mockforge-http-0.3.142/src/handlers/threat_modeling.rs:29:5
   |
29 | use crate::database::Database;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no `Database` in `database`
```

**Root cause:** #611 moved the `database` module from mockforge-http to mockforge-intelligence, but two `use crate::database::Database;` statements in mockforge-http (`threat_modeling.rs:29`, `lib.rs:2387`) were left bare instead of being gated behind `#[cfg(feature = "database")]`. mockforge-http's default features don't include `database`, so default-feature consumers (which is what `cargo install` builds) fail to compile.

The fix already landed on `main` in #616/#618, but it wasn't in the v0.3.142 tag (commit 4887de4d). The Release workflow's gate failed earlier on the mockforge-intelligence half of the refactor; my fallback `publish-crates.sh` local-publish path doesn't run the same verification.

## Hotfix

- **Yanked 0.3.142** of all 18 crates in the broken dep chain (cli, http, import, pipelines, proxy, workspace, core, bench, chaos, collab, recorder, registry-server, k8s-operator, vbr, sdk, test, reporting, ui).
- **Cut 0.3.143 from current main** (`8b6cc53d`), which has the `#[cfg(feature = "database")]` gates in place.
- **Verified end-to-end** via `cargo install --path crates/mockforge-cli --locked --offline` — installs cleanly.

Same #79 round-10 bench fix (cap VU recommendation + iteration coverage) ships in 0.3.143.

## Test plan

- [x] `cargo install --path crates/mockforge-cli --locked --offline` — installs cleanly to `/tmp/mockforge-install-test`
- [x] `cargo check -p mockforge-cli -p mockforge-http -p mockforge-bench -p mockforge-core -p mockforge-import` — clean