### PR TITLE
fix(registry): green Registry E2E — published-bit + test contracts + rate limit

### DIFF
--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -63,6 +63,16 @@ jobs:
       # `DEFAULT_WEBHOOK_SECRET` constant in tests/paid_flow_e2e.rs.
       STRIPE_WEBHOOK_SECRET: "whsec_e2e_test_secret"
 
+      # Lift the rate limiter for E2E. All requests originate from
+      # localhost so they share the same `ip:unknown` bucket; the
+      # default 60/min global + 100/min per-user is exhausted by the
+      # marketplace tests' register -> org -> workspace -> publish -> search
+      # chains multiplied across 5 tests serialized by --test-threads=1.
+      # The cap is still > test demand by ~3 orders of magnitude, so
+      # any genuine runaway loop in a future test will still be caught.
+      RATE_LIMIT_PER_MINUTE: "100000"
+      RATE_LIMIT_PER_USER: "100000"
+
     steps:
       - name: Set per-runner CARGO_HOME
         # `runner.name` is unavailable in workflow- or job-level `env:` blocks

--- a/crates/mockforge-registry-core/src/models/template.rs
+++ b/crates/mockforge-registry-core/src/models/template.rs
@@ -97,13 +97,20 @@ impl Template {
         category: TemplateCategory,
         content_json: serde_json::Value,
     ) -> sqlx::Result<Self> {
+        // Templates inserted via this constructor come from
+        // `POST /api/v1/marketplace/templates/publish`, which IS the publish
+        // action. The row must be searchable immediately — `search_templates`
+        // filters on `published = TRUE`. Prior to this fix the column was
+        // hard-coded FALSE with no code path ever flipping it back to TRUE,
+        // so every just-published template was invisible to the search
+        // endpoint it was supposedly published to.
         sqlx::query_as::<_, Self>(
             r#"
             INSERT INTO templates (
                 org_id, name, slug, description, author_id, version,
                 category, content_json, published
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, FALSE)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE)
             RETURNING *
             "#,
         )

--- a/crates/mockforge-registry-server/tests/marketplace_e2e.rs
+++ b/crates/mockforge-registry-server/tests/marketplace_e2e.rs
@@ -233,12 +233,16 @@ async fn test_plugin_marketplace_workflow() {
         get_response.json().await.expect("Failed to parse response");
     assert_eq!(plugin_body["name"], plugin_name);
 
-    // Step 6: Submit a review
+    // Step 6: Submit a review.
+    //
+    // `SubmitReviewRequest` requires `version` + `rating` + `comment`. Without
+    // `version` the body is rejected with 422 before the handler runs.
     let review_response = helper
         .client
         .post(format!("{}/api/v1/plugins/{}/reviews", helper.base_url, plugin_name))
         .header("Authorization", helper.auth_header().unwrap())
         .json(&json!({
+            "version": "1.0.0",
             "rating": 5,
             "title": "Great plugin!",
             "comment": "This plugin works perfectly for testing purposes."
@@ -247,7 +251,11 @@ async fn test_plugin_marketplace_workflow() {
         .await
         .expect("Failed to submit review");
 
-    assert!(review_response.status().is_success());
+    assert!(
+        review_response.status().is_success(),
+        "Plugin review submit failed: {:?}",
+        review_response.text().await
+    );
 
     // Step 7: Get reviews
     let reviews_response = helper
@@ -327,9 +335,16 @@ async fn test_template_marketplace_workflow() {
     //
     // `TemplateSearchQuery` lives under `/marketplace/templates/search` and uses
     // snake_case fields; `tags` is required (no `#[serde(default)]`).
+    //
+    // The publish step stored the template with `org_id = $X-Org-Id`, so the
+    // search must replay both the auth header and X-Org-Id — without them,
+    // `resolve_org_context` short-circuits and the WHERE clause narrows to
+    // `org_id IS NULL`, which excludes the row we just published.
     let search_response = helper
         .client
         .post(format!("{}/api/v1/marketplace/templates/search", helper.base_url))
+        .header("Authorization", helper.auth_header().unwrap())
+        .header("X-Org-Id", helper.org_id.unwrap().to_string())
         .json(&json!({
             "query": template_name.clone(),
             "tags": json!([]),
@@ -421,9 +436,16 @@ async fn test_scenario_marketplace_workflow() {
     //
     // `ScenarioSearchQuery` uses snake_case; `tags` is required (no
     // `#[serde(default)]`).
+    //
+    // The publish step stored the scenario with `org_id = $X-Org-Id`. The
+    // search must replay both headers, otherwise `resolve_org_context` falls
+    // through and the WHERE clause narrows to `org_id IS NULL`, hiding the
+    // row we just published.
     let search_response = helper
         .client
         .post(format!("{}/api/v1/marketplace/scenarios/search", helper.base_url))
+        .header("Authorization", helper.auth_header().unwrap())
+        .header("X-Org-Id", helper.org_id.unwrap().to_string())
         .json(&json!({
             "query": scenario_name.clone(),
             "tags": json!([]),


### PR DESCRIPTION
## Summary

Four independent bugs were stacked beneath the `marketplace_e2e` failures that #621 partially uncovered. With #621's outer-layer fixes merged, the tests now progress further into the flow and surface three new layers; this PR closes them all.

| # | Layer | Bug | Fix |
|---|---|---|---|
| 1 | Server | `Template::create` inserts `published=FALSE`, and nothing in the workspace ever flips it back to TRUE → `search_templates` (which filters on `published=TRUE`) never returns just-published templates. | Insert with `published=TRUE`. |
| 2 | Test | Plugin review POST missing `version` field — `SubmitReviewRequest` requires it (no serde default) → 422. | Send `\"version\": \"1.0.0\"`. |
| 3 | Test | Template/scenario *search* sends no auth, but their *publish* sent `X-Org-Id` → rows are org-scoped; `resolve_org_context` falls through; WHERE narrows to `org_id IS NULL`; the just-published row is invisible. | Replay `Authorization` + `X-Org-Id` on both searches. |
| 4 | Infra | Registry boots with `RATE_LIMIT_PER_MINUTE=60, RATE_LIMIT_PER_USER=100`. All E2E requests originate from localhost (same `ip:unknown` bucket); `register→org→workspace→publish→search` chains × 5 tests in `--test-threads=1` exhaust the bucket → 429. | Workflow exports `RATE_LIMIT_PER_MINUTE=100000, RATE_LIMIT_PER_USER=100000` (still ~3 orders of magnitude above test demand). |

## Why #1 is server-side and not a test fix

The constructor is *only* called from the marketplace publish handler. There is no separate \"approve\" or \"mark published\" code path — the column was effectively dead. Flipping the default to TRUE is the right semantic; if a future moderation workflow is wanted it should use an explicit separate column (e.g. `approval_state`) rather than reusing this one.

## Confirmed against the live server log

From the Registry E2E run after #621 merged (`f3e3ec53`), all four failure modes verified in `/var/log/registry-server.log`:

```
POST /api/v1/plugins/test-plugin-.../reviews                   → 422
POST /api/v1/marketplace/templates/publish                     → 429 (rate limit)
POST /api/v1/auth/register                                     → 429 (rate limit)
POST /api/v1/marketplace/scenarios/publish                     → 200 (search returns 0 results — org scoping)
POST /api/v1/marketplace/templates/publish                     → 200 (search returns 0 results — published bit)
```

## Verification

- ✅ `cargo check -p mockforge-registry-core -p mockforge-registry-server --tests` clean
- ✅ `cargo clippy -p mockforge-registry-core -p mockforge-registry-server --tests -- -D warnings` clean
- ✅ `cargo fmt --all --check` clean
- ✅ Pre-commit hooks all green
- ⏳ Registry E2E in CI — the load-bearing test for this PR

## Test plan

- [x] All local checks clean
- [ ] Registry E2E reaches green on CI run for this PR