### PR TITLE
docs(core): refresh consumer_mapping deferral rationale (#605)

### DIFF
--- a/crates/mockforge-core/src/contract_drift/consumer_mapping.rs
+++ b/crates/mockforge-core/src/contract_drift/consumer_mapping.rs
@@ -6,8 +6,16 @@
 //!
 //! The data types (`AppType`, `ConsumingApp`, `SDKMethod`, `ConsumerMapping`,
 //! `ConsumerImpact`) live in `mockforge-foundation::contract_drift_types` so
-//! consumers do not need to depend on deprecated core modules. The registry and
-//! analyzer logic stays here because it does not have cross-crate consumers yet.
+//! consumers do not need to depend on deprecated core modules.
+//!
+//! Promotion to foundation (issue #605) was audited 2026-05-23 and deferred.
+//! `mockforge-http` is a cross-crate consumer of `ConsumerImpactAnalyzer` /
+//! `ConsumerMappingRegistry`, but it already depends on `mockforge-core` for
+//! many unrelated reasons, so moving the logic to foundation would not shrink
+//! its dep graph — it would only grow foundation's surface area by ~470 LOC.
+//! Promote when a consumer that does *not* already depend on `mockforge-core`
+//! needs this logic, or when the registry/analyzer become part of a stable
+//! public API surface.
 
 pub use mockforge_foundation::contract_drift_types::{
     AppType, ConsumerImpact, ConsumerMapping, ConsumingApp, SDKMethod,


### PR DESCRIPTION
## Summary

- Audited #605 on 2026-05-23. The original module docstring claim ("does not have cross-crate consumers yet") is stale: `mockforge-http` consumes both `ConsumerImpactAnalyzer` and `ConsumerMappingRegistry` (`crates/mockforge-http/src/lib.rs:2682,2684` and `crates/mockforge-http/src/handlers/protocol_contracts.rs:40`).
- However, the spirit of the YAGNI deferral still holds: `mockforge-http` already pulls in `mockforge-core` for many other reasons, so promoting the types to foundation would not shrink its dep graph — it would only grow foundation's surface area by ~470 LOC.
- Refreshed the docstring to reflect the audit and refine the trigger condition.

## Decision

`ConsumerMappingRegistry` and `ConsumerImpactAnalyzer` stay in `mockforge-core` for now. Promote when a consumer that does NOT already depend on `mockforge-core` needs the logic, or when the registry/analyzer become a stable public API surface.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p mockforge-core --all-targets -- -D warnings`
- [x] Docs-only change — no behavioral surface changed

Closes #605.