### PR TITLE
feat(recorder): Kafka/MQTT/AMQP event variants + builder helpers (#683)

### DIFF
--- a/crates/mockforge-recorder/src/models.rs
+++ b/crates/mockforge-recorder/src/models.rs
@@ -5,6 +5,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Protocol type
+///
+/// Each variant lowercases to its on-disk sqlx string; adding a new
+/// protocol is a no-migration change because the `protocol` column is
+/// stored as TEXT. The async-broker variants (#683) — Kafka, Mqtt,
+/// Amqp — let downstream brokers feed the same recorder pipeline that
+/// HTTP/gRPC/WebSocket/GraphQL already use, so traffic from every
+/// protocol surface lands in a single sqlite for replay + diff.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "TEXT")]
 #[sqlx(rename_all = "lowercase")]
@@ -17,6 +24,21 @@ pub enum Protocol {
     WebSocket,
     #[sqlx(rename = "graphql")]
     GraphQL,
+    /// Kafka — a single produce/consume exchange. `method` carries the
+    /// API kind ("produce" | "consume"); `path` carries the topic name;
+    /// optional partition/offset/key live in `query_params` as a small
+    /// JSON object so we don't need a column migration per protocol.
+    #[sqlx(rename = "kafka")]
+    Kafka,
+    /// MQTT — `method` carries "publish" or "subscribe"; `path` carries
+    /// the topic; `query_params` may carry `{"qos": 1, "retain": true}`.
+    #[sqlx(rename = "mqtt")]
+    Mqtt,
+    /// AMQP — `method` carries the basic-op ("publish" | "deliver" |
+    /// "ack" | "nack"); `path` carries `<exchange>/<routing-key>` or the
+    /// queue name for consumer-side ops.
+    #[sqlx(rename = "amqp")]
+    Amqp,
 }
 
 impl Protocol {
@@ -26,6 +48,9 @@ impl Protocol {
             Protocol::Grpc => "grpc",
             Protocol::WebSocket => "websocket",
             Protocol::GraphQL => "graphql",
+            Protocol::Kafka => "kafka",
+            Protocol::Mqtt => "mqtt",
+            Protocol::Amqp => "amqp",
         }
     }
 }

--- a/crates/mockforge-recorder/src/protocols.rs
+++ b/crates/mockforge-recorder/src/protocols.rs
@@ -1,5 +1,6 @@
 //! Protocol-specific recording helpers
 
+pub mod async_brokers;
 pub mod graphql;
 pub mod grpc;
 pub mod websocket;

--- a/crates/mockforge-recorder/src/protocols/async_brokers.rs
+++ b/crates/mockforge-recorder/src/protocols/async_brokers.rs
@@ -1,0 +1,187 @@
+//! Convenience builders for recording Kafka / MQTT / AMQP exchanges (#683).
+//!
+//! Each broker server can call these to drop an event into the recorder
+//! sqlite with a consistent shape, so replay + diff tooling sees a
+//! single uniform schema regardless of source protocol. Without this
+//! shim every broker would invent its own \`RecordedRequest\` shape and
+//! the query side would have to special-case each one.
+//!
+//! Storage convention:
+//! - \`method\` is the broker-op verb (produce/consume, publish/subscribe,
+//!   publish/deliver/ack/nack)
+//! - \`path\` is the topic name (Kafka, MQTT) or
+//!   \`<exchange>/<routing-key>\` (AMQP publish) / queue name (AMQP consume)
+//! - \`query_params\` carries protocol-specific metadata as compact JSON
+//!   so we don't need a column-migration per protocol
+//! - \`body\` carries the message payload UTF-8 when valid, base64
+//!   otherwise (matches the HTTP/gRPC convention)
+
+use crate::models::{Protocol, RecordedRequest};
+use chrono::Utc;
+use serde_json::json;
+use uuid::Uuid;
+
+/// Encode an opaque payload for storage. UTF-8 when the bytes parse
+/// cleanly, base64 otherwise — mirrors how the HTTP recorder handles
+/// binary bodies.
+fn encode_body(payload: &[u8]) -> (Option<String>, String) {
+    match std::str::from_utf8(payload) {
+        Ok(s) => (Some(s.to_string()), "utf8".to_string()),
+        Err(_) => {
+            use base64::Engine;
+            (
+                Some(base64::engine::general_purpose::STANDARD.encode(payload)),
+                "base64".to_string(),
+            )
+        }
+    }
+}
+
+/// Build a `RecordedRequest` for a Kafka produce/consume exchange.
+///
+/// `op` is "produce" or "consume". `partition` / `offset` / `key` are
+/// optional — they go into `query_params` as compact JSON.
+pub fn kafka_event(
+    op: &str,
+    topic: &str,
+    partition: Option<i32>,
+    offset: Option<i64>,
+    key: Option<&str>,
+    payload: &[u8],
+) -> RecordedRequest {
+    let (body, body_encoding) = encode_body(payload);
+    let meta = json!({
+        "partition": partition,
+        "offset": offset,
+        "key": key,
+    });
+    RecordedRequest {
+        id: Uuid::new_v4().to_string(),
+        protocol: Protocol::Kafka,
+        timestamp: Utc::now(),
+        method: op.to_string(),
+        path: topic.to_string(),
+        query_params: Some(meta.to_string()),
+        headers: "{}".to_string(),
+        body,
+        body_encoding,
+        client_ip: None,
+        trace_id: None,
+        span_id: None,
+        duration_ms: None,
+        status_code: None,
+        tags: None,
+    }
+}
+
+/// Build a `RecordedRequest` for an MQTT publish/subscribe.
+///
+/// `op` is "publish" or "subscribe". QoS + retain go into
+/// `query_params`.
+pub fn mqtt_event(op: &str, topic: &str, qos: u8, retain: bool, payload: &[u8]) -> RecordedRequest {
+    let (body, body_encoding) = encode_body(payload);
+    let meta = json!({
+        "qos": qos,
+        "retain": retain,
+    });
+    RecordedRequest {
+        id: Uuid::new_v4().to_string(),
+        protocol: Protocol::Mqtt,
+        timestamp: Utc::now(),
+        method: op.to_string(),
+        path: topic.to_string(),
+        query_params: Some(meta.to_string()),
+        headers: "{}".to_string(),
+        body,
+        body_encoding,
+        client_ip: None,
+        trace_id: None,
+        span_id: None,
+        duration_ms: None,
+        status_code: None,
+        tags: None,
+    }
+}
+
+/// Build a `RecordedRequest` for an AMQP basic-op event.
+///
+/// For publish, pass `exchange` + `routing_key` (joined as the path);
+/// for consumer-side ops (deliver/ack/nack) pass the queue name as
+/// `routing_key` and leave `exchange` as empty.
+pub fn amqp_event(op: &str, exchange: &str, routing_key: &str, payload: &[u8]) -> RecordedRequest {
+    let (body, body_encoding) = encode_body(payload);
+    let path = if exchange.is_empty() {
+        routing_key.to_string()
+    } else {
+        format!("{exchange}/{routing_key}")
+    };
+    RecordedRequest {
+        id: Uuid::new_v4().to_string(),
+        protocol: Protocol::Amqp,
+        timestamp: Utc::now(),
+        method: op.to_string(),
+        path,
+        query_params: None,
+        headers: "{}".to_string(),
+        body,
+        body_encoding,
+        client_ip: None,
+        trace_id: None,
+        span_id: None,
+        duration_ms: None,
+        status_code: None,
+        tags: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kafka_event_encodes_utf8_payload_as_utf8() {
+        let r = kafka_event("produce", "orders", Some(0), Some(42), Some("k1"), b"hello");
+        assert_eq!(r.protocol, Protocol::Kafka);
+        assert_eq!(r.method, "produce");
+        assert_eq!(r.path, "orders");
+        assert_eq!(r.body.as_deref(), Some("hello"));
+        assert_eq!(r.body_encoding, "utf8");
+        let meta: serde_json::Value =
+            serde_json::from_str(r.query_params.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["partition"], 0);
+        assert_eq!(meta["offset"], 42);
+        assert_eq!(meta["key"], "k1");
+    }
+
+    #[test]
+    fn kafka_event_encodes_binary_payload_as_base64() {
+        // Invalid UTF-8 should round-trip via base64.
+        let r = kafka_event("produce", "orders", None, None, None, &[0xff, 0xfe, 0x00]);
+        assert_eq!(r.body_encoding, "base64");
+        assert!(r.body.is_some());
+    }
+
+    #[test]
+    fn mqtt_event_carries_qos_and_retain() {
+        let r = mqtt_event("publish", "sensors/temp", 1, true, b"22.5");
+        assert_eq!(r.protocol, Protocol::Mqtt);
+        assert_eq!(r.method, "publish");
+        assert_eq!(r.path, "sensors/temp");
+        let meta: serde_json::Value =
+            serde_json::from_str(r.query_params.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["qos"], 1);
+        assert_eq!(meta["retain"], true);
+    }
+
+    #[test]
+    fn amqp_event_joins_exchange_and_routing_key() {
+        let r = amqp_event("publish", "orders", "order.created", b"{}");
+        assert_eq!(r.path, "orders/order.created");
+    }
+
+    #[test]
+    fn amqp_event_consumer_side_uses_queue_name() {
+        let r = amqp_event("deliver", "", "orders.new", b"{}");
+        assert_eq!(r.path, "orders.new");
+    }
+}


### PR DESCRIPTION
Closes #683.

## Problem

The recorder only knew HTTP/gRPC/WebSocket/GraphQL. Broker traffic for Kafka/MQTT/AMQP had no way to land in the recorder sqlite, so Record & Replay was HTTP-only despite the brokers being real wire-protocol implementations.

## Change

- \`Protocol::Kafka\` / \`Mqtt\` / \`Amqp\` — three new enum variants with \`#[sqlx(rename)]\`. **No migration** needed because the \`protocol\` column is TEXT.
- \`protocols/async_brokers.rs\` — three builder helpers (\`kafka_event\`, \`mqtt_event\`, \`amqp_event\`) that produce a \`RecordedRequest\` with a consistent shape:
  - \`method\` is the broker-op verb (produce/consume, publish/subscribe, publish/deliver/ack/nack)
  - \`path\` is topic / exchange/routing-key / queue name
  - \`query_params\` carries protocol-specific metadata (partition+offset+key for Kafka, qos+retain for MQTT) as compact JSON so we don't migrate per protocol
  - \`body\` is UTF-8 when valid, base64 otherwise — same convention HTTP/gRPC use
- 5 unit tests covering UTF-8 vs binary encoding, metadata pass-through, and path conventions.

## Follow-up

Each broker server still needs to call these helpers from its produce / publish / consume paths. That's a one-liner per call site (\`recorder.record(async_brokers::kafka_event(...))\`) and would balloon this PR. The recorder side is the gating change — with variants + builders in place, broker wiring is mechanical.

## Test plan

- [x] \`cargo test -p mockforge-recorder --lib protocols::async_brokers\` — 5/5 pass
- [x] Pre-commit hooks pass