### PR TITLE
refactor(http): drop stale #555 TODO; document remaining cleavage (#555)

### DIFF
--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -1,8 +1,36 @@
-// TODO: remove once mockforge-intelligence, mockforge-proxy, etc. crates are extracted
-// Deprecation allowances are now scoped to individual handler files
-// (handlers/*.rs, middleware/drift_tracking.rs, rag_ai_generator.rs,
-// management/ai_gen.rs) and to specific build_router functions below,
-// rather than being crate-wide.
+// Issue #555 extracted `mockforge-intelligence` and `mockforge-proxy`
+// out of this crate; both now exist as independent workspace members.
+// AI-touching handlers (ai_studio, forecasting, fidelity, deceptive_canary,
+// consistency, scenario_studio, xray, pr_generation, semantic_drift,
+// threat_modeling, rag_ai_generator) and proxy logic (proxy_server,
+// reality_proxy) all live in their target crates; the files remaining
+// here under those names are thin `pub use ...::*` re-export shims kept
+// for one minor version so external callers don't break.
+//
+// Deprecation allowances are scoped to individual handler files
+// (handlers/*.rs, middleware/drift_tracking.rs, management/ai_gen.rs)
+// and to specific build_router functions below, rather than being
+// crate-wide.
+//
+// What remains in `mockforge-http`:
+//   - HTTP-native machinery: routing, builders, middleware, SSE, TLS,
+//     fixtures/scenarios/state-machine/time-travel/contract-diff APIs,
+//     management UI, request logging, etc.
+//   - Governance/security HTTP handlers (access_review, change_management,
+//     compliance_dashboard, consent, privileged_access, …) which front
+//     `mockforge_core::security` services and so belong in the same
+//     crate as the rest of the security-services HTTP surface, not in
+//     mockforge-intelligence.
+//   - `handlers::behavioral_cloning` — wired into both
+//     `mockforge_intelligence::behavioral_cloning` (algorithms) and
+//     `mockforge_recorder::database` (trace I/O). Since
+//     `mockforge-recorder` already depends on `mockforge-intelligence`,
+//     intelligence cannot host the orchestration layer without a cycle,
+//     so this handler stays here intentionally.
+//   - `handlers::{contract_health, drift_budget, failure_designer,
+//     incident_replay, protocol_contracts}` — coupled to
+//     `mockforge_chaos`, the chaos crate would need its own #555-style
+//     bucket before these can follow.
 
 //! # MockForge HTTP
 //!


### PR DESCRIPTION
## Summary

Issue #555 lists "The TODO comment at `lib.rs:1` is gone" as an acceptance criterion. This PR replaces that sentinel with a paragraph that records what actually happened across phases 1–10 and why the remaining files stay where they are.

## What's now factual

- `mockforge-intelligence` and `mockforge-proxy` both exist as independent workspace crates with their own `Cargo.toml` and clippy-clean builds.
- The AI-touching handlers (`ai_studio`, `forecasting`, `fidelity`, `deceptive_canary`, `consistency`, `scenario_studio`, `xray`, `pr_generation`, `semantic_drift`, `threat_modeling`, `rag_ai_generator`) and the proxy-side modules (`proxy_server`, `reality_proxy`) all moved out.
- The files remaining under those names in `mockforge-http` are thin `pub use ...::*` shims kept for one minor version to preserve external callers.

## What stays in `mockforge-http` (and why)

- **HTTP-native machinery** — routing, builders, middleware, SSE, TLS, fixtures/scenarios/state-machine/time-travel/contract-diff APIs, management UI, request logging.
- **Governance / security HTTP handlers** (`access_review`, `change_management`, `compliance_dashboard`, `consent`, `privileged_access`, …) which front `mockforge_core::security` services and belong with the rest of the security-services HTTP surface, not in `mockforge-intelligence`.
- **`handlers::behavioral_cloning`** — wired into both `mockforge_intelligence::behavioral_cloning` (algorithms) and `mockforge_recorder::database` (trace I/O). Since `mockforge-recorder` already depends on `mockforge-intelligence`, intelligence cannot host the orchestration layer without a cycle, so this handler stays here intentionally.
- **`handlers::{contract_health, drift_budget, failure_designer, incident_replay, protocol_contracts}`** — coupled to `mockforge_chaos`. The chaos crate would need its own #555-style bucket before these can follow.

## Acceptance criteria reconciliation

- [x] Phase plan documented — PRs across phases 1–10 (`#607`, `#610`, `#611`, `#616`, `#617`, `#623`, `#626`, `#628`, `#640`, this one) each describe a phase
- [x] Two new crates exist with their own `Cargo.toml` and pass clippy — `mockforge-intelligence` + `mockforge-proxy`
- [x] `mockforge-http` shrinks meaningfully — bulk of AI + proxy surface has left
- [x] No public-API regression for downstream consumers — preserved via shims
- [x] The TODO comment at `lib.rs:1` is gone

## Test plan

- [x] cargo build -p mockforge-http
- [x] cargo fmt --all --check
- [x] No code changes — comment-only

Closes #555.