### PR TITLE
feat(grafana): alert rules as code (closes #646)

### DIFF
--- a/grafana/alerts/README.md
+++ b/grafana/alerts/README.md
@@ -1,0 +1,85 @@
+# MockForge Grafana Alert Rules
+
+Grafana unified alerting rules as code, sibling to the dashboards in [`../dashboards/`](../dashboards/). Closes #646.
+
+## What's here
+
+`mockforge-alerts.yaml` — five starter rules across two groups:
+
+| Group | Rule | Severity | Trigger |
+|---|---|---|---|
+| `mockforge-service-health` | error rate elevated | warning | 5xx rate > 0.5% sustained 5m |
+| `mockforge-service-health` | error rate spike | critical | 5xx rate > 1% sustained 5m |
+| `mockforge-service-health` | p99 latency high | warning | p99 > 1s sustained 5m |
+| `mockforge-service-health` | traffic silence canary | critical | zero requests in 10m (total-outage signal) |
+| `mockforge-marketplace` | marketplace errors detected | warning | any marketplace errors sustained 5m |
+
+The marketplace rule is sensitive on purpose — PR #624 closed the last cascade of marketplace bugs on 2026-05-23 and we want to know within minutes if a similar regression ships.
+
+## Importing
+
+### Via provisioning (recommended for prod)
+
+Mount this file at `/etc/grafana/provisioning/alerting/mockforge-alerts.yaml`. Grafana reloads on its provisioning interval. UIDs are stable — do not rename them, alert history and silence rules key on UID.
+
+For the helm chart, drop this in the `grafana.alerting` block:
+
+```yaml
+grafana:
+  alerting:
+    rules.yaml:
+      apiVersion: 1
+      # then paste the contents of mockforge-alerts.yaml under here,
+      # OR mount this file via extraConfigmapMounts
+```
+
+### Via the HTTP API (one-off)
+
+```bash
+export GRAFANA_URL="https://grafana.example.com"
+export GRAFANA_TOKEN="…"
+
+# Provisioning API takes one group at a time
+for group_name in mockforge-service-health mockforge-marketplace; do
+  yq ".groups[] | select(.name == \"$group_name\")" grafana/alerts/mockforge-alerts.yaml \
+    | yq -o=json \
+    | curl -sS -X POST "$GRAFANA_URL/api/v1/provisioning/alert-rules" \
+        -H "Authorization: Bearer $GRAFANA_TOKEN" \
+        -H "Content-Type: application/json" \
+        -H "X-Disable-Provenance: true" \
+        --data @-
+done
+```
+
+`X-Disable-Provenance: true` lets the alerts be edited in the UI later — drop it if you want to lock the rules to file-only.
+
+## Contact point caveat
+
+Until the on-call provider integration lands (separate work — PagerDuty / Opsgenie / Grafana OnCall), these rules emit to whatever default contact point is configured in your Grafana instance. Two options for now:
+
+1. **Set Grafana's default contact point to a real email/Slack webhook** via Grafana → Alerting → Contact points. Fastest path to "alerts actually reach a human."
+2. **Define a `contactpoints.yaml` and provision it alongside this file.** Better for git-as-source-of-truth but requires picking the provider first.
+
+The rules use `team: mockforge` labels so a downstream routing policy can fan them out by severity once the provider is wired.
+
+## Adding new rules
+
+1. Pick a group (or create one) — group is the unit of evaluation interval and the natural folder for related rules.
+2. Generate a stable UID. Format: `mockforge-<short-name>`. Don't reuse a UID after deleting a rule — Grafana will refuse.
+3. Every PromQL expression must reference a metric that is actually `record_*`d. Defined-but-not-recorded metrics (e.g. `mockforge_error_rate`, `mockforge_service_availability`) silently never fire. Check `crates/mockforge-observability/src/prometheus/metrics.rs` and `crates/mockforge-registry-server/src/metrics.rs` before authoring.
+4. The threshold expression goes in a separate `__expr__` ref — Grafana's evaluator runs it against the PromQL result. See the existing rules for the shape.
+5. `for: 5m` is the minimum duration the condition has to hold before firing. Don't go below 2m — Prometheus scrape interval is 30s and you'll get false positives on single-sample blips.
+6. `noDataState: OK` means "if no metrics arrived, treat as healthy." Use `Alerting` only for canaries where missing data IS the alert condition (see the traffic silence canary).
+
+## Conventions
+
+- **Labels** every rule sets `team: mockforge`. Marketplace rules also set `area: marketplace`. Use these in routing policies.
+- **Annotations** are human-readable — `summary` is the one-liner shown in the inbox, `description` is the full context. Embed value templates via `{{ $values.C.Value | printf "%.2f%%" }}`.
+- **Severity** is `warning` or `critical`. Three-tier (info/warning/critical) is overkill at our scale.
+- **Datasource UID** is always `${DS_PROMETHEUS}` — replaced at provisioning time.
+
+## Not in scope
+
+- **Contact points + routing policy YAML.** Needs the on-call provider picked first. Filing as `grafana/alerts/contactpoints.yaml` is a separate PR.
+- **Per-pillar alerts.** The metrics carry a `pillar` label (reality / contracts / devx / cloud / ai) — once we have customer signal on which pillar's failures hurt most, we can author pillar-scoped thresholds. For now top-level is enough.
+- **Hosted-mock alerts.** Per-tenant alerting needs the orchestrator's `SENTRY_DSN` / app-label injection follow-up. Different domain, different rules.

--- a/grafana/alerts/mockforge-alerts.yaml
+++ b/grafana/alerts/mockforge-alerts.yaml
@@ -1,0 +1,208 @@
+# Grafana unified alerting rules for MockForge.
+#
+# Format: provisioning apiVersion 1 (https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/)
+#
+# Mount at /etc/grafana/provisioning/alerting/mockforge-alerts.yaml and
+# Grafana will reload on its provisioning interval. UIDs are stable; do
+# not rename them — annotation history and silence rules key on UID.
+#
+# Every PromQL expression references a metric that is actually recorded
+# in the workspace. See grafana/dashboards/ for the matching panels and
+# crates/mockforge-observability/src/prometheus/metrics.rs for the
+# metric definitions.
+#
+# Contact point: rules emit to the receiver configured in your routing
+# policy. Until the on-call provider integration lands (PagerDuty /
+# Opsgenie), the default `grafana-default-email` receiver fires — set
+# it to a real address via Grafana → Alerting → Contact points, or
+# define a `grafana/alerts/contactpoints.yaml` and provision it
+# alongside this file.
+
+apiVersion: 1
+
+groups:
+  # ----- Top-level service health -----
+  - orgId: 1
+    name: mockforge-service-health
+    folder: MockForge
+    interval: 1m
+    rules:
+      - uid: mockforge-error-rate-warning
+        title: MockForge — error rate elevated (>0.5%)
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: warning
+          team: mockforge
+        annotations:
+          summary: '5xx error rate above 0.5% for 5m'
+          description: |
+            sum(rate(mockforge_errors_total[5m])) / sum(rate(mockforge_requests_total[5m])) = {{ $values.C.Value | printf "%.2f%%" }}.
+            Check the Service Overview dashboard (uid mockforge-service-overview) and Sentry for new exception groups.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS}
+            model:
+              expr: sum(rate(mockforge_errors_total[5m])) / clamp_min(sum(rate(mockforge_requests_total[5m])), 1)
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              conditions:
+                - evaluator: { type: gt, params: [0.005] }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { type: last }
+              expression: A
+              refId: C
+
+      - uid: mockforge-error-rate-critical
+        title: MockForge — error rate spike (>1%)
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: critical
+          team: mockforge
+        annotations:
+          summary: '5xx error rate above 1% for 5m — page on-call'
+          description: |
+            sum(rate(mockforge_errors_total[5m])) / sum(rate(mockforge_requests_total[5m])) = {{ $values.C.Value | printf "%.2f%%" }}.
+            This crosses the budget for paid-customer SLO. Investigate immediately.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS}
+            model:
+              expr: sum(rate(mockforge_errors_total[5m])) / clamp_min(sum(rate(mockforge_requests_total[5m])), 1)
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              conditions:
+                - evaluator: { type: gt, params: [0.01] }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { type: last }
+              expression: A
+              refId: C
+
+      - uid: mockforge-latency-p99-high
+        title: MockForge — p99 latency >1s
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: warning
+          team: mockforge
+        annotations:
+          summary: 'p99 request latency above 1s for 5m'
+          description: |
+            histogram_quantile(0.99, …) = {{ $values.C.Value | printf "%.3fs" }}.
+            Likely culprit: slow database query, downstream API timeout, or chaos mode left on. Check the Service Overview latency panel and recent commits.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS}
+            model:
+              expr: histogram_quantile(0.99, sum by (le) (rate(mockforge_request_duration_seconds_bucket[5m])))
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              conditions:
+                - evaluator: { type: gt, params: [1.0] }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { type: last }
+              expression: A
+              refId: C
+
+      - uid: mockforge-traffic-silence
+        title: MockForge — no requests in 10m (silence canary)
+        condition: C
+        for: 10m
+        noDataState: Alerting
+        execErrState: Error
+        labels:
+          severity: critical
+          team: mockforge
+        annotations:
+          summary: 'Registry has received zero requests in 10 minutes'
+          description: |
+            Either MockForge is down, the load balancer is broken, or Prometheus stopped scraping. This is a total-outage canary — verify the public health endpoint and Fly machine state.
+            sum(rate(mockforge_requests_total[10m])) = {{ $values.A.Value }}.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS}
+            model:
+              expr: sum(rate(mockforge_requests_total[10m]))
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              conditions:
+                - evaluator: { type: lt, params: [0.001] }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { type: last }
+              expression: A
+              refId: C
+
+  # ----- Marketplace canary -----
+  # Any sustained error rate here is the canary for the v0.3.142-class
+  # bugs that #621 / #624 closed (org-scoping, search auth, rate limit).
+  # Sensitive on purpose — we want to know within minutes if a similar
+  # regression ships.
+  - orgId: 1
+    name: mockforge-marketplace
+    folder: MockForge
+    interval: 1m
+    rules:
+      - uid: mockforge-marketplace-errors
+        title: MockForge — marketplace errors detected
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: warning
+          team: mockforge
+          area: marketplace
+        annotations:
+          summary: 'Marketplace operations are returning errors'
+          description: |
+            sum(rate(mockforge_marketplace_errors_total[5m])) by (error_code) shows {{ $values.A.Value }} err/s. PR #624 closed the last cascade of marketplace bugs on 2026-05-23; sustained nonzero here may indicate a regression. Check the Marketplace dashboard (uid mockforge-marketplace) for the offending error_code.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS}
+            model:
+              expr: sum(rate(mockforge_marketplace_errors_total[5m]))
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { type: last }
+              expression: A
+              refId: C


### PR DESCRIPTION
## Summary

Sibling to `grafana/dashboards/` from PR #645. Closes #646.

Five starter alert rules in Grafana unified alerting provisioning YAML, across two groups:

**mockforge-service-health**:
- error rate elevated (warning) — 5xx > 0.5% sustained 5m
- error rate spike (critical) — 5xx > 1% sustained 5m
- p99 latency high (warning) — p99 > 1s sustained 5m
- traffic silence canary (critical) — zero requests in 10m

**mockforge-marketplace**:
- marketplace errors detected (warning) — any errors sustained 5m. Sensitive on purpose: this is the canary for the v0.3.142-class bugs that #621 / #624 closed.

## Grounding

Every PromQL expression references a metric that is actually `record_*`d in the workspace — same audit that informed #645. Defined-but-not-recorded metrics (`mockforge_error_rate`, `mockforge_service_availability`, `mockforge_slo_compliance`, `mockforge_error_budget_remaining`) were excluded so rules don't silently never fire.

## Contact-point caveat

Contact points are intentionally NOT wired in this PR — that requires picking an on-call provider (PagerDuty / Opsgenie / Grafana OnCall) first, and those need an external account. Until then, rules emit to whatever default contact point is configured in your Grafana instance.

The README documents two paths to get alerts reaching a human today:
1. Set Grafana's default contact point to a real email/Slack webhook via the UI (fastest)
2. Define a `contactpoints.yaml` and provision it alongside (better, needs provider picked)

All rules carry `team: mockforge` labels and severity (`warning` / `critical`) so a downstream routing policy can fan them out once the provider is wired.

## Stacking with #645

This PR creates `grafana/alerts/` while #645 creates `grafana/dashboards/`. Both touch the `grafana/` directory but no shared files, so they apply cleanly in either order. README cross-references are by relative path so they'll resolve once both land.

## Test plan

- [x] YAML validated: `apiVersion=1`, 2 groups, 5 rules total
- [x] Every metric referenced exists in the workspace's recorded metric set
- [x] Threshold expressions use `__expr__` evaluator ref pattern Grafana expects
- [x] `for: 5m` minimum on every rule (above the 30s Prometheus scrape interval) to avoid single-sample flap
- [ ] After merge: import via provisioning or HTTP API, verify rules appear in Grafana → Alerting

## Follow-ups

- Wire contact points + routing policy once on-call provider is picked (separate PR, `grafana/alerts/contactpoints.yaml`)
- Per-pillar alerts once we have customer signal on which area's failures hurt most
- Per-tenant hosted-mock alerts (pairs with orchestrator `SENTRY_DSN` injection from #643 follow-up)