### PR TITLE
chore(release): gate tag publish on cargo install smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,16 @@ jobs:
       if: always()
       run: sccache --show-stats 2>/dev/null || echo "sccache was not used in this run"
 
+    # Hard gate against v0.3.142-class failures: `cargo build --workspace`
+    # passed for that release but `cargo install mockforge-cli` failed in
+    # users' hands because workspace feature unification masked an ungated
+    # import in mockforge-http. 18 crates were yanked. This step reproduces
+    # the install-path build so the same break aborts the tag BEFORE we
+    # publish anything. No untrusted input is interpolated here — the
+    # script is a static file in the repo.
+    - name: Smoke-test cargo install path
+      run: scripts/smoke-test-install.sh
+
     - name: Generate changelog
       id: changelog
       env:

--- a/scripts/smoke-test-install.sh
+++ b/scripts/smoke-test-install.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the `cargo install mockforge-cli` path before publishing.
+#
+# Why this exists: v0.3.142 published 53 crates with a broken `mockforge-cli`
+# because `cargo build --workspace` unified features across workspace members
+# and masked an ungated `use crate::database::Database;` in `mockforge-http`
+# (PR #611). End-users running `cargo install mockforge-cli` got a hard compile
+# error on the default-features build — 18 crates were yanked, v0.3.143 was a
+# hotfix. `cargo build --workspace` and `cargo publish --dry-run` did not catch
+# it because workspace feature unification activated the missing `database`
+# feature transitively.
+#
+# This script reproduces exactly what `cargo install mockforge-cli` does, so
+# the same compile error aborts the release BEFORE the tag is published.
+#
+# Usage:
+#   scripts/smoke-test-install.sh             # full check (build + install)
+#   scripts/smoke-test-install.sh --fast      # build-only (skip the fresh-
+#                                             # target-dir install simulation)
+
+set -euo pipefail
+
+FAST=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fast) FAST=true; shift ;;
+    -h|--help)
+      sed -n '3,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+cd "$(dirname "$0")/.."
+
+blue()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+
+# Stage 1: build mockforge-cli with --locked and ONLY its default features.
+# `-p mockforge-cli` (no --workspace) prevents feature unification across
+# workspace members, so cargo resolves features the same way `cargo install`
+# does. This is the cheapest reproduction of the v0.3.142 failure mode.
+blue "==> [1/2] cargo build -p mockforge-cli --locked --release"
+if ! cargo build -p mockforge-cli --locked --release; then
+  red "FAIL: mockforge-cli default-features build failed."
+  red "      This is the v0.3.142 failure mode — fix before tagging a release."
+  red "      Check for crate-internal items used without a feature gate."
+  exit 1
+fi
+
+if ! ./target/release/mockforge --version; then
+  red "FAIL: target/release/mockforge --version did not exit cleanly."
+  exit 1
+fi
+green "  default-features build + --version OK"
+
+if [ "$FAST" = true ]; then
+  green "smoke-test (--fast) PASSED"
+  exit 0
+fi
+
+# Stage 2: simulate `cargo install --locked mockforge-cli` from local path in
+# a fresh target dir. This catches issues that the workspace target dir could
+# mask (e.g. cached artifacts compiled with a wider feature set during an
+# earlier `cargo build --workspace`).
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+blue "==> [2/2] cargo install --locked --path crates/mockforge-cli --root $TMP --force"
+if ! cargo install --locked --path crates/mockforge-cli --root "$TMP" --force; then
+  red "FAIL: cargo install --locked --path failed."
+  red "      Users running 'cargo install mockforge-cli' would hit the same error."
+  exit 1
+fi
+
+if ! "$TMP/bin/mockforge" --version; then
+  red "FAIL: installed binary did not exit cleanly on --version."
+  exit 1
+fi
+
+green "smoke-test PASSED"


### PR DESCRIPTION
## Summary

- Add `scripts/smoke-test-install.sh` that reproduces what `cargo install mockforge-cli` does on a user machine: `cargo build -p mockforge-cli --locked --release`, run `--version`, then `cargo install --locked --path` in a fresh target dir for full fidelity.
- Wire it into `release.yml` as a hard gate between the workspace build and GH release creation. If it fails, the tag never becomes a release, so the `publish` / `deploy-registry` / `helm` jobs (which all `needs: release`) never run.

## Why now

v0.3.142 (2026-05-22) published 53 crates with a broken `mockforge-cli`. PR #611 left `use crate::database::Database;` ungated in `mockforge-http`. `cargo build --workspace` unified features across the workspace and masked it. `cargo publish --dry-run` doesn't compile. End-users running `cargo install mockforge-cli` hit:

```
error[E0432]: unresolved import `crate::database`
```

18 crates were yanked. v0.3.143 was a hotfix. This PR makes the same failure mode abort the tag BEFORE we publish anything.

## How it catches the bug

Running `cargo build -p mockforge-cli --locked --release` (no `--workspace`) forces cargo to resolve features the same way `cargo install` does — only `mockforge-cli`'s declared default features get activated, no workspace-wide unification. In local verification on `main` (v0.3.143), cargo recompiled `mockforge-http` with the narrower feature set during this step — exactly the resolution path that would have flagged the v0.3.142 break.

## Test plan

- [x] `bash -n scripts/smoke-test-install.sh` — syntax valid
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — workflow YAML valid
- [x] `scripts/smoke-test-install.sh --fast` on main — PASSES (13min cold; will be much faster in CI with rust-cache)
- [ ] Next release tag exercises the gate end-to-end

## Follow-ups (not in scope here)

- Add the same gate to `ci.yml` as a pre-merge check (would catch the bug at PR review, not just release tag). Trade-off: adds ~3–5min to every PR's CI.
- Extend smoke test to `mockforge-plugin-cli` once it's flipped to `publish = true`.