### PR TITLE
fix(tui,ui): Conformance tab actually appears + admin server exposes the endpoint (#79 r12 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.3.146] - 2026-05-25
+
+### Fixed
+
+- **[DevX]** TUI `Conformance` tab now appears in the tab strip + admin server exposes the violations endpoint (#79 round 12 hotfix)
+  - **Bug 1 — invisible tab.** v0.3.145 added `ScreenId::Conformance` to the enum but forgot to push `ConformanceScreen::new()` onto `App::new`'s screens vec. `render_header` iterates `self.screens` so it rendered the other 22 tabs and silently dropped the new one. Fixed; also added a `debug_assert_eq!(screens.len(), ScreenId::ALL.len())` and a `app_screens_match_screen_id_all` unit test so any future enum/vec drift fails before tagging instead of after.
+  - **Bug 2 — admin server didn't expose the endpoint.** The TUI client polls the admin URL (`http://localhost:9080`) at `/__mockforge/api/conformance/violations`, but v0.3.145 only wired the route into `mockforge-http`'s management router (which runs on the *mock-traffic* HTTP port, not the admin port). TUI got the SPA HTML fallback. Added matching `get_conformance_violations` / `clear_conformance_violations` handlers in `mockforge-ui` and routed them at the same path on the admin server — both ports now serve it.
+
 ## [0.3.145] - 2026-05-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7715,7 +7715,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8341,7 +8341,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8388,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8423,7 +8423,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8445,7 +8445,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8562,7 +8562,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8670,7 +8670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8685,7 +8685,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8709,7 +8709,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8786,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8811,7 +8811,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8998,7 +8998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9011,7 +9011,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9070,7 +9070,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9178,14 +9178,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9212,7 +9212,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9223,7 +9223,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9263,7 +9263,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9317,7 +9317,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9404,7 +9404,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9415,7 +9415,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9432,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15263,7 +15263,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.145"
+version = "0.3.146"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.145"
+version = "0.3.146"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.146] - 2026-05-25
+
+### Fixed
+
+- **[DevX]** TUI `Conformance` tab now appears + admin server exposes the violations endpoint (#79 round 12 hotfix) — v0.3.145 had two bugs: (1) `ScreenId::Conformance` was added to the enum but `ConformanceScreen::new()` was missing from `App::new`'s screens vec, so the tab silently dropped from the header; (2) the endpoint was only wired into `mockforge-http`'s management router (mock-traffic port), not the admin server the TUI polls. Fixed both, plus added an `app_screens_match_screen_id_all` regression test.
+
 ## [0.3.145] - 2026-05-24
 
 ### Added

--- a/crates/mockforge-tui/src/app.rs
+++ b/crates/mockforge-tui/src/app.rs
@@ -74,7 +74,20 @@ impl App {
             Box::new(screens::contract_diff::ContractDiffScreen::new()),
             Box::new(screens::federation::FederationScreen::new()),
             Box::new(screens::behavioral_cloning::BehavioralCloningScreen::new()),
+            Box::new(screens::conformance::ConformanceScreen::new()),
         ];
+
+        // Invariant: every entry in `ScreenId::ALL` must have a matching
+        // boxed Screen at the same index. The header renders tabs from
+        // `self.screens` and routing looks up `self.screens[i]` keyed off
+        // `ScreenId::ALL[i]` — if these go out of sync, a tab silently
+        // disappears (regression first hit in v0.3.145: Conformance was
+        // added to `ScreenId::ALL` but the Box was missed here).
+        debug_assert_eq!(
+            screens.len(),
+            ScreenId::ALL.len(),
+            "screens vec must match ScreenId::ALL length"
+        );
 
         let active_tab = if initial_tab < screens.len() {
             initial_tab
@@ -432,5 +445,26 @@ impl App {
         }
         let tabs = Line::from(tab_spans);
         frame.render_widget(Paragraph::new(tabs).style(Theme::base()), chunks[1]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TuiConfig;
+
+    /// Regression test for v0.3.145 → v0.3.146 hotfix: every entry in
+    /// `ScreenId::ALL` must have a corresponding `Box<dyn Screen>` in
+    /// `App::new`. When they go out of sync, the missing tab silently
+    /// disappears from the header (`render_header` iterates `self.screens`
+    /// while routing iterates `ScreenId::ALL`).
+    #[test]
+    fn app_screens_match_screen_id_all() {
+        let app = App::new(TuiConfig::default(), None);
+        assert_eq!(
+            app.screens.len(),
+            ScreenId::ALL.len(),
+            "App::new must instantiate a Screen for every ScreenId::ALL entry"
+        );
     }
 }

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -1322,6 +1322,33 @@ pub async fn get_server_info(State(state): State<AdminState>) -> Json<serde_json
     }))
 }
 
+/// Server-side conformance violations — see #79 round 12.
+///
+/// Mirrors what `mockforge-http`'s `/__mockforge/api/conformance/violations`
+/// exposes, but on the admin server too so the TUI (which talks to the
+/// admin port) can render the new `Conformance` tab. Without this,
+/// v0.3.145 surfaced the endpoint only on the HTTP-mock port and the
+/// TUI got the SPA HTML fallback when it tried to poll.
+pub async fn get_conformance_violations(
+    axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let snap = mockforge_foundation::conformance_violations::snapshot();
+    let total = snap.len();
+    let limit: Option<usize> = q.get("limit").and_then(|s| s.parse().ok());
+    let limited: Vec<_> = match limit {
+        Some(n) => snap.into_iter().take(n).collect(),
+        None => snap,
+    };
+    Json(json!({"violations": limited, "total": total}))
+}
+
+/// Clear the server-side conformance violation ring buffer.
+pub async fn clear_conformance_violations() -> impl IntoResponse {
+    let n = mockforge_foundation::conformance_violations::len();
+    mockforge_foundation::conformance_violations::clear();
+    Json(json!({"cleared": n}))
+}
+
 /// Get health check status
 pub async fn get_health() -> Json<HealthCheck> {
     Json(

--- a/crates/mockforge-ui/src/routes.rs
+++ b/crates/mockforge-ui/src/routes.rs
@@ -169,6 +169,14 @@ pub fn create_admin_router(
         .route("/__mockforge/fixtures/bulk", delete(delete_fixtures_bulk))
         .route("/__mockforge/audit/logs", get(get_audit_logs))
         .route("/__mockforge/audit/stats", get(get_audit_stats))
+        // Issue #79 round 12 hotfix — server-side conformance violations
+        // for the TUI Conformance tab. Mounted here on the admin server
+        // (where the TUI client connects) in addition to the mockforge-http
+        // management router.
+        .route(
+            "/__mockforge/api/conformance/violations",
+            get(get_conformance_violations).delete(clear_conformance_violations),
+        )
         .route("/__mockforge/fixtures/{id}/download", get(download_fixture))
         .route("/__mockforge/fixtures/{id}/rename", post(rename_fixture))
         .route("/__mockforge/fixtures/{id}/move", post(move_fixture))


### PR DESCRIPTION
## Summary

v0.3.145 shipped the Conformance feature with two bugs that silently neutered it — Srikanth flagged the invisible tab on the release thread. This hotfix bumps to 0.3.146.

### Bug 1 — invisible tab

`ScreenId::Conformance` was added to `ScreenId::ALL` (23 entries) but the matching `Box::new(ConformanceScreen::new())` was missing from `App::new`'s `screens` vec (22 entries). `render_header` iterates `self.screens` so it drew the other 22 tabs and dropped the new one without a peep.

Fix:
- Added the missing `Box` in `crates/mockforge-tui/src/app.rs`
- Added a `debug_assert_eq!(screens.len(), ScreenId::ALL.len())` so this fails at runtime in any dev/debug build instead of silently shipping
- Added a `app_screens_match_screen_id_all` regression test that exercises `App::new` and asserts the lengths match

### Bug 2 — admin server didn't expose the endpoint

The TUI client polls the *admin* URL (default `http://localhost:9080`) at `/__mockforge/api/conformance/violations`, but v0.3.145 only wired the route into `mockforge-http`'s `management_router` — which runs on the *mock-traffic* HTTP port, not the admin port. The TUI got the SPA HTML fallback and stayed in `Loading…` forever.

Fix:
- Added `get_conformance_violations` / `clear_conformance_violations` in `crates/mockforge-ui/src/handlers.rs` (delegates to `mockforge_foundation::conformance_violations::{snapshot, clear}`)
- Registered both at `/__mockforge/api/conformance/violations` on the admin router in `crates/mockforge-ui/src/routes.rs`
- Path is identical to the existing `mockforge-http` route, so the TUI client needs no change

## Test plan

- [x] `cargo test -p mockforge-tui --lib app_screens_match_screen_id_all` — passes (would fail before the Box was added)
- [x] `cargo clippy -p mockforge-tui -p mockforge-ui --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Local mockforge serve on admin port 19460 → `curl http://127.0.0.1:19460/__mockforge/api/conformance/violations` returns `{"total":0,"violations":[]}` instead of the SPA HTML
- [x] Endpoint also still served on the mock HTTP port (port 13460)
- [x] Recording path verified: `mockforge_foundation::conformance_violations::record(...)` is called from `mockforge-openapi/src/openapi_routes.rs:755` whenever the validator rejects a request

Workspace 0.3.145 → 0.3.146. Closes the #79 round-12 follow-up on the tab visibility.