### PR TITLE
fix(registry-server): fail-fast guard for unsupported slim build

### DIFF
--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -18,9 +18,15 @@ publish = false
 # Default build is the full multi-tenant SaaS server.
 default = ["saas"]
 
-# Bundles every SaaS-only integration. The `mockforge-registry-server` binary
-# requires this feature. OSS consumers (e.g. `mockforge-ui`) can depend on this
-# crate with `default-features = false` and opt into only what they need.
+# Bundles every SaaS-only integration. This is the ONLY supported build
+# configuration for this crate: `stripe`, `email`, `storage-s3`, and
+# `cache-redis` are referenced unconditionally across the crate, so a
+# slimmed-down build (`--no-default-features --features postgres`) does not
+# compile — a `compile_error!` in `lib.rs` enforces this with an actionable
+# message. This is intentional: `mockforge-registry-server` is the SaaS binary,
+# and the OSS-friendly registry library is `mockforge-registry-core` (consumed
+# by `mockforge-ui`). OSS consumers should depend on `mockforge-registry-core`,
+# not feature-slice this crate. Context: #644.
 saas = [
   "postgres",
   "storage-s3",

--- a/crates/mockforge-registry-server/src/lib.rs
+++ b/crates/mockforge-registry-server/src/lib.rs
@@ -6,14 +6,44 @@
 //!
 //! MockForge Plugin Registry Server — library crate.
 //!
-//! This crate is being extracted into a reusable library so that both the
-//! multi-tenant SaaS binary (`mockforge-registry-server`) and the single-tenant
-//! OSS admin server (`mockforge-ui`) can share the same domain models,
-//! storage layer, handlers, and authentication middleware.
+//! This is the multi-tenant **SaaS binary** crate. The reusable, OSS-friendly
+//! pieces — domain models, the `RegistryStore` trait + SQLite/Postgres
+//! backends, auth, and TOTP/2FA helpers — live in `mockforge-registry-core`
+//! and are consumed directly by single-tenant builds such as `mockforge-ui`
+//! (`mockforge-registry-core` with `default-features = false, features =
+//! ["sqlite"]`). This crate re-exports a few of them for path stability but
+//! is *not* itself intended to be consumed as a slimmed-down library; that
+//! role belongs to `mockforge-registry-core`.
 //!
-//! Phase 0 of the extraction: expose the existing modules via `lib.rs`
-//! without behavior changes. Later phases will introduce a `RegistryStore`
-//! trait, a SQLite backend, and feature gates for SaaS-only integrations.
+//! Consequently this crate requires its full integration set. The SaaS-only
+//! integrations (`stripe`, `email`, `storage-s3`, `cache-redis`) are referenced
+//! unconditionally throughout the crate, so the only supported build is the
+//! `saas` rollup (the default). A slimmed-down build such as
+//! `--no-default-features --features postgres` is not supported — see #644.
+//! The guard below turns that into one actionable message instead of 30+
+//! "unresolved crate" errors. If OSS consumers ever need a smaller surface of
+//! *this* crate, the right move is to extend `mockforge-registry-core`, not to
+//! feature-gate the SaaS server.
+
+// This crate requires its full integration set (see the module docs above and
+// #644). Keyed on the actual load-bearing integrations rather than the `saas`
+// umbrella, so an explicit `--features postgres,stripe,email,storage-s3,
+// cache-redis` build is allowed, and the guard naturally shrinks if any of
+// these are ever properly feature-gated.
+#[cfg(not(all(
+    feature = "stripe",
+    feature = "email",
+    feature = "storage-s3",
+    feature = "cache-redis"
+)))]
+compile_error!(
+    "mockforge-registry-server is the SaaS binary and must be built with its \
+     full integration set. Use the default `saas` feature (or at minimum \
+     `--features postgres,stripe,email,storage-s3,cache-redis`). The `stripe`, \
+     `email`, `storage-s3`, and `cache-redis` integrations are referenced \
+     unconditionally, so a slimmer build does not compile. For an OSS-friendly \
+     registry library, depend on `mockforge-registry-core` instead. See #644."
+);
 
 /// JWT/password auth helpers moved to `mockforge-registry-core`.
 pub use mockforge_registry_core::auth;


### PR DESCRIPTION
## Summary
`cargo build -p mockforge-registry-server --no-default-features --features postgres` failed with **33 cryptic "unresolved crate" errors** (`stripe`, `redis`, `aws_config`, `lettre`). This replaces that wall with one actionable `compile_error!` and corrects the docs that invited the unsupported build.

## Why fail-fast, not feature-gate
`registry-server` is the SaaS **binary**. The reusable OSS surface already lives in **`mockforge-registry-core`** (domain models, `RegistryStore` + SQLite/Postgres backends, auth, TOTP) and is consumed directly by `mockforge-ui` (`registry-core`, sqlite) — that path **builds clean** (verified). Slim-gating the server would duplicate registry-core's role and leave two crates claiming the "shared lib" mantle. No crate anywhere depends on `registry-server` (it's a leaf binary, `publish = false`).

## What changed
- `lib.rs`: `compile_error!` keyed on the actual load-bearing integrations (`stripe`/`email`/`storage-s3`/`cache-redis`) — inactive under the default `saas` build, fires with a clear message + pointer to `registry-core` otherwise. The condition naturally shrinks if any integration is ever properly gated.
- `lib.rs` doc: corrected the stale claim that the *server* would be shared with `mockforge-ui`; clarifies `registry-core` owns that role.
- `Cargo.toml`: removed the misleading "OSS consumers can depend with `default-features = false`" invitation.

## Test plan
- [x] Slim build now leads with the actionable message
- [x] Default `saas` build unaffected (only an inactive `#[cfg]` block + comments added; rust-analyzer confirms inactive; clippy + fmt pass in pre-commit)
- [x] Real OSS consumer `mockforge-ui` (→ registry-core, sqlite) builds clean (exit 0)

Closes #644.