### PR TITLE
fix(tui): move Conformance tab before Verification so Tab nav reaches it (#79 r12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.147] - 2026-05-25
+
+### Changed
+
+- **[DevX]** TUI `Conformance` tab moved before `Verification` (#79 round 12 follow-up) — Verification consumes `Tab` to cycle its internal fields, so Tab-navigating past it required clicking elsewhere to break the focus. Putting Conformance before Verification keeps it reachable via plain Tab from the earlier screens. Srikanth's ask.
+
 ## [0.3.146] - 2026-05-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7715,7 +7715,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8341,7 +8341,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8388,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8423,7 +8423,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8445,7 +8445,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8562,7 +8562,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8670,7 +8670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8685,7 +8685,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8709,7 +8709,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8786,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8811,7 +8811,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8998,7 +8998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9011,7 +9011,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9070,7 +9070,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9178,14 +9178,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9212,7 +9212,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9223,7 +9223,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9263,7 +9263,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9317,7 +9317,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9404,7 +9404,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9415,7 +9415,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9432,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15263,7 +15263,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.146"
+version = "0.3.147"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.146"
+version = "0.3.147"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.147] - 2026-05-25
+
+### Changed
+
+- **[DevX]** TUI `Conformance` tab moved before `Verification` (#79 round 12 follow-up) — Verification's `Tab` cycles internal fields so it acts as a dead-end for plain Tab nav. Putting Conformance earlier in the strip keeps it reachable.
+
 ## [0.3.146] - 2026-05-25
 
 ### Fixed

--- a/crates/mockforge-tui/src/app.rs
+++ b/crates/mockforge-tui/src/app.rs
@@ -65,6 +65,12 @@ impl App {
             Box::new(screens::smoke_tests::SmokeTestsScreen::new()),
             Box::new(screens::time_travel::TimeTravelScreen::new()),
             Box::new(screens::chains::ChainsScreen::new()),
+            // Conformance is intentionally placed before Verification —
+            // Verification's `Tab` is consumed to cycle internal fields,
+            // so plain Tab nav gets stuck on it. Order must match
+            // `ScreenId::ALL`; the `app_screens_match_screen_id_all`
+            // test asserts the lengths align.
+            Box::new(screens::conformance::ConformanceScreen::new()),
             Box::new(screens::verification::VerificationScreen::new()),
             Box::new(screens::analytics::AnalyticsScreen::new()),
             Box::new(screens::recorder::RecorderScreen::new()),
@@ -74,7 +80,6 @@ impl App {
             Box::new(screens::contract_diff::ContractDiffScreen::new()),
             Box::new(screens::federation::FederationScreen::new()),
             Box::new(screens::behavioral_cloning::BehavioralCloningScreen::new()),
-            Box::new(screens::conformance::ConformanceScreen::new()),
         ];
 
         // Invariant: every entry in `ScreenId::ALL` must have a matching

--- a/crates/mockforge-tui/src/screens/mod.rs
+++ b/crates/mockforge-tui/src/screens/mod.rs
@@ -116,6 +116,13 @@ impl ScreenId {
         Self::SmokeTests,
         Self::TimeTravel,
         Self::Chains,
+        // Conformance sits before Verification — Verification's `Tab`
+        // is consumed to cycle internal fields, so it acts as a
+        // dead-end for tab navigation. Putting Conformance earlier
+        // keeps it reachable via plain Tab without forcing the user
+        // to click-and-tab around the stuck Verification screen.
+        // (Reordered after Srikanth flagged it on Issue #79 round 12.)
+        Self::Conformance,
         Self::Verification,
         Self::Analytics,
         Self::Recorder,
@@ -125,7 +132,6 @@ impl ScreenId {
         Self::ContractDiff,
         Self::Federation,
         Self::BehavioralCloning,
-        Self::Conformance,
     ];
 
     pub fn label(self) -> &'static str {


### PR DESCRIPTION
## Summary

Srikanth flagged on Issue #79 that **Tab** navigation got stuck on the Verification tab — Verification's `handle_key` consumes `Tab` to cycle its internal field focus (`Method` / `Path` / `Min Count`), so it never returns false and `handle_global_key` (which handles tab switching) never runs. The only way past it was mouse-click-then-Tab.

He explicitly asked: *"Can we move conformance Tab before Verification Tab if possible?"*

Done. Moved `Self::Conformance` to right before `Self::Verification` in `ScreenId::ALL` and pushed `Box::new(ConformanceScreen::new())` to the same position in `App::new`'s screens vec.

## Test plan

- [x] `cargo test -p mockforge-tui --lib` — 291 pass (including the `app_screens_match_screen_id_all` invariant added in v0.3.146)
- [x] `cargo clippy -p mockforge-tui --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Workspace 0.3.146 → 0.3.147.