### PR TITLE
feat(observability): drift Prometheus metrics + chaos/async/workspace dashboards (#678, #684)

### DIFF
--- a/crates/mockforge-http/src/middleware/drift_tracking.rs
+++ b/crates/mockforge-http/src/middleware/drift_tracking.rs
@@ -170,6 +170,24 @@ pub async fn drift_tracking_middleware_with_extensions(
                 // Evaluate drift budget
                 let drift_result = state.drift_engine.evaluate(&diff_result, &path, &method);
 
+                // Emit Prometheus gauges for the drift dashboard (#678). The
+                // workspace_id is not yet plumbed through the middleware —
+                // pass an empty label so a single global series records,
+                // matching the pattern used for the non-workspace
+                // `pillar_tracking` calls below. When workspace identification
+                // lands we can switch this label to the resolved id.
+                mockforge_observability::get_global_registry().record_drift_evaluation(
+                    mockforge_observability::DriftEvaluationSample {
+                        workspace_id: "",
+                        endpoint: &path,
+                        method: &method,
+                        total: drift_result.metrics.total_changes,
+                        breaking: drift_result.breaking_changes,
+                        potentially_breaking: drift_result.potentially_breaking_changes,
+                        budget_exceeded: drift_result.budget_exceeded,
+                    },
+                );
+
                 // Record contracts pillar usage for drift detection
                 mockforge_core::pillar_tracking::record_contracts_usage(
                     None, // workspace_id could be extracted from request if available

--- a/crates/mockforge-observability/src/lib.rs
+++ b/crates/mockforge-observability/src/lib.rs
@@ -28,7 +28,7 @@ pub mod tracing_integration;
 
 // Re-export commonly used items
 pub use logging::{init_logging, init_logging_with_otel, LoggingConfig};
-pub use prometheus::{get_global_registry, MetricsRegistry};
+pub use prometheus::{get_global_registry, DriftEvaluationSample, MetricsRegistry};
 #[cfg(feature = "sentry")]
 pub use sentry_init::init_sentry;
 pub use system_metrics::{start_system_metrics_collector, SystemMetricsConfig};

--- a/crates/mockforge-observability/src/prometheus/metrics.rs
+++ b/crates/mockforge-observability/src/prometheus/metrics.rs
@@ -8,6 +8,24 @@ use prometheus::{
 use std::sync::Arc;
 use tracing::debug;
 
+/// A single drift evaluation sample to feed into
+/// [`MetricsRegistry::record_drift_evaluation`]. Borrows the string labels
+/// so callers don't have to allocate per-request.
+///
+/// `workspace_id` should be the empty string when the request isn't tied to a
+/// specific tenant (the global "drift-by-endpoint" series remains useful and
+/// the dashboards collapse the label).
+#[derive(Debug, Clone, Copy)]
+pub struct DriftEvaluationSample<'a> {
+    pub workspace_id: &'a str,
+    pub endpoint: &'a str,
+    pub method: &'a str,
+    pub total: u32,
+    pub breaking: u32,
+    pub potentially_breaking: u32,
+    pub budget_exceeded: bool,
+}
+
 /// Global metrics registry for MockForge
 #[derive(Clone)]
 pub struct MetricsRegistry {
@@ -89,6 +107,21 @@ pub struct MetricsRegistry {
     pub marketplace_search_duration_seconds: HistogramVec,
     pub marketplace_errors_total: IntCounterVec,
     pub marketplace_items_total: IntGaugeVec,
+
+    // Contract-drift metrics (issue #678) — emitted whenever
+    // `DriftBudgetEngine::evaluate*` runs against a request via the HTTP
+    // drift-tracking middleware. Labelled by workspace and endpoint so the
+    // MockOps UI's DriftPercentageDashboard can break down per-resource.
+    /// Drift severity as a 0.0–100.0 percentage (breaking + potentially-breaking
+    /// changes ÷ total observed mismatches × 100). 0 means no drift detected.
+    pub drift_percentage: GaugeVec,
+    /// Count of total mismatches observed in the last evaluation.
+    pub drift_total_changes: IntGaugeVec,
+    /// Count of breaking changes in the last evaluation. > 0 indicates a
+    /// contract-breaking drift event that should page someone.
+    pub drift_breaking_changes: IntGaugeVec,
+    /// Boolean (0 or 1) — was the configured drift budget exceeded?
+    pub drift_budget_exceeded: IntGaugeVec,
 }
 
 impl MetricsRegistry {
@@ -495,6 +528,44 @@ impl MetricsRegistry {
         )
         .expect("Failed to create marketplace_items_total metric");
 
+        // Drift metrics (#678). Labelled by workspace + endpoint + method so
+        // both the MockOps drift dashboard and per-API alerting work.
+        let drift_percentage = GaugeVec::new(
+            Opts::new(
+                "mockforge_drift_percentage",
+                "Contract drift severity as a 0.0–100.0 percentage (breaking + potentially-breaking ÷ total observed × 100)",
+            ),
+            &["workspace_id", "endpoint", "method"],
+        )
+        .expect("Failed to create drift_percentage metric");
+
+        let drift_total_changes = IntGaugeVec::new(
+            Opts::new(
+                "mockforge_drift_total_changes",
+                "Total mismatches observed in the most recent drift evaluation",
+            ),
+            &["workspace_id", "endpoint", "method"],
+        )
+        .expect("Failed to create drift_total_changes metric");
+
+        let drift_breaking_changes = IntGaugeVec::new(
+            Opts::new(
+                "mockforge_drift_breaking_changes",
+                "Breaking changes observed in the most recent drift evaluation",
+            ),
+            &["workspace_id", "endpoint", "method"],
+        )
+        .expect("Failed to create drift_breaking_changes metric");
+
+        let drift_budget_exceeded = IntGaugeVec::new(
+            Opts::new(
+                "mockforge_drift_budget_exceeded",
+                "1 when the configured drift budget was exceeded by the most recent evaluation, 0 otherwise",
+            ),
+            &["workspace_id", "endpoint", "method"],
+        )
+        .expect("Failed to create drift_budget_exceeded metric");
+
         // Register all metrics
         registry
             .register(Box::new(requests_total.clone()))
@@ -655,6 +726,18 @@ impl MetricsRegistry {
         registry
             .register(Box::new(marketplace_items_total.clone()))
             .expect("Failed to register marketplace_items_total");
+        registry
+            .register(Box::new(drift_percentage.clone()))
+            .expect("Failed to register drift_percentage");
+        registry
+            .register(Box::new(drift_total_changes.clone()))
+            .expect("Failed to register drift_total_changes");
+        registry
+            .register(Box::new(drift_breaking_changes.clone()))
+            .expect("Failed to register drift_breaking_changes");
+        registry
+            .register(Box::new(drift_budget_exceeded.clone()))
+            .expect("Failed to register drift_budget_exceeded");
 
         debug!("Initialized Prometheus metrics registry");
 
@@ -713,7 +796,42 @@ impl MetricsRegistry {
             marketplace_search_duration_seconds,
             marketplace_errors_total,
             marketplace_items_total,
+            drift_percentage,
+            drift_total_changes,
+            drift_breaking_changes,
+            drift_budget_exceeded,
         }
+    }
+
+    /// Record a contract-drift evaluation result against the workspace +
+    /// endpoint Prometheus gauges. Closes part of #678.
+    ///
+    /// Callers pass:
+    /// - `workspace_id` — empty string for un-attributed evaluations (legacy)
+    /// - `endpoint` and `method` — the request that was evaluated
+    /// - `total`, `breaking`, `potentially_breaking`, `non_breaking` — counts
+    ///   from `DriftResult`
+    /// - `budget_exceeded` — whether the configured budget tripped
+    ///
+    /// The "drift percentage" is computed as
+    /// `(breaking + potentially_breaking) / total * 100`. A zero-total
+    /// evaluation records 0% drift (the request matched the contract
+    /// exactly).
+    pub fn record_drift_evaluation(&self, sample: DriftEvaluationSample<'_>) {
+        let pct = if sample.total == 0 {
+            0.0
+        } else {
+            (sample.breaking + sample.potentially_breaking) as f64 / sample.total as f64 * 100.0
+        };
+        let labels = [sample.workspace_id, sample.endpoint, sample.method];
+        self.drift_percentage.with_label_values(&labels).set(pct);
+        self.drift_total_changes.with_label_values(&labels).set(sample.total as i64);
+        self.drift_breaking_changes
+            .with_label_values(&labels)
+            .set(sample.breaking as i64);
+        self.drift_budget_exceeded
+            .with_label_values(&labels)
+            .set(if sample.budget_exceeded { 1 } else { 0 });
     }
 
     /// Get the underlying Prometheus registry
@@ -1111,6 +1229,80 @@ mod tests {
     fn test_global_registry() {
         let registry = get_global_registry();
         assert!(registry.is_initialized());
+    }
+
+    #[test]
+    fn test_record_drift_evaluation_basic_percentage() {
+        let registry = MetricsRegistry::new();
+        // 1 breaking + 2 potentially_breaking out of 10 total = 30%
+        registry.record_drift_evaluation(DriftEvaluationSample {
+            workspace_id: "ws-a",
+            endpoint: "/users",
+            method: "GET",
+            total: 10,
+            breaking: 1,
+            potentially_breaking: 2,
+            budget_exceeded: false,
+        });
+
+        let pct = registry.drift_percentage.with_label_values(&["ws-a", "/users", "GET"]).get();
+        assert!((pct - 30.0).abs() < f64::EPSILON);
+        assert_eq!(
+            registry.drift_total_changes.with_label_values(&["ws-a", "/users", "GET"]).get(),
+            10
+        );
+        assert_eq!(
+            registry
+                .drift_breaking_changes
+                .with_label_values(&["ws-a", "/users", "GET"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            registry
+                .drift_budget_exceeded
+                .with_label_values(&["ws-a", "/users", "GET"])
+                .get(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_record_drift_evaluation_zero_total_is_zero_percent() {
+        let registry = MetricsRegistry::new();
+        // No mismatches observed → 0% drift, not a divide-by-zero.
+        registry.record_drift_evaluation(DriftEvaluationSample {
+            workspace_id: "",
+            endpoint: "/health",
+            method: "GET",
+            total: 0,
+            breaking: 0,
+            potentially_breaking: 0,
+            budget_exceeded: false,
+        });
+        let pct = registry.drift_percentage.with_label_values(&["", "/health", "GET"]).get();
+        assert_eq!(pct, 0.0);
+    }
+
+    #[test]
+    fn test_record_drift_evaluation_budget_exceeded_flag() {
+        let registry = MetricsRegistry::new();
+        registry.record_drift_evaluation(DriftEvaluationSample {
+            workspace_id: "ws-b",
+            endpoint: "/orders",
+            method: "POST",
+            total: 4,
+            breaking: 2,
+            potentially_breaking: 0,
+            budget_exceeded: true,
+        });
+        assert_eq!(
+            registry
+                .drift_budget_exceeded
+                .with_label_values(&["ws-b", "/orders", "POST"])
+                .get(),
+            1
+        );
     }
 
     #[test]

--- a/crates/mockforge-observability/src/prometheus/mod.rs
+++ b/crates/mockforge-observability/src/prometheus/mod.rs
@@ -11,7 +11,7 @@ mod exporter;
 mod metrics;
 
 pub use exporter::{metrics_handler, prometheus_router};
-pub use metrics::{get_global_registry, MetricsRegistry};
+pub use metrics::{get_global_registry, DriftEvaluationSample, MetricsRegistry};
 
 // Re-export prometheus types for users who need to access metrics directly
 pub use prometheus;

--- a/grafana/dashboards/mockforge-async-protocols.json
+++ b/grafana/dashboards/mockforge-async-protocols.json
@@ -1,0 +1,150 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping the MockForge /metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "Async protocol brokers (Kafka, MQTT, AMQP, WebSocket, SMTP). Visualises connection counts, message throughput, and broker-specific gauges (MQTT topics / retained messages, WS connections). Pair with service-overview when async traffic is part of the system under test.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "uid": "mockforge-async-protocols",
+  "title": "MockForge — Async Protocols",
+  "tags": ["mockforge", "kafka", "mqtt", "amqp", "websocket"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "WS connections",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [{ "expr": "mockforge_ws_connections_active", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "MQTT connections",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [{ "expr": "mockforge_mqtt_connections_active", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "MQTT topics",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [{ "expr": "mockforge_mqtt_topics_active", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "SMTP connections",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [{ "expr": "mockforge_smtp_connections_active", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "timeseries",
+      "title": "WebSocket: messages sent / received (rate)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        { "expr": "sum(rate(mockforge_ws_messages_sent[5m]))", "legendFormat": "sent", "refId": "A" },
+        { "expr": "sum(rate(mockforge_ws_messages_received[5m]))", "legendFormat": "received", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "MQTT: messages published / received (rate)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        { "expr": "sum(rate(mockforge_mqtt_messages_published_total[5m]))", "legendFormat": "published", "refId": "A" },
+        { "expr": "sum(rate(mockforge_mqtt_messages_received_total[5m]))", "legendFormat": "received", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "SMTP: messages received / stored (rate)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        { "expr": "sum(rate(mockforge_smtp_messages_received_total[5m]))", "legendFormat": "received", "refId": "A" },
+        { "expr": "sum(rate(mockforge_smtp_messages_stored_total[5m]))", "legendFormat": "stored", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Async errors (rate)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        { "expr": "sum(rate(mockforge_ws_errors_total[5m]))", "legendFormat": "ws", "refId": "A" },
+        { "expr": "sum(rate(mockforge_mqtt_errors_total[5m]))", "legendFormat": "mqtt", "refId": "B" },
+        { "expr": "sum(rate(mockforge_smtp_errors_total[5m]))", "legendFormat": "smtp", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "MQTT retained messages + subscriptions",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "targets": [
+        { "expr": "mockforge_mqtt_retained_messages", "legendFormat": "retained", "refId": "A" },
+        { "expr": "mockforge_mqtt_subscriptions_active", "legendFormat": "subscriptions", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "WS connection durations (p50 / p95 / p99)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))", "legendFormat": "p50", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))", "legendFormat": "p95", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))", "legendFormat": "p99", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    }
+  ]
+}

--- a/grafana/dashboards/mockforge-chaos.json
+++ b/grafana/dashboards/mockforge-chaos.json
@@ -1,0 +1,222 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping the MockForge /metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "Chaos engineering activity for the MockForge stack. Visualises latency / fault / rate-limit / scenario triggers emitted by mockforge-chaos middleware against the active scenario mode and drift evaluations from mockforge-http drift_tracking. Pair with the service-overview dashboard to correlate chaos with downstream latency/error spikes.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "uid": "mockforge-chaos",
+  "title": "MockForge — Chaos & Resilience",
+  "tags": ["mockforge", "chaos", "reality"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "trigger_type",
+        "label": "Trigger type",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(mockforge_chaos_triggers_total, trigger_type)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Active scenario mode",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        { "expr": "max(mockforge_active_scenario_mode)", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "off" }, "1": { "text": "running" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Chaos trigger rate (1m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        { "expr": "sum(rate(mockforge_chaos_triggers_total{trigger_type=~\"$trigger_type\"}[1m]))", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "decimals": 2,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        }
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Drift % (max across endpoints)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        { "expr": "max(mockforge_drift_percentage)", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 25 }
+            ]
+          }
+        }
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Endpoints over drift budget",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        { "expr": "sum(mockforge_drift_budget_exceeded == 1)", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Chaos triggers by type",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "expr": "sum by (trigger_type) (rate(mockforge_chaos_triggers_total{trigger_type=~\"$trigger_type\"}[5m]))",
+          "legendFormat": "{{trigger_type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Drift % over time (top 10 endpoints)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        {
+          "expr": "topk(10, mockforge_drift_percentage)",
+          "legendFormat": "{{method}} {{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Breaking changes detected (rate)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "expr": "sum by (endpoint, method) (rate(mockforge_drift_breaking_changes[5m]))",
+          "legendFormat": "{{method}} {{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Error rate during chaos (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "expr": "sum by (protocol) (rate(mockforge_errors_total[5m])) / clamp_min(sum by (protocol) (rate(mockforge_requests_total[5m])), 1)",
+          "legendFormat": "{{protocol}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" }
+        }
+      }
+    }
+  ]
+}

--- a/grafana/dashboards/mockforge-workspace.json
+++ b/grafana/dashboards/mockforge-workspace.json
@@ -1,0 +1,195 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping the MockForge /metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "table", "name": "Table", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "Per-workspace request rate, errors, latency, and SLO posture. Use the workspace dropdown to drill into a single tenant. Wired against mockforge_workspace_* metrics emitted by the HTTP middleware when workspace_id is resolved on the request path.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "uid": "mockforge-workspace",
+  "title": "MockForge — Workspace",
+  "tags": ["mockforge", "workspace", "slo"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "workspace",
+        "label": "Workspace",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(mockforge_workspace_requests_total, workspace_id)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Request rate (now)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        { "expr": "sum(rate(mockforge_workspace_requests_total{workspace_id=~\"$workspace\"}[1m]))", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 1, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Error rate (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        { "expr": "sum(rate(mockforge_workspace_errors_total{workspace_id=~\"$workspace\"}[5m])) / clamp_min(sum(rate(mockforge_workspace_requests_total{workspace_id=~\"$workspace\"}[5m])), 1)", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "red", "value": 0.01 }
+            ]
+          }
+        }
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "p95 latency (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_workspace_requests_duration_seconds_bucket{workspace_id=~\"$workspace\"}[5m])))", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 3, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.5 }, { "color": "red", "value": 1 }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Active routes (sum)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        { "expr": "sum(mockforge_workspace_active_routes{workspace_id=~\"$workspace\"})", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } } },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate per workspace",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        { "expr": "sum by (workspace_id) (rate(mockforge_workspace_requests_total{workspace_id=~\"$workspace\"}[5m]))", "legendFormat": "{{workspace_id}}", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Error rate per workspace",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        { "expr": "sum by (workspace_id) (rate(mockforge_workspace_errors_total{workspace_id=~\"$workspace\"}[5m])) / clamp_min(sum by (workspace_id) (rate(mockforge_workspace_requests_total{workspace_id=~\"$workspace\"}[5m])), 1)", "legendFormat": "{{workspace_id}}", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "p95 latency per workspace",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (workspace_id, le) (rate(mockforge_workspace_requests_duration_seconds_bucket{workspace_id=~\"$workspace\"}[5m])))", "legendFormat": "{{workspace_id}}", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "SLO compliance — service availability",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        { "expr": "max by (service) (mockforge_service_availability)", "legendFormat": "{{service}}", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.99 },
+              { "color": "green", "value": 0.999 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Error budget remaining",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "targets": [
+        { "expr": "max by (service) (mockforge_error_budget_remaining)", "legendFormat": "{{service}}", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.25 },
+              { "color": "green", "value": 0.5 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #678 and #684.

## #678 — drift metrics emission

Until now `DriftPercentageDashboard.tsx` queried \`mockforge_drift_percentage\` that nobody emitted.

- Four labelled gauges: \`mockforge_drift_percentage\`, \`mockforge_drift_total_changes\`, \`mockforge_drift_breaking_changes\`, \`mockforge_drift_budget_exceeded\` (workspace_id + endpoint + method)
- \`MetricsRegistry::record_drift_evaluation(DriftEvaluationSample)\` helper. Borrowed struct keeps clippy happy and lets us add sample fields later without touching call sites
- Wired into \`mockforge-http::middleware::drift_tracking\` right after each \`evaluate()\` — every spec-validated request updates the gauges
- 3 unit tests (basic %, zero-total ⇒ 0 not NaN, budget-exceeded flag)

## #684 — additional Grafana dashboards

- \`mockforge-chaos.json\` — scenario mode, chaos trigger rate, drift % top-10, breaking-change rate, error rate during chaos
- \`mockforge-async-protocols.json\` — WS/MQTT/SMTP connections + publish/receive rates + retained messages + connection p50/p95/p99
- \`mockforge-workspace.json\` — per-workspace request rate / error rate / p95 + SLO + error budget

All queries verified against \`crates/mockforge-observability/src/prometheus/metrics.rs\`.

## Test plan

- [x] \`cargo test -p mockforge-observability --lib test_record_drift\` — 3/3 pass
- [x] \`cargo check -p mockforge-observability -p mockforge-http\` — clean
- [x] Pre-commit hooks (clippy, fmt, typos) pass