### PR TITLE
chore(scripts): dev-host cleanup script for the worktree pattern

### DIFF
--- a/scripts/dev-host-cleanup.sh
+++ b/scripts/dev-host-cleanup.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# Dev-host disk pressure cleanup for the mockforge worktree pattern.
+#
+# Sibling of the runner-host cleanup script that lives at
+# /usr/local/bin/runner-host-cleanup.sh on the Hetzner CI runner —
+# different paths, different "safe to delete" heuristic (we use GitHub
+# PR state via `gh`), same pressure-tier idea.
+#
+# Each `Agent`-style coding session in this repo creates a git worktree
+# under `<repo>/.claude/worktrees/<branch>/`, with its own
+# `target/` directory that can be 15–35 GB. After a couple of sessions
+# the disk fills up and cargo dies mid-build with "No space left on
+# device". This script reclaims the target/ dirs on worktrees whose
+# branch has already merged (or, under heavier pressure, closed),
+# without touching source files or active worktrees.
+#
+# Usage:
+#   dev-host-cleanup.sh                                  # dry-run on default repo
+#   dev-host-cleanup.sh --force                          # actually delete
+#   dev-host-cleanup.sh --repo /path/to/repo --force
+#   dev-host-cleanup.sh --mount /mnt/projects --force    # pressure check on a specific mount
+#
+# Thresholds (matched to the runner's, lowered 2026-05-23):
+#   soft pressure   ≥ 65%  → delete target/ on worktrees with MERGED PRs
+#   aggressive      ≥ 80%  → also delete target/ on worktrees with CLOSED PRs
+#
+# Safety:
+# - Only touches *.claude/worktrees/<name>/target/ directories.
+# - Never removes the worktree itself, never touches source files,
+#   never runs `git clean` (which could nuke local edits).
+# - Skips worktrees whose branch has no PR (assume in-flight work).
+# - Skips worktrees whose branch has an OPEN PR.
+# - Logs everything to stderr and to /var/tmp/dev-host-cleanup.log.
+
+set -uo pipefail
+
+REPO="${HOME}/dev/projects/work/mockforge"
+# Fallback: most callers will be running from inside the project tree.
+if [ ! -d "$REPO" ]; then
+  REPO="/mnt/projects/mockforge"
+fi
+MOUNT="/mnt/projects"
+SOFT_THRESHOLD=65
+AGGRESSIVE_THRESHOLD=80
+FORCE=false
+LOG_FILE="/var/tmp/dev-host-cleanup.log"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force) FORCE=true; shift ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --mount) MOUNT="$2"; shift 2 ;;
+    --soft) SOFT_THRESHOLD="$2"; shift 2 ;;
+    --aggressive) AGGRESSIVE_THRESHOLD="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '3,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() {
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "[$ts] $*" | tee -a "$LOG_FILE" >&2
+}
+
+if [ ! -d "$REPO/.claude/worktrees" ]; then
+  log "no worktrees dir at $REPO/.claude/worktrees — nothing to do"
+  exit 0
+fi
+
+# Disk pressure tier. df reports as a percentage string with a trailing %.
+USAGE=$(df --output=pcent "$MOUNT" | tail -1 | tr -d ' %' || echo 0)
+TIER="ok"
+if [ "$USAGE" -ge "$AGGRESSIVE_THRESHOLD" ]; then
+  TIER="aggressive"
+elif [ "$USAGE" -ge "$SOFT_THRESHOLD" ]; then
+  TIER="soft"
+fi
+log "disk usage $USAGE% on $MOUNT — tier=$TIER (soft≥${SOFT_THRESHOLD}%, aggressive≥${AGGRESSIVE_THRESHOLD}%)"
+if [ "$TIER" = "ok" ]; then
+  log "no pressure; exiting"
+  exit 0
+fi
+[ "$FORCE" = false ] && log "DRY-RUN — pass --force to actually delete"
+
+# Reconcile gh auth before we walk: a stale token gives every PR as
+# "UNKNOWN" and the script would skip everything. Fail loud rather
+# than silently no-op.
+if ! gh auth status >/dev/null 2>&1; then
+  log "ERROR: gh CLI is not authenticated. Run 'gh auth login' on this host."
+  exit 1
+fi
+
+# Resolve the repo's GitHub slug once (e.g. SaaSy-Solutions/mockforge).
+# Saves one network call per worktree.
+REPO_SLUG=$(cd "$REPO" && gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+if [ -z "$REPO_SLUG" ]; then
+  log "ERROR: could not determine GitHub slug for $REPO"
+  exit 1
+fi
+log "repo=$REPO_SLUG"
+
+# Convert a worktree branch name back to the original branch.
+# EnterWorktree creates branches like `worktree-<sanitised-name>` —
+# the worktree dir itself is named after the user-supplied slug,
+# with `+` substituted for `/`. There's also the case of a worktree
+# entered via `path` against an already-existing branch (no rename).
+worktree_branch() {
+  local wt_path="$1"
+  # Prefer the actual branch name from git; fall back to the dir name.
+  git -C "$wt_path" symbolic-ref --short HEAD 2>/dev/null || basename "$wt_path"
+}
+
+# Try to find a PR whose head ref matches the worktree's branch.
+# Returns the PR state (MERGED|CLOSED|OPEN) or empty if no PR exists.
+pr_state_for_branch() {
+  local branch="$1"
+  # Strip the EnterWorktree `worktree-` prefix when present so we
+  # find the real PR. Both `<slug>` and `worktree-<slug>` variants
+  # can exist depending on whether the user committed under the
+  # session branch or rebased onto a `feat/...` branch later.
+  local stripped="${branch#worktree-}"
+  # The actual PR branch usually uses `/` separators where the
+  # worktree path used `+`. Map back.
+  local candidate="${stripped//+/\/}"
+
+  local state
+  state=$(gh pr list --repo "$REPO_SLUG" --state all --head "$candidate" \
+            --limit 1 --json state --jq '.[0].state // ""' 2>/dev/null)
+  if [ -z "$state" ] && [ "$candidate" != "$branch" ]; then
+    state=$(gh pr list --repo "$REPO_SLUG" --state all --head "$branch" \
+              --limit 1 --json state --jq '.[0].state // ""' 2>/dev/null)
+  fi
+  echo "$state"
+}
+
+freed_bytes=0
+checked=0
+deleted=0
+skipped_open=0
+skipped_unknown=0
+
+for wt_target in "$REPO/.claude/worktrees"/*/target; do
+  [ -d "$wt_target" ] || continue
+  checked=$((checked + 1))
+
+  wt_dir="$(dirname "$wt_target")"
+  wt_name="$(basename "$wt_dir")"
+  branch=$(worktree_branch "$wt_dir")
+  state=$(pr_state_for_branch "$branch")
+  size=$(du -sb "$wt_target" 2>/dev/null | cut -f1 || echo 0)
+  size_h=$(numfmt --to=iec --suffix=B "$size" 2>/dev/null || echo "${size}B")
+
+  case "$state" in
+    MERGED)
+      eligible=true
+      reason="MERGED"
+      ;;
+    CLOSED)
+      if [ "$TIER" = "aggressive" ]; then
+        eligible=true
+        reason="CLOSED (aggressive tier)"
+      else
+        eligible=false
+        reason="CLOSED (skipped at soft tier — open --aggressive to clean)"
+      fi
+      ;;
+    OPEN)
+      eligible=false
+      reason="OPEN PR — actively in use"
+      skipped_open=$((skipped_open + 1))
+      ;;
+    "")
+      eligible=false
+      reason="no PR found — assuming in-flight"
+      skipped_unknown=$((skipped_unknown + 1))
+      ;;
+    *)
+      eligible=false
+      reason="unknown PR state '$state'"
+      skipped_unknown=$((skipped_unknown + 1))
+      ;;
+  esac
+
+  if [ "$eligible" = true ]; then
+    if [ "$FORCE" = true ]; then
+      log "DELETE  $wt_name  ($size_h, $reason)"
+      rm -rf "$wt_target"
+      deleted=$((deleted + 1))
+      freed_bytes=$((freed_bytes + size))
+    else
+      log "WOULD   $wt_name  ($size_h, $reason)"
+      freed_bytes=$((freed_bytes + size))
+    fi
+  else
+    log "skip    $wt_name  ($size_h, $reason)"
+  fi
+done
+
+freed_h=$(numfmt --to=iec --suffix=B "$freed_bytes" 2>/dev/null || echo "${freed_bytes}B")
+log "done — checked=$checked deleted=$deleted skipped_open=$skipped_open skipped_unknown=$skipped_unknown freed=$freed_h"


### PR DESCRIPTION
## Summary

Sibling of `/usr/local/bin/runner-host-cleanup.sh` on the Hetzner CI runner, but for the dev box. Each `Agent`-style session in this repo creates a worktree under `.claude/worktrees/<branch>/` with its own `target/` dir that can be 15–35 GB; after a couple of sessions the disk fills and cargo dies with "No space left on device" mid-build (we hit it this session at 96% used).

## Heuristic

| Tier | Trigger | Action |
|---|---|---|
| ok | disk < 65% | exit immediately |
| soft | 65–80% | delete `target/` on worktrees whose branch has a **MERGED** PR |
| aggressive | ≥ 80% | also delete `target/` on worktrees with **CLOSED** PRs |

Never touches worktrees whose branch has an OPEN PR or no PR at all (assumed in-flight). Never touches source files, never runs `git clean`, never removes the worktree directory itself.

PR state is fetched via `gh pr list --head <branch>`. Branch name reconstructed from the worktree directory name, with `+` reverted to `/` to match GitHub branch conventions.

## Verified against the current host

```
$ scripts/dev-host-cleanup.sh
disk usage 86% on /mnt/projects — tier=aggressive (soft≥65%, aggressive≥80%)
DRY-RUN — pass --force to actually delete
repo=SaaSy-Solutions/mockforge
WOULD   555-phase-10-rag-ai-generator  (17GB, MERGED)
WOULD   555-phase-8-governance-handlers  (24GB, MERGED)
skip    656-ai-gen-split  (32GB, no PR found — assuming in-flight)
WOULD   656-ai-handler-to-intelligence  (17GB, MERGED)
skip    ci+ratchet-on-pr-clippy  (4.5GB, OPEN PR — actively in use)
skip    feat+registry-server-shared-sentry  (33GB, OPEN PR — actively in use)
done — checked=6 deleted=0 skipped_open=2 skipped_unknown=1 freed=56GB
```

Open-PR worktrees correctly preserved. The 656-ai-gen-split worktree (32 GB, no PR yet) correctly left alone.

## Install (per dev box)

```bash
# Symlink onto $PATH
ln -sf $(pwd)/scripts/dev-host-cleanup.sh ~/.local/bin/dev-host-cleanup

# Cron every 30 min (matches runner-host cadence)
( crontab -l 2>/dev/null; \
  echo '*/30 * * * * /home/user/.local/bin/dev-host-cleanup --force' \
) | crontab -
```

(Adjust the home path; the script also accepts `--repo` / `--mount` for non-default layouts.)

## Test plan

- [x] `bash -n` syntax check
- [x] Dry-run on the current host correctly classifies 6 worktrees (3 reclaim, 3 skip with the right reasons)
- [ ] After merge: install on dev box, verify cron fires, verify log lands at `/var/tmp/dev-host-cleanup.log`

## Why in-repo

Versioned, reviewable, shareable across dev machines. The runner's equivalent script is *not* in the repo (per memory `reference_runner_disk_cleanup`) which has been a footgun — the source of truth lives only on the runner host, so edits drift untracked. Putting this one in `scripts/` avoids that pattern from day one.

## Out of scope

- A symmetric `scripts/runner-host-cleanup.sh` to version the runner's script. Would be nice but the runner script has been edited live multiple times and reconstructing the current state is its own task.
- Cleaning the worktree directories themselves (not just `target/`). That's a much bigger blast radius — better as a manual decision (`git worktree remove`).
- Generalising to other repos. The path defaults are mockforge-specific but `--repo` makes it portable; cross-repo cleanup is a follow-up if/when other repos adopt the same Agent-worktree pattern.