### PR TITLE
feat: --shadow flag + lifetime seen-totals + violation logs + wrapped TUI detail (#79 round 15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.3.151] - 2026-05-27
+
+### Added
+
+- **[Reality]** `mockforge serve --shadow` CLI flag (#79 round 15) — Srikanth's (g) ask: a first-class flag for shadow mode instead of only `MOCKFORGE_SHADOW_MODE=true`, so it can't be silently forgotten. Sets the env var under the hood; the `👻 SHADOW MODE ON` startup banner still prints.
+- **[Contracts][DevX]** Lifetime "seen total" counters for conformance violations and unknown paths (#79 round 15) — the ring buffers cap at 256 entries, which made a 656k-request run look like "only 256". Both the admin API (`total_seen` field) and the TUI titles now show the true lifetime count alongside the buffered count (e.g. `Conformance Violations (256 buffered, 256 shown, 4821 seen total)`). Answers Srikanth's (f) question.
+
+### Changed
+
+- **[DevX]** Server-side per-violation debug log (#79 round 15) — each recorded conformance violation now emits a `tracing::debug!` line under target `mockforge::conformance` with method/path/status/category/reason. Enable precisely with `RUST_LOG=mockforge::conformance=debug` to get grep-able server-side logs of *why* each request was rejected, without turning on firehose debug logging. Srikanth's (b)/(d) ask for "why is this a violation" via logs.
+- **[DevX]** TUI Conformance tab readability (#79 round 15) — the `Enter` violation-detail view and the Top Offending Endpoints panel now wrap long lines, so big Microsoft Graph paths and validation reasons are fully visible instead of clipped at the right edge. Srikanth's (c) ask. (`Enter` for full detail, `j`/`k` to scroll.)
+
 ## [0.3.150] - 2026-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7716,7 +7716,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7753,7 +7753,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7794,7 +7794,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7810,7 +7810,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7891,7 +7891,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7936,7 +7936,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8077,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8110,7 +8110,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8133,7 +8133,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8157,7 +8157,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8362,7 +8362,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8391,7 +8391,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8426,7 +8426,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8448,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8475,7 +8475,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8500,7 +8500,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8549,7 +8549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8614,7 +8614,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8644,7 +8644,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8673,7 +8673,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8688,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8712,7 +8712,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8789,7 +8789,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8814,7 +8814,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8832,7 +8832,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8866,7 +8866,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8904,7 +8904,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8981,7 +8981,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9001,7 +9001,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9014,7 +9014,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9073,7 +9073,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9101,7 +9101,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9131,7 +9131,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9158,7 +9158,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9181,14 +9181,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9215,7 +9215,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9248,7 +9248,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9320,7 +9320,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9372,7 +9372,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9407,7 +9407,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9418,7 +9418,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9435,7 +9435,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15266,7 +15266,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.150"
+version = "0.3.151"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.150"
+version = "0.3.151"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,17 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.151] - 2026-05-27
+
+### Added
+
+- **[Reality]** `mockforge serve --shadow` CLI flag (#79 round 15) — first-class flag for shadow mode (alias for `MOCKFORGE_SHADOW_MODE=true`) so it can't be forgotten.
+- **[Contracts][DevX]** Lifetime "seen total" counters for conformance violations + unknown paths — admin API `total_seen` field and TUI titles now show the true lifetime count alongside the 256-cap buffered count.
+
+### Changed
+
+- **[DevX]** Per-violation server log under target `mockforge::conformance` (enable with `RUST_LOG=mockforge::conformance=debug`) showing method/path/status/category/reason.
+- **[DevX]** TUI Conformance detail view + Top Offending Endpoints panel now wrap long lines so big paths/reasons are fully readable.
+
 ## [0.3.150] - 2026-05-26
 
 ### Fixed

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -556,6 +556,15 @@ struct ServeCliArgs {
     #[arg(long, help_heading = "Server Configuration")]
     pub no_rate_limit: bool,
 
+    /// Shadow / report-only mode (Issue #79): return 200 for unknown
+    /// paths and spec violations instead of 404/400/422, while still
+    /// recording them to the Conformance tab + unknown-paths feed.
+    /// Lets a proxy replay flow through non-blocking with full
+    /// violation capture. Equivalent to `MOCKFORGE_SHADOW_MODE=true`,
+    /// but as a flag so it's not silently forgotten.
+    #[arg(long, help_heading = "Server Configuration")]
+    pub shadow: bool,
+
     #[command(flatten)]
     pub ports: PortArgs,
 
@@ -2389,6 +2398,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     match cli.command {
         Commands::Serve(args) => {
+            // Issue #79 round 15 — `--shadow` is a thin alias for the
+            // env var the server reads at request time. Set it before
+            // anything boots so `shadow_mode_enabled()` sees it. A flag
+            // is harder to forget than an env var (Srikanth's (g) ask).
+            if args.shadow {
+                std::env::set_var("MOCKFORGE_SHADOW_MODE", "true");
+            }
             // Handle --list-network-profiles flag
             if args.traffic.list_network_profiles {
                 let catalog = mockforge_core::NetworkProfileCatalog::new();

--- a/crates/mockforge-foundation/src/conformance_violations.rs
+++ b/crates/mockforge-foundation/src/conformance_violations.rs
@@ -19,6 +19,7 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A single server-side conformance violation captured at the OpenAPI
 /// router. Mirrors `ConformanceViolation` semantics from the bench-side
@@ -48,10 +49,18 @@ const DEFAULT_BUFFER_SIZE: usize = 256;
 static VIOLATIONS: Lazy<Mutex<VecDeque<ServerConformanceViolation>>> =
     Lazy::new(|| Mutex::new(VecDeque::with_capacity(DEFAULT_BUFFER_SIZE)));
 
+/// Lifetime count of violations recorded since process start (Issue #79
+/// round 15). The ring buffer only keeps the most recent
+/// `DEFAULT_BUFFER_SIZE`; this counter answers Srikanth's "I sent 656k
+/// requests but only see 256" — the 256 is the buffer cap, this is the
+/// true total seen.
+static TOTAL_SEEN: AtomicU64 = AtomicU64::new(0);
+
 /// Record a violation. Old entries are dropped when the buffer is full
 /// (FIFO). Cheap enough to call from the hot path — uses a parking_lot
 /// Mutex which is uncontended in steady state.
 pub fn record(violation: ServerConformanceViolation) {
+    TOTAL_SEEN.fetch_add(1, Ordering::Relaxed);
     let mut buf = VIOLATIONS.lock();
     if buf.len() == DEFAULT_BUFFER_SIZE {
         buf.pop_front();
@@ -65,14 +74,22 @@ pub fn snapshot() -> Vec<ServerConformanceViolation> {
     buf.iter().rev().cloned().collect()
 }
 
-/// Number of violations currently buffered.
+/// Number of violations currently buffered (≤ `DEFAULT_BUFFER_SIZE`).
 pub fn len() -> usize {
     VIOLATIONS.lock().len()
 }
 
-/// Clear the buffer. Primarily for tests and TUI "reset" actions.
+/// Lifetime total of violations recorded since process start, including
+/// ones the ring buffer has since evicted.
+pub fn total_seen() -> u64 {
+    TOTAL_SEEN.load(Ordering::Relaxed)
+}
+
+/// Clear the buffer and reset the lifetime counter. Primarily for tests
+/// and TUI "reset" actions.
 pub fn clear() {
     VIOLATIONS.lock().clear();
+    TOTAL_SEEN.store(0, Ordering::Relaxed);
 }
 
 #[cfg(test)]

--- a/crates/mockforge-foundation/src/unknown_paths.rs
+++ b/crates/mockforge-foundation/src/unknown_paths.rs
@@ -16,6 +16,7 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Issue #79 round 14 — Srikanth's shadow-mode ask. When enabled, the
 /// server returns `200` for requests that would otherwise be rejected
@@ -64,8 +65,15 @@ const DEFAULT_BUFFER_SIZE: usize = 256;
 static UNKNOWN_PATHS: Lazy<Mutex<VecDeque<UnknownPathRequest>>> =
     Lazy::new(|| Mutex::new(VecDeque::with_capacity(DEFAULT_BUFFER_SIZE)));
 
-/// Record an unmatched-path 404. FIFO when the buffer is full.
+/// Lifetime count of unknown-path requests since process start (Issue
+/// #79 round 15). The ring buffer keeps only the most recent
+/// `DEFAULT_BUFFER_SIZE`; this is the true total seen — answers "I sent
+/// hundreds of thousands of requests but the feed only shows 256".
+static TOTAL_SEEN: AtomicU64 = AtomicU64::new(0);
+
+/// Record an unmatched-path request. FIFO when the buffer is full.
 pub fn record(req: UnknownPathRequest) {
+    TOTAL_SEEN.fetch_add(1, Ordering::Relaxed);
     let mut buf = UNKNOWN_PATHS.lock();
     if buf.len() == DEFAULT_BUFFER_SIZE {
         buf.pop_front();
@@ -79,14 +87,21 @@ pub fn snapshot() -> Vec<UnknownPathRequest> {
     buf.iter().rev().cloned().collect()
 }
 
-/// Current buffer length.
+/// Current buffer length (≤ `DEFAULT_BUFFER_SIZE`).
 pub fn len() -> usize {
     UNKNOWN_PATHS.lock().len()
 }
 
-/// Clear the buffer.
+/// Lifetime total of unknown-path requests recorded since process
+/// start, including ones the ring buffer has since evicted.
+pub fn total_seen() -> u64 {
+    TOTAL_SEEN.load(Ordering::Relaxed)
+}
+
+/// Clear the buffer and reset the lifetime counter.
 pub fn clear() {
     UNKNOWN_PATHS.lock().clear();
+    TOTAL_SEEN.store(0, Ordering::Relaxed);
 }
 
 #[cfg(test)]

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -1108,6 +1108,22 @@ impl OpenApiRouteRegistry {
                     .to_string()
             });
         let category = classify_validation_reason(&reason);
+        // Issue #79 round 15 — Srikanth asked for server-side logs of
+        // *why* a request was a violation. Emit one line per violation
+        // under a dedicated target so it can be enabled precisely
+        // (`RUST_LOG=mockforge::conformance=debug`) without turning on
+        // firehose debug logging. DEBUG (not WARN) so it doesn't spam
+        // the default log under load — the aggregate is in the
+        // Conformance tab / API; this is the opt-in detail channel.
+        tracing::debug!(
+            target: "mockforge::conformance",
+            method = %method,
+            path = %path_template,
+            status = status_code,
+            category = %category,
+            reason = %reason,
+            "request conformance violation"
+        );
         mockforge_foundation::conformance_violations::record(
             mockforge_foundation::conformance_violations::ServerConformanceViolation {
                 timestamp: Utc::now(),

--- a/crates/mockforge-tui/src/api/models.rs
+++ b/crates/mockforge-tui/src/api/models.rs
@@ -66,6 +66,10 @@ pub struct ConformanceViolationsResponse {
     pub violations: Vec<ConformanceViolation>,
     #[serde(default)]
     pub total: usize,
+    /// Lifetime count since server start (Issue #79 round 15); the
+    /// buffer caps `total` at 256, this is the true number seen.
+    #[serde(default)]
+    pub total_seen: u64,
 }
 
 /// One unmatched-path request (Issue #79 round 13).
@@ -94,6 +98,9 @@ pub struct UnknownPathsResponse {
     pub requests: Vec<UnknownPathRequest>,
     #[serde(default)]
     pub total: usize,
+    /// Lifetime count since server start (Issue #79 round 15).
+    #[serde(default)]
+    pub total_seen: u64,
 }
 
 // ── Dashboard ────────────────────────────────────────────────────────

--- a/crates/mockforge-tui/src/screens/conformance.rs
+++ b/crates/mockforge-tui/src/screens/conformance.rs
@@ -22,7 +22,7 @@ use std::time::Instant;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
-    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap},
     Frame,
 };
 use tokio::sync::mpsc;
@@ -125,9 +125,14 @@ pub struct ConformanceScreen {
     /// Full snapshot from the server, newest-first.
     violations: Vec<ConformanceViolation>,
     total: usize,
+    /// Round-15: lifetime count of violations seen server-side (the
+    /// buffer caps `total` at 256; this is the true total).
+    total_seen: u64,
     /// Round-13: unmatched-path requests captured by the HTTP fallback.
     unknown_paths: Vec<UnknownPathRequest>,
     unknown_total: usize,
+    /// Round-15: lifetime count of unknown-path requests seen.
+    unknown_total_seen: u64,
     /// Toggled by `u` between violations and unknown-paths views.
     view_mode: ViewMode,
     table: TableState,
@@ -156,8 +161,10 @@ impl ConformanceScreen {
             loaded: false,
             violations: Vec::new(),
             total: 0,
+            total_seen: 0,
             unknown_paths: Vec::new(),
             unknown_total: 0,
+            unknown_total_seen: 0,
             view_mode: ViewMode::Violations,
             table: TableState::new(),
             error: None,
@@ -423,14 +430,21 @@ impl Screen for ConformanceScreen {
         if self.detail_open {
             let detail =
                 self.selected_detail().unwrap_or_else(|| "(no violation selected)".to_string());
-            let para = Paragraph::new(detail).scroll((self.detail_scroll, 0)).block(
-                Block::default()
-                    .title(" Violation Detail (Esc to close) ")
-                    .title_style(Theme::title())
-                    .borders(Borders::ALL)
-                    .border_style(Theme::dim())
-                    .style(Theme::surface()),
-            );
+            // Issue #79 round 15 — wrap long lines so big Microsoft
+            // Graph paths and validation reasons are fully readable
+            // (Srikanth couldn't see the full path/reason). j/k still
+            // scroll vertically through the wrapped detail.
+            let para = Paragraph::new(detail)
+                .wrap(Wrap { trim: false })
+                .scroll((self.detail_scroll, 0))
+                .block(
+                    Block::default()
+                        .title(" Violation Detail (Esc to close, j/k scroll) ")
+                        .title_style(Theme::title())
+                        .borders(Borders::ALL)
+                        .border_style(Theme::dim())
+                        .style(Theme::surface()),
+                );
             frame.render_widget(para, area);
             return;
         }
@@ -504,6 +518,7 @@ impl Screen for ConformanceScreen {
                     if let Ok(payload) = serde_json::to_string(&serde_json::json!({
                         "violations": resp.violations,
                         "total": resp.total,
+                        "total_seen": resp.total_seen,
                     })) {
                         let _ = tx_v.send(Event::Data {
                             screen: "conformance",
@@ -527,6 +542,7 @@ impl Screen for ConformanceScreen {
                     if let Ok(payload) = serde_json::to_string(&serde_json::json!({
                         "unknown_requests": resp.requests,
                         "unknown_total": resp.total,
+                        "unknown_total_seen": resp.total_seen,
                     })) {
                         let _ = tx_u.send(Event::Data {
                             screen: "conformance",
@@ -553,10 +569,13 @@ impl Screen for ConformanceScreen {
             unknown_requests: Vec<UnknownPathRequest>,
             #[serde(default)]
             unknown_total: usize,
+            #[serde(default)]
+            unknown_total_seen: u64,
         }
         if let Ok(parsed) = serde_json::from_str::<UnknownWire>(payload) {
             self.unknown_paths = parsed.unknown_requests;
             self.unknown_total = parsed.unknown_total;
+            self.unknown_total_seen = parsed.unknown_total_seen;
             if matches!(self.view_mode, ViewMode::UnknownPaths) {
                 self.table.set_total(self.current_row_count());
             }
@@ -571,12 +590,15 @@ impl Screen for ConformanceScreen {
             #[serde(default)]
             total: usize,
             #[serde(default)]
+            total_seen: u64,
+            #[serde(default)]
             cleared: Option<usize>,
         }
         match serde_json::from_str::<Wire>(payload) {
             Ok(parsed) => {
                 self.violations = parsed.violations;
                 self.total = parsed.total;
+                self.total_seen = parsed.total_seen;
                 if matches!(self.view_mode, ViewMode::Violations) {
                     self.table.set_total(self.current_row_count());
                 }
@@ -671,13 +693,20 @@ impl ConformanceScreen {
 
         let filtered_count = indices.len();
         let filter_suffix = self.filter_label_suffix();
+        // Round-15: show lifetime `total_seen` alongside the buffered
+        // count so a 656k-request run doesn't look like "only 256".
+        let seen_suffix = if self.total_seen as usize > self.total {
+            format!(", {} seen total", self.total_seen)
+        } else {
+            String::new()
+        };
         let title = if self.total > filtered_count {
             format!(
-                " Conformance Violations ({} buffered, {} shown{}) ",
-                self.total, filtered_count, filter_suffix
+                " Conformance Violations ({} buffered, {} shown{}{}) ",
+                self.total, filtered_count, seen_suffix, filter_suffix
             )
         } else {
-            format!(" Conformance Violations ({}{}) ", filtered_count, filter_suffix)
+            format!(" Conformance Violations ({}{}{}) ", filtered_count, seen_suffix, filter_suffix)
         };
 
         let table = Table::new(rows, widths)
@@ -740,13 +769,20 @@ impl ConformanceScreen {
 
         let filtered_count = indices.len();
         let filter_suffix = self.filter_label_suffix();
+        // Round-15: lifetime total so the 256-cap buffer doesn't read
+        // as the whole story (Srikanth's 656k-vs-256 question).
+        let seen_suffix = if self.unknown_total_seen as usize > self.unknown_total {
+            format!(", {} seen total", self.unknown_total_seen)
+        } else {
+            String::new()
+        };
         let title = if self.unknown_total > filtered_count {
             format!(
-                " Unknown Paths ({} buffered, {} shown{}) ",
-                self.unknown_total, filtered_count, filter_suffix
+                " Unknown Paths ({} buffered, {} shown{}{}) ",
+                self.unknown_total, filtered_count, seen_suffix, filter_suffix
             )
         } else {
-            format!(" Unknown Paths ({}{}) ", filtered_count, filter_suffix)
+            format!(" Unknown Paths ({}{}{}) ", filtered_count, seen_suffix, filter_suffix)
         };
 
         let table = Table::new(rows, widths)
@@ -775,7 +811,9 @@ impl ConformanceScreen {
                 .collect::<Vec<_>>()
                 .join("\n")
         };
-        let para = Paragraph::new(body).style(Theme::dim()).block(
+        // Issue #79 round 15 — wrap so long `METHOD /very/long/graph/path`
+        // entries don't get clipped at the panel's right edge.
+        let para = Paragraph::new(body).style(Theme::dim()).wrap(Wrap { trim: false }).block(
             Block::default()
                 .title(" Top Offending Endpoints ")
                 .title_style(Theme::title())

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -1334,12 +1334,15 @@ pub async fn get_conformance_violations(
 ) -> impl IntoResponse {
     let snap = mockforge_foundation::conformance_violations::snapshot();
     let total = snap.len();
+    let total_seen = mockforge_foundation::conformance_violations::total_seen();
     let limit: Option<usize> = q.get("limit").and_then(|s| s.parse().ok());
     let limited: Vec<_> = match limit {
         Some(n) => snap.into_iter().take(n).collect(),
         None => snap,
     };
-    Json(json!({"violations": limited, "total": total}))
+    // `total` = entries currently in the 256-cap ring buffer;
+    // `total_seen` = lifetime count since server start (Issue #79 r15).
+    Json(json!({"violations": limited, "total": total, "total_seen": total_seen}))
 }
 
 /// Clear the server-side conformance violation ring buffer.
@@ -1357,12 +1360,13 @@ pub async fn get_unknown_paths(
 ) -> impl IntoResponse {
     let snap = mockforge_foundation::unknown_paths::snapshot();
     let total = snap.len();
+    let total_seen = mockforge_foundation::unknown_paths::total_seen();
     let limit: Option<usize> = q.get("limit").and_then(|s| s.parse().ok());
     let limited: Vec<_> = match limit {
         Some(n) => snap.into_iter().take(n).collect(),
         None => snap,
     };
-    Json(json!({"requests": limited, "total": total}))
+    Json(json!({"requests": limited, "total": total, "total_seen": total_seen}))
 }
 
 /// Clear the unknown-paths ring buffer.


### PR DESCRIPTION
## Summary

Five follow-ups from Srikanth's 0.3.150 testing on Issue #79.

- **(g)** `mockforge serve --shadow` — first-class CLI flag for shadow mode (alias for `MOCKFORGE_SHADOW_MODE=true`) so it can't be silently forgotten. Sets the env var before boot; the `👻 SHADOW MODE ON` banner still prints.
- **(f)** Lifetime "seen total" counters on both ring buffers (conformance_violations + unknown_paths). The buffers cap at 256, so a 656k-request run read as "only 256". New `AtomicU64` + `total_seen()` expose the true lifetime count — surfaced as `total_seen` in the admin API and in the TUI titles (`256 buffered, … 263 seen total`). **Verified: 260 unknown requests → buffered=256, total_seen=263.**
- **(b/d)** Server-side per-violation log: `run_validation_with_recording` emits `tracing::debug!` under target `mockforge::conformance` with method/path/status/category/reason. Grep-able with `RUST_LOG=mockforge::conformance=debug`; off by default so it doesn't spam under load.
- **(c)** TUI readability: the `Enter` violation-detail view and the Top Offending Endpoints panel now wrap long lines, so big Microsoft Graph paths/reasons are fully visible instead of clipped.

(e) needed no change. (h) `--conformance-self-test` vs `--validate-requests` is a synthetic-vs-real-traffic distinction (explained in the issue reply).

## Test plan

- [x] End-to-end on a release build: `--shadow` banner + 200 for unknown path / violation; `total_seen` exceeds the 256 buffer cap (263 after 260 requests)
- [x] `cargo test -p mockforge-foundation --lib` (conformance_violations + unknown_paths) — 6 pass
- [x] `cargo test -p mockforge-tui --lib` — 291 pass
- [x] `cargo clippy -p mockforge-foundation -p mockforge-openapi -p mockforge-ui -p mockforge-tui -p mockforge-cli --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Workspace 0.3.150 → 0.3.151.