### PR TITLE
feat(grafana): commit baseline dashboards as code

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,91 @@
+# MockForge Grafana Dashboards
+
+Dashboards-as-code for the MockForge observability stack. JSON files in `dashboards/` are checked into git as the source of truth; the production Grafana instance is provisioned from them.
+
+## Why this exists
+
+Before this directory, dashboards lived only in the running Grafana instance — there was no record of what panels existed, no review for changes, no easy way to roll back a broken dashboard, and no way to stand up a second environment (staging, preview) with parity.
+
+Per the 2026-05-23 go-live readiness audit, this is one piece of observability blocker #3 (the others were [server-side Sentry](../crates/mockforge-observability/src/sentry_init.rs) and on-call provider integration).
+
+## What's here
+
+| Dashboard | UID | Covers |
+|---|---|---|
+| [Service Overview](dashboards/mockforge-service-overview.json) | `mockforge-service-overview` | Request rate, error rate, latency p50/p95/p99, in-flight requests — all by protocol and pillar. Top-10 paths by rate and latency. The default landing page for "is MockForge healthy right now?" |
+| [Marketplace](dashboards/mockforge-marketplace.json) | `mockforge-marketplace` | Publish / download / search operations on the plugin/template/scenario marketplace. Operation rates, p95 durations, errors by code, total items. Spike in `errors_total` is the canary for the kind of bugs that drove PRs #621 / #624. |
+
+## Metric sources
+
+All dashboards reference real series exported at `/metrics` from:
+- `mockforge-registry-server` (the multi-tenant SaaS registry on Fly)
+- The per-tenant `mockforge` binary (hosted mocks, when scraped via Fly Managed Prometheus)
+
+The full metrics catalogue is built up in `crates/mockforge-observability/src/prometheus/metrics.rs` (core) and `crates/mockforge-registry-server/src/metrics.rs` (marketplace). When you add a new dashboard, ground every PromQL expression in a metric that is actually `record_*`d somewhere — defined-but-never-recorded metrics will silently show empty panels.
+
+## Importing into Grafana
+
+### Via the UI (one-off)
+
+1. Grafana → Dashboards → New → Import
+2. Upload the JSON file
+3. Pick your Prometheus datasource when prompted (the `${DS_PROMETHEUS}` template variable resolves from this).
+
+### Via the HTTP API (CI / scripted)
+
+```bash
+# Set these once
+export GRAFANA_URL="https://grafana.example.com"
+export GRAFANA_TOKEN="…"  # service account token with Editor on the target folder
+
+for f in grafana/dashboards/*.json; do
+  jq '{dashboard: (.|del(.__inputs, .__requires)), overwrite: true, folderUid: ""}' "$f" \
+    | curl -sS -X POST "$GRAFANA_URL/api/dashboards/db" \
+        -H "Authorization: Bearer $GRAFANA_TOKEN" \
+        -H "Content-Type: application/json" \
+        --data @-
+done
+```
+
+The `del(.__inputs, .__requires)` removes the import-only fields Grafana adds to exported dashboards; leaving them in tries to provision a datasource on every push.
+
+### Via provisioning (recommended for prod)
+
+In `grafana.ini` or the helm chart, mount this directory as a dashboard provider:
+
+```yaml
+apiVersion: 1
+providers:
+  - name: mockforge
+    orgId: 1
+    folder: MockForge
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 60
+    allowUiUpdates: false  # source of truth is git
+    options:
+      path: /var/lib/grafana/dashboards/mockforge
+```
+
+`allowUiUpdates: false` is important — it prevents Grafana operators from editing in the UI without round-tripping through git. Without it, changes made in Grafana get overwritten on the next provisioning sync and people lose work silently.
+
+## Updating a dashboard
+
+1. Edit the JSON directly, or edit in Grafana and export.
+2. If exported from Grafana: open the JSON and remove the `id`, the `__elements` map, and any `iteration` field at the top level. Set `version` back to 1 (Grafana increments it on save; the diff is noise).
+3. Bump the `version` field if you want Grafana to detect a change on next provisioning sync.
+4. Open a PR. CI should pick up dashboard JSON in any future linting we add.
+
+## Conventions
+
+- **UID** stable across edits. Don't rename — Grafana keeps URL aliases on UIDs, not titles.
+- **Datasource variable name** is always `DS_PROMETHEUS`. Don't hard-code datasource UIDs.
+- **PromQL** uses `clamp_min(..., 1)` on denominators of error-rate-style divisions so an idle period doesn't divide by zero.
+- **Default time range** is `now-1h` to `now` for overview, `now-6h` to `now` for trend dashboards.
+- **Refresh** is `30s` — matches Prometheus default scrape interval; a faster refresh wastes Prometheus.
+
+## Not in scope here
+
+- **Alert rules.** Tracked separately — alerts-as-code will land as a sibling `grafana/alerts/` directory using Grafana unified alerting YAML. The metrics being dashboarded here are the right starting point for alert thresholds (error rate > 1% sustained 5m, p99 > 1s sustained 5m, marketplace publish errors > 0 sustained 5m).
+- **Per-tenant hosted-mock dashboards.** Fly Managed Prometheus aggregates per-app, so a per-tenant panel needs the `app` label which the orchestrator sets — easier to land after the orchestrator's `SENTRY_DSN` injection follow-up.
+- **Business / SLO dashboards.** Several metrics (`mockforge_service_availability`, `mockforge_slo_compliance`, `mockforge_error_budget_remaining`) are defined in core but not yet `record_`d anywhere. Once they have data, they get their own dashboard.

--- a/grafana/dashboards/mockforge-marketplace.json
+++ b/grafana/dashboards/mockforge-marketplace.json
@@ -1,0 +1,216 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping mockforge-registry-server /metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "MockForge marketplace operations — plugin/template/scenario publish, download, search rates plus latency and error breakdown. Sourced from mockforge_marketplace_* metrics recorded in crates/mockforge-registry-server/src/metrics.rs.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "uid": "mockforge-marketplace",
+  "title": "MockForge — Marketplace",
+  "tags": ["mockforge", "marketplace", "registry"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "type",
+        "label": "Item type",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(mockforge_marketplace_publish_total, type)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Total items",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(mockforge_marketplace_items_total{type=~\"$type\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0 }
+      },
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Publishes (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(increase(mockforge_marketplace_publish_total{type=~\"$type\",status=\"success\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 } },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Downloads (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(increase(mockforge_marketplace_download_total{type=~\"$type\",status=\"success\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 } },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Searches (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(increase(mockforge_marketplace_search_total{type=~\"$type\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 } },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Operation rate by type",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "expr": "sum by (type) (rate(mockforge_marketplace_publish_total{type=~\"$type\"}[5m]))",
+          "legendFormat": "publish — {{type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (type) (rate(mockforge_marketplace_download_total{type=~\"$type\"}[5m]))",
+          "legendFormat": "download — {{type}}",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (type) (rate(mockforge_marketplace_search_total{type=~\"$type\"}[5m]))",
+          "legendFormat": "search — {{type}}",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "p95 latency by operation",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_marketplace_publish_duration_seconds_bucket{type=~\"$type\"}[5m])))",
+          "legendFormat": "publish p95",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_marketplace_download_duration_seconds_bucket{type=~\"$type\"}[5m])))",
+          "legendFormat": "download p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_marketplace_search_duration_seconds_bucket{type=~\"$type\"}[5m])))",
+          "legendFormat": "search p95",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2, "fillOpacity": 0, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Errors by code",
+      "description": "Spike here is the canary for the v0.3.142-class marketplace bugs that #621/#624 closed. Sustained nonzero rate ⇒ investigate.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "expr": "sum by (error_code) (rate(mockforge_marketplace_errors_total{type=~\"$type\"}[5m]))",
+          "legendFormat": "{{error_code}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 20, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Items in marketplace by type",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "expr": "mockforge_marketplace_items_total{type=~\"$type\"}",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" }
+        }
+      }
+    }
+  ]
+}

--- a/grafana/dashboards/mockforge-service-overview.json
+++ b/grafana/dashboards/mockforge-service-overview.json
@@ -1,0 +1,299 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping the MockForge /metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "Top-level health for the MockForge stack. Wired against the metrics exported at /metrics on mockforge-registry-server and every hosted-mock binary (mockforge_requests_total, mockforge_errors_total, mockforge_request_duration_seconds, mockforge_requests_in_flight). Pillar panel uses the `pillar` label set by the HTTP middleware (reality / contracts / devx / cloud / ai / unknown).",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "uid": "mockforge-service-overview",
+  "title": "MockForge — Service Overview",
+  "tags": ["mockforge", "overview"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "protocol",
+        "label": "Protocol",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(mockforge_requests_total, protocol)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Request rate (now)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(mockforge_requests_total{protocol=~\"$protocol\"}[1m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Error rate (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(mockforge_errors_total{protocol=~\"$protocol\"}[5m])) / clamp_min(sum(rate(mockforge_requests_total{protocol=~\"$protocol\"}[5m])), 1)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "red", "value": 0.01 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "p95 latency (5m, all protocols)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_request_duration_seconds_bucket{protocol=~\"$protocol\"}[5m])))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "In-flight requests (total)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(mockforge_requests_in_flight{protocol=~\"$protocol\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate by protocol",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "expr": "sum by (protocol) (rate(mockforge_requests_total{protocol=~\"$protocol\"}[5m]))",
+          "legendFormat": "{{protocol}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency p50 / p95 / p99 (all protocols)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(mockforge_request_duration_seconds_bucket{protocol=~\"$protocol\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_request_duration_seconds_bucket{protocol=~\"$protocol\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(mockforge_request_duration_seconds_bucket{protocol=~\"$protocol\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2, "fillOpacity": 0, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Error rate by protocol",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "expr": "sum by (protocol) (rate(mockforge_errors_total{protocol=~\"$protocol\"}[5m])) / clamp_min(sum by (protocol) (rate(mockforge_requests_total{protocol=~\"$protocol\"}[5m])), 1)",
+          "legendFormat": "{{protocol}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate by pillar (business view)",
+      "description": "Pillars are set by the HTTP middleware from request path. Useful for spotting which feature area is driving load.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "expr": "sum by (pillar) (rate(mockforge_requests_total{protocol=~\"$protocol\"}[5m]))",
+          "legendFormat": "{{pillar}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 30, "drawStyle": "line", "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Top 10 paths by request rate",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (path) (rate(mockforge_requests_by_path_total[5m])))",
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 1, "fillOpacity": 5, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Top 10 paths by p95 latency",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "targets": [
+        {
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, path) (rate(mockforge_request_duration_by_path_seconds_bucket[5m]))))",
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 1, "fillOpacity": 0, "drawStyle": "line" }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Two starter Grafana dashboards committed under `grafana/dashboards/`:

- **Service Overview** (`mockforge-service-overview`) — request rate / error rate / p50-p95-p99 latency / in-flight requests by protocol + pillar. Top-10 paths by rate and latency. The default "is MockForge healthy right now?" landing page.
- **Marketplace** (`mockforge-marketplace`) — publish / download / search rates, p95 durations, errors by code, total items. Spike in `mockforge_marketplace_errors_total` is the canary for the v0.3.142-class bugs that #621 / #624 closed.

Plus `grafana/README.md` covering import via UI, HTTP API, and provisioning, with the recommendation to set `allowUiUpdates: false` so git stays the source of truth.

## Why this slice

Per the 2026-05-23 go-live readiness audit, observability was blocker #3 with three sub-items:

1. ~~Server-side Sentry~~ — landed in PR #642 (registry-server) and PR #643 (hosted-mocks).
2. **Grafana dashboards-as-code** ← this PR.
3. On-call provider integration — separate effort, needs an account first.

Before this directory, dashboards lived only in the running Grafana instance. No record of what panels existed, no PR review on changes, no rollback when one broke.

## Grounding

Every PromQL expression references a metric that is actually `record_*`d somewhere in the workspace. The audit that informed this PR mapped the full metric surface:

- `mockforge_requests_total{protocol, method, status, pillar}` — recorded in `crates/mockforge-core/src/middleware/metrics_middleware.rs:124`
- `mockforge_request_duration_seconds{protocol, method, pillar}` — same site
- `mockforge_errors_total{protocol, error_type, pillar}` — same middleware
- `mockforge_marketplace_*` family — recorded in `crates/mockforge-registry-server/src/metrics.rs:25-54`
- `mockforge_requests_by_path_total{path, method, status}` + `mockforge_request_duration_by_path_seconds{path, method}` — top-10 path panels

Defined-but-not-recorded metrics (e.g. `mockforge_error_rate`, `mockforge_service_availability`, `mockforge_slo_compliance`) were excluded to avoid empty panels.

## Test plan

- [x] Both JSON files parse cleanly (`python3 -c "import json; json.load(...)"`)
- [x] Every metric name referenced was cross-checked against the metrics registry definitions
- [x] PromQL uses `clamp_min(..., 1)` on denominators of error-rate-style divisions so idle periods don't divide by zero
- [x] Dashboards use `${DS_PROMETHEUS}` template variable rather than hard-coded datasource UIDs
- [ ] After merge: import into the running Grafana instance and visually verify panels render with live data

## Follow-ups (not in scope)

- **Alerts-as-code**: Grafana unified alerting YAML in a sibling `grafana/alerts/` dir. The metrics here are the right basis: error rate > 1% sustained 5m, p99 > 1s sustained 5m, marketplace errors > 0 sustained 5m. Filing as a separate issue.
- **Per-tenant hosted-mock dashboards**: Fly Managed Prometheus aggregates per-app; per-tenant slicing needs the `app` label injected by the orchestrator. Pairs naturally with the `SENTRY_DSN` orchestrator follow-up from PR #643.
- **`/metrics` is unauthenticated** (`crates/mockforge-registry-server/src/main.rs`). Probably fine if Prometheus scraping is internal-only, but a footgun if the endpoint ever becomes publicly reachable. Worth filing.