### PR TITLE
feat: server-side shadow mode + unknown-paths status column (#79 round 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [0.3.150] - 2026-05-26
 
+### Fixed
+
+- **[Reality]** Server no longer OOM-killed at startup on large specs (#79 round 14) — building the OpenAPI router cloned the *entire* routes Vec into every per-route handler closure (each closure captured its own `clone_for_validation()`), making router construction **O(N²) in memory**: ~260 GB resident for an 11,422-operation spec (Microsoft Graph), which the OOM killer reaped immediately after the `Stored N routes` log line. Srikanth hit this on 0.3.148/0.3.149. Fixed by sharing a single validator across all handlers via `Arc` (per-closure cost drops from a full deep clone to an 8-byte pointer). Applies to all three router builders (`build_router_with_context`, `build_router_with_mockai`, `build_router_with_ai`). Reproduced with a 22,000-operation synthetic spec: pre-fix died with `memory allocation failed` right after `Stored 22000 routes`; post-fix starts and serves cleanly.
+
 ### Added
 
 - **[Reality][Contracts]** Server-side **shadow mode** (`MOCKFORGE_SHADOW_MODE=true`) (#79 round 14) — Srikanth's (a) ask. When enabled, the server returns **200** for requests it would normally reject — unknown paths (instead of 404) and spec violations (instead of 400/422) — while *still* recording them to the conformance + unknown-paths buffers. A "report-only" / monitor mode: replay proxy traffic through MockForge non-blocking and capture every violation for cross-checking, without the rejections breaking the client flow. Unknown paths get a minimal `{"shadow":true,"matched":false}` 200 stub; spec-violating requests fall through to normal response synthesis. Startup prints a `👻 SHADOW MODE ON` banner so the behavior is never a surprise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3.150] - 2026-05-26
+
+### Added
+
+- **[Reality][Contracts]** Server-side **shadow mode** (`MOCKFORGE_SHADOW_MODE=true`) (#79 round 14) — Srikanth's (a) ask. When enabled, the server returns **200** for requests it would normally reject — unknown paths (instead of 404) and spec violations (instead of 400/422) — while *still* recording them to the conformance + unknown-paths buffers. A "report-only" / monitor mode: replay proxy traffic through MockForge non-blocking and capture every violation for cross-checking, without the rejections breaking the client flow. Unknown paths get a minimal `{"shadow":true,"matched":false}` 200 stub; spec-violating requests fall through to normal response synthesis. Startup prints a `👻 SHADOW MODE ON` banner so the behavior is never a surprise.
+- **[Contracts][DevX]** Status column on the TUI unknown-paths view (#79 round 14) — the unknown-paths feed now carries the HTTP status the server actually returned (404 normally, 200 in shadow mode), surfaced as a colored `Status` column in the `u`-toggled unknown-paths view so you can tell at a glance which requests shadow mode let through.
+
 ## [0.3.149] - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7715,7 +7715,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8341,7 +8341,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8388,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8423,7 +8423,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8445,7 +8445,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8562,7 +8562,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8670,7 +8670,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8685,7 +8685,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8709,7 +8709,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8786,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8811,7 +8811,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8998,7 +8998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9011,7 +9011,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9070,7 +9070,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9178,14 +9178,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9212,7 +9212,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9223,7 +9223,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9263,7 +9263,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9317,7 +9317,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9404,7 +9404,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9415,7 +9415,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9432,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15263,7 +15263,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.149"
+version = "0.3.150"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.149"
+version = "0.3.150"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -2,6 +2,10 @@
 
 ## [0.3.150] - 2026-05-26
 
+### Fixed
+
+- **[Reality]** Server no longer OOM-killed at startup on large specs (#79 round 14) — router construction cloned the entire routes Vec into every per-route handler (O(N²) memory; ~260 GB for an 11,422-op spec). Fixed by sharing one validator via `Arc` across all handlers. Reproduced + verified with a 22,000-operation synthetic spec.
+
 ### Added
 
 - **[Reality][Contracts]** Server-side **shadow mode** (`MOCKFORGE_SHADOW_MODE=true`) (#79 round 14) — returns 200 for unknown paths and spec violations while still recording them to the conformance + unknown-paths buffers (report-only / monitor mode for proxy-replay traffic). Startup prints a `👻 SHADOW MODE ON` banner.

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,12 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.150] - 2026-05-26
+
+### Added
+
+- **[Reality][Contracts]** Server-side **shadow mode** (`MOCKFORGE_SHADOW_MODE=true`) (#79 round 14) — returns 200 for unknown paths and spec violations while still recording them to the conformance + unknown-paths buffers (report-only / monitor mode for proxy-replay traffic). Startup prints a `👻 SHADOW MODE ON` banner.
+- **[Contracts][DevX]** Status column on the TUI unknown-paths view — surfaces the HTTP status the server returned (404 normally, 200 in shadow mode).
+
 ## [0.3.149] - 2026-05-25
 
 ### Added

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -924,6 +924,18 @@ pub async fn handle_serve(
 
     println!("🚀 Starting MockForge servers...");
 
+    // Issue #79 round 14 — surface shadow mode loudly at startup so an
+    // operator never wonders why a 404/validation-rejection came back
+    // as 200. Shadow mode returns 200 for unknown paths + spec
+    // violations while still recording them to the conformance and
+    // unknown-paths buffers (report-only / monitor mode).
+    if mockforge_foundation::unknown_paths::shadow_mode_enabled() {
+        println!(
+            "👻 SHADOW MODE ON (MOCKFORGE_SHADOW_MODE) — unknown paths and spec violations \
+             return 200 but are still recorded to the Conformance tab"
+        );
+    }
+
     // Initialize the global request logger early, BEFORE any server tasks are spawned.
     // This ensures HTTP request logs are captured from the very first request,
     // not just after the admin UI router happens to initialize.

--- a/crates/mockforge-foundation/src/unknown_paths.rs
+++ b/crates/mockforge-foundation/src/unknown_paths.rs
@@ -17,6 +17,22 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 
+/// Issue #79 round 14 — Srikanth's shadow-mode ask. When enabled, the
+/// server returns `200` for requests that would otherwise be rejected
+/// (unknown paths → 404, spec violations → 400/422) while still
+/// recording them to the unknown-paths / conformance buffers. Lets a
+/// proxy replay run flow through non-blocking with full violation
+/// capture — a "report-only" / monitor mode.
+///
+/// Read once per request from `MOCKFORGE_SHADOW_MODE` (`1`/`true`).
+/// Cheap enough for the hot path; no caching needed since env lookups
+/// are fast and this keeps the flag dynamically toggleable in tests.
+pub fn shadow_mode_enabled() -> bool {
+    std::env::var("MOCKFORGE_SHADOW_MODE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 /// One unmatched-path request — captured by the HTTP server's fallback
 /// when no registered route matches.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,6 +47,16 @@ pub struct UnknownPathRequest {
     pub client_ip: String,
     /// Query string portion, if any.
     pub query: String,
+    /// HTTP status the server actually returned for this request.
+    /// Normally `404`; in shadow mode (Issue #79 round 14) the server
+    /// returns `200` instead but still records the unknown path here,
+    /// so the column reflects what the client saw.
+    #[serde(default = "default_unknown_status")]
+    pub status: u16,
+}
+
+fn default_unknown_status() -> u16 {
+    404
 }
 
 const DEFAULT_BUFFER_SIZE: usize = 256;
@@ -67,23 +93,28 @@ pub fn clear() {
 mod tests {
     use super::*;
 
+    /// The buffer tests mutate the global `UNKNOWN_PATHS` static, so
+    /// they must not interleave (cargo runs tests in parallel by
+    /// default). Serialize them through a shared lock.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn req(path: &str) -> UnknownPathRequest {
+        UnknownPathRequest {
+            timestamp: Utc::now(),
+            method: "GET".into(),
+            path: path.into(),
+            client_ip: "127.0.0.1".into(),
+            query: String::new(),
+            status: 404,
+        }
+    }
+
     #[test]
     fn record_and_snapshot_lifo() {
+        let _guard = TEST_LOCK.lock();
         clear();
-        record(UnknownPathRequest {
-            timestamp: Utc::now(),
-            method: "GET".into(),
-            path: "/first".into(),
-            client_ip: "127.0.0.1".into(),
-            query: String::new(),
-        });
-        record(UnknownPathRequest {
-            timestamp: Utc::now(),
-            method: "GET".into(),
-            path: "/second".into(),
-            client_ip: "127.0.0.1".into(),
-            query: String::new(),
-        });
+        record(req("/first"));
+        record(req("/second"));
         let snap = snapshot();
         assert_eq!(snap.len(), 2);
         assert_eq!(snap[0].path, "/second");
@@ -92,19 +123,35 @@ mod tests {
 
     #[test]
     fn drops_oldest_at_capacity() {
+        let _guard = TEST_LOCK.lock();
         clear();
         for i in 0..(DEFAULT_BUFFER_SIZE + 5) {
-            record(UnknownPathRequest {
-                timestamp: Utc::now(),
-                method: "GET".into(),
-                path: format!("/p/{i}"),
-                client_ip: "127.0.0.1".into(),
-                query: String::new(),
-            });
+            record(req(&format!("/p/{i}")));
         }
         assert_eq!(len(), DEFAULT_BUFFER_SIZE);
         let snap = snapshot();
         assert_eq!(snap[0].path, format!("/p/{}", DEFAULT_BUFFER_SIZE + 4));
         assert_eq!(snap[DEFAULT_BUFFER_SIZE - 1].path, "/p/5");
+    }
+
+    #[test]
+    fn shadow_mode_reads_env() {
+        std::env::set_var("MOCKFORGE_SHADOW_MODE", "true");
+        assert!(shadow_mode_enabled());
+        std::env::set_var("MOCKFORGE_SHADOW_MODE", "1");
+        assert!(shadow_mode_enabled());
+        std::env::set_var("MOCKFORGE_SHADOW_MODE", "0");
+        assert!(!shadow_mode_enabled());
+        std::env::remove_var("MOCKFORGE_SHADOW_MODE");
+        assert!(!shadow_mode_enabled());
+    }
+
+    #[test]
+    fn status_defaults_to_404_on_legacy_payload() {
+        // Old payloads (round 13) had no `status` field; serde default
+        // must fill 404 so the TUI column doesn't break on older servers.
+        let json = r#"{"timestamp":"2026-05-26T00:00:00Z","method":"GET","path":"/x","client_ip":"unknown","query":""}"#;
+        let parsed: UnknownPathRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.status, 404);
     }
 }

--- a/crates/mockforge-http/src/management/mod.rs
+++ b/crates/mockforge-http/src/management/mod.rs
@@ -1157,6 +1157,16 @@ pub async fn dynamic_mock_fallback(
     match serve_dynamic_mock(&state, req).await {
         Some(resp) => resp,
         None => {
+            // Issue #79 round 14 — shadow mode returns 200 for unknown
+            // paths (instead of 404) while still recording them, so a
+            // proxy replay flows through non-blocking. The recorded
+            // `status` reflects what the client actually saw.
+            let shadow = mockforge_foundation::unknown_paths::shadow_mode_enabled();
+            let status = if shadow {
+                StatusCode::OK
+            } else {
+                StatusCode::NOT_FOUND
+            };
             mockforge_foundation::unknown_paths::record(
                 mockforge_foundation::unknown_paths::UnknownPathRequest {
                     timestamp: chrono::Utc::now(),
@@ -1164,9 +1174,22 @@ pub async fn dynamic_mock_fallback(
                     path,
                     client_ip: "unknown".to_string(),
                     query,
+                    status: status.as_u16(),
                 },
             );
-            StatusCode::NOT_FOUND.into_response()
+            if shadow {
+                // Minimal JSON stub so clients expecting a body don't
+                // choke. Shadow mode is for traffic-replay observability,
+                // not realistic response shapes.
+                (
+                    StatusCode::OK,
+                    [(axum::http::header::CONTENT_TYPE, "application/json")],
+                    r#"{"shadow":true,"matched":false}"#,
+                )
+                    .into_response()
+            } else {
+                StatusCode::NOT_FOUND.into_response()
+            }
         }
     }
 }

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -417,12 +417,20 @@ impl OpenApiRouteRegistry {
 
         let deduped = self.deduplicated_routes();
         let ctx = Arc::new(ctx);
+        // Issue #79 round 14 hotfix — share ONE validator across all
+        // route handlers via Arc. Previously each of N route closures
+        // captured its own `clone_for_validation()` (which deep-clones
+        // the entire N-element routes Vec), making router construction
+        // O(N²) in memory — ~260 GB resident for an 11,422-operation
+        // spec (Microsoft Graph), which the OOM killer reaped right
+        // after "Stored N routes". An Arc clone is 8 bytes.
+        let validator = Arc::new(self.clone_for_validation());
         for (axum_path, route) in &deduped {
             tracing::debug!("Adding route: {} {}", route.method, route.path);
             let operation = route.operation.clone();
             let method = route.method.clone();
             let path_template = route.path.clone();
-            let validator = self.clone_for_validation();
+            let validator = validator.clone();
             let route_clone = (*route).clone();
             let ctx = ctx.clone();
 
@@ -1464,15 +1472,19 @@ impl OpenApiRouteRegistry {
         let deduped = self.deduplicated_routes();
         tracing::debug!("Building router with AI support from {} routes", self.routes.len());
 
+        // Issue #79 round 14 hotfix — one shared validator (Arc) instead
+        // of a per-route deep clone. See `build_router_with_context` for
+        // the O(N²)/OOM rationale.
+        let validator = Arc::new(self.clone_for_validation());
         for (axum_path, route) in &deduped {
             tracing::debug!("Adding AI-enabled route: {} {}", route.method, route.path);
 
             let route_clone = (*route).clone();
             let ai_generator_clone = ai_generator.clone();
             // Issue #79 round 13 — same validation bypass as
-            // `build_router_with_mockai`. Clone the validator into the
-            // closure and run validation before AI response generation.
-            let validator_clone = self.clone_for_validation();
+            // `build_router_with_mockai`. Run validation before AI
+            // response generation; the validator is shared via Arc.
+            let validator_clone = validator.clone();
 
             // Create async handler that extracts request data and builds context
             let handler = move |AxumPath(path_params): AxumPath<HashMap<String, String>>,
@@ -1595,6 +1607,10 @@ impl OpenApiRouteRegistry {
         tracing::debug!("Building router with MockAI support from {} routes", self.routes.len());
 
         let custom_loader = self.custom_fixture_loader.clone();
+        // Issue #79 round 14 hotfix — one shared validator (Arc) instead
+        // of a per-route deep clone. See `build_router_with_context` for
+        // the O(N²)/OOM rationale.
+        let validator = Arc::new(self.clone_for_validation());
         for (axum_path, route) in &deduped {
             tracing::debug!("Adding MockAI-enabled route: {} {}", route.method, route.path);
 
@@ -1603,12 +1619,10 @@ impl OpenApiRouteRegistry {
             let custom_loader_clone = custom_loader.clone();
             // Issue #79 round 13 — the MockAI handler was bypassing
             // request validation entirely, so spec violations never
-            // populated the conformance ring buffer. Clone the
-            // validator into the closure and call
+            // populated the conformance ring buffer. Run
             // `run_validation_with_recording` before fixture/MockAI/
-            // mock-response synthesis, mirroring what
-            // `build_router_with_context` does at line ~686.
-            let validator_clone = self.clone_for_validation();
+            // mock-response synthesis; the validator is shared via Arc.
+            let validator_clone = validator.clone();
 
             // Create async handler that processes requests through MockAI
             // Query params are extracted via Query extractor with HashMap

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -1112,6 +1112,16 @@ impl OpenApiRouteRegistry {
             },
         );
 
+        // Issue #79 round 14 — shadow mode: the violation is recorded
+        // above (so the Conformance tab still shows it, with its real
+        // 400/422 classification), but we return Ok so the handler
+        // proceeds to synthesise a normal 2xx response. Lets a proxy
+        // replay run flow through non-blocking while capturing every
+        // violation.
+        if mockforge_foundation::unknown_paths::shadow_mode_enabled() {
+            return Ok(());
+        }
+
         Err((status_code, payload))
     }
 

--- a/crates/mockforge-tui/src/api/models.rs
+++ b/crates/mockforge-tui/src/api/models.rs
@@ -78,6 +78,14 @@ pub struct UnknownPathRequest {
     pub client_ip: String,
     #[serde(default)]
     pub query: String,
+    /// HTTP status the server returned (404 normally; 200 in shadow
+    /// mode — Issue #79 round 14). Defaults to 404 for older servers.
+    #[serde(default = "default_unknown_status")]
+    pub status: u16,
+}
+
+fn default_unknown_status() -> u16 {
+    404
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/mockforge-tui/src/screens/conformance.rs
+++ b/crates/mockforge-tui/src/screens/conformance.rs
@@ -701,6 +701,7 @@ impl ConformanceScreen {
             Cell::from("When").style(Theme::dim()),
             Cell::from("Method").style(Theme::dim()),
             Cell::from("Path").style(Theme::dim()),
+            Cell::from("Status").style(Theme::dim()),
             Cell::from("Query").style(Theme::dim()),
             Cell::from("Client").style(Theme::dim()),
         ])
@@ -717,6 +718,7 @@ impl ConformanceScreen {
                     Cell::from(r.timestamp.format("%H:%M:%S").to_string()),
                     Cell::from(r.method.clone()).style(Theme::http_method(&r.method)),
                     Cell::from(r.path.clone()),
+                    Cell::from(r.status.to_string()).style(Theme::status_code(r.status)),
                     Cell::from(if r.query.is_empty() {
                         "-".to_string()
                     } else {
@@ -731,7 +733,8 @@ impl ConformanceScreen {
             Constraint::Length(10),
             Constraint::Length(8),
             Constraint::Min(20),
-            Constraint::Min(15),
+            Constraint::Length(7),
+            Constraint::Min(12),
             Constraint::Length(16),
         ];
 


### PR DESCRIPTION
## Summary

Round-14 — Srikanth's (a) ask on Issue #79: a **shadow mode** on the mockforge server that returns `200` for unknown APIs / spec violations (with an accepted base path) for testing shadow APIs, while still capturing the violations.

### Shadow mode (`MOCKFORGE_SHADOW_MODE=true`)

New `mockforge_foundation::unknown_paths::shadow_mode_enabled()` gate (read per-request from the env var, matching the other `MOCKFORGE_*` runtime toggles). When enabled:

- **Unknown paths** — instead of 404, return a minimal `{"shadow":true,"matched":false}` 200 stub and record the entry with `status: 200`.
- **Spec violations** — record the violation with its real 400/422 classification (Conformance tab stays accurate), but return `Ok` so the handler proceeds to normal response synthesis → client gets a 2xx.

Net effect: replay proxy traffic through MockForge **non-blocking** and capture every violation for cross-checking, without rejections breaking the client flow. A report-only / monitor mode. Startup prints a `👻 SHADOW MODE ON` banner.

### Unknown-paths status column

`UnknownPathRequest` gains a `status: u16` (serde-default 404 for older payloads). The TUI unknown-paths view (`u` toggle) renders it as a colored `Status` column, so you can see which requests shadow mode let through as 200 vs normal 404s.

## Verified end-to-end

Release build, `MOCKFORGE_SHADOW_MODE=true mockforge serve --spec examples/openapi-demo.json`:

```
👻 SHADOW MODE ON (MOCKFORGE_SHADOW_MODE) — unknown paths and spec violations return 200 ...

$ curl /not-in-spec?x=1            -> 200 {"shadow":true,"matched":false}
$ curl -X POST /users -d '{}'      -> 201 (passed through)

$ GET /__mockforge/api/conformance/unknown-paths   -> {total:1, statuses:[200]}
$ GET /__mockforge/api/conformance/violations      -> {total:1, cats:["request-body"]}
```

- `cargo test -p mockforge-foundation --lib unknown_paths` — 4 pass (added shadow-env + legacy-status-default tests, plus a `TEST_LOCK` to serialize the global-buffer tests)
- `cargo test -p mockforge-tui --lib` — 291 pass
- `cargo test -p mockforge-http --lib management` — 9 pass
- `cargo clippy -p mockforge-foundation -p mockforge-openapi -p mockforge-http -p mockforge-tui --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Workspace 0.3.149 → 0.3.150. Closes the (a) line item from Srikanth's #79 round-13 follow-ups.