### PR TITLE
ci: promote unused_qualifications into the main PR clippy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,16 @@ jobs:
       run: cargo fmt --all -- --check
       if: matrix.rust == 'stable'
 
+    # `-D unused_qualifications` mirrors the workspace-wide ratchet in
+    # scripts/lint-warning-gate.sh, but surfaces it here in the main
+    # clippy step so qualifier drift hits the same row in the PR-checks
+    # UI as the standard correctness lints. The dedicated warning-gate
+    # job has been historically ignored when red; pulling the check into
+    # the main clippy line makes it much harder to merge over.
+    # The dedicated gate stays as defense-in-depth.
+    # Static command — no untrusted input is interpolated.
     - name: Run clippy
-      run: cargo clippy --workspace --exclude mockforge-desktop --lib --bins --all-features -- -D clippy::correctness
+      run: cargo clippy --workspace --exclude mockforge-desktop --lib --bins --all-features -- -D clippy::correctness -D unused_qualifications
       if: matrix.rust == 'stable'
 
     - name: Build workspace


### PR DESCRIPTION
## Summary

The chronic 5-failing-checks state on main during 2026-05-23/25 exposed a **feedback-loop bug**, not a technical-gate bug. The workspace-wide `-Dunused_qualifications` ratchet was already enforced by `scripts/lint-warning-gate.sh` under a dedicated "Incremental Warning Gate" CI job — but that job has been historically dismissed as "the gate that's always red," and qualifier drift kept landing.

Move the same lint into the main `Run clippy` step alongside `-D clippy::correctness`. Same lint, same job, same exit code, but it now surfaces in the row developers actually look at during PR review.

```diff
- run: cargo clippy ... -- -D clippy::correctness
+ run: cargo clippy ... -- -D clippy::correctness -D unused_qualifications
```

The dedicated warning-gate job stays as defense-in-depth.

## Verified locally

Running the new clippy command on current `main` (pre-#692) reproduces the exact 5 errors in `mockforge-http/{contract_diff_middleware,middleware/drift_tracking}` that #692 removes:

```
error: unnecessary qualification  (×5)
error: could not compile `mockforge-http` (lib) due to 5 previous errors
```

Confirms the lint catches the drift class that broke main for 2+ days.

## ⚠️ Depends on #692

This PR's own CI will fail until #692 lands in `main` — that's intentional, the new lint catches the exact drift #692 fixes. **Don't merge this until #692 is in main.** Auto-merge handles the sequencing: this won't merge until its own CI passes, which requires #692 in main first.

## Why not also include the fixes here?

Mixed scope. #692 is "fix the drift that already exists." This PR is "prevent the drift from recurring." Keeping them separate makes the intent of each review pass cleaner. The cost is one round of post-#692 CI re-run on this PR.

## Out of scope

- Pre-commit hook for `unused_qualifications` — would catch even earlier, but `cargo` startup makes pre-commit hooks slow. Worth a discussion but not in this PR.
- Promoting `-D unused_imports` / `-D unused_must_use` / `-D unused_mut` / `-D private_interfaces` (the other lints that lint-warning-gate.sh enforces on `mockforge-cli` + `mockforge-ui` only) to workspace-wide. Each would need a backlog burndown first. File separately when there's appetite.
- Adjusting the "Incremental Warning Gate" job to be a no-op now that the main clippy step covers the same ground. Keeping it as defense-in-depth for now.