### PR TITLE
feat(ui): pricing CTAs reflect the new 14-day trial

### DIFF
--- a/crates/mockforge-ui/ui/src/pages/PricingPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PricingPage.tsx
@@ -89,6 +89,7 @@ export function PricingPage() {
               <span className="text-4xl font-bold">$29</span>
               <span className="text-muted-foreground">/month</span>
             </div>
+            <p className="text-sm text-success-600 font-medium mt-1">14-day free trial · no commitment</p>
             <CardDescription>For professional developers</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -127,7 +128,7 @@ export function PricingPage() {
               </li>
             </ul>
             <Button className="w-full" variant="default" onClick={() => handleUpgrade('pro')}>
-              Upgrade to Pro
+              Start free trial
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </CardContent>
@@ -141,6 +142,7 @@ export function PricingPage() {
               <span className="text-4xl font-bold">$99</span>
               <span className="text-muted-foreground">/month</span>
             </div>
+            <p className="text-sm text-success-600 font-medium mt-1">14-day free trial · no commitment</p>
             <CardDescription>For growing teams</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -179,7 +181,7 @@ export function PricingPage() {
               </li>
             </ul>
             <Button className="w-full" variant="outline" onClick={() => handleUpgrade('team')}>
-              Upgrade to Team
+              Start free trial
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </CardContent>


### PR DESCRIPTION
## Summary

Sibling to PR #649 (which added the trial period to the Stripe checkout backend). This syncs the in-product `PricingPage` copy so what users see matches what actually happens when they click.

- Pro button: `Upgrade to Pro` → `Start free trial`
- Team button: `Upgrade to Team` → `Start free trial`
- New subtitle under each price: `14-day free trial · no commitment`

## Why both PRs together

Three surfaces were out of sync:

| Surface | Before | After |
|---|---|---|
| **Marketing** (`mockforge.dev/pricing.html`) | "Start Pro Trial" / "Start Team Trial" | unchanged (was already correct) |
| **In-product** (`PricingPage.tsx`) | "Upgrade to Pro" / "Upgrade to Team" | "Start free trial" — **this PR** |
| **Stripe checkout** (`billing.rs`) | no trial, charged immediately | 14-day trial — PR #649 |

Marketing promised something the backend didn't deliver, and the in-product UI was silent about the trial entirely. After #649 + this PR, all three say the same thing.

## What's hard-coded vs configurable

- **Backend trial length** is env-configurable (`STRIPE_TRIAL_PERIOD_DAYS`, default 14) — set in #649.
- **UI copy** here hard-codes "14-day" to match the default. If we ever override `STRIPE_TRIAL_PERIOD_DAYS` in prod, this copy needs to track it. **Filed as follow-up:** wire a tiny `/api/v1/billing/config` endpoint returning `{ trial_period_days, plans: [...] }` so the UI fetches the live values. Not in scope here — the default is the operative number for the foreseeable future.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — 0 errors, 956 pre-existing warnings (this PR adds none)
- [ ] After merge: load `/pricing` in the admin UI, confirm both Pro and Team cards show the new subtitle and button text, click through and verify it lands on Stripe checkout with `trial_end` set to T+14d (full flow requires #649 also merged + `STRIPE_PRICE_ID_PRO`/`STRIPE_PRICE_ID_TEAM` env vars set)