### PR TITLE
fix(conformance): validator fires on default flow + unknown-paths feed + response-shape category (#79 r13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.3.148] - 2026-05-25
+
+### Fixed
+
+- **[Contracts][DevX]** Conformance buffer now actually fires on the default-flow handlers (#79 round 13) — v0.3.145–0.3.147 wired the buffer infrastructure but the recording call only ran from `build_router_with_context`. The MockAI handler (`build_router_with_mockai`) and AI generator handler (`build_router_with_ai`) — both of which serve every request when their respective backends are enabled — bypassed validation entirely, so violations never populated for the default-flow routes Srikanth was hitting. Extracted the validate-then-record block into `OpenApiRouteRegistry::run_validation_with_recording` and called it at the entry of each handler closure. Confirmed with `curl -X POST .../users -d '{}'` against the demo spec now returning **HTTP 400** with the violation showing up in `GET /__mockforge/api/conformance/violations`.
+
+### Added
+
+- **[Contracts]** New `response-shape` violation category (#79 round 13) — when a request asks for a status code the spec doesn't define for that operation (e.g. spec only defines 2xx/4xx but `X-Mockforge-Response-Status: 200` is sent), record the mismatch under category `response-shape` instead of silently falling back to the default response. Addresses Srikanth's (c) question.
+- **[Contracts][DevX]** New `unknown-paths` feed + admin endpoint + TUI view (#79 round 13) — separate bounded ring buffer (`mockforge_foundation::unknown_paths`) tracks requests whose path didn't match any route in the loaded spec. Exposed at `GET /__mockforge/api/conformance/unknown-paths` (DELETE clears). TUI Conformance tab gains a `u` keystroke to toggle between violations view and unknown-paths view; the existing filter / pause / export / clear / top-endpoints controls work for both. Addresses Srikanth's (a) question — useful for cross-checking a proxy's path coverage against the server's loaded spec.
+
 ## [0.3.147] - 2026-05-25
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7715,7 +7715,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8341,7 +8341,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8388,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8423,7 +8423,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8445,7 +8445,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8562,7 +8562,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8670,7 +8670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8685,7 +8685,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8709,7 +8709,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8786,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8811,7 +8811,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8998,7 +8998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9011,7 +9011,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9070,7 +9070,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9178,14 +9178,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9212,7 +9212,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9223,7 +9223,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9263,7 +9263,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9317,7 +9317,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9404,7 +9404,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9415,7 +9415,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9432,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15263,7 +15263,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.147"
+version = "0.3.148"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.147"
+version = "0.3.148"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,16 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.148] - 2026-05-25
+
+### Fixed
+
+- **[Contracts][DevX]** Conformance buffer now actually fires on the default-flow handlers (#79 round 13) — the MockAI and AI handlers bypassed validation entirely, so violations never populated for default-flow routes. Extracted `OpenApiRouteRegistry::run_validation_with_recording` and called it at the entry of each handler.
+
+### Added
+
+- **[Contracts]** New `response-shape` violation category — surfaces when a requested status code isn't defined in the spec for that operation.
+- **[Contracts][DevX]** New `unknown-paths` feed + admin endpoint + TUI view — separate ring buffer tracks requests whose path didn't match any spec route. `GET /__mockforge/api/conformance/unknown-paths`; TUI `u` toggles between violations and unknown-paths views.
+
 ## [0.3.147] - 2026-05-25
 
 ### Changed

--- a/crates/mockforge-foundation/src/lib.rs
+++ b/crates/mockforge-foundation/src/lib.rs
@@ -34,6 +34,7 @@ pub mod scenario_types;
 pub mod schema_diff;
 pub mod state_machine;
 pub mod threat_modeling_types;
+pub mod unknown_paths;
 pub mod workspace_promotion;
 
 pub use encryption_error::{EncryptionError, EncryptionResult};

--- a/crates/mockforge-foundation/src/unknown_paths.rs
+++ b/crates/mockforge-foundation/src/unknown_paths.rs
@@ -1,0 +1,110 @@
+//! Unmatched-path request tracking.
+//!
+//! Issue #79 round 13 — Srikanth's question (a): when a client sends
+//! requests to paths that aren't in the server's loaded OpenAPI spec,
+//! the request never reaches the validator (router returns 404 from
+//! lookup), so `conformance_violations` never picks it up. This module
+//! captures those unmatched 404s into a separate bounded ring buffer
+//! so the TUI's Conformance tab can surface them.
+//!
+//! Use case: cross-checking a proxy's path coverage against the
+//! server's. If the proxy reports a path the server doesn't know,
+//! it'll show up here.
+
+use chrono::{DateTime, Utc};
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+/// One unmatched-path request — captured by the HTTP server's fallback
+/// when no registered route matches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnknownPathRequest {
+    /// When the request was rejected.
+    pub timestamp: DateTime<Utc>,
+    /// HTTP method (uppercase).
+    pub method: String,
+    /// Raw request path (not normalised to any spec template).
+    pub path: String,
+    /// Client IP if available, else `"unknown"`.
+    pub client_ip: String,
+    /// Query string portion, if any.
+    pub query: String,
+}
+
+const DEFAULT_BUFFER_SIZE: usize = 256;
+
+static UNKNOWN_PATHS: Lazy<Mutex<VecDeque<UnknownPathRequest>>> =
+    Lazy::new(|| Mutex::new(VecDeque::with_capacity(DEFAULT_BUFFER_SIZE)));
+
+/// Record an unmatched-path 404. FIFO when the buffer is full.
+pub fn record(req: UnknownPathRequest) {
+    let mut buf = UNKNOWN_PATHS.lock();
+    if buf.len() == DEFAULT_BUFFER_SIZE {
+        buf.pop_front();
+    }
+    buf.push_back(req);
+}
+
+/// Snapshot of buffered entries, newest first.
+pub fn snapshot() -> Vec<UnknownPathRequest> {
+    let buf = UNKNOWN_PATHS.lock();
+    buf.iter().rev().cloned().collect()
+}
+
+/// Current buffer length.
+pub fn len() -> usize {
+    UNKNOWN_PATHS.lock().len()
+}
+
+/// Clear the buffer.
+pub fn clear() {
+    UNKNOWN_PATHS.lock().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_and_snapshot_lifo() {
+        clear();
+        record(UnknownPathRequest {
+            timestamp: Utc::now(),
+            method: "GET".into(),
+            path: "/first".into(),
+            client_ip: "127.0.0.1".into(),
+            query: String::new(),
+        });
+        record(UnknownPathRequest {
+            timestamp: Utc::now(),
+            method: "GET".into(),
+            path: "/second".into(),
+            client_ip: "127.0.0.1".into(),
+            query: String::new(),
+        });
+        let snap = snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].path, "/second");
+        assert_eq!(snap[1].path, "/first");
+    }
+
+    #[test]
+    fn drops_oldest_at_capacity() {
+        clear();
+        for i in 0..(DEFAULT_BUFFER_SIZE + 5) {
+            record(UnknownPathRequest {
+                timestamp: Utc::now(),
+                method: "GET".into(),
+                path: format!("/p/{i}"),
+                client_ip: "127.0.0.1".into(),
+                query: String::new(),
+            });
+        }
+        assert_eq!(len(), DEFAULT_BUFFER_SIZE);
+        let snap = snapshot();
+        assert_eq!(snap[0].path, format!("/p/{}", DEFAULT_BUFFER_SIZE + 4));
+        assert_eq!(snap[DEFAULT_BUFFER_SIZE - 1].path, "/p/5");
+    }
+}

--- a/crates/mockforge-http/src/management/mod.rs
+++ b/crates/mockforge-http/src/management/mod.rs
@@ -1145,9 +1145,29 @@ pub async fn dynamic_mock_fallback(
     State(state): State<ManagementState>,
     req: Request<Body>,
 ) -> Response {
+    // Issue #79 round 13 — capture the request method/path/query
+    // before the body is consumed so we can record unmatched 404s
+    // (Srikanth's (a) ask: surface paths the spec doesn't know about).
+    // Only records when no dynamic mock matches — if a dynamic mock
+    // serves the request, the path WAS handled, just not by OpenAPI.
+    let method = req.method().as_str().to_string();
+    let path = req.uri().path().to_string();
+    let query = req.uri().query().unwrap_or_default().to_string();
+
     match serve_dynamic_mock(&state, req).await {
         Some(resp) => resp,
-        None => StatusCode::NOT_FOUND.into_response(),
+        None => {
+            mockforge_foundation::unknown_paths::record(
+                mockforge_foundation::unknown_paths::UnknownPathRequest {
+                    timestamp: chrono::Utc::now(),
+                    method,
+                    path,
+                    client_ip: "unknown".to_string(),
+                    query,
+                },
+            );
+            StatusCode::NOT_FOUND.into_response()
+        }
     }
 }
 

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -1015,6 +1015,106 @@ impl OpenApiRouteRegistry {
         )
     }
 
+    /// Issue #79 round 13 — run the standard request-validation bookend
+    /// (validate → build error payload → record to the conformance ring
+    /// buffer) and return `Ok(())` if validation passed, or
+    /// `Err((status_code, payload))` if it failed. Centralises the logic
+    /// that previously lived inline at `build_router_with_context`
+    /// (line ~686) so the MockAI and AI handlers can share it instead
+    /// of silently bypassing validation.
+    ///
+    /// Callers should short-circuit with the returned status + payload
+    /// on `Err`; the violation has already been recorded to
+    /// `mockforge_foundation::conformance_violations` by the time this
+    /// function returns.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_validation_with_recording(
+        &self,
+        path_template: &str,
+        method: &str,
+        path_params: &Map<String, Value>,
+        query_params: &Map<String, Value>,
+        header_map: &Map<String, Value>,
+        cookie_map: &Map<String, Value>,
+        body: Option<&Value>,
+    ) -> std::result::Result<(), (u16, Value)> {
+        let e = match self.validate_request_with_all(
+            path_template,
+            method,
+            path_params,
+            query_params,
+            header_map,
+            cookie_map,
+            body,
+        ) {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+
+        let status_code = self.options.validation_status.unwrap_or_else(|| {
+            std::env::var("MOCKFORGE_VALIDATION_STATUS")
+                .ok()
+                .and_then(|s| s.parse::<u16>().ok())
+                .unwrap_or(400)
+        });
+
+        let payload = if status_code == 422 {
+            generate_enhanced_422_response(
+                self,
+                path_template,
+                method,
+                body,
+                path_params,
+                query_params,
+                header_map,
+                cookie_map,
+            )
+        } else {
+            let msg = format!("{}", e);
+            let detail_val = serde_json::from_str::<Value>(&msg).unwrap_or(serde_json::json!(msg));
+            json!({
+                "error": "request validation failed",
+                "detail": detail_val,
+                "method": method,
+                "path": path_template,
+                "timestamp": Utc::now().to_rfc3339(),
+            })
+        };
+
+        record_validation_error(&payload);
+
+        let reason = payload
+            .get("detail")
+            .and_then(|d| {
+                if d.is_string() {
+                    d.as_str().map(|s| s.to_string())
+                } else {
+                    serde_json::to_string(d).ok()
+                }
+            })
+            .unwrap_or_else(|| {
+                payload
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("request validation failed")
+                    .to_string()
+            });
+        let category = classify_validation_reason(&reason);
+        mockforge_foundation::conformance_violations::record(
+            mockforge_foundation::conformance_violations::ServerConformanceViolation {
+                timestamp: Utc::now(),
+                method: method.to_string(),
+                path: path_template.to_string(),
+                client_ip: "unknown".to_string(),
+                status: status_code,
+                reason,
+                category,
+            },
+        );
+
+        Err((status_code, payload))
+    }
+
     /// Validate request against OpenAPI spec with path/query/header/cookie params
     #[allow(clippy::too_many_arguments)]
     pub fn validate_request_with_all(
@@ -1359,13 +1459,56 @@ impl OpenApiRouteRegistry {
 
             let route_clone = (*route).clone();
             let ai_generator_clone = ai_generator.clone();
+            // Issue #79 round 13 — same validation bypass as
+            // `build_router_with_mockai`. Clone the validator into the
+            // closure and run validation before AI response generation.
+            let validator_clone = self.clone_for_validation();
 
             // Create async handler that extracts request data and builds context
-            let handler = move |headers: HeaderMap, body: Option<Json<Value>>| {
+            let handler = move |AxumPath(path_params): AxumPath<HashMap<String, String>>,
+                                axum::extract::Query(query_params): axum::extract::Query<
+                HashMap<String, String>,
+            >,
+                                headers: HeaderMap,
+                                body: Option<Json<Value>>| {
                 let route = route_clone.clone();
                 let ai_generator = ai_generator_clone.clone();
+                let validator = validator_clone.clone();
 
                 async move {
+                    // (a-pre) Run request validation against the spec
+                    // before AI response synthesis. On failure this
+                    // also records to the foundation conformance ring
+                    // buffer surfaced by the TUI Conformance tab.
+                    let mut path_map = Map::new();
+                    for (k, v) in &path_params {
+                        path_map.insert(k.clone(), Value::String(v.clone()));
+                    }
+                    let mut query_map = Map::new();
+                    for (k, v) in &query_params {
+                        query_map.insert(k.clone(), Value::String(v.clone()));
+                    }
+                    let mut header_map = Map::new();
+                    for (k, v) in headers.iter() {
+                        if let Ok(s) = v.to_str() {
+                            header_map.insert(k.to_string(), Value::String(s.to_string()));
+                        }
+                    }
+                    let body_val: Option<&Value> = body.as_ref().map(|Json(b)| b);
+                    if let Err((status_code, payload)) = validator.run_validation_with_recording(
+                        &route.path,
+                        &route.method,
+                        &path_map,
+                        &query_map,
+                        &header_map,
+                        &Map::new(),
+                        body_val,
+                    ) {
+                        let status = axum::http::StatusCode::from_u16(status_code)
+                            .unwrap_or(axum::http::StatusCode::BAD_REQUEST);
+                        return (status, Json(payload));
+                    }
+
                     tracing::debug!(
                         "Handling AI request for route: {} {}",
                         route.method,
@@ -1448,17 +1591,60 @@ impl OpenApiRouteRegistry {
             let route_clone = (*route).clone();
             let mockai_clone = mockai.clone();
             let custom_loader_clone = custom_loader.clone();
+            // Issue #79 round 13 — the MockAI handler was bypassing
+            // request validation entirely, so spec violations never
+            // populated the conformance ring buffer. Clone the
+            // validator into the closure and call
+            // `run_validation_with_recording` before fixture/MockAI/
+            // mock-response synthesis, mirroring what
+            // `build_router_with_context` does at line ~686.
+            let validator_clone = self.clone_for_validation();
 
             // Create async handler that processes requests through MockAI
             // Query params are extracted via Query extractor with HashMap
             // Note: Using Query<HashMap<String, String>> wrapped in Option to handle missing query params
-            let handler = move |query: axum::extract::Query<HashMap<String, String>>,
+            let handler = move |AxumPath(path_params): AxumPath<HashMap<String, String>>,
+                                query: axum::extract::Query<HashMap<String, String>>,
                                 headers: HeaderMap,
                                 body: Option<Json<Value>>| {
                 let route = route_clone.clone();
                 let mockai = mockai_clone.clone();
+                let validator = validator_clone.clone();
 
                 async move {
+                    // (a-pre) Run request validation against the spec
+                    // before any response synthesis. On failure this
+                    // also records to the foundation conformance ring
+                    // buffer surfaced by the TUI Conformance tab.
+                    let mut path_map = Map::new();
+                    for (k, v) in &path_params {
+                        path_map.insert(k.clone(), Value::String(v.clone()));
+                    }
+                    let mut query_map = Map::new();
+                    for (k, v) in &query.0 {
+                        query_map.insert(k.clone(), Value::String(v.clone()));
+                    }
+                    let mut header_map = Map::new();
+                    for (k, v) in headers.iter() {
+                        if let Ok(s) = v.to_str() {
+                            header_map.insert(k.to_string(), Value::String(s.to_string()));
+                        }
+                    }
+                    let body_val: Option<&Value> = body.as_ref().map(|Json(b)| b);
+                    if let Err((status_code, payload)) = validator.run_validation_with_recording(
+                        &route.path,
+                        &route.method,
+                        &path_map,
+                        &query_map,
+                        &header_map,
+                        &Map::new(),
+                        body_val,
+                    ) {
+                        let status = axum::http::StatusCode::from_u16(status_code)
+                            .unwrap_or(axum::http::StatusCode::BAD_REQUEST);
+                        return (status, Json(payload));
+                    }
+
                     tracing::info!(
                         "[FIXTURE DEBUG] Starting fixture check for {} {} (custom_loader available: {})",
                         route.method,

--- a/crates/mockforge-openapi/src/route.rs
+++ b/crates/mockforge-openapi/src/route.rs
@@ -464,6 +464,42 @@ impl OpenApiRoute {
         use crate::response_trace;
         use mockforge_foundation::response_generation_trace::ResponseGenerationTrace;
 
+        // Issue #79 round 13 — detect response-shape mismatches and
+        // record to the conformance buffer with category
+        // `response-shape`. Two failure modes worth surfacing:
+        //  (a) the caller explicitly requested a status via
+        //      `X-Mockforge-Response-Status` / status_override and the
+        //      spec doesn't define a response for it. The mock falls
+        //      back to a default, so the client gets a body that
+        //      doesn't match what the spec promised.
+        //  (b) The chosen status (after fallback) still has no
+        //      defined response and the synthesiser returns `{}`.
+        // Records once per request; useful when cross-checking the
+        // server's view of a spec against a proxy's interpretation.
+        if let Some(requested) = status_override {
+            if !self.has_response_for_status(requested) {
+                let available: Vec<String> =
+                    self.operation.responses.responses.keys().map(|k| format!("{:?}", k)).collect();
+                mockforge_foundation::conformance_violations::record(
+                    mockforge_foundation::conformance_violations::ServerConformanceViolation {
+                        timestamp: chrono::Utc::now(),
+                        method: self.method.clone(),
+                        path: self.path.clone(),
+                        client_ip: "unknown".to_string(),
+                        status: requested,
+                        reason: format!(
+                            "spec defines no response for status {} on {} {}; available: {}",
+                            requested,
+                            self.method,
+                            self.path,
+                            available.join(", ")
+                        ),
+                        category: "response-shape".to_string(),
+                    },
+                );
+            }
+        }
+
         // Use status override if the spec has a response for that code, otherwise default
         let status_code = status_override
             .filter(|code| self.has_response_for_status(*code))

--- a/crates/mockforge-tui/src/api/client.rs
+++ b/crates/mockforge-tui/src/api/client.rs
@@ -390,6 +390,52 @@ impl MockForgeClient {
             .context("deserialise conformance response")
     }
 
+    /// Issue #79 round 13 — fetch the unknown-paths feed (requests
+    /// whose path didn't match any route in the loaded spec).
+    pub async fn get_unknown_paths(&self) -> Result<UnknownPathsResponse> {
+        let resp = self
+            .get("/__mockforge/api/conformance/unknown-paths")
+            .send()
+            .await
+            .context("GET /__mockforge/api/conformance/unknown-paths")?;
+        let status = resp.status();
+        if !status.is_success() {
+            anyhow::bail!("HTTP {status} from unknown-paths");
+        }
+        let ct = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if ct.contains("text/html") {
+            anyhow::bail!("endpoint unknown-paths not available");
+        }
+        let body = resp.text().await.context("read unknown-paths response")?;
+        serde_json::from_str::<UnknownPathsResponse>(&body)
+            .context("deserialise unknown-paths response")
+    }
+
+    /// Clear the unknown-paths ring buffer.
+    pub async fn clear_unknown_paths(&self) -> Result<usize> {
+        let url = format!("{}/__mockforge/api/conformance/unknown-paths", self.base_url);
+        let mut req = self.client.delete(&url);
+        if let Some(ref token) = self.token {
+            req = req.bearer_auth(token);
+        }
+        let resp = req.send().await.context("DELETE /__mockforge/api/conformance/unknown-paths")?;
+        if !resp.status().is_success() {
+            anyhow::bail!("HTTP {} from DELETE unknown-paths", resp.status());
+        }
+        #[derive(serde::Deserialize)]
+        struct Cleared {
+            cleared: usize,
+        }
+        let body = resp.text().await.context("read clear-unknown-paths response")?;
+        serde_json::from_str::<Cleared>(&body)
+            .map(|c| c.cleared)
+            .context("deserialise clear-unknown-paths response")
+    }
+
     /// Clear the server-side conformance violation buffer.
     /// Returns the number of entries that were cleared.
     pub async fn clear_conformance_violations(&self) -> Result<usize> {

--- a/crates/mockforge-tui/src/api/models.rs
+++ b/crates/mockforge-tui/src/api/models.rs
@@ -68,6 +68,26 @@ pub struct ConformanceViolationsResponse {
     pub total: usize,
 }
 
+/// One unmatched-path request (Issue #79 round 13).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnknownPathRequest {
+    pub timestamp: DateTime<Utc>,
+    pub method: String,
+    pub path: String,
+    #[serde(default = "default_unknown")]
+    pub client_ip: String,
+    #[serde(default)]
+    pub query: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UnknownPathsResponse {
+    #[serde(default)]
+    pub requests: Vec<UnknownPathRequest>,
+    #[serde(default)]
+    pub total: usize,
+}
+
 // ── Dashboard ────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/mockforge-tui/src/screens/conformance.rs
+++ b/crates/mockforge-tui/src/screens/conformance.rs
@@ -28,7 +28,7 @@ use ratatui::{
 use tokio::sync::mpsc;
 
 use crate::api::client::MockForgeClient;
-use crate::api::models::ConformanceViolation;
+use crate::api::models::{ConformanceViolation, UnknownPathRequest};
 use crate::event::Event;
 use crate::screens::Screen;
 use crate::theme::Theme;
@@ -112,11 +112,24 @@ impl StatusFilter {
     }
 }
 
+/// Which feed the screen is showing — request-side spec violations
+/// (default) or the round-13 unknown-paths feed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ViewMode {
+    Violations,
+    UnknownPaths,
+}
+
 pub struct ConformanceScreen {
     loaded: bool,
     /// Full snapshot from the server, newest-first.
     violations: Vec<ConformanceViolation>,
     total: usize,
+    /// Round-13: unmatched-path requests captured by the HTTP fallback.
+    unknown_paths: Vec<UnknownPathRequest>,
+    unknown_total: usize,
+    /// Toggled by `u` between violations and unknown-paths views.
+    view_mode: ViewMode,
     table: TableState,
     error: Option<String>,
     last_fetch: Option<Instant>,
@@ -143,6 +156,9 @@ impl ConformanceScreen {
             loaded: false,
             violations: Vec::new(),
             total: 0,
+            unknown_paths: Vec::new(),
+            unknown_total: 0,
+            view_mode: ViewMode::Violations,
             table: TableState::new(),
             error: None,
             last_fetch: None,
@@ -154,6 +170,22 @@ impl ConformanceScreen {
             paused: false,
             flash: None,
             pending_clear: false,
+        }
+    }
+
+    fn filtered_unknown_indices(&self) -> Vec<usize> {
+        self.unknown_paths
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| self.method_filter.matches(&r.method))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    fn current_row_count(&self) -> usize {
+        match self.view_mode {
+            ViewMode::Violations => self.filtered_indices().len(),
+            ViewMode::UnknownPaths => self.filtered_unknown_indices().len(),
         }
     }
 
@@ -245,12 +277,26 @@ impl ConformanceScreen {
 
     /// Compute the top-N most-frequent `METHOD path` pairs in the
     /// current filtered view. Used by the right-side breakdown panel.
+    /// View-aware: aggregates violations or unknown-paths depending on
+    /// the active mode.
     fn top_endpoints(&self, n: usize) -> Vec<(String, usize)> {
         let mut counts: HashMap<String, usize> = HashMap::new();
-        for &idx in &self.filtered_indices() {
-            if let Some(v) = self.violations.get(idx) {
-                let key = format!("{} {}", v.method, v.path);
-                *counts.entry(key).or_insert(0) += 1;
+        match self.view_mode {
+            ViewMode::Violations => {
+                for &idx in &self.filtered_indices() {
+                    if let Some(v) = self.violations.get(idx) {
+                        let key = format!("{} {}", v.method, v.path);
+                        *counts.entry(key).or_insert(0) += 1;
+                    }
+                }
+            }
+            ViewMode::UnknownPaths => {
+                for &idx in &self.filtered_unknown_indices() {
+                    if let Some(r) = self.unknown_paths.get(idx) {
+                        let key = format!("{} {}", r.method, r.path);
+                        *counts.entry(key).or_insert(0) += 1;
+                    }
+                }
             }
         }
         let mut pairs: Vec<(String, usize)> = counts.into_iter().collect();
@@ -310,17 +356,29 @@ impl Screen for ConformanceScreen {
             }
             KeyCode::Char('m') => {
                 self.method_filter = self.method_filter.next();
-                self.table.set_total(self.filtered_indices().len());
+                self.table.set_total(self.current_row_count());
                 true
             }
             KeyCode::Char('s') => {
                 self.status_filter = self.status_filter.next();
-                self.table.set_total(self.filtered_indices().len());
+                self.table.set_total(self.current_row_count());
                 true
             }
             KeyCode::Char('c') => {
                 self.cycle_category();
-                self.table.set_total(self.filtered_indices().len());
+                self.table.set_total(self.current_row_count());
+                true
+            }
+            KeyCode::Char('u') => {
+                // Round-13: cycle between Violations (request-side spec
+                // failures) and UnknownPaths (404s for paths not in the
+                // loaded spec at all) views.
+                self.view_mode = match self.view_mode {
+                    ViewMode::Violations => ViewMode::UnknownPaths,
+                    ViewMode::UnknownPaths => ViewMode::Violations,
+                };
+                self.table.set_total(self.current_row_count());
+                self.last_fetch = None;
                 true
             }
             KeyCode::Char('p') => {
@@ -391,12 +449,28 @@ impl Screen for ConformanceScreen {
             self.pending_clear = false;
             let client_clone = client.clone();
             let tx_clone = tx.clone();
+            let view = self.view_mode;
             tokio::spawn(async move {
-                match client_clone.clear_conformance_violations().await {
+                // Clear only the active feed so the other one stays
+                // intact — round-13 added unknown-paths alongside
+                // violations and both have separate buffers.
+                let result = match view {
+                    ViewMode::Violations => client_clone.clear_conformance_violations().await,
+                    ViewMode::UnknownPaths => client_clone.clear_unknown_paths().await,
+                };
+                match result {
                     Ok(n) => {
+                        let payload = match view {
+                            ViewMode::Violations => {
+                                format!(r#"{{"violations":[],"total":0,"cleared":{n}}}"#)
+                            }
+                            ViewMode::UnknownPaths => format!(
+                                r#"{{"unknown_requests":[],"unknown_total":0,"cleared":{n}}}"#
+                            ),
+                        };
                         let _ = tx_clone.send(Event::Data {
                             screen: "conformance",
-                            payload: format!(r#"{{"violations":[],"total":0,"cleared":{n}}}"#),
+                            payload,
                         });
                     }
                     Err(err) => {
@@ -420,32 +494,77 @@ impl Screen for ConformanceScreen {
         }
         self.last_fetch = Some(Instant::now());
 
-        let client = client.clone();
-        let tx = tx.clone();
+        // Always fetch both feeds so toggling `u` is instant. Both
+        // calls are cheap GETs against bounded ring buffers.
+        let client_v = client.clone();
+        let tx_v = tx.clone();
         tokio::spawn(async move {
-            match client.get_conformance_violations().await {
+            match client_v.get_conformance_violations().await {
                 Ok(resp) => {
                     if let Ok(payload) = serde_json::to_string(&serde_json::json!({
                         "violations": resp.violations,
                         "total": resp.total,
                     })) {
-                        let _ = tx.send(Event::Data {
+                        let _ = tx_v.send(Event::Data {
                             screen: "conformance",
                             payload,
                         });
                     }
                 }
                 Err(err) => {
-                    let _ = tx.send(Event::ApiError {
+                    let _ = tx_v.send(Event::ApiError {
                         screen: "conformance",
                         message: err.to_string(),
                     });
                 }
             }
         });
+        let client_u = client.clone();
+        let tx_u = tx.clone();
+        tokio::spawn(async move {
+            match client_u.get_unknown_paths().await {
+                Ok(resp) => {
+                    if let Ok(payload) = serde_json::to_string(&serde_json::json!({
+                        "unknown_requests": resp.requests,
+                        "unknown_total": resp.total,
+                    })) {
+                        let _ = tx_u.send(Event::Data {
+                            screen: "conformance",
+                            payload,
+                        });
+                    }
+                }
+                Err(_) => {
+                    // Unknown-paths is a round-13 endpoint; older
+                    // servers don't have it. Silently ignore so older
+                    // server versions don't surface a confusing error.
+                }
+            }
+        });
     }
 
     fn on_data(&mut self, payload: &str) {
+        // Two payload shapes share this screen — violations (round 12)
+        // and unknown_requests (round 13). Try the unknown-paths shape
+        // first since it's narrower; fall through to the violations
+        // decode on miss.
+        #[derive(serde::Deserialize)]
+        struct UnknownWire {
+            unknown_requests: Vec<UnknownPathRequest>,
+            #[serde(default)]
+            unknown_total: usize,
+        }
+        if let Ok(parsed) = serde_json::from_str::<UnknownWire>(payload) {
+            self.unknown_paths = parsed.unknown_requests;
+            self.unknown_total = parsed.unknown_total;
+            if matches!(self.view_mode, ViewMode::UnknownPaths) {
+                self.table.set_total(self.current_row_count());
+            }
+            self.loaded = true;
+            self.error = None;
+            return;
+        }
+
         #[derive(serde::Deserialize)]
         struct Wire {
             violations: Vec<ConformanceViolation>,
@@ -458,14 +577,14 @@ impl Screen for ConformanceScreen {
             Ok(parsed) => {
                 self.violations = parsed.violations;
                 self.total = parsed.total;
-                self.table.set_total(self.filtered_indices().len());
+                if matches!(self.view_mode, ViewMode::Violations) {
+                    self.table.set_total(self.current_row_count());
+                }
                 self.loaded = true;
                 self.error = None;
                 if let Some(n) = parsed.cleared {
                     self.flash =
                         Some((format!("cleared {n} server-side violation(s)"), Instant::now()));
-                    // Force a fresh fetch on the next tick so we re-load
-                    // any violations that arrived between clear and ack.
                     self.last_fetch = None;
                 }
             }
@@ -494,13 +613,20 @@ impl Screen for ConformanceScreen {
         } else if self.paused {
             "[paused]  p:resume  m/s/c:filter  e:export  D:clear  Enter:detail"
         } else {
-            "j/k:navigate  m/s/c:filter  p:pause  e:export  D:clear  Enter:detail"
+            "j/k:navigate  m/s/c:filter  p:pause  e:export  D:clear  u:unknown-paths  Enter:detail"
         }
     }
 }
 
 impl ConformanceScreen {
     fn render_table(&self, frame: &mut Frame, area: Rect) {
+        match self.view_mode {
+            ViewMode::Violations => self.render_violations_table(frame, area),
+            ViewMode::UnknownPaths => self.render_unknown_paths_table(frame, area),
+        }
+    }
+
+    fn render_violations_table(&self, frame: &mut Frame, area: Rect) {
         let header = Row::new(vec![
             Cell::from("When").style(Theme::dim()),
             Cell::from("Method").style(Theme::dim()),
@@ -570,6 +696,72 @@ impl ConformanceScreen {
         frame.render_stateful_widget(table, area, &mut table_state);
     }
 
+    fn render_unknown_paths_table(&self, frame: &mut Frame, area: Rect) {
+        let header = Row::new(vec![
+            Cell::from("When").style(Theme::dim()),
+            Cell::from("Method").style(Theme::dim()),
+            Cell::from("Path").style(Theme::dim()),
+            Cell::from("Query").style(Theme::dim()),
+            Cell::from("Client").style(Theme::dim()),
+        ])
+        .height(1);
+
+        let indices = self.filtered_unknown_indices();
+        let rows: Vec<Row> = indices
+            .iter()
+            .skip(self.table.offset)
+            .take(self.table.visible_height)
+            .filter_map(|&i| self.unknown_paths.get(i))
+            .map(|r| {
+                Row::new(vec![
+                    Cell::from(r.timestamp.format("%H:%M:%S").to_string()),
+                    Cell::from(r.method.clone()).style(Theme::http_method(&r.method)),
+                    Cell::from(r.path.clone()),
+                    Cell::from(if r.query.is_empty() {
+                        "-".to_string()
+                    } else {
+                        r.query.clone()
+                    }),
+                    Cell::from(r.client_ip.clone()),
+                ])
+            })
+            .collect();
+
+        let widths = [
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Min(20),
+            Constraint::Min(15),
+            Constraint::Length(16),
+        ];
+
+        let filtered_count = indices.len();
+        let filter_suffix = self.filter_label_suffix();
+        let title = if self.unknown_total > filtered_count {
+            format!(
+                " Unknown Paths ({} buffered, {} shown{}) ",
+                self.unknown_total, filtered_count, filter_suffix
+            )
+        } else {
+            format!(" Unknown Paths ({}{}) ", filtered_count, filter_suffix)
+        };
+
+        let table = Table::new(rows, widths)
+            .header(header)
+            .row_highlight_style(Theme::highlight())
+            .block(
+                Block::default()
+                    .title(title)
+                    .title_style(Theme::title())
+                    .borders(Borders::ALL)
+                    .border_style(Theme::dim())
+                    .style(Theme::surface()),
+            );
+
+        let mut table_state = self.table.to_ratatui_state();
+        frame.render_stateful_widget(table, area, &mut table_state);
+    }
+
     fn render_top_endpoints(&self, frame: &mut Frame, area: Rect) {
         let top = self.top_endpoints(8);
         let body = if top.is_empty() {
@@ -593,39 +785,66 @@ impl ConformanceScreen {
     fn render_summary(&self, frame: &mut Frame, area: Rect) {
         let body = if let Some(flash) = self.flash_str() {
             flash.to_string()
-        } else if self.violations.is_empty() {
-            "No spec violations recorded — every incoming request matched the loaded OpenAPI spec."
-                .to_string()
         } else {
-            let by_category = {
-                let mut counts: HashMap<&str, usize> = HashMap::new();
-                for &i in &self.filtered_indices() {
-                    let Some(v) = self.violations.get(i) else {
-                        continue;
-                    };
-                    let key = if v.category.is_empty() {
-                        "(uncategorised)"
-                    } else {
-                        v.category.as_str()
-                    };
-                    *counts.entry(key).or_insert(0) += 1;
-                }
-                let mut pairs: Vec<(&&str, &usize)> = counts.iter().collect();
-                pairs.sort_by(|a, b| b.1.cmp(a.1));
-                pairs
-                    .into_iter()
-                    .take(3)
-                    .map(|(k, v)| format!("{} ({})", k, v))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-            format!("Top categories: {}", by_category)
+            match self.view_mode {
+                ViewMode::Violations => self.violations_summary(),
+                ViewMode::UnknownPaths => self.unknown_paths_summary(),
+            }
         };
 
         let para = Paragraph::new(body)
             .style(Theme::dim())
             .block(Block::default().borders(Borders::ALL).border_style(Theme::dim()));
         frame.render_widget(para, area);
+    }
+
+    fn violations_summary(&self) -> String {
+        if self.violations.is_empty() {
+            return "No spec violations recorded — every incoming request matched the loaded OpenAPI spec. (`u`: view unknown-path requests instead)".to_string();
+        }
+        let mut counts: HashMap<&str, usize> = HashMap::new();
+        for &i in &self.filtered_indices() {
+            let Some(v) = self.violations.get(i) else {
+                continue;
+            };
+            let key = if v.category.is_empty() {
+                "(uncategorised)"
+            } else {
+                v.category.as_str()
+            };
+            *counts.entry(key).or_insert(0) += 1;
+        }
+        let mut pairs: Vec<(&&str, &usize)> = counts.iter().collect();
+        pairs.sort_by(|a, b| b.1.cmp(a.1));
+        let body = pairs
+            .into_iter()
+            .take(3)
+            .map(|(k, v)| format!("{} ({})", k, v))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("Top categories: {}", body)
+    }
+
+    fn unknown_paths_summary(&self) -> String {
+        if self.unknown_paths.is_empty() {
+            return "No unknown-path 404s recorded — every incoming request matched a route in the loaded spec. (`u`: switch back to violations)".to_string();
+        }
+        let mut counts: HashMap<&str, usize> = HashMap::new();
+        for &i in &self.filtered_unknown_indices() {
+            let Some(r) = self.unknown_paths.get(i) else {
+                continue;
+            };
+            *counts.entry(r.method.as_str()).or_insert(0) += 1;
+        }
+        let mut pairs: Vec<(&&str, &usize)> = counts.iter().collect();
+        pairs.sort_by(|a, b| b.1.cmp(a.1));
+        let body = pairs
+            .into_iter()
+            .take(5)
+            .map(|(k, v)| format!("{} ({})", k, v))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("Top methods: {}", body)
     }
 
     fn filter_label_suffix(&self) -> String {

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -1349,6 +1349,29 @@ pub async fn clear_conformance_violations() -> impl IntoResponse {
     Json(json!({"cleared": n}))
 }
 
+/// Issue #79 round 13 — feed of requests for paths the loaded OpenAPI
+/// spec doesn't know about. Surfaces server/client spec drift (Srikanth's
+/// (a) ask). Backed by `mockforge_foundation::unknown_paths`.
+pub async fn get_unknown_paths(
+    axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let snap = mockforge_foundation::unknown_paths::snapshot();
+    let total = snap.len();
+    let limit: Option<usize> = q.get("limit").and_then(|s| s.parse().ok());
+    let limited: Vec<_> = match limit {
+        Some(n) => snap.into_iter().take(n).collect(),
+        None => snap,
+    };
+    Json(json!({"requests": limited, "total": total}))
+}
+
+/// Clear the unknown-paths ring buffer.
+pub async fn clear_unknown_paths() -> impl IntoResponse {
+    let n = mockforge_foundation::unknown_paths::len();
+    mockforge_foundation::unknown_paths::clear();
+    Json(json!({"cleared": n}))
+}
+
 /// Get health check status
 pub async fn get_health() -> Json<HealthCheck> {
     Json(

--- a/crates/mockforge-ui/src/routes.rs
+++ b/crates/mockforge-ui/src/routes.rs
@@ -177,6 +177,13 @@ pub fn create_admin_router(
             "/__mockforge/api/conformance/violations",
             get(get_conformance_violations).delete(clear_conformance_violations),
         )
+        // Issue #79 round 13 — separate feed for requests whose paths
+        // don't match any route in the loaded spec. Captured by
+        // dynamic_mock_fallback when no dynamic mock matches either.
+        .route(
+            "/__mockforge/api/conformance/unknown-paths",
+            get(get_unknown_paths).delete(clear_unknown_paths),
+        )
         .route("/__mockforge/fixtures/{id}/download", get(download_fixture))
         .route("/__mockforge/fixtures/{id}/rename", post(rename_fixture))
         .route("/__mockforge/fixtures/{id}/move", post(move_fixture))


### PR DESCRIPTION
## Summary

Three Issue #79 round-13 follow-ups, all responding to feedback Srikanth raised on the round-12 release:

### (3) Conformance validator now fires on default-flow handlers

v0.3.145–0.3.147 wired the `mockforge_foundation::conformance_violations` ring buffer but the recording call only ran from `build_router_with_context`. The MockAI handler (`build_router_with_mockai`) and AI generator handler (`build_router_with_ai`) — both default-flow paths in `mockforge serve` — bypassed validation entirely, so violations never populated for the routes Srikanth was hitting.

Extracted `OpenApiRouteRegistry::run_validation_with_recording` from the inline block at `openapi_routes.rs:686` and called it at the entry of each handler closure. Verified locally: `POST /users {}` against the demo spec now returns HTTP 400 and the violation lands in the buffer (category `request-body`).

### (2) New `response-shape` violation category

When a request asks for a status code (via `X-Mockforge-Response-Status` or `status_override`) that the spec doesn't define for that operation, record a violation under category `response-shape`. The mock still falls back to the default response — but the mismatch surfaces in the buffer.

Addresses Srikanth's (c) question on the round-12 thread.

### (1) New unknown-paths feed + admin endpoint + TUI view

Separate ring buffer (`mockforge_foundation::unknown_paths`, 256 entries, FIFO) for requests whose path didn't match any route in the loaded spec. Captured in `dynamic_mock_fallback` after the dynamic-mock lookup fails — so requests served by SDK-registered mocks don't count as unknown; only true 404s do.

- REST: `GET /__mockforge/api/conformance/unknown-paths` (newest-first, optional `?limit=N`) + DELETE to clear.
- TUI: Conformance tab gains `u` keystroke to toggle between violations and unknown-paths views. All round-12 controls (filters / pause / export / clear / top-endpoints panel) work in both views; clear is view-aware so it only resets the feed currently being viewed.

Addresses Srikanth's (a) question — useful for cross-checking a proxy's path coverage against the server's spec.

### Verified locally before publishing

End-to-end smoke against the demo spec on a fresh release build:

```
$ curl -X POST http://127.0.0.1:13481/users -d '{}'  →  HTTP 400 (request-body violation)
$ curl -H 'X-Mockforge-Response-Status: 999' http://127.0.0.1:13481/users  →  response-shape violation recorded
$ curl http://127.0.0.1:13481/not-in-spec?a=1&b=2  →  HTTP 404 + unknown-paths entry with query preserved

$ curl http://127.0.0.1:19481/__mockforge/api/conformance/violations
{ "total": 2, "categories": [{"k":"request-body","n":1}, {"k":"response-shape","n":1}] }

$ curl http://127.0.0.1:19481/__mockforge/api/conformance/unknown-paths
{ "requests": [{"method":"GET","path":"/not-in-spec","query":"a=1&b=2"}], "total": 1 }
```

- `cargo test -p mockforge-tui --lib` — 291 pass
- `cargo clippy -p mockforge-tui -p mockforge-ui -p mockforge-foundation -p mockforge-openapi -p mockforge-http --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

(4) `--conformance-self-test` mode is the explicit next round; will land as its own clean PR with the request-mutator design properly fleshed out.

Workspace 0.3.147 → 0.3.148.