### PR TITLE
feat(observability,cli): Sentry support in mockforge-cli for hosted-mocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,6 +3541,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
+ "serde",
  "uuid",
 ]
 
@@ -7287,7 +7288,7 @@ dependencies = [
  "libc",
  "md-5",
  "moka",
- "nix",
+ "nix 0.30.1",
  "prometheus",
  "proxy-protocol",
  "rustls 0.23.40",
@@ -8503,6 +8504,8 @@ dependencies = [
  "once_cell",
  "prometheus",
  "reqwest 0.12.28",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "sysinfo",
@@ -9682,6 +9685,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nkeys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10656,6 +10671,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.3",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13350,6 +13381,103 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "sentry"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
+dependencies = [
+ "httpdate",
+ "reqwest 0.12.28",
+ "rustls 0.23.40",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565ec31ad37bab8e6d9f289f34913ed8768347b133706192f10606dabd5c6bc4"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e860275f25f27e8c0c7726ce116c7d5c928c5bba2ee73306e52b20a752298ea6"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653942e6141f16651273159f4b8b1eaeedf37a7554c00cd798953e64b8a9bf72"
+dependencies = [
+ "once_cell",
+ "rand 0.8.6",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105e3a956c8aa9dab1e4087b1657b03271bfc49d838c6ae9bfc7c58c802fd0ef"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e75c831b4d8b34a5aec1f65f67c5d46a26c7c5d3c7abd8b5ef430796900cf8"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4203359e60724aa05cf2385aaf5d4f147e837185d7dd2b9ccf1ee77f4420c8"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -16173,6 +16301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16320,6 +16457,21 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"

--- a/crates/mockforge-cli/Cargo.toml
+++ b/crates/mockforge-cli/Cargo.toml
@@ -39,7 +39,7 @@ mockforge-smtp = { version = "0.3.70", path = "../mockforge-smtp", optional = tr
 mockforge-mqtt = { version = "0.3.70", path = "../mockforge-mqtt", optional = true }
 mockforge-data = { version = "0.3.70", path = "../mockforge-data" }
 mockforge-ui = { version = "0.3.70", path = "../mockforge-ui", optional = true }
-mockforge-observability = { version = "0.3.70", path = "../mockforge-observability" }
+mockforge-observability = { version = "0.3.70", path = "../mockforge-observability", default-features = false, features = ["sysinfo", "log-shipper"] }
 mockforge-tracing = { version = "0.3.70", path = "../mockforge-tracing", optional = true }
 mockforge-recorder = { version = "0.3.70", path = "../mockforge-recorder", optional = true }
 mockforge-federation = { version = "0.3.70", path = "../mockforge-federation", optional = true }
@@ -118,7 +118,13 @@ cloud = [
     "kafka",
     "amqp",
     "tcp",
+    "sentry",
 ]
+# Server-side Sentry error tracking. No-op at runtime when SENTRY_DSN is
+# unset, so leaving this on in the `cloud` rollup is safe: hosted-mock
+# Fly machines that get a DSN start capturing; local `cargo install` users
+# never reach the network even with the feature compiled in.
+sentry = ["mockforge-observability/sentry"]
 # Feature-gated CLI subsystems
 admin = ["dep:mockforge-ui"]
 bench = ["dep:mockforge-bench"]

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2313,6 +2313,14 @@ fn cli_command_name(cmd: &Commands) -> &'static str {
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cli = Cli::parse();
 
+    // Initialize Sentry first so panics and errors during the rest of startup
+    // are captured. No-op at runtime when SENTRY_DSN is unset, so it's safe
+    // to call on every CLI invocation (local, CI, hosted-mock). The guard's
+    // Drop flushes queued events — bind to a main-scoped local so it lives
+    // for the whole program.
+    #[cfg(feature = "sentry")]
+    let _sentry_guard = mockforge_observability::init_sentry();
+
     // Initialize logging with the provided log level
     // Note: Full logging configuration (JSON format, file output) will be applied
     // after loading the config file in the serve command

--- a/crates/mockforge-observability/Cargo.toml
+++ b/crates/mockforge-observability/Cargo.toml
@@ -46,12 +46,22 @@ tracing-opentelemetry = { version = "0.22", optional = true }
 # MockForge tracing integration (optional)
 mockforge-tracing = { version = "0.3.70", path = "../mockforge-tracing", optional = true }
 
+# Server-side Sentry error tracking (feature: `sentry`). Same 0.36 line as
+# mockforge-registry-server so the workspace only pulls one sentry tree.
+# default-features=false keeps native-tls out of the dep graph; rustls
+# matches the rest of the HTTP clients in the workspace.
+sentry = { version = "0.36", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls"], optional = true }
+sentry-tracing = { version = "0.36", optional = true }
+
 [features]
 default = ["sysinfo", "log-shipper"]
 sysinfo = ["dep:sysinfo"]
 opentelemetry = ["dep:tracing-opentelemetry", "mockforge-tracing"]
 mockforge-tracing = ["dep:mockforge-tracing"]
 log-shipper = ["dep:reqwest"]
+# Sentry error capture. Pulls in the sentry tracing layer automatically so
+# `tracing::error!` events flow to Sentry when SENTRY_DSN is set.
+sentry = ["dep:sentry", "dep:sentry-tracing"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/mockforge-observability/src/lib.rs
+++ b/crates/mockforge-observability/src/lib.rs
@@ -21,12 +21,16 @@
 pub mod log_shipper;
 pub mod logging;
 pub mod prometheus;
+#[cfg(feature = "sentry")]
+pub mod sentry_init;
 pub mod system_metrics;
 pub mod tracing_integration;
 
 // Re-export commonly used items
 pub use logging::{init_logging, init_logging_with_otel, LoggingConfig};
 pub use prometheus::{get_global_registry, MetricsRegistry};
+#[cfg(feature = "sentry")]
+pub use sentry_init::init_sentry;
 pub use system_metrics::{start_system_metrics_collector, SystemMetricsConfig};
 pub use tracing_integration::{init_with_otel, shutdown_otel, OtelTracingConfig};
 

--- a/crates/mockforge-observability/src/logging.rs
+++ b/crates/mockforge-observability/src/logging.rs
@@ -144,7 +144,13 @@ pub fn init_logging(config: LoggingConfig) -> Result<(), Box<dyn std::error::Err
                 .boxed()
         };
 
-        registry.with(console_layer).with(file_layer).init();
+        // The sentry-tracing layer forwards `tracing::error!` events to Sentry
+        // when the `sentry` feature is on. It's a no-op at runtime when
+        // SENTRY_DSN was unset at init_sentry() time.
+        let composed = registry.with(console_layer).with(file_layer);
+        #[cfg(feature = "sentry")]
+        let composed = composed.with(sentry_tracing::layer());
+        composed.init();
 
         tracing::info!(
             "Logging initialized: level={}, format={}, file={}",
@@ -153,7 +159,10 @@ pub fn init_logging(config: LoggingConfig) -> Result<(), Box<dyn std::error::Err
             file_path.display()
         );
     } else {
-        registry.with(console_layer).init();
+        let composed = registry.with(console_layer);
+        #[cfg(feature = "sentry")]
+        let composed = composed.with(sentry_tracing::layer());
+        composed.init();
 
         tracing::info!(
             "Logging initialized: level={}, format={}",

--- a/crates/mockforge-observability/src/sentry_init.rs
+++ b/crates/mockforge-observability/src/sentry_init.rs
@@ -1,0 +1,53 @@
+//! Server-side Sentry initialization (feature: `sentry`).
+//!
+//! Used by `mockforge-registry-server` and by `mockforge-cli` when running as
+//! a hosted-mock on Fly. Shared here so the two binaries agree on env-var
+//! names and defaults — drift between them would mean some deployments
+//! capture errors and others don't.
+//!
+//! Configuration is env-driven so the same binary works locally (no DSN
+//! ⇒ no-op) and in production (DSN set ⇒ events captured):
+//!
+//! - `SENTRY_DSN` — required. Empty/unset disables capture entirely.
+//! - `SENTRY_ENVIRONMENT` — defaults to "production".
+//! - `SENTRY_RELEASE` — defaults to the workspace crate version.
+//! - `SENTRY_TRACES_SAMPLE_RATE` — performance trace sampling rate
+//!   (0.0–1.0). Defaults to 0.0 (errors only).
+//!
+//! The returned guard MUST be kept alive for the lifetime of the program;
+//! dropping it flushes queued events and tears down the transport.
+
+use sentry::ClientInitGuard;
+
+/// Initialize Sentry from env vars. Returns `None` when `SENTRY_DSN` is unset
+/// or empty so binaries can safely call this unconditionally.
+pub fn init_sentry() -> Option<ClientInitGuard> {
+    let dsn = std::env::var("SENTRY_DSN").ok().filter(|s| !s.is_empty())?;
+
+    let environment =
+        std::env::var("SENTRY_ENVIRONMENT").unwrap_or_else(|_| "production".to_string());
+
+    let release = std::env::var("SENTRY_RELEASE")
+        .ok()
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    let traces_sample_rate = std::env::var("SENTRY_TRACES_SAMPLE_RATE")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(0.0);
+
+    let guard = sentry::init((
+        dsn,
+        sentry::ClientOptions {
+            release: Some(release.into()),
+            environment: Some(environment.into()),
+            traces_sample_rate,
+            attach_stacktrace: true,
+            ..Default::default()
+        },
+    ));
+
+    tracing::info!(traces_sample_rate, "Sentry initialized (server-side error capture enabled)");
+
+    Some(guard)
+}


### PR DESCRIPTION
## Summary

Extends server-side Sentry error capture to the **per-tenant hosted-mock binaries** running on customer Fly machines. PR #642 wired the registry server; this PR closes the matching gap on the actual mock-serving binary that customers' requests hit.

- New `sentry` feature on `mockforge-observability` adds an `init_sentry()` helper and threads `sentry_tracing::layer()` through `init_logging()` so `tracing::error!` flows to Sentry automatically.
- New `sentry` feature on `mockforge-cli`, included in the `cloud` rollup — hosted-mock images (`ghcr.io/saasy-solutions/mockforge:latest`, built with `--features cloud`) get it; OSS `cargo install mockforge-cli` users don't pull the Sentry dep.
- `main.rs` calls `init_sentry()` immediately after CLI arg parsing, before `init_logging()`, so the guard lives for the whole program.
- Same env-driven config as registry-server: `SENTRY_DSN` / `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` / `SENTRY_TRACES_SAMPLE_RATE`. Unset DSN ⇒ no-op.

## Architecture note

The Sentry init lived directly in `mockforge-registry-server::sentry_init` after #642. This PR moves it to `mockforge-observability` so both binaries share one implementation. Env var names, default sample rate, and guard semantics now have a single source of truth — drift between the two would mean some deployments capture errors and others don't.

Follow-up (filed separately): refactor `mockforge-registry-server` to drop its local `sentry_init` and use the shared one from observability.

## Test plan

- [x] `cargo build -p mockforge-cli` (default features, no sentry) — passes
- [x] `cargo build -p mockforge-cli --features cloud` (sentry on) — passes
- [x] `cargo clippy -p mockforge-observability -p mockforge-cli --all-targets --features cloud -- -D warnings` — passes
- [x] `cargo fmt --all --check` — passes
- [ ] After merge: registry deployment orchestrator should inject `SENTRY_DSN` into per-tenant Fly machine env so each hosted-mock reports to the same Sentry project. Tracked as a follow-up — orchestrator change is out of scope here.

## Follow-ups (not in scope)

- Orchestrator: inject `SENTRY_DSN` into per-tenant Fly machine env (`crates/mockforge-registry-server/src/deployment/orchestrator.rs`).
- Refactor registry-server's local `sentry_init` to use the shared `mockforge_observability::init_sentry`.
- Pre-existing: registry-server's `--no-default-features --features postgres` build path fails on `main` (33 errors). Not introduced here.