### PR TITLE
fix(registry): optional bearer-token auth for /metrics (closes #647)

### DIFF
--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -368,7 +368,20 @@ fn create_app(state: AppState, rate_limiter: RateLimiterState) -> Router {
         .unwrap_or(10 * 1024 * 1024); // 10MB default
     tracing::info!("Request body size limit: {} bytes", max_body_size);
 
-    // Add metrics endpoint (separate router without state)
+    // Add metrics endpoint (separate router without state). Auth on this
+    // endpoint is opt-in via PROMETHEUS_SCRAPE_TOKEN — warn loudly at boot
+    // if it's unset on what looks like a public deployment, so the metric
+    // labels (workspace IDs, error rates, traffic patterns) don't leak.
+    if std::env::var("PROMETHEUS_SCRAPE_TOKEN")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .is_none()
+    {
+        tracing::warn!(
+            "PROMETHEUS_SCRAPE_TOKEN is unset — /metrics is publicly readable. Set this env var \
+             to require `Authorization: Bearer <token>` on scrape requests (issue #647)."
+        );
+    }
     let metrics_router = Router::new()
         .route("/metrics", axum::routing::get(metrics_handler))
         .route("/metrics/health", axum::routing::get(|| async { "OK" }));
@@ -387,9 +400,31 @@ fn create_app(state: AppState, rate_limiter: RateLimiterState) -> Router {
         .with_state(state)
 }
 
-async fn metrics_handler() -> impl IntoResponse {
+async fn metrics_handler(headers: axum::http::HeaderMap) -> impl IntoResponse {
     use mockforge_observability::get_global_registry;
     use prometheus::{Encoder, TextEncoder};
+
+    // Optional bearer-token gate (#647). When PROMETHEUS_SCRAPE_TOKEN is set,
+    // /metrics requires `Authorization: Bearer <token>` matching it. When the
+    // env var is unset or empty, the endpoint stays open — keeps local dev
+    // and OSS deployments working unchanged. Production should always set
+    // the token because the metric labels leak workspace IDs, per-endpoint
+    // request rates, and error patterns.
+    if let Ok(required) = std::env::var("PROMETHEUS_SCRAPE_TOKEN") {
+        if !required.is_empty() {
+            let supplied = headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.strip_prefix("Bearer "));
+            if supplied != Some(required.as_str()) {
+                return (
+                    axum::http::StatusCode::UNAUTHORIZED,
+                    "metrics endpoint requires Authorization: Bearer <PROMETHEUS_SCRAPE_TOKEN>",
+                )
+                    .into_response();
+            }
+        }
+    }
 
     let encoder = TextEncoder::new();
     let metric_families = get_global_registry().registry().gather();

--- a/fly.registry.toml
+++ b/fly.registry.toml
@@ -30,6 +30,7 @@ primary_region = "iad"
 #   SMTP_PORT             - "587"
 #   SMTP_USERNAME         - Brevo login email
 #   SMTP_PASSWORD         - Brevo SMTP key
+#   PROMETHEUS_SCRAPE_TOKEN - Optional: bearer token Prometheus must send to scrape /metrics. When unset, /metrics is publicly readable — set this in production (issue #647). Configure in Prometheus via `bearer_token` (or `bearer_token_file`) on the scrape config.
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary

Closes #647. The `/metrics` endpoint on `mockforge-registry-server` was publicly readable. The exported series leak workspace IDs (path / workspace labels), per-route error rates, and traffic patterns — useful intel for anyone scoping the system, and a footgun if `/metrics` becomes externally reachable.

Opt-in bearer-token gate driven by `PROMETHEUS_SCRAPE_TOKEN`:

- Set → `/metrics` requires `Authorization: Bearer <token>` matching the env var, else 401.
- Unset/empty → endpoint stays open. Backwards-compat for local dev and OSS deployments, with a loud startup warning so operators of public deployments notice in their boot logs:

  ```
  WARN  PROMETHEUS_SCRAPE_TOKEN is unset — /metrics is publicly readable. Set this env var to require `Authorization: Bearer <token>` on scrape requests (issue #647).
  ```

Documented in `fly.registry.toml`.

## Why opt-in (not always-on)

Going always-on would break local dev (`curl localhost:8080/metrics`) and any existing OSS deployments that haven't set the token. Opt-in with a loud warning gives operators a clean migration path: deploy this PR → see the warning → set the secret → re-deploy.

## Operational steps after merge

```bash
# 1. Generate a token
TOKEN=$(openssl rand -hex 32)

# 2. Set on the registry app
flyctl secrets set --app mockforge-registry PROMETHEUS_SCRAPE_TOKEN="$TOKEN"

# 3. Set the matching bearer_token in your Prometheus scrape config
# scrape_configs:
#   - job_name: mockforge-registry
#     bearer_token: <TOKEN>
#     static_configs:
#       - targets: ['mockforge-registry.fly.dev']
```

## Test plan

- [x] `cargo build -p mockforge-registry-server` — green
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` — green
- [x] `cargo fmt --all --check` — green
- [ ] Post-deploy unset: `curl https://mockforge-registry.fly.dev/metrics` returns 200 (and boot logs show the warning)
- [ ] Post-deploy set: `curl https://mockforge-registry.fly.dev/metrics` returns 401; with `-H "Authorization: Bearer $TOKEN"` returns 200

## Out of scope

- Auth on the `MultitenantRouter`'s per-tenant mock endpoints — different domain (`<slug>.mockforge.dev`), different threat model. File separately if needed.
- Constant-time comparison via `subtle` crate. Plain `==` here is fine because the token doesn't gate truly sensitive data and the timing window is microseconds wide.