### PR TITLE
refactor(intelligence,http): move ai_studio + forecasting handlers (#555 phase 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8397,6 +8397,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "indexmap 2.14.0",
+ "mockforge-contracts",
  "mockforge-foundation",
  "mockforge-openapi",
  "mockforge-template-expansion",

--- a/crates/mockforge-http/src/handlers/mod.rs
+++ b/crates/mockforge-http/src/handlers/mod.rs
@@ -2,7 +2,6 @@
 
 pub mod ab_testing;
 pub mod access_review;
-pub mod ai_studio;
 pub mod auth_helpers;
 #[cfg(feature = "behavioral-cloning")]
 pub mod behavioral_cloning;
@@ -18,7 +17,6 @@ pub mod deceptive_canary;
 pub mod drift_budget;
 pub mod failure_designer;
 pub mod fidelity;
-pub mod forecasting;
 pub mod incident_replay;
 pub mod oauth2_server;
 pub mod performance;
@@ -41,7 +39,6 @@ pub use ab_testing::{ab_testing_router, ABTestingState};
 pub use access_review::{
     access_review_router, AccessReviewState, ApproveAccessRequest, RevokeAccessRequest,
 };
-pub use ai_studio::{ai_studio_router, AiStudioState};
 pub use auth_helpers::OptionalAuthClaims;
 #[cfg(feature = "behavioral-cloning")]
 pub use behavioral_cloning::{
@@ -63,10 +60,11 @@ pub use failure_designer::{
     generate_scenario, preview_config, validate_rule, FailureDesignerState,
 };
 pub use fidelity::{calculate_fidelity, fidelity_router, get_fidelity, FidelityState};
-pub use forecasting::{forecasting_router, ForecastingState};
 pub use incident_replay::{
     generate_replay, import_and_generate, import_incident, IncidentReplayState,
 };
+pub use mockforge_intelligence::handlers::ai_studio::{ai_studio_router, AiStudioState};
+pub use mockforge_intelligence::handlers::forecasting::{forecasting_router, ForecastingState};
 pub use mockforge_intelligence::handlers::semantic_drift::{
     semantic_drift_router, SemanticDriftState,
 };

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -2523,11 +2523,11 @@ pub async fn build_router_with_chains_and_multi_tenant(
     // Add governance endpoints (forecasting, semantic drift, threat modeling, contract health)
     {
         use crate::handlers::contract_health::{contract_health_router, ContractHealthState};
-        use crate::handlers::forecasting::{forecasting_router, ForecastingState};
         use mockforge_contracts::contract_drift::forecasting::{Forecaster, ForecastingConfig};
         use mockforge_core::contract_drift::threat_modeling::ThreatAnalyzer;
         use mockforge_core::incidents::semantic_manager::SemanticIncidentManager;
         use mockforge_foundation::threat_modeling_types::ThreatModelingConfig;
+        use mockforge_intelligence::handlers::forecasting::{forecasting_router, ForecastingState};
         use mockforge_intelligence::handlers::semantic_drift::{
             semantic_drift_router, SemanticDriftState,
         };

--- a/crates/mockforge-intelligence/Cargo.toml
+++ b/crates/mockforge-intelligence/Cargo.toml
@@ -21,12 +21,16 @@ mockforge-foundation = { path = "../mockforge-foundation", default-features = fa
 # and `OpenApiRouteRegistry`. `mockforge-openapi` is foundation-only, so this
 # dep is cycle-safe — it does NOT pull `mockforge-core` back in.
 mockforge-openapi = { path = "../mockforge-openapi" }
+# `handlers::forecasting` (#555 phase 5) needs the contract-drift forecasting
+# engine. Cycle-safe: `mockforge-contracts` depends only on `mockforge-foundation`.
+mockforge-contracts = { path = "../mockforge-contracts" }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 # `handlers::*` (HTTP-handler files migrated out of `mockforge-http` under
 # Issue #555) need axum. Cycle-safe: `mockforge-http` already depends on
-# `mockforge-intelligence`, never the reverse.
-axum = { workspace = true }
+# `mockforge-intelligence`, never the reverse. `macros` is for
+# `#[axum::debug_handler]` in `handlers::ai_studio` (#555 phase 5).
+axum = { workspace = true, features = ["macros"] }
 base64 = { workspace = true }
 chrono = { workspace = true }
 dirs = "5.0"

--- a/crates/mockforge-intelligence/src/handlers/ai_studio.rs
+++ b/crates/mockforge-intelligence/src/handlers/ai_studio.rs
@@ -11,20 +11,18 @@
 // remaining engine imports.
 #![allow(deprecated)]
 
+use crate::ai_studio::{
+    api_critique::ApiCritiqueEngine, artifact_freezer::ArtifactFreezer,
+    behavioral_simulator::BehavioralSimulator, config::DeterministicModeConfig,
+    system_generator::SystemGenerator,
+};
+use crate::intelligent_behavior::IntelligentBehaviorConfig;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
     routing::post,
     Router,
-};
-use mockforge_core::{
-    ai_studio::{
-        api_critique::ApiCritiqueEngine, artifact_freezer::ArtifactFreezer,
-        behavioral_simulator::BehavioralSimulator, config::DeterministicModeConfig,
-        system_generator::SystemGenerator,
-    },
-    intelligent_behavior::IntelligentBehaviorConfig,
 };
 use mockforge_foundation::ai_studio_types::{
     CreateAgentRequest, CritiqueRequest, FreezeMetadata, FreezeRequest, SimulateBehaviorRequest,
@@ -111,7 +109,7 @@ pub struct ApiCritiqueRequest {
 #[derive(Debug, Serialize)]
 pub struct ApiCritiqueResponse {
     /// The critique result
-    pub critique: mockforge_core::ai_studio::api_critique::ApiCritique,
+    pub critique: crate::ai_studio::api_critique::ApiCritique,
 
     /// Artifact ID if stored
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -230,7 +228,7 @@ pub struct ApplySystemRequest {
 #[derive(Debug, Serialize)]
 pub struct ApplySystemResponse {
     /// Applied system result
-    pub applied: mockforge_core::ai_studio::system_generator::AppliedSystem,
+    pub applied: crate::ai_studio::system_generator::AppliedSystem,
 }
 
 /// Request body for freeze artifacts endpoint
@@ -556,7 +554,7 @@ mod tests {
                 api_key: None,
                 temperature: 0.7,
                 max_tokens: 2000,
-                rules: mockforge_core::intelligent_behavior::types::BehaviorRules::default(),
+                rules: crate::intelligent_behavior::types::BehaviorRules::default(),
             },
             ..Default::default()
         };

--- a/crates/mockforge-intelligence/src/handlers/forecasting.rs
+++ b/crates/mockforge-intelligence/src/handlers/forecasting.rs
@@ -397,7 +397,7 @@ pub async fn refresh_forecasts(
     })?;
 
     // Map rows to DriftIncident and generate forecasts
-    use mockforge_core::incidents::types::{IncidentSeverity, IncidentStatus, IncidentType};
+    use mockforge_foundation::incidents_types::{IncidentSeverity, IncidentStatus, IncidentType};
     use sqlx::Row;
     let mut incidents = Vec::new();
     for row in rows {
@@ -489,7 +489,7 @@ pub async fn refresh_forecasts(
     }
 
     // Generate forecasts from incidents by grouping by endpoint/method
-    use mockforge_core::incidents::types::DriftIncident;
+    use mockforge_foundation::incidents_types::DriftIncident;
     use std::collections::HashMap;
     let mut forecasts_generated = 0;
     let mut endpoint_groups: HashMap<(String, String), Vec<DriftIncident>> = HashMap::new();

--- a/crates/mockforge-intelligence/src/handlers/mod.rs
+++ b/crates/mockforge-intelligence/src/handlers/mod.rs
@@ -21,6 +21,8 @@
 //!   phase 9, and the threat types live in
 //!   `mockforge_foundation::threat_modeling_types`.
 
+pub mod ai_studio;
+pub mod forecasting;
 pub mod pr_generation;
 pub mod semantic_drift;
 pub mod threat_modeling;


### PR DESCRIPTION
## Summary
- **ai_studio.rs** (586 LOC) → `mockforge-intelligence/src/handlers/`. Only foreign refs were `mockforge_core::{ai_studio, intelligent_behavior}` which were already re-exports from intelligence; rewrote them to `crate::*`.
- **forecasting.rs** (610 LOC) → `mockforge-intelligence/src/handlers/`. Adds `mockforge-contracts` to intelligence's deps (cycle-safe — contracts depends only on foundation). The two inline `mockforge_core::incidents::types::*` refs route through `mockforge_foundation::incidents_types` (already there from phase 3/4).
- Enable `axum/macros` on intelligence — needed by `#[axum::debug_handler]` in ai_studio; was previously enabled transitively in the http build tree only, so `cargo build -p mockforge-intelligence --features database` would fail without it.
- `mockforge-http`'s `handlers/mod.rs` keeps `pub use mockforge_intelligence::handlers::{ai_studio, forecasting}::*` shims so downstream code resolves unchanged.

## Remaining intelligence-bucket handlers (per ADR 0001)
All blocked on prereq moves still in core:
- `contract_health` — `IncidentManager` (structural; intelligence has the semantic variant only)
- `fidelity` — `mockforge_core::fidelity::*`
- `risk_assessment` / `compliance_dashboard` — `mockforge_core::security::*`
- `risk_simulation` — `crate::auth::*` (SPLIT target per ADR)
- `scenario_studio` — `mockforge_core::scenario_studio::*`
- `xray` — `mockforge_core::consistency::*`
- `incident_replay` / `failure_designer` — `mockforge_chaos::*` (would add a new dep on intelligence)
- `deceptive_canary` — `mockforge_core::deceptive_canary::*` + `crate::middleware::*`
- `snapshot_diff` — `mockforge_http::management::ManagementState` (http-specific state, not a move candidate)
- `drift_budget` — `mockforge_core::{contract_drift::DriftBudgetEngine, drift_gitops::*, incidents::*}`

## Test plan
- [x] `cargo build -p mockforge-intelligence` + `--features database`
- [x] `cargo build -p mockforge-http` + `--features database`
- [x] `cargo clippy -p mockforge-intelligence --all-targets [--features database] -- -D warnings`
- [x] `cargo clippy -p mockforge-http --all-targets [--features database] -- -D warnings`
- [x] `cargo test -p mockforge-intelligence`
- [x] `cargo test -p mockforge-http --lib`
- [x] `cargo fmt --all --check`

Refs #555.