### PR TITLE
feat(registry): wire registry-server to shared init_sentry helper

### DIFF
--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -30,7 +30,15 @@ saas = [
   "saml",
   "cache-redis",
   "platform-signing-aws-kms",
+  "sentry",
 ]
+
+# Server-side error tracking via Sentry. Delegates to the shared helper in
+# `mockforge-observability` (PR #643) so registry-server, mockforge-cli, and
+# any future binary share one source of truth on env var names + defaults.
+# No-op at runtime when SENTRY_DSN is unset, so this stays on in the saas
+# rollup without forcing OSS users to stand up a Sentry account.
+sentry = ["mockforge-observability/sentry"]
 
 # HSM-backed platform signing-root rotation via AWS KMS (Issue #550).
 # Off in OSS builds — the registry can still load + verify rotation
@@ -155,7 +163,7 @@ mockforge-core = { version = "0.3.70", path = "../mockforge-core" }
 mockforge-federation = { version = "0.3.70", path = "../mockforge-federation" }
 mockforge-scenarios = { version = "0.3.70", path = "../mockforge-scenarios" }
 mockforge-plugin-registry = { version = "0.3.70", path = "../mockforge-plugin-registry" }
-mockforge-observability = { version = "0.3.70", path = "../mockforge-observability" }
+mockforge-observability = { version = "0.3.70", path = "../mockforge-observability", default-features = false, features = ["sysinfo", "log-shipper"] }
 # SSRF guard reused at the trigger_run handler — primary enforcement
 # before runs hit the Redis queue. The runner-side guard in
 # mockforge_bench::cloud_api is defense-in-depth.

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 use tokio::signal;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::trace::TraceLayer;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use mockforge_registry_server::circuit_breaker::{self, CircuitBreaker, CircuitBreakerRegistry};
 use mockforge_registry_server::config::Config;
@@ -35,14 +34,24 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize tracing
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "mockforge_registry_server=info,tower_http=debug".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    // Initialize Sentry first so panics and errors during the rest of startup
+    // are captured. No-op at runtime when SENTRY_DSN is unset. The returned
+    // guard's Drop flushes queued events on shutdown — bind it to a
+    // main-scoped local so it lives for the whole program. Uses the shared
+    // helper in mockforge-observability (PR #643) so registry-server and
+    // mockforge-cli agree on env var names + defaults.
+    #[cfg(feature = "sentry")]
+    let _sentry_guard = mockforge_observability::init_sentry();
+
+    // Initialize tracing via the shared init_logging — which automatically
+    // includes the sentry-tracing layer when the `sentry` feature is on, so
+    // `tracing::error!` flows to Sentry without an extra wire-up here.
+    if let Err(e) =
+        mockforge_observability::init_logging(mockforge_observability::LoggingConfig::default())
+    {
+        eprintln!("Failed to initialize logging: {}", e);
+        std::process::exit(1);
+    }
 
     // Load configuration
     let config = Config::load()?;

--- a/fly.registry.toml
+++ b/fly.registry.toml
@@ -32,6 +32,10 @@ primary_region = "iad"
 #   SMTP_USERNAME         - Brevo login email
 #   SMTP_PASSWORD         - Brevo SMTP key
 #   PROMETHEUS_SCRAPE_TOKEN - Optional: bearer token Prometheus must send to scrape /metrics. When unset, /metrics is publicly readable — set this in production (issue #647). Configure in Prometheus via `bearer_token` (or `bearer_token_file`) on the scrape config.
+#   SENTRY_DSN            - Optional: server-side error tracking. When unset/empty, no events are captured.
+#   SENTRY_ENVIRONMENT    - Optional: defaults to "production". Use "staging" / "preview" on non-prod apps.
+#   SENTRY_RELEASE        - Optional: defaults to the crate version. Override to tag deploys with a git SHA or Fly release ID.
+#   SENTRY_TRACES_SAMPLE_RATE - Optional: 0.0–1.0 perf trace sampling. Default 0.0 (errors only).
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary

Replaces the now-closed [#642](https://github.com/SaaSy-Solutions/mockforge/pull/642). That PR added a registry-server-local copy of the Sentry init module, but PR #643 introduced the canonical shared helper in `mockforge-observability` with the same env-var contract. #642's branch is structurally stale against the post-#643 main, and a registry-server-local copy alongside the shared one would be the kind of drift the shared helper was meant to prevent.

This PR threads registry-server through the shared helper instead.

## Changes

- New `sentry` feature on `mockforge-registry-server`, included in the `saas` rollup. Activates `mockforge-observability/sentry`.
- `main.rs`: call `mockforge_observability::init_sentry()` first so panics during startup are captured, then `mockforge_observability::init_logging(...)` instead of the inline `tracing_subscriber::registry()` block. `init_logging` already adds the `sentry-tracing` layer behind the `sentry` feature (PR #643), so `tracing::error!` flows to Sentry without extra wire-up.
- `fly.registry.toml`: documents the `SENTRY_DSN` / `ENVIRONMENT` / `RELEASE` / `TRACES_SAMPLE_RATE` secrets.

## Behaviour change worth flagging

The prior inline subscriber defaulted the env filter to `"mockforge_registry_server=info,tower_http=debug"` when `RUST_LOG` was unset. `init_logging` defaults to `"info"` only. To get the tower_http debug noise back, set `RUST_LOG` explicitly in `fly.registry.toml`'s `[env]` section. Negligible loss in practice — that extra debug logging wasn't load-bearing.

## Test plan

- [x] `cargo build -p mockforge-registry-server` — green
- [x] `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` — green
- [x] `cargo fmt --all --check` — green
- [ ] After deploy: set `SENTRY_DSN` via `flyctl secrets set --app mockforge-registry SENTRY_DSN=…` and verify a deliberate `tracing::error!` shows up in the Sentry project. Without setting the DSN, behaviour is unchanged from today.

## Closes the registry-server side of issue #654 item 2 (observability)

After this lands and `SENTRY_DSN` is set in prod, server-side error capture is complete across both the registry server and the per-tenant hosted mocks (PR #643 already covered the latter via mockforge-cli).