### PR TITLE
feat(billing): public /api/v1/billing/config + dynamic Pricing CTA copy

### DIFF
--- a/crates/mockforge-registry-server/src/config.rs
+++ b/crates/mockforge-registry-server/src/config.rs
@@ -66,6 +66,11 @@ pub struct Config {
     /// Stripe webhook secret for verifying webhook signatures
     pub stripe_webhook_secret: Option<String>,
 
+    /// Trial length for Pro/Team checkout sessions. Defaults to 14 days
+    /// (standard B2B dev-tool convention) and applies to both plans
+    /// uniformly. Set to 0 via env to disable the trial entirely.
+    pub stripe_trial_period_days: u32,
+
     /// GitHub OAuth client ID
     pub oauth_github_client_id: Option<String>,
 
@@ -173,6 +178,10 @@ impl Config {
             stripe_price_id_pro: std::env::var("STRIPE_PRICE_ID_PRO").ok(),
             stripe_price_id_team: std::env::var("STRIPE_PRICE_ID_TEAM").ok(),
             stripe_webhook_secret: std::env::var("STRIPE_WEBHOOK_SECRET").ok(),
+            stripe_trial_period_days: std::env::var("STRIPE_TRIAL_PERIOD_DAYS")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(14),
             oauth_github_client_id: std::env::var("OAUTH_GITHUB_CLIENT_ID").ok(),
             oauth_github_client_secret: std::env::var("OAUTH_GITHUB_CLIENT_SECRET").ok(),
             oauth_google_client_id: std::env::var("OAUTH_GOOGLE_CLIENT_ID").ok(),

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -19,6 +19,31 @@ use crate::{
     AppState,
 };
 
+/// Public billing-config response: thin shape that the unauthenticated
+/// pricing page can use to render trial copy without inheriting the rest
+/// of the auth-gated billing surface.
+#[derive(Serialize)]
+pub struct BillingConfigResponse {
+    /// Free-trial length in days for new Pro/Team subscriptions. `0` means
+    /// trials are disabled and checkout charges immediately — UI should
+    /// hide trial-related copy in that case.
+    pub trial_period_days: u32,
+}
+
+/// Public billing config (no auth required).
+///
+/// Returns just enough metadata for the marketing / pricing UI to render
+/// dynamic trial copy. Plan prices stay hard-coded on the client side
+/// because they're already tied to operator-set STRIPE_PRICE_ID_* env vars
+/// — exposing them here would duplicate the source of truth.
+pub async fn get_billing_config(
+    State(state): State<AppState>,
+) -> ApiResult<Json<BillingConfigResponse>> {
+    Ok(Json(BillingConfigResponse {
+        trial_period_days: state.config.stripe_trial_period_days,
+    }))
+}
+
 /// Get current subscription status
 pub async fn get_subscription(
     State(state): State<AppState>,

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -4,8 +4,8 @@ use axum::{extract::State, http::HeaderMap, Json};
 use serde::{Deserialize, Serialize};
 use stripe::{
     BillingPortalSession, CheckoutSession, CheckoutSessionMode, Client, CreateBillingPortalSession,
-    CreateCheckoutSession, CreateCheckoutSessionLineItems, EventObject, EventType, Invoice,
-    ListInvoices,
+    CreateCheckoutSession, CreateCheckoutSessionLineItems, CreateCheckoutSessionSubscriptionData,
+    EventObject, EventType, Invoice, ListInvoices,
 };
 use uuid::Uuid;
 
@@ -204,6 +204,18 @@ pub async fn create_checkout(
         quantity: Some(1),
         ..Default::default()
     }]);
+
+    // Apply a free trial when one is configured. Default is 14 days (set in
+    // Config::from_env); STRIPE_TRIAL_PERIOD_DAYS=0 disables it entirely.
+    // The marketing pricing page ("Start Pro/Team Trial") promises this;
+    // without it the CTA copy is a bait-and-switch — checkout would charge
+    // immediately. Standard B2B dev-tool convention at this price point.
+    if state.config.stripe_trial_period_days > 0 {
+        checkout_params.subscription_data = Some(CreateCheckoutSessionSubscriptionData {
+            trial_period_days: Some(state.config.stripe_trial_period_days),
+            ..Default::default()
+        });
+    }
 
     // Create the checkout session
     let session = CheckoutSession::create(&client, checkout_params)

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -43,6 +43,10 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/faq", get(handlers::faq::get_faq))
         .route("/api/v1/legal/terms", get(handlers::legal::get_terms))
         .route("/api/v1/legal/privacy", get(handlers::legal::get_privacy))
+        // Billing config (public): trial length and other display-time
+        // settings the unauthenticated pricing page needs. Separate from
+        // the auth-gated /api/v1/billing/* routes below.
+        .route("/api/v1/billing/config", get(handlers::billing::get_billing_config))
         .route("/api/v1/legal/dpa", get(handlers::legal::get_dpa))
         .route("/api/v1/status", get(handlers::status::get_status))
         // Support contact (public, works with or without auth)

--- a/crates/mockforge-ui/ui/src/pages/PricingPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PricingPage.tsx
@@ -1,9 +1,37 @@
 import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/button';
 import { CheckCircle2, XCircle, ArrowRight } from 'lucide-react';
 
+// Public billing-config endpoint. Returns trial length so the pricing
+// CTA copy can stay in sync with the operator-set
+// STRIPE_TRIAL_PERIOD_DAYS env var without redeploying the UI.
+type BillingConfig = { trial_period_days: number };
+
+async function fetchBillingConfig(): Promise<BillingConfig> {
+  const res = await fetch('/api/v1/billing/config');
+  if (!res.ok) {
+    throw new Error(`billing config fetch failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 export function PricingPage() {
+  // Soft-fail: if the endpoint isn't reachable (offline, OSS build,
+  // unconfigured), fall back to a sensible default rather than hiding
+  // the price page. 14 matches the backend default in config.rs.
+  const { data: billingConfig } = useQuery({
+    queryKey: ['billing-config'],
+    queryFn: fetchBillingConfig,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+  const trialDays = billingConfig?.trial_period_days ?? 14;
+  const hasTrial = trialDays > 0;
+  const trialSubtitle = hasTrial ? `${trialDays}-day free trial · no commitment` : null;
+  const paidCtaLabel = hasTrial ? 'Start free trial' : 'Upgrade';
+
   const handleGetStarted = () => {
     // Navigate to sign up or login
     window.location.href = '/signup';
@@ -89,6 +117,9 @@ export function PricingPage() {
               <span className="text-4xl font-bold">$29</span>
               <span className="text-muted-foreground">/month</span>
             </div>
+            {trialSubtitle && (
+              <p className="text-sm text-success-600 font-medium mt-1">{trialSubtitle}</p>
+            )}
             <CardDescription>For professional developers</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -127,7 +158,7 @@ export function PricingPage() {
               </li>
             </ul>
             <Button className="w-full" variant="default" onClick={() => handleUpgrade('pro')}>
-              Upgrade to Pro
+              {hasTrial ? paidCtaLabel : 'Upgrade to Pro'}
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </CardContent>
@@ -141,6 +172,9 @@ export function PricingPage() {
               <span className="text-4xl font-bold">$99</span>
               <span className="text-muted-foreground">/month</span>
             </div>
+            {trialSubtitle && (
+              <p className="text-sm text-success-600 font-medium mt-1">{trialSubtitle}</p>
+            )}
             <CardDescription>For growing teams</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -179,7 +213,7 @@ export function PricingPage() {
               </li>
             </ul>
             <Button className="w-full" variant="outline" onClick={() => handleUpgrade('team')}>
-              Upgrade to Team
+              {hasTrial ? paidCtaLabel : 'Upgrade to Team'}
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </CardContent>

--- a/fly.registry.toml
+++ b/fly.registry.toml
@@ -26,6 +26,7 @@ primary_region = "iad"
 #   AWS_SECRET_ACCESS_KEY - R2 API token Secret Access Key
 #   STRIPE_SECRET_KEY     - Stripe API key
 #   STRIPE_WEBHOOK_SECRET - Stripe webhook signing secret
+#   STRIPE_TRIAL_PERIOD_DAYS - Optional: free-trial days for Pro/Team checkout. Default 14. Set to 0 to disable.
 #   SMTP_HOST             - "smtp-relay.brevo.com"
 #   SMTP_PORT             - "587"
 #   SMTP_USERNAME         - Brevo login email


### PR DESCRIPTION
## Summary

Closes the trial-copy-stays-in-sync follow-up from PR #649. After #649 landed the 14-day Stripe trial as `STRIPE_TRIAL_PERIOD_DAYS`, the in-product Pricing page still had hard-coded "14-day" copy — overriding the env var (e.g. `STRIPE_TRIAL_PERIOD_DAYS=7` for an A/B test, or `=0` to disable trials) would silently make the UI lie.

This PR adds a thin public endpoint + wires the Pricing page to use it.

## Backend

- New `BillingConfigResponse { trial_period_days: u32 }`
- `handlers::billing::get_billing_config(State<AppState>) -> Json<BillingConfigResponse>`
- Mounted on `public_routes`: `GET /api/v1/billing/config` — no auth required (pricing page renders before login)
- Intentionally thin: doesn't expose plan prices. Those stay tied to operator-set `STRIPE_PRICE_ID_*` env vars and the UI's hard-coded `$29` / `$99` display. Adding them here would create a third source of truth and a third place to keep in sync.

## UI

- `PricingPage.tsx` fetches the config via TanStack Query (5-min stale time, 1 retry). Falls back to **14** on error so the page renders even if the API is unreachable.
- Pro + Team cards render `{trialDays}-day free trial · no commitment` only when `trial_period_days > 0`.
- Button text is `Start free trial` when trials are on, `Upgrade to Pro` / `Upgrade to Team` when disabled (i.e. the prior CTA is preserved as a fallback).

## Stack note

PR #649 (the trial backend) hasn't merged yet but is auto-merge-armed. To avoid building on a missing field, this PR cherry-picks #649's commit. Result:

- If #649 merges first → my cherry-pick is a no-op duplicate, git merges cleanly.
- If this PR merges first → the trial backend lands too (defensible since #649 is unblocked).
- Either way, no broken intermediate state.

Supersedes **PR #650** (the simpler static-copy version) — closed with pointer here.

## Test plan

- [x] `cargo build -p mockforge-registry-server` — green
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` — green
- [x] `cargo fmt --all --check` — green
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — 0 errors (956 pre-existing warnings, none new)
- [ ] After deploy: `curl https://mockforge-registry.fly.dev/api/v1/billing/config` returns `{"trial_period_days": 14}` without auth
- [ ] After deploy: load `/pricing` in the admin UI without being logged in, confirm Pro+Team show "14-day free trial · no commitment" + "Start free trial" button text
- [ ] After deploy: `flyctl secrets set --app mockforge-registry STRIPE_TRIAL_PERIOD_DAYS=7`, redeploy, confirm UI updates to "7-day free trial" without a UI redeploy
- [ ] After deploy: `flyctl secrets set --app mockforge-registry STRIPE_TRIAL_PERIOD_DAYS=0`, confirm UI hides subtitle and reverts button to "Upgrade to Pro/Team"

## Future expansion (not needed yet)

If we eventually want the endpoint to also drive price display in the UI cards, add fields like:

\`\`\`json
{
  \"trial_period_days\": 14,
  \"plans\": [
    { \"id\": \"pro\", \"price_usd\": 29, \"display\": \"\$29/month\" },
    { \"id\": \"team\", \"price_usd\": 99, \"display\": \"\$99/month\" }
  ]
}
\`\`\`

Out of scope for this PR — the price-display drift problem is dormant today because nobody changes `STRIPE_PRICE_ID_PRO`/`_TEAM` casually.