### PR TITLE
feat(tui,bench): export dedup + self-test coverage gaps (#79 round 16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.3.152] - 2026-05-28
+
+### Changed
+
+- **[Contracts][DevX]** TUI Conformance export (`e`) now deduplicates by `(method, path, category, reason)` and sorts by occurrence count descending (#79 round 16) — Srikanth's (c-ii) ask: under sustained traffic the export was 256 mostly-identical rows. Each group now carries a `count` and `first_seen` / `last_seen` window so the time range is preserved while the file collapses from "256 rows of mostly the same thing" to a ranked unique-violation list. The TUI table itself still shows each occurrence (unchanged). The flash message now reads `exported N unique violation(s) (M occurrences) to …`.
+- **[DevX]** `mockforge bench --conformance --conformance-self-test` now produces negatives for two previously-zero-coverage shapes (#79 round 16 (h)) — addresses Srikanth's "always all passing" report on operations that fell through the gaps:
+  1. **Operations with a required body but no synthesised sample** — the `request-body:empty` and `request-body:wrong-type` negatives now fire whenever the spec declares a request body content type, regardless of whether the body annotator could produce a positive sample.
+  2. **Operations with a path-param and no required body / query / header** — emits a new `parameters:bad-path-param` probe that substitutes the first path parameter with `"self-test-invalid-id"`. Operations whose spec types the param as integer / UUID / regex-patterned will catch this (4xx); operations that allow free-form strings will let it through. Either outcome is informative — a category that's all-`missed` is the spec telling you path-param types are loose.
+
 ## [0.3.151] - 2026-05-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7716,7 +7716,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7753,7 +7753,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7794,7 +7794,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7810,7 +7810,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7891,7 +7891,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7936,7 +7936,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8077,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8110,7 +8110,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8133,7 +8133,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8157,7 +8157,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8362,7 +8362,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8391,7 +8391,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8426,7 +8426,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8448,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8475,7 +8475,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8500,7 +8500,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8549,7 +8549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8614,7 +8614,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8644,7 +8644,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8673,7 +8673,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8688,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8712,7 +8712,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8789,7 +8789,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8814,7 +8814,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8832,7 +8832,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8866,7 +8866,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8904,7 +8904,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8981,7 +8981,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9001,7 +9001,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9014,7 +9014,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9073,7 +9073,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9101,7 +9101,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9131,7 +9131,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9158,7 +9158,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9181,14 +9181,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9215,7 +9215,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9248,7 +9248,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9320,7 +9320,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9372,7 +9372,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9407,7 +9407,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9418,7 +9418,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9435,7 +9435,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15266,7 +15266,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.151"
+version = "0.3.152"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.151"
+version = "0.3.152"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,12 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.152] - 2026-05-28
+
+### Changed
+
+- **[Contracts][DevX]** TUI Conformance export (`e`) now deduplicates by `(method, path, category, reason)` with a `count` + `first_seen` / `last_seen` window (#79 round 16).
+- **[DevX]** `--conformance-self-test` produces negatives for two previously-zero-coverage shapes: operations with a required body but no synthesised sample, and operations whose only spec input is a path parameter (`parameters:bad-path-param` probe).
+
 ## [0.3.151] - 2026-05-27
 
 ### Added

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -179,8 +179,15 @@ async fn test_operation(
     // ── Negative cases ───────────────────────────────────────────
     let mut negatives = Vec::new();
 
-    // (a) empty body when one is required
-    if op.request_body_content_type.is_some() && op.sample_body.is_some() {
+    // (a) empty body when one is required.
+    //
+    // Round 16 — drop the `sample_body.is_some()` precondition. Operations
+    // whose body annotator couldn't synthesize a sample previously got
+    // zero negatives (so the self-test reported "all passing" even on
+    // POST /resource with a required body). The spec saying the operation
+    // *has* a request body is enough — an empty object is a valid
+    // negative regardless of whether we have a positive sample.
+    if op.request_body_content_type.is_some() {
         negatives.push(
             send_case(
                 client,
@@ -213,6 +220,58 @@ async fn test_operation(
             )
             .await,
         );
+    }
+
+    // (e) Round 16 — path-param type probe. Send the first path
+    // parameter as a literal `"self-test-invalid-id"`: a string that
+    // contains hyphens, won't parse as an integer, won't parse as a
+    // UUID, and won't match any typical regex pattern. Operations
+    // whose spec types the param as `integer` or `string` with a
+    // `format`/`pattern` will catch this (caught: server returned
+    // 4xx); operations whose spec lets path params be free-form
+    // strings will let it through (missed: server returned 2xx).
+    // Either outcome is informative: a category that's all "missed"
+    // tells the user their spec is loose on path-param types, which
+    // is itself worth knowing. Addresses Srikanth's "always all
+    // passing" report — operations with a path param now produce at
+    // least one probe instead of zero.
+    if !op.path_params.is_empty() {
+        let mut url_with_placeholder = op.path.clone();
+        if let Some((first_name, _)) = op.path_params.first() {
+            // Substitute every other path-param with its sample so the
+            // route shape stays intact and only the first param is bad.
+            for (name, value) in op.path_params.iter().skip(1) {
+                if !value.is_empty() {
+                    url_with_placeholder =
+                        url_with_placeholder.replace(&format!("{{{name}}}"), value);
+                }
+            }
+            // Substitute the first param with a guaranteed-invalid
+            // sentinel that's unlikely to match any reasonable schema:
+            // contains characters disallowed in numeric IDs *and* UUIDs.
+            url_with_placeholder =
+                url_with_placeholder.replace(&format!("{{{first_name}}}"), "self-test-invalid-id");
+            let target = config.target_url.trim_end_matches('/');
+            let bad_url = if url_with_placeholder.starts_with('/') {
+                format!("{}{}", target, url_with_placeholder)
+            } else {
+                format!("{}/{}", target, url_with_placeholder)
+            };
+            negatives.push(
+                send_case(
+                    client,
+                    config,
+                    method.clone(),
+                    &bad_url,
+                    "parameters:bad-path-param",
+                    true,
+                    op.sample_body.as_deref(),
+                    op.query_params.clone(),
+                    op.header_params.clone(),
+                )
+                .await,
+            );
+        }
     }
 
     // (c) drop the first required query param
@@ -427,6 +486,58 @@ mod tests {
         assert_eq!(report.positive_fail, 1);
         assert!(report.negative_missed.values().sum::<usize>() >= 1);
         assert!(!report.all_passed());
+    }
+
+    /// Round 16 — operations with a body OR a path-param now produce
+    /// negatives even without a sample body. Previously a POST whose
+    /// body annotator failed produced *zero* negatives, so the self-test
+    /// always reported "all passing" for that endpoint.
+    #[tokio::test]
+    async fn no_sample_body_still_produces_request_body_negatives() {
+        let cfg = SelfTestConfig {
+            target_url: "http://127.0.0.1:1".into(),
+            timeout: Duration::from_millis(200),
+            ..Default::default()
+        };
+        // POST with a body content type but no sample (annotator gap).
+        let ops = vec![op("POST", "/x", None, vec![], vec![], vec![])];
+        // No sample_body but request_body_content_type set:
+        let mut ops_fixed = ops;
+        ops_fixed[0].request_body_content_type = Some("application/json".into());
+        let report = run_self_test(&ops_fixed, &cfg).await.expect("client builds");
+        // Both request-body negatives (empty + wrong-type) should fire,
+        // landing in `negative_missed` because the unreachable target
+        // returns no 4xx. The point: count > 0.
+        assert!(
+            report.negative_missed.values().sum::<usize>() >= 2,
+            "expected ≥2 request-body negatives, got {:?}",
+            report.negative_missed
+        );
+    }
+
+    /// Round 16 — operations with a path-param now get a probe even
+    /// when there's no body / required query / required header.
+    /// Previously `/teams/{team-id}` with no other required fields
+    /// produced zero negatives → always "all passing".
+    #[tokio::test]
+    async fn path_param_only_endpoint_produces_a_probe() {
+        let cfg = SelfTestConfig {
+            target_url: "http://127.0.0.1:1".into(),
+            timeout: Duration::from_millis(200),
+            ..Default::default()
+        };
+        let ops = vec![op(
+            "GET",
+            "/teams/{team-id}",
+            None,
+            vec![],
+            vec![],
+            vec![("team-id", "1")],
+        )];
+        let report = run_self_test(&ops, &cfg).await.expect("client builds");
+        let total: usize = report.negative_caught.values().sum::<usize>()
+            + report.negative_missed.values().sum::<usize>();
+        assert!(total >= 1, "expected ≥1 path-param probe, got {:?}", report);
     }
 
     #[test]

--- a/crates/mockforge-tui/src/screens/conformance.rs
+++ b/crates/mockforge-tui/src/screens/conformance.rs
@@ -120,6 +120,27 @@ enum ViewMode {
     UnknownPaths,
 }
 
+/// Group key for export dedup — same (method, path, category, reason)
+/// rolls up. Aliased so clippy doesn't flag the inner HashMap value.
+type DedupKey = (String, String, String, String);
+
+/// Round 16 — JSON shape written by the export action (`e`). Same
+/// fields as `ConformanceViolation` minus `client_ip` (which is always
+/// `"unknown"` for now and just adds noise to the file), plus a `count`
+/// and a `first_seen` / `last_seen` window. Same-shape lines are
+/// collapsed by `export_filtered`.
+#[derive(Debug, serde::Serialize)]
+struct DedupedViolation {
+    method: String,
+    path: String,
+    category: String,
+    reason: String,
+    status: u16,
+    count: u32,
+    first_seen: chrono::DateTime<chrono::Utc>,
+    last_seen: chrono::DateTime<chrono::Utc>,
+}
+
 pub struct ConformanceScreen {
     loaded: bool,
     /// Full snapshot from the server, newest-first.
@@ -258,17 +279,82 @@ impl ConformanceScreen {
     /// Export the current filtered snapshot to a JSON file in CWD so
     /// the user can drop it next to their proxy logs and grep across
     /// both sides. Returns the path or an error message via `flash`.
+    ///
+    /// Round 16 — exports are **deduplicated** by
+    /// `(method, path, category, reason)`, sorted by occurrence count
+    /// descending, so a 500k-request run no longer produces a 256-entry
+    /// JSON of mostly-identical rows. Each group keeps the *first* and
+    /// *last* timestamps so you can still see the time window. The TUI
+    /// keeps showing each occurrence — only the export collapses.
     fn export_filtered(&mut self) {
         let now = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
         let path = PathBuf::from(format!("conformance-violations-{}.json", now));
         let indices = self.filtered_indices();
-        let snapshot: Vec<&ConformanceViolation> =
-            indices.iter().filter_map(|&i| self.violations.get(i)).collect();
-        match serde_json::to_string_pretty(&snapshot) {
+
+        // Group by (method, path, category, reason). Insertion order
+        // doesn't matter — we sort by count at the end.
+        let mut groups: HashMap<DedupKey, (DedupedViolation, u32, chrono::DateTime<chrono::Utc>)> =
+            HashMap::new();
+        for &i in &indices {
+            let Some(v) = self.violations.get(i) else {
+                continue;
+            };
+            let key = (v.method.clone(), v.path.clone(), v.category.clone(), v.reason.clone());
+            match groups.get_mut(&key) {
+                Some(slot) => {
+                    slot.1 += 1;
+                    if v.timestamp < slot.0.first_seen {
+                        slot.0.first_seen = v.timestamp;
+                    }
+                    if v.timestamp > slot.2 {
+                        slot.2 = v.timestamp;
+                        slot.0.last_seen = v.timestamp;
+                    }
+                }
+                None => {
+                    groups.insert(
+                        key,
+                        (
+                            DedupedViolation {
+                                method: v.method.clone(),
+                                path: v.path.clone(),
+                                category: v.category.clone(),
+                                reason: v.reason.clone(),
+                                status: v.status,
+                                count: 1,
+                                first_seen: v.timestamp,
+                                last_seen: v.timestamp,
+                            },
+                            1,
+                            v.timestamp,
+                        ),
+                    );
+                }
+            }
+        }
+
+        let mut deduped: Vec<DedupedViolation> = groups
+            .into_iter()
+            .map(|(_, (mut d, n, _))| {
+                d.count = n;
+                d
+            })
+            .collect();
+        deduped.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.path.cmp(&b.path)));
+
+        let total_occurrences: u32 = deduped.iter().map(|d| d.count).sum();
+        let unique_groups = deduped.len();
+
+        match serde_json::to_string_pretty(&deduped) {
             Ok(json) => match std::fs::write(&path, json) {
                 Ok(()) => {
                     self.flash = Some((
-                        format!("exported {} violation(s) to {}", snapshot.len(), path.display()),
+                        format!(
+                            "exported {} unique violation(s) ({} occurrences) to {}",
+                            unique_groups,
+                            total_occurrences,
+                            path.display()
+                        ),
                         Instant::now(),
                     ));
                 }


### PR DESCRIPTION
## Summary

Addresses two of Srikanth's round-16 asks on Issue #79. The rest of his feedback is being addressed in the issue reply (mostly explaining behaviour or scoping into round 17).

### (c-ii) TUI Conformance export dedup

Pressing **`e`** in the Conformance tab now groups violations by `(method, path, category, reason)` and sorts by occurrence count descending. Each group carries a `count` plus `first_seen` / `last_seen` window so the time range is preserved while the file collapses from ring-buffer dump to ranked list. The flash message now reads:

```
exported 47 unique violation(s) (517498 occurrences) to conformance-violations-…json
```

The TUI table itself is unchanged — still shows every occurrence.

### (h) `--conformance-self-test` coverage gaps (phase 17.1)

The "always all passing" report Srikanth saw on Microsoft Graph operations was because some legitimate violation shapes were producing **zero** negatives:

1. **Body required but no synthesised sample** — the `request-body:empty` and `request-body:wrong-type` negatives previously required `sample_body.is_some()`. They now fire whenever the spec declares a `requestBody.content` type, regardless of the annotator's positive sample.
2. **Path-param-only operations** (e.g. `GET /teams/{team-id}` with no required body / query / header) — previously got zero negatives. New `parameters:bad-path-param` probe substitutes the first path param with `"self-test-invalid-id"`. Operations whose spec types the param as integer / UUID / regex-patterned will catch this (4xx); operations that allow free-form strings will let it through. **Either outcome is informative** — an all-missed category tells the user their spec is loose on path-param types.

Two new tests guard the regression:
- `no_sample_body_still_produces_request_body_negatives` 
- `path_param_only_endpoint_produces_a_probe`

## Test plan

- [x] `cargo test -p mockforge-bench --lib self_test` — 8 pass (was 6, +2 regression tests)
- [x] `cargo test -p mockforge-tui --lib` — 291 pass
- [x] `cargo clippy -p mockforge-bench -p mockforge-tui --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Workspace 0.3.151 → 0.3.152.