### PR TITLE
feat(ui): align admin UI typography with the brand (Geist)

### DIFF
--- a/crates/mockforge-ui/ui/index.html
+++ b/crates/mockforge-ui/ui/index.html
@@ -8,7 +8,7 @@
 
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.json" />
-    <meta name="theme-color" content="#3b82f6" />
+    <meta name="theme-color" content="#D35400" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
@@ -20,7 +20,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
     <!-- Font Optimization: Load fonts with display=swap -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
 
     <title>MockForge Admin</title>
   </head>

--- a/crates/mockforge-ui/ui/src/index.css
+++ b/crates/mockforge-ui/ui/src/index.css
@@ -284,7 +284,7 @@
   body {
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
-    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    font-family: Geist, Inter, ui-sans-serif, system-ui, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }

--- a/crates/mockforge-ui/ui/tailwind.config.js
+++ b/crates/mockforge-ui/ui/tailwind.config.js
@@ -8,7 +8,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        sans: ['Geist', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
         mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
       screens: {


### PR DESCRIPTION
## Summary
First increment of applying the new `mockforge-product-ui` design skill to the authenticated admin UI: bring its typography in line with mockforge.dev.

- Switch the UI font from **Inter → Geist** (keeping JetBrains Mono for data/code): Google Fonts link, Tailwind `sans` stack, and the `body` font-family.
- Fix the PWA `theme-color` from a stray blue (`#3b82f6`) to brand orange (`#D35400`).

The app's **color tokens were already on-brand** (the `brand` ramp is hue-24 burnt orange, with `success`/`warning`/`danger`/`info` semantic colors and bg/text hierarchy already defined), so this is purely the typography alignment. No component/logic changes.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm build` succeeds
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [x] Dev server renders in Geist (verified computed `font-family` on body + headings) with the brand-orange primary button

## Follow-ups (per the skill, need the running app + backend to verify safely)
- Converge the screens that still import `@mui/material` onto the Radix/Tailwind/CVA system (one system).
- Per-surface polish (tables: sticky headers + `tabular-nums`; every-state discipline) on the data-heavy pages.