### PR TITLE
feat(registry): server-side Sentry for production error capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,6 +3541,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
+ "serde",
  "uuid",
 ]
 
@@ -7287,7 +7288,7 @@ dependencies = [
  "libc",
  "md-5",
  "moka",
- "nix",
+ "nix 0.30.1",
  "prometheus",
  "proxy-protocol",
  "rustls 0.23.40",
@@ -8945,6 +8946,8 @@ dependencies = [
  "ring",
  "rust_decimal",
  "rustls-pemfile 2.2.0",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -9674,6 +9677,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
@@ -10656,6 +10671,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.3",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13350,6 +13381,103 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "sentry"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
+dependencies = [
+ "httpdate",
+ "reqwest 0.12.28",
+ "rustls 0.23.40",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565ec31ad37bab8e6d9f289f34913ed8768347b133706192f10606dabd5c6bc4"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e860275f25f27e8c0c7726ce116c7d5c928c5bba2ee73306e52b20a752298ea6"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653942e6141f16651273159f4b8b1eaeedf37a7554c00cd798953e64b8a9bf72"
+dependencies = [
+ "once_cell",
+ "rand 0.8.6",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105e3a956c8aa9dab1e4087b1657b03271bfc49d838c6ae9bfc7c58c802fd0ef"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e75c831b4d8b34a5aec1f65f67c5d46a26c7c5d3c7abd8b5ef430796900cf8"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4203359e60724aa05cf2385aaf5d4f147e837185d7dd2b9ccf1ee77f4420c8"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -16173,6 +16301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16320,6 +16457,21 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -30,7 +30,13 @@ saas = [
   "saml",
   "cache-redis",
   "platform-signing-aws-kms",
+  "sentry",
 ]
+
+# Server-side error tracking via Sentry. No-op at runtime when SENTRY_DSN is
+# unset, so this can stay on in the saas rollup without forcing OSS users to
+# stand up a Sentry account.
+sentry = ["dep:sentry", "dep:sentry-tracing"]
 
 # HSM-backed platform signing-root rotation via AWS KMS (Issue #550).
 # Off in OSS builds — the registry can still load + verify rotation
@@ -193,6 +199,14 @@ oauth2 = { version = "4.4", features = ["reqwest"], optional = true }
 
 # Stripe payments (feature: `stripe`)
 async-stripe = { version = "0.41", default-features = false, features = ["runtime-tokio-hyper", "checkout", "webhook-events", "billing", "connect"], optional = true }
+
+# Sentry server-side error tracking (feature: `sentry`). default-features=false
+# drops the bundled native-tls transport in favour of rustls — every other
+# HTTP client in this crate (reqwest, async-stripe, oauth2) already uses
+# rustls so this keeps the dep graph consistent. `panic` auto-captures
+# panics; `tracing` is the bridge wired through sentry-tracing below.
+sentry = { version = "0.36", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls"], optional = true }
+sentry-tracing = { version = "0.36", optional = true }
 
 # Tempfile handling for the scanner worker (writes artifacts to disk before
 # handing the path to the scanner subprocess).

--- a/crates/mockforge-registry-server/src/lib.rs
+++ b/crates/mockforge-registry-server/src/lib.rs
@@ -43,6 +43,8 @@ pub mod platform_signing;
 pub mod redis;
 pub mod routes;
 pub mod run_queue;
+#[cfg(feature = "sentry")]
+pub mod sentry_init;
 pub mod storage;
 /// Storage trait + backends now live in `mockforge-registry-core`.
 /// Re-exported so existing `crate::store::*` paths keep working.

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -35,14 +35,27 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize tracing
-    tracing_subscriber::registry()
+    // Initialize Sentry first so any panic during the rest of startup is
+    // captured. The returned guard's Drop flushes queued events on shutdown
+    // — bind it to a `main`-scoped local so it lives for the whole program.
+    // No-op at runtime when SENTRY_DSN is unset, safe on every boot.
+    #[cfg(feature = "sentry")]
+    let _sentry_guard = mockforge_registry_server::sentry_init::init();
+
+    // Initialize tracing. The sentry-tracing layer forwards `tracing::error!`
+    // (and breadcrumbs from lower levels) to Sentry; when the `sentry` feature
+    // is off or DSN is unset, the layer is a no-op at runtime.
+    let registry = tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| "mockforge_registry_server=info,tower_http=debug".into()),
         )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+        .with(tracing_subscriber::fmt::layer());
+
+    #[cfg(feature = "sentry")]
+    let registry = registry.with(sentry_tracing::layer());
+
+    registry.init();
 
     // Load configuration
     let config = Config::load()?;

--- a/crates/mockforge-registry-server/src/sentry_init.rs
+++ b/crates/mockforge-registry-server/src/sentry_init.rs
@@ -1,0 +1,58 @@
+//! Server-side Sentry initialization (feature: `sentry`).
+//!
+//! The UI has had opt-in Sentry via `@sentry/react` for a while
+//! (`crates/mockforge-ui/ui/src/services/errorReporting.ts`), but until this
+//! module the Rust server flew blind in production — panics, 5xxs, and
+//! `tracing::error!` calls went to stderr and nowhere else. First production
+//! incident would have been investigated by tailing Fly logs.
+//!
+//! Configuration is env-driven so the same binary works locally (no DSN
+//! ⇒ no-op) and in production (DSN set ⇒ events captured):
+//!
+//! - `SENTRY_DSN` — required. Empty/unset disables capture entirely.
+//! - `SENTRY_ENVIRONMENT` — defaults to "production".
+//! - `SENTRY_RELEASE` — defaults to the crate version (matches the published
+//!   binary). Override to tag deploys with a git SHA or Fly release ID.
+//! - `SENTRY_TRACES_SAMPLE_RATE` — performance trace sampling rate (0.0–1.0).
+//!   Defaults to 0.0 (errors only). Bump to ~0.05 in production when you
+//!   want trace data without blowing past the Sentry quota.
+//!
+//! The returned guard MUST be kept alive for the lifetime of the program;
+//! dropping it flushes queued events and tears down the transport.
+
+use sentry::ClientInitGuard;
+
+/// Initialize Sentry from env vars. Returns `None` when `SENTRY_DSN` is unset
+/// or empty so binaries can safely call this unconditionally.
+pub fn init() -> Option<ClientInitGuard> {
+    let dsn = std::env::var("SENTRY_DSN").ok().filter(|s| !s.is_empty())?;
+
+    let environment =
+        std::env::var("SENTRY_ENVIRONMENT").unwrap_or_else(|_| "production".to_string());
+
+    let release = std::env::var("SENTRY_RELEASE")
+        .ok()
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    let traces_sample_rate = std::env::var("SENTRY_TRACES_SAMPLE_RATE")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(0.0);
+
+    let guard = sentry::init((
+        dsn,
+        sentry::ClientOptions {
+            release: Some(release.into()),
+            environment: Some(environment.into()),
+            traces_sample_rate,
+            attach_stacktrace: true,
+            // The `panic` feature wires this automatically, but being explicit
+            // here documents the contract: we want panic events.
+            ..Default::default()
+        },
+    ));
+
+    tracing::info!(traces_sample_rate, "Sentry initialized (server-side error capture enabled)");
+
+    Some(guard)
+}

--- a/fly.registry.toml
+++ b/fly.registry.toml
@@ -30,6 +30,9 @@ primary_region = "iad"
 #   SMTP_PORT             - "587"
 #   SMTP_USERNAME         - Brevo login email
 #   SMTP_PASSWORD         - Brevo SMTP key
+#   SENTRY_DSN            - Optional: server-side error tracking. When unset, no events are captured.
+#   SENTRY_ENVIRONMENT    - Optional: defaults to "production". Use "staging" / "preview" on non-prod apps.
+#   SENTRY_TRACES_SAMPLE_RATE - Optional: 0.0–1.0 perf trace sampling. Default 0.0 (errors only).
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary

Add feature-gated server-side Sentry to `mockforge-registry-server`. The Rust server has been flying blind in production — panics, 5xxs, and `tracing::error!` go to Fly logs only. The UI has had opt-in `@sentry/react` for a while; this closes the matching gap on the server.

- New optional deps: `sentry` + `sentry-tracing` 0.36, rustls transport (matches the rest of the HTTP stack).
- New `sentry` feature, included in the `saas` rollup. OSS builds opt out by not enabling `saas`.
- `sentry_init::init()` reads `SENTRY_DSN` / `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` / `SENTRY_TRACES_SAMPLE_RATE` from env. Empty/unset DSN ⇒ no-op, so the same binary runs unchanged locally, in CI, and in prod.
- `main.rs` initializes Sentry before tracing setup and adds the `sentry_tracing::layer()` so `tracing::error!` flows to Sentry.
- `fly.registry.toml` documents the new secrets.

## Why this slice first

Per the go-live readiness audit, observability is the third blocker for paid-customer launch. Of the three sub-items (server Sentry, Grafana dashboards-as-code, on-call provider), this one is purely code, doesn't need external account provisioning, and is the prerequisite — once events are flowing into Sentry, the dashboard + alert work has something real to wire against.

## Test plan

- [x] `cargo build -p mockforge-registry-server` (default = saas with sentry) — passes
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` — passes
- [x] `cargo fmt --all --check` — passes
- [ ] After merge: set `SENTRY_DSN` via `flyctl secrets set` on the prod app, deploy, and trigger a test event with `sentry-cli send-event` or a deliberate `tracing::error!` to confirm the integration.

## Notes

- The OSS `cargo build --no-default-features --features postgres` path fails with 33 errors re: `stripe`/`redis` references missing feature gates. **This is pre-existing on `main`** (confirmed by stashing my changes and reproducing) — not introduced by this PR. Worth filing as a separate issue when someone has cycles for it.
- Default `SENTRY_TRACES_SAMPLE_RATE` is `0.0` (errors only). Bump to `0.05` once we have a Sentry account and want performance traces.
- Panics are auto-captured via `sentry::integrations::panic` (bundled in the `panic` feature).

## Follow-ups (not in scope)

- Wire Sentry into hosted-mock Fly machines (the per-tenant mockforge servers) as a separate config knob.
- Grafana dashboards-as-code committed to repo.
- Pick PagerDuty / Opsgenie and wire alerts.