### PR TITLE
feat(billing): add 14-day Stripe trial period to Pro/Team checkout

### DIFF
--- a/crates/mockforge-registry-server/src/config.rs
+++ b/crates/mockforge-registry-server/src/config.rs
@@ -66,6 +66,11 @@ pub struct Config {
     /// Stripe webhook secret for verifying webhook signatures
     pub stripe_webhook_secret: Option<String>,
 
+    /// Trial length for Pro/Team checkout sessions. Defaults to 14 days
+    /// (standard B2B dev-tool convention) and applies to both plans
+    /// uniformly. Set to 0 via env to disable the trial entirely.
+    pub stripe_trial_period_days: u32,
+
     /// GitHub OAuth client ID
     pub oauth_github_client_id: Option<String>,
 
@@ -173,6 +178,10 @@ impl Config {
             stripe_price_id_pro: std::env::var("STRIPE_PRICE_ID_PRO").ok(),
             stripe_price_id_team: std::env::var("STRIPE_PRICE_ID_TEAM").ok(),
             stripe_webhook_secret: std::env::var("STRIPE_WEBHOOK_SECRET").ok(),
+            stripe_trial_period_days: std::env::var("STRIPE_TRIAL_PERIOD_DAYS")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(14),
             oauth_github_client_id: std::env::var("OAUTH_GITHUB_CLIENT_ID").ok(),
             oauth_github_client_secret: std::env::var("OAUTH_GITHUB_CLIENT_SECRET").ok(),
             oauth_google_client_id: std::env::var("OAUTH_GOOGLE_CLIENT_ID").ok(),

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -4,8 +4,8 @@ use axum::{extract::State, http::HeaderMap, Json};
 use serde::{Deserialize, Serialize};
 use stripe::{
     BillingPortalSession, CheckoutSession, CheckoutSessionMode, Client, CreateBillingPortalSession,
-    CreateCheckoutSession, CreateCheckoutSessionLineItems, EventObject, EventType, Invoice,
-    ListInvoices,
+    CreateCheckoutSession, CreateCheckoutSessionLineItems, CreateCheckoutSessionSubscriptionData,
+    EventObject, EventType, Invoice, ListInvoices,
 };
 use uuid::Uuid;
 
@@ -204,6 +204,18 @@ pub async fn create_checkout(
         quantity: Some(1),
         ..Default::default()
     }]);
+
+    // Apply a free trial when one is configured. Default is 14 days (set in
+    // Config::from_env); STRIPE_TRIAL_PERIOD_DAYS=0 disables it entirely.
+    // The marketing pricing page ("Start Pro/Team Trial") promises this;
+    // without it the CTA copy is a bait-and-switch — checkout would charge
+    // immediately. Standard B2B dev-tool convention at this price point.
+    if state.config.stripe_trial_period_days > 0 {
+        checkout_params.subscription_data = Some(CreateCheckoutSessionSubscriptionData {
+            trial_period_days: Some(state.config.stripe_trial_period_days),
+            ..Default::default()
+        });
+    }
 
     // Create the checkout session
     let session = CheckoutSession::create(&client, checkout_params)

--- a/fly.registry.toml
+++ b/fly.registry.toml
@@ -26,6 +26,7 @@ primary_region = "iad"
 #   AWS_SECRET_ACCESS_KEY - R2 API token Secret Access Key
 #   STRIPE_SECRET_KEY     - Stripe API key
 #   STRIPE_WEBHOOK_SECRET - Stripe webhook signing secret
+#   STRIPE_TRIAL_PERIOD_DAYS - Optional: free-trial days for Pro/Team checkout. Default 14. Set to 0 to disable.
 #   SMTP_HOST             - "smtp-relay.brevo.com"
 #   SMTP_PORT             - "587"
 #   SMTP_USERNAME         - Brevo login email


### PR DESCRIPTION
## Summary

The marketing pricing page (`mockforge.dev/pricing.html`) promises **"Start Pro Trial"** / **"Start Team Trial"**, but the Stripe checkout in `handlers/billing.rs` was creating a subscription with no trial — checkout charged immediately. Bait-and-switch.

This PR adds an env-configurable trial period. Default **14 days** (standard B2B dev-tool convention: Linear, Vercel Pro, Cursor, Copilot, GitHub all do this at the $20-100/mo price band). Set `STRIPE_TRIAL_PERIOD_DAYS=0` to disable trials entirely (campaign or A/B-test escape hatch).

## Why $99/Team and $29/Pro were both verified first

Per session context, this work was gated on confirming the Team tier price (the audit said "$99/mo on pricing.html needs verification"). Verified by reading the in-product PricingPage:

- `crates/mockforge-ui/ui/src/pages/PricingPage.tsx:89` — `<span className="text-4xl font-bold">$29</span>` (Pro)
- `crates/mockforge-ui/ui/src/pages/PricingPage.tsx:141` — `<span className="text-4xl font-bold">$99</span>` (Team)

Both match the marketing site. **The actual amount Stripe charges still depends on operator-set `STRIPE_PRICE_ID_PRO` / `STRIPE_PRICE_ID_TEAM` env vars** matching what the UI displays — outside this PR's scope.

## Implementation

- `config.rs`: new `stripe_trial_period_days: u32` field, read from `STRIPE_TRIAL_PERIOD_DAYS` env var, default 14.
- `handlers/billing.rs`: when `> 0`, sets `subscription_data.trial_period_days` on the `CreateCheckoutSession`. When `0`, no `subscription_data` is sent and the prior immediate-charge behavior is preserved.
- `fly.registry.toml`: documents the new optional secret.

## Trial UX after merge

The current checkout flow collects a payment method up-front (standard Stripe Checkout), so the trial uses Stripe's default `trial_settings.end_behavior` — subscription auto-bills on day 14 unless the user cancels. That's the right pattern for $29-99 dev-tool plans: low friction to start, no abandoned-trial bookkeeping for us.

If we later want a no-card trial, that's a separate change involving `payment_method_collection: "if_required"` + `trial_settings.end_behavior.missing_payment_method: "pause"`.

## Test plan

- [x] `cargo build -p mockforge-registry-server` — green
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` — green
- [x] `cargo fmt --all --check` — green
- [x] `crates/mockforge-registry-server/tests/paid_flow_e2e.rs` does not assert no-trial behavior — verified via grep
- [ ] After deploy: trigger a checkout via `app.mockforge.dev/register?plan=pro` against Stripe test mode, confirm session has `trial_end` set to T+14d, confirm webhook `customer.subscription.trial_will_end` fires at T+11d
- [ ] Verify the in-product PricingPage button text ("Upgrade to Pro" / "Upgrade to Team") — consider updating to "Start 14-day free trial" to match the marketing site copy, separate UI PR

## Operational

After merge, `flyctl secrets set --app mockforge-registry STRIPE_TRIAL_PERIOD_DAYS=14` is **not required** — 14 is the default. The env var only needs to be set if you want to override (e.g. `=0` for no trial, `=7` for a tighter funnel test).