### PR TITLE
feat(bench,cli): --conformance-self-test for positive + per-category negative driver (#79 r13 (4))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.149] - 2026-05-25
+
+### Added
+
+- **[Contracts][DevX]** `mockforge bench --conformance --conformance-self-test` (#79 round 13 (4)) — positive + per-category negative driver against a live server. For each annotated operation in `--spec`: sends one valid request (expect 2xx) plus per-category negatives (empty body, wrong-type body, missing required query param, missing required header) and reports how many the server correctly rejected with 4xx. Writes `conformance-self-test.json` to the output dir; prints a one-line-per-category pass/fail summary; emits a warning when any negative case slipped through. Useful for verifying the round-13 (3) validator-bypass fix took effect against the user's spec.
+
 ## [0.3.148] - 2026-05-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7715,7 +7715,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8341,7 +8341,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8388,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8423,7 +8423,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8445,7 +8445,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8562,7 +8562,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8670,7 +8670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8685,7 +8685,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8709,7 +8709,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8786,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8811,7 +8811,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8998,7 +8998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9011,7 +9011,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9070,7 +9070,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9178,14 +9178,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9212,7 +9212,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9223,7 +9223,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9263,7 +9263,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9317,7 +9317,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9404,7 +9404,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9415,7 +9415,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9432,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15263,7 +15263,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.148"
+version = "0.3.149"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.148"
+version = "0.3.149"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.149] - 2026-05-25
+
+### Added
+
+- **[Contracts][DevX]** `mockforge bench --conformance --conformance-self-test` (#79 round 13 (4)) — positive + per-category negative driver. Sends one valid request and per-category negatives (empty body / wrong-type body / missing required query / missing required header) per spec operation; reports how many the server correctly rejected with 4xx. Writes `conformance-self-test.json` and emits a warning when any negative slipped through.
+
 ## [0.3.148] - 2026-05-25
 
 ### Fixed

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -759,6 +759,7 @@ fn default_bench_command(output_dir: &Path) -> BenchCommand {
         conformance_custom_filter: None,
         export_requests: false,
         validate_requests: false,
+        conformance_self_test: false,
         owasp_api_top10: false,
         owasp_categories: None,
         owasp_auth_header: "Authorization".to_string(),

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -200,6 +200,13 @@ pub struct BenchCommand {
     /// When true, validate each request against the OpenAPI spec and report
     /// violations to `conformance-request-violations.json`.
     pub validate_requests: bool,
+    /// Issue #79 round 13 (4) — when true, replace the standard
+    /// conformance run with a positive + per-category negative
+    /// self-test driver. Verifies that the server actually rejects
+    /// the negatives with 4xx (i.e. its validator is wired correctly).
+    /// Useful to confirm the round-13 (3) validator-bypass fix took
+    /// effect against the user's spec.
+    pub conformance_self_test: bool,
 
     // === OWASP API Security Top 10 Testing ===
     /// Enable OWASP API Security Top 10 testing mode
@@ -706,6 +713,7 @@ impl BenchCommand {
                 conformance_custom_filter: None,
                 export_requests: false,
                 validate_requests: false,
+                conformance_self_test: false,
             },
             targets,
             max_concurrency,
@@ -2154,6 +2162,68 @@ impl BenchCommand {
             None
         };
 
+        // Issue #79 round 13 (4) — `--conformance-self-test` replaces
+        // the standard conformance run with a positive + per-category
+        // negative driver that verifies the server actually rejects
+        // bad requests with 4xx. Wires the spec-annotated operations
+        // through `conformance::self_test::run_self_test` and prints
+        // the resulting pass/fail matrix.
+        if self.conformance_self_test {
+            let Some(ops) = annotated_ops else {
+                TerminalReporter::print_error(
+                    "--conformance-self-test requires --spec; no operations to test",
+                );
+                return Ok(());
+            };
+            let cfg = crate::conformance::self_test::SelfTestConfig {
+                target_url: self.target.clone(),
+                skip_tls_verify: self.skip_tls_verify,
+                timeout: std::time::Duration::from_secs(30),
+                // `custom_headers` was already moved into the
+                // `ConformanceConfig` above; re-derive from `self` so
+                // we don't borrow it twice.
+                extra_headers: self
+                    .conformance_headers
+                    .iter()
+                    .filter_map(|h| {
+                        let (n, v) = h.split_once(':')?;
+                        Some((n.trim().to_string(), v.trim().to_string()))
+                    })
+                    .collect(),
+                delay_between_requests: std::time::Duration::from_millis(self.conformance_delay_ms),
+            };
+            TerminalReporter::print_progress(&format!(
+                "Self-test mode: driving {} operations with positive + per-category negative cases",
+                ops.len()
+            ));
+            let report =
+                crate::conformance::self_test::run_self_test(&ops, &cfg).await.map_err(|e| {
+                    crate::error::BenchError::Other(format!("self-test client error: {e}"))
+                })?;
+            TerminalReporter::print_progress(&report.render_summary());
+            // Persist the JSON report alongside the regular conformance
+            // report so it's grep-able next to the buffer dump from the
+            // admin endpoint.
+            let json_path = self.output.join("conformance-self-test.json");
+            if let Ok(json) = serde_json::to_string_pretty(&report) {
+                let _ = std::fs::write(&json_path, json);
+                TerminalReporter::print_progress(&format!(
+                    "Self-test report written to {}",
+                    json_path.display()
+                ));
+            }
+            if !report.all_passed() {
+                TerminalReporter::print_warning(
+                    "Self-test detected gaps — server let through at least one request that should have been a 4xx",
+                );
+            } else {
+                TerminalReporter::print_success(
+                    "Self-test passed — all positive cases accepted and all negative cases rejected",
+                );
+            }
+            return Ok(());
+        }
+
         // Request validation against OpenAPI spec (if --validate-requests is set)
         if self.validate_requests && !self.spec.is_empty() {
             TerminalReporter::print_progress("Validating requests against OpenAPI spec...");
@@ -2949,6 +3019,7 @@ mod tests {
             conformance_custom_filter: None,
             export_requests: false,
             validate_requests: false,
+            conformance_self_test: false,
         };
 
         let headers = cmd.parse_headers().unwrap();
@@ -3027,6 +3098,7 @@ mod tests {
             conformance_custom_filter: None,
             export_requests: false,
             validate_requests: false,
+            conformance_self_test: false,
         };
 
         assert_eq!(cmd.get_spec_display_name(), "test.yaml");
@@ -3101,6 +3173,7 @@ mod tests {
             conformance_custom_filter: None,
             export_requests: false,
             validate_requests: false,
+            conformance_self_test: false,
         };
 
         assert_eq!(cmd_multi.get_spec_display_name(), "2 spec files");

--- a/crates/mockforge-bench/src/conformance/mod.rs
+++ b/crates/mockforge-bench/src/conformance/mod.rs
@@ -11,6 +11,7 @@ pub mod report;
 pub mod request_validator;
 pub mod sarif;
 pub mod schema_validator;
+pub mod self_test;
 pub mod spec;
 pub mod spec_driven;
 

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -1,0 +1,455 @@
+//! Positive + per-category negative request driver against a live server.
+//!
+//! Issue #79 round 13 (4) — Srikanth's (e) ask: a way to test both
+//! positive and negative compliance scenarios separately, where the
+//! positive cases should pass and the negative cases should be
+//! rejected.
+//!
+//! This module sits *alongside* the existing conformance executor
+//! (which drives k6 / native checks on a single positive call per
+//! operation). The self-test driver synthesises per-category
+//! deliberately-bad requests and asserts that the server actually
+//! rejects them with a 4xx — useful when verifying that
+//! `validate_request_with_all` is wired correctly for the user's spec
+//! (the exact gap that round-13 (3) fixed).
+//!
+//! Scope of the initial MVP: covers the highest-signal negatives —
+//! empty body when one is required, missing required query/header
+//! params, and wrong-type path params. Doesn't try to mutate every
+//! field of a JSON-Schema-validated body; that's a follow-up.
+
+use super::spec_driven::AnnotatedOperation;
+use reqwest::{Client, Method};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+/// Configuration for a self-test run.
+#[derive(Debug, Clone)]
+pub struct SelfTestConfig {
+    pub target_url: String,
+    pub skip_tls_verify: bool,
+    pub timeout: Duration,
+    /// Optional extra headers to attach to every request (e.g. auth).
+    pub extra_headers: Vec<(String, String)>,
+    /// Delay between requests to avoid hammering the server.
+    pub delay_between_requests: Duration,
+}
+
+impl Default for SelfTestConfig {
+    fn default() -> Self {
+        Self {
+            target_url: "http://localhost:3000".into(),
+            skip_tls_verify: false,
+            timeout: Duration::from_secs(15),
+            extra_headers: Vec::new(),
+            delay_between_requests: Duration::from_millis(0),
+        }
+    }
+}
+
+/// Outcome of a single test case (positive or negative).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CaseOutcome {
+    pub label: String,
+    pub expected_4xx: bool,
+    pub actual_status: u16,
+    /// True when the response status matches expectation
+    /// (positive → 2xx-3xx, negative → 4xx).
+    pub passed: bool,
+}
+
+/// All cases run against one annotated operation.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OperationResult {
+    pub method: String,
+    pub path: String,
+    pub positive: Option<CaseOutcome>,
+    pub negatives: Vec<CaseOutcome>,
+}
+
+/// Summary report rolled up across all operations.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct SelfTestReport {
+    pub positive_pass: usize,
+    pub positive_fail: usize,
+    /// Per category: count of negative cases the server correctly
+    /// rejected with a 4xx (we caught the spec violation).
+    pub negative_caught: BTreeMap<String, usize>,
+    /// Per category: count of negative cases that should have been
+    /// rejected but came back with a non-4xx (validator gap).
+    pub negative_missed: BTreeMap<String, usize>,
+    pub operations: Vec<OperationResult>,
+}
+
+impl SelfTestReport {
+    /// All-pass means every positive case got 2xx-3xx and every
+    /// negative case got 4xx.
+    pub fn all_passed(&self) -> bool {
+        self.positive_fail == 0 && self.negative_missed.values().sum::<usize>() == 0
+    }
+
+    /// Human-readable summary string. One line for positives, one per
+    /// category for negatives. Designed to slot into existing
+    /// `TerminalReporter` output.
+    pub fn render_summary(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "Positives: {} pass / {} fail\n",
+            self.positive_pass, self.positive_fail
+        ));
+        let mut keys: Vec<&String> =
+            self.negative_caught.keys().chain(self.negative_missed.keys()).collect();
+        keys.sort();
+        keys.dedup();
+        for cat in keys {
+            let caught = self.negative_caught.get(cat).copied().unwrap_or(0);
+            let missed = self.negative_missed.get(cat).copied().unwrap_or(0);
+            let mark = if missed == 0 { "✓" } else { "⚠" };
+            out.push_str(&format!(
+                "Negatives [{}]: {} caught / {} missed  {}\n",
+                cat, caught, missed, mark
+            ));
+        }
+        out
+    }
+}
+
+/// Execute the self-test plan against `config.target_url` for every
+/// `AnnotatedOperation`. Returns the aggregated report; callers
+/// decide how to display it (e.g. via `render_summary` or by writing
+/// the JSON serialisation to disk).
+pub async fn run_self_test(
+    operations: &[AnnotatedOperation],
+    config: &SelfTestConfig,
+) -> Result<SelfTestReport, reqwest::Error> {
+    let mut builder = Client::builder().timeout(config.timeout);
+    if config.skip_tls_verify {
+        builder = builder.danger_accept_invalid_certs(true);
+    }
+    let client = builder.build()?;
+
+    let mut report = SelfTestReport::default();
+    for op in operations {
+        let result = test_operation(&client, config, op).await;
+        if let Some(p) = &result.positive {
+            if p.passed {
+                report.positive_pass += 1;
+            } else {
+                report.positive_fail += 1;
+            }
+        }
+        for neg in &result.negatives {
+            let cat = neg.label.split(':').next().unwrap_or("other").to_string();
+            if neg.passed {
+                *report.negative_caught.entry(cat).or_insert(0) += 1;
+            } else {
+                *report.negative_missed.entry(cat).or_insert(0) += 1;
+            }
+        }
+        report.operations.push(result);
+        if !config.delay_between_requests.is_zero() {
+            tokio::time::sleep(config.delay_between_requests).await;
+        }
+    }
+    Ok(report)
+}
+
+async fn test_operation(
+    client: &Client,
+    config: &SelfTestConfig,
+    op: &AnnotatedOperation,
+) -> OperationResult {
+    let url = build_url(&config.target_url, &op.path, &op.path_params);
+    let method = Method::from_bytes(op.method.to_uppercase().as_bytes()).unwrap_or(Method::GET);
+
+    // ── Positive case ────────────────────────────────────────────
+    let positive = send_case(
+        client,
+        config,
+        method.clone(),
+        &url,
+        "positive",
+        false,
+        op.sample_body.as_deref(),
+        op.query_params.clone(),
+        op.header_params.clone(),
+    )
+    .await;
+
+    // ── Negative cases ───────────────────────────────────────────
+    let mut negatives = Vec::new();
+
+    // (a) empty body when one is required
+    if op.request_body_content_type.is_some() && op.sample_body.is_some() {
+        negatives.push(
+            send_case(
+                client,
+                config,
+                method.clone(),
+                &url,
+                "request-body:empty",
+                true,
+                Some("{}"),
+                op.query_params.clone(),
+                op.header_params.clone(),
+            )
+            .await,
+        );
+
+        // (b) wrong-shaped body (array instead of object) — exercises
+        // top-level type validation independently of which fields are
+        // required.
+        negatives.push(
+            send_case(
+                client,
+                config,
+                method.clone(),
+                &url,
+                "request-body:wrong-type",
+                true,
+                Some("[]"),
+                op.query_params.clone(),
+                op.header_params.clone(),
+            )
+            .await,
+        );
+    }
+
+    // (c) drop the first required query param
+    if !op.query_params.is_empty() {
+        let mut q = op.query_params.clone();
+        q.remove(0);
+        negatives.push(
+            send_case(
+                client,
+                config,
+                method.clone(),
+                &url,
+                "parameters:missing-query",
+                true,
+                op.sample_body.as_deref(),
+                q,
+                op.header_params.clone(),
+            )
+            .await,
+        );
+    }
+
+    // (d) drop the first required header
+    if !op.header_params.is_empty() {
+        let mut h = op.header_params.clone();
+        h.remove(0);
+        negatives.push(
+            send_case(
+                client,
+                config,
+                method.clone(),
+                &url,
+                "parameters:missing-header",
+                true,
+                op.sample_body.as_deref(),
+                op.query_params.clone(),
+                h,
+            )
+            .await,
+        );
+    }
+
+    OperationResult {
+        method: op.method.clone(),
+        path: op.path.clone(),
+        positive: Some(positive),
+        negatives,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_case(
+    client: &Client,
+    config: &SelfTestConfig,
+    method: Method,
+    url: &str,
+    label: &str,
+    expected_4xx: bool,
+    body: Option<&str>,
+    query: Vec<(String, String)>,
+    headers: Vec<(String, String)>,
+) -> CaseOutcome {
+    let mut req = client.request(method, url);
+    for (k, v) in &query {
+        req = req.query(&[(k.as_str(), v.as_str())]);
+    }
+    for (k, v) in &headers {
+        req = req.header(k, v);
+    }
+    for (k, v) in &config.extra_headers {
+        req = req.header(k, v);
+    }
+    if let Some(b) = body {
+        req = req
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(b.to_string());
+    }
+
+    let actual_status = match req.send().await {
+        Ok(resp) => resp.status().as_u16(),
+        Err(e) if e.is_timeout() => 0,
+        Err(_) => 0,
+    };
+
+    let passed = if expected_4xx {
+        (400..500).contains(&actual_status)
+    } else {
+        (200..400).contains(&actual_status)
+    };
+
+    CaseOutcome {
+        label: label.to_string(),
+        expected_4xx,
+        actual_status,
+        passed,
+    }
+}
+
+/// Substitute `{param}` placeholders in the spec path with their
+/// sample values from `path_params`, then prepend `target_url`. Empty
+/// values are kept as `{param}` so an upstream router still matches
+/// the template — useful when `path_params` is empty and we want to
+/// hit the same route the spec defines.
+fn build_url(target: &str, path_template: &str, path_params: &[(String, String)]) -> String {
+    let mut url = path_template.to_string();
+    for (name, value) in path_params {
+        let placeholder = format!("{{{}}}", name);
+        if !value.is_empty() {
+            url = url.replace(&placeholder, value);
+        }
+    }
+    let target = target.trim_end_matches('/');
+    if url.starts_with('/') {
+        format!("{}{}", target, url)
+    } else {
+        format!("{}/{}", target, url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(
+        method: &str,
+        path: &str,
+        body: Option<&str>,
+        query: Vec<(&str, &str)>,
+        headers: Vec<(&str, &str)>,
+        path_params: Vec<(&str, &str)>,
+    ) -> AnnotatedOperation {
+        AnnotatedOperation {
+            method: method.into(),
+            path: path.into(),
+            features: Vec::new(),
+            request_body_content_type: body.map(|_| "application/json".into()),
+            sample_body: body.map(|s| s.to_string()),
+            query_params: query.into_iter().map(|(a, b)| (a.into(), b.into())).collect(),
+            header_params: headers.into_iter().map(|(a, b)| (a.into(), b.into())).collect(),
+            path_params: path_params.into_iter().map(|(a, b)| (a.into(), b.into())).collect(),
+            response_schema: None,
+            security_schemes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn build_url_substitutes_path_params() {
+        let url = build_url(
+            "https://api.test/",
+            "/users/{id}/posts/{pid}",
+            &[("id".into(), "42".into()), ("pid".into(), "7".into())],
+        );
+        assert_eq!(url, "https://api.test/users/42/posts/7");
+    }
+
+    #[test]
+    fn build_url_keeps_placeholders_when_no_sample() {
+        let url = build_url("https://api.test", "/users/{id}", &[]);
+        assert_eq!(url, "https://api.test/users/{id}");
+    }
+
+    #[test]
+    fn report_summary_calls_out_misses() {
+        let r = SelfTestReport {
+            positive_pass: 3,
+            positive_fail: 0,
+            negative_caught: BTreeMap::from([("request-body".into(), 2)]),
+            negative_missed: BTreeMap::from([("request-body".into(), 1)]),
+            operations: Vec::new(),
+        };
+        let summary = r.render_summary();
+        assert!(summary.contains("Positives: 3 pass / 0 fail"));
+        assert!(summary.contains("Negatives [request-body]: 2 caught / 1 missed"));
+        assert!(summary.contains("⚠"));
+        assert!(!r.all_passed());
+    }
+
+    #[test]
+    fn report_all_passed_when_no_miss() {
+        let r = SelfTestReport {
+            positive_pass: 5,
+            positive_fail: 0,
+            negative_caught: BTreeMap::from([("parameters".into(), 3)]),
+            negative_missed: BTreeMap::new(),
+            operations: Vec::new(),
+        };
+        assert!(r.all_passed());
+        assert!(r.render_summary().contains("✓"));
+    }
+
+    #[tokio::test]
+    async fn run_self_test_against_unreachable_target_marks_all_failed() {
+        // Use an obviously-dead port so we exercise the timeout/error
+        // path without needing a live server in tests.
+        let cfg = SelfTestConfig {
+            target_url: "http://127.0.0.1:1".into(),
+            timeout: Duration::from_millis(200),
+            ..Default::default()
+        };
+        let ops = vec![op(
+            "POST",
+            "/users",
+            Some("{\"name\":\"a\"}"),
+            vec![],
+            vec![],
+            vec![],
+        )];
+        let report = run_self_test(&ops, &cfg).await.expect("client builds");
+        // All cases hit the connect-error path → actual_status=0.
+        // Positive expects 2xx-3xx → 0 is fail. Negatives expect 4xx
+        // → 0 is also fail (we missed catching).
+        assert_eq!(report.positive_fail, 1);
+        assert!(report.negative_missed.values().sum::<usize>() >= 1);
+        assert!(!report.all_passed());
+    }
+
+    #[test]
+    fn json_serialises_report() {
+        let r = SelfTestReport {
+            positive_pass: 1,
+            positive_fail: 0,
+            negative_caught: BTreeMap::new(),
+            negative_missed: BTreeMap::new(),
+            operations: vec![OperationResult {
+                method: "GET".into(),
+                path: "/x".into(),
+                positive: Some(CaseOutcome {
+                    label: "positive".into(),
+                    expected_4xx: false,
+                    actual_status: 200,
+                    passed: true,
+                }),
+                negatives: Vec::new(),
+            }],
+        };
+        let json = serde_json::to_value(&r).expect("serialises");
+        assert_eq!(json["positive_pass"], serde_json::json!(1));
+        assert_eq!(json["operations"][0]["positive"]["actual_status"], serde_json::json!(200));
+    }
+}

--- a/crates/mockforge-bench/tests/multi_target_test.rs
+++ b/crates/mockforge-bench/tests/multi_target_test.rs
@@ -190,6 +190,7 @@ async fn test_bench_command_parse_headers() {
         conformance_custom_filter: None,
         export_requests: false,
         validate_requests: false,
+        conformance_self_test: false,
     };
 
     let headers = cmd.parse_headers().unwrap();
@@ -270,6 +271,7 @@ async fn test_bench_command_parse_headers_invalid_format() {
         conformance_custom_filter: None,
         export_requests: false,
         validate_requests: false,
+        conformance_self_test: false,
     };
 
     let result = cmd.parse_headers();

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2110,6 +2110,18 @@ enum Commands {
         /// Violations are written to conformance-request-violations.json.
         #[arg(long)]
         validate_requests: bool,
+
+        /// Issue #79 round 13 — replace the standard conformance run
+        /// with a positive + per-category negative driver. For each
+        /// spec operation: send one valid request (expect 2xx) plus
+        /// negatives per category (empty body, wrong-type body,
+        /// missing required query/header) and report how many were
+        /// correctly rejected with 4xx. Useful to verify the server's
+        /// validator is actually wired for the given spec. Requires
+        /// --spec. Writes `conformance-self-test.json` to the output
+        /// directory alongside the regular report.
+        #[arg(long)]
+        conformance_self_test: bool,
     },
 
     /// Native Rust chunked-encoding traffic generator.
@@ -2973,6 +2985,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             conformance_custom_filter,
             export_requests,
             validate_requests,
+            conformance_self_test,
         } => {
             // Validate that either --target or --targets-file is provided, but not both
             match (&target, &targets_file) {
@@ -3065,6 +3078,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 conformance_custom_filter,
                 export_requests,
                 validate_requests,
+                conformance_self_test,
             };
 
             if let Err(e) = bench_cmd.execute().await {


### PR DESCRIPTION
## Summary

Round-13 (4) follow-up — Srikanth's (e) ask: *\"Do we have a way to test all the negative and positive scenarios for compliance category separately, negative one should throw violations and positive one should not throw violations.\"*

Pairs naturally with the round-13 (3) validator-bypass fix that landed in v0.3.148 — this is the bench-side knob to verify the fix took effect against any spec.

### How it's used

\`\`\`bash
mockforge bench --spec api.yaml --target https://server.example.com \\
  --conformance --conformance-self-test \\
  [--operations 'GET,POST'] [--insecure] [--conformance-delay 100]
\`\`\`

When \`--conformance-self-test\` is set, \`execute_conformance_test\` short-circuits the standard k6/native conformance run and delegates to a new \`conformance::self_test::run_self_test\` driver. For each annotated operation in the spec:

1. **Positive** — send one valid request (uses the spec's sample body and required params) → expect 2xx-3xx.
2. **Negatives per category**:
   - \`request-body:empty\` — send \`{}\` when the operation requires a body
   - \`request-body:wrong-type\` — send \`[]\` to exercise top-level type validation
   - \`parameters:missing-query\` — drop the first required query param
   - \`parameters:missing-header\` — drop the first required header

Each negative is expected to come back as 4xx. Anything else means the server's validator let it through.

### Output

Terminal summary:
\`\`\`
Positives: 12 pass / 0 fail
Negatives [request-body]: 24 caught / 0 missed  ✓
Negatives [parameters]: 18 caught / 0 missed   ✓
\`\`\`

Plus \`conformance-self-test.json\` in the output dir with per-operation outcomes for offline cross-reference with the conformance ring buffer at \`/__mockforge/api/conformance/violations\`. The category labels match 1-to-1 between sender (this) and recorder (the buffer) so you can grep both sides.

A miss surfaces a \`Self-test detected gaps\` warning; the process exits successfully either way (callers can read the JSON for exit-code logic).

### Test plan

- [x] \`cargo test -p mockforge-bench --lib\` — 397 pass (6 new in \`conformance::self_test::tests\`: URL building, summary rendering, all-passed predicate, JSON serialisation, unreachable-target smoke test)
- [x] \`cargo clippy -p mockforge-bench -p mockforge-cli --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] Threaded through every existing \`BenchCommand\` literal in the workspace (\`cloud_api.rs\`, \`multi_target_test.rs\`, and the four defaults in \`command.rs\`) so all callers stay compatible.

Requires \`--spec\` since the mutator needs annotated operations.

Workspace 0.3.148 → 0.3.149. Closes the (4) line item from Srikanth's #79 round-13 follow-ups.