### PR TITLE
feat(tui,foundation,openapi,ui): clipboard copy + total_ok counter (#79 round 17.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3.153] - 2026-05-29
+
+### Added
+
+- **[Contracts][DevX]** TUI Conformance detail view gains a **`c`** keystroke to copy the selected violation to the system clipboard as pretty-printed JSON (#79 round 17.1) — Srikanth's (c-i) ask. Uses `arboard` with default features so it works on X11, Wayland, macOS NSPasteboard, and Win32 without per-platform setup. On a clipboard-less TTY the failure surfaces in the flash strip instead of silently no-op'ing.
+- **[Contracts]** New `total_ok` lifetime counter on the conformance violations API (#79 round 17.1) — Srikanth's (f) follow-up. Each request that *passes* the validator bumps the counter; the admin API returns `total_ok` alongside `total_seen`, and the TUI title now reads e.g. `Conformance Violations (256 buffered, 256 shown, 517498/522830 validated failed)`. Gives the real pass/fail ratio under sustained traffic instead of just the violation count.
+
 ## [0.3.152] - 2026-05-28
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image 0.25.9",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +2510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,6 +4285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4358,6 +4393,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fd-lock"
@@ -6341,6 +6382,8 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -7671,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7694,7 +7737,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7716,7 +7759,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7753,7 +7796,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7794,7 +7837,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7810,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7891,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7936,7 +7979,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7946,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7971,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8044,7 +8087,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8077,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8110,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8133,7 +8176,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8157,7 +8200,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8183,7 +8226,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8221,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8264,7 +8307,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8345,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8363,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8392,7 +8435,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8427,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8449,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8476,7 +8519,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8501,7 +8544,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8524,7 +8567,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8550,7 +8593,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8566,7 +8609,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8596,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8615,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8645,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8674,7 +8717,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8689,7 +8732,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8713,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8753,7 +8796,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8771,7 +8814,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8790,7 +8833,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8815,7 +8858,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8833,7 +8876,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8867,7 +8910,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8905,7 +8948,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8982,7 +9025,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9002,7 +9045,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9015,7 +9058,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9037,7 +9080,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9074,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9102,7 +9145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9132,7 +9175,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9159,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9182,14 +9225,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9216,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9227,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9249,7 +9292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9267,9 +9310,10 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
+ "arboard",
  "chrono",
  "clap",
  "crossterm",
@@ -9290,7 +9334,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9321,7 +9365,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9373,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9408,7 +9452,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9419,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9436,7 +9480,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -10091,6 +10135,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -11953,6 +11998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13155,7 +13206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -15267,7 +15318,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.152"
+version = "0.3.153"
 dependencies = [
  "mockforge-core",
  "serde_json",
@@ -15343,6 +15394,20 @@ dependencies = [
  "log",
  "ordered-float 2.10.1",
  "threadpool",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error 2.0.1",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -18955,6 +19020,21 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.152"
+version = "0.3.153"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,12 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.153] - 2026-05-29
+
+### Added
+
+- **[Contracts][DevX]** TUI Conformance detail view: **`c`** copies the selected violation to the system clipboard as JSON (#79 round 17.1, Srikanth's (c-i)).
+- **[Contracts]** `total_ok` lifetime counter alongside `total_seen` — admin API and TUI title now show the real pass/fail ratio (#79 round 17.1, Srikanth's (f) follow-up).
+
 ## [0.3.152] - 2026-05-28
 
 ### Changed

--- a/crates/mockforge-foundation/src/conformance_violations.rs
+++ b/crates/mockforge-foundation/src/conformance_violations.rs
@@ -56,6 +56,24 @@ static VIOLATIONS: Lazy<Mutex<VecDeque<ServerConformanceViolation>>> =
 /// true total seen.
 static TOTAL_SEEN: AtomicU64 = AtomicU64::new(0);
 
+/// Lifetime count of requests that *passed* the spec validator (round
+/// 17.1). Bumped on the `Ok(())` branch of
+/// `run_validation_with_recording`. Lets the TUI display
+/// "X conformant / Y violations" instead of just one side.
+static TOTAL_OK: AtomicU64 = AtomicU64::new(0);
+
+/// Bump the conformant-request counter. Called from the validator's
+/// success path. Bench code can call it directly when wiring its own
+/// counters too.
+pub fn record_ok() {
+    TOTAL_OK.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Lifetime total of requests that passed the spec validator.
+pub fn total_ok() -> u64 {
+    TOTAL_OK.load(Ordering::Relaxed)
+}
+
 /// Record a violation. Old entries are dropped when the buffer is full
 /// (FIFO). Cheap enough to call from the hot path — uses a parking_lot
 /// Mutex which is uncontended in steady state.
@@ -85,11 +103,12 @@ pub fn total_seen() -> u64 {
     TOTAL_SEEN.load(Ordering::Relaxed)
 }
 
-/// Clear the buffer and reset the lifetime counter. Primarily for tests
-/// and TUI "reset" actions.
+/// Clear the buffer and reset both lifetime counters. Primarily for
+/// tests and TUI "reset" actions.
 pub fn clear() {
     VIOLATIONS.lock().clear();
     TOTAL_SEEN.store(0, Ordering::Relaxed);
+    TOTAL_OK.store(0, Ordering::Relaxed);
 }
 
 #[cfg(test)]

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -1055,7 +1055,13 @@ impl OpenApiRouteRegistry {
             cookie_map,
             body,
         ) {
-            Ok(()) => return Ok(()),
+            Ok(()) => {
+                // Round 17.1 — track conformant requests alongside
+                // violations so the TUI can show the real pass/fail
+                // ratio (Srikanth's (f) follow-up).
+                mockforge_foundation::conformance_violations::record_ok();
+                return Ok(());
+            }
             Err(e) => e,
         };
 

--- a/crates/mockforge-tui/Cargo.toml
+++ b/crates/mockforge-tui/Cargo.toml
@@ -38,6 +38,9 @@ tracing-appender = "0.2"
 clap = { version = "4", features = ["derive"] }
 toml = { workspace = true }
 unicode-width = "0.2"
+# Round 17.1 — clipboard for the Conformance detail-view `c` keystroke.
+# Default features cover X11 + Wayland + macOS NSPasteboard + Win32.
+arboard = "3"
 
 [lints]
 workspace = true

--- a/crates/mockforge-tui/src/api/models.rs
+++ b/crates/mockforge-tui/src/api/models.rs
@@ -70,6 +70,11 @@ pub struct ConformanceViolationsResponse {
     /// buffer caps `total` at 256, this is the true number seen.
     #[serde(default)]
     pub total_seen: u64,
+    /// Lifetime count of requests that *passed* the validator (Issue
+    /// #79 round 17.1). With `total_seen` this gives the real pass/fail
+    /// ratio under sustained traffic.
+    #[serde(default)]
+    pub total_ok: u64,
 }
 
 /// One unmatched-path request (Issue #79 round 13).

--- a/crates/mockforge-tui/src/screens/conformance.rs
+++ b/crates/mockforge-tui/src/screens/conformance.rs
@@ -149,6 +149,9 @@ pub struct ConformanceScreen {
     /// Round-15: lifetime count of violations seen server-side (the
     /// buffer caps `total` at 256; this is the true total).
     total_seen: u64,
+    /// Round-17.1: lifetime count of requests that passed the validator.
+    /// With `total_seen` this gives the actual pass/fail ratio.
+    total_ok: u64,
     /// Round-13: unmatched-path requests captured by the HTTP fallback.
     unknown_paths: Vec<UnknownPathRequest>,
     unknown_total: usize,
@@ -183,6 +186,7 @@ impl ConformanceScreen {
             violations: Vec::new(),
             total: 0,
             total_seen: 0,
+            total_ok: 0,
             unknown_paths: Vec::new(),
             unknown_total: 0,
             unknown_total_seen: 0,
@@ -248,6 +252,40 @@ impl ConformanceScreen {
             if v.category.is_empty() { "(uncategorised)" } else { v.category.as_str() },
             v.reason,
         ))
+    }
+
+    /// Round 17.1 — `c` in the detail view: copy the selected
+    /// violation as pretty-printed JSON to the system clipboard via
+    /// `arboard`. Useful for pasting into bug reports / proxy logs /
+    /// Slack. Surfaces success and failure through the same `flash`
+    /// strip the export action uses.
+    ///
+    /// Failure modes worth knowing about:
+    /// - No clipboard daemon (pure-SSH terminal with no `xclip` /
+    ///   `wl-clipboard` / Pasteboard available) → arboard returns an
+    ///   error; we report it so the user knows the keystroke didn't
+    ///   silently no-op.
+    /// - The `arboard::Clipboard` handle is created per-press rather
+    ///   than cached, so the TUI doesn't hold any clipboard server
+    ///   connection while idle.
+    fn copy_selected_to_clipboard(&mut self) {
+        let Some(v) = self.selected_violation() else {
+            self.flash = Some(("no violation selected".to_string(), Instant::now()));
+            return;
+        };
+        let payload =
+            serde_json::to_string_pretty(v).unwrap_or_else(|_| "(serialise failed)".to_string());
+        match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(payload)) {
+            Ok(()) => {
+                self.flash = Some((
+                    format!("copied violation ({} {}) to clipboard", v.method, v.path),
+                    Instant::now(),
+                ));
+            }
+            Err(e) => {
+                self.flash = Some((format!("clipboard unavailable: {e}"), Instant::now()));
+            }
+        }
     }
 
     /// Cycle the category filter through every distinct category in the
@@ -435,6 +473,15 @@ impl Screen for ConformanceScreen {
                     self.detail_scroll = self.detail_scroll.saturating_sub(1);
                     return true;
                 }
+                KeyCode::Char('c') => {
+                    // Round 17.1 — Srikanth's (c-i) ask: copy the
+                    // current violation to system clipboard. arboard
+                    // handles X11/Wayland/macOS/Win32 in default
+                    // features; on a TTY with no clipboard backend it
+                    // returns an error we surface via the flash strip.
+                    self.copy_selected_to_clipboard();
+                    return true;
+                }
                 _ => return true,
             }
         }
@@ -525,7 +572,7 @@ impl Screen for ConformanceScreen {
                 .scroll((self.detail_scroll, 0))
                 .block(
                     Block::default()
-                        .title(" Violation Detail (Esc to close, j/k scroll) ")
+                        .title(" Violation Detail (Esc:close  j/k:scroll  c:copy) ")
                         .title_style(Theme::title())
                         .borders(Borders::ALL)
                         .border_style(Theme::dim())
@@ -605,6 +652,7 @@ impl Screen for ConformanceScreen {
                         "violations": resp.violations,
                         "total": resp.total,
                         "total_seen": resp.total_seen,
+                        "total_ok": resp.total_ok,
                     })) {
                         let _ = tx_v.send(Event::Data {
                             screen: "conformance",
@@ -678,6 +726,8 @@ impl Screen for ConformanceScreen {
             #[serde(default)]
             total_seen: u64,
             #[serde(default)]
+            total_ok: u64,
+            #[serde(default)]
             cleared: Option<usize>,
         }
         match serde_json::from_str::<Wire>(payload) {
@@ -685,6 +735,7 @@ impl Screen for ConformanceScreen {
                 self.violations = parsed.violations;
                 self.total = parsed.total;
                 self.total_seen = parsed.total_seen;
+                self.total_ok = parsed.total_ok;
                 if matches!(self.view_mode, ViewMode::Violations) {
                     self.table.set_total(self.current_row_count());
                 }
@@ -717,7 +768,7 @@ impl Screen for ConformanceScreen {
 
     fn status_hint(&self) -> &str {
         if self.detail_open {
-            "Esc:close  j/k:scroll"
+            "Esc:close  j/k:scroll  c:copy-to-clipboard"
         } else if self.paused {
             "[paused]  p:resume  m/s/c:filter  e:export  D:clear  Enter:detail"
         } else {
@@ -779,10 +830,14 @@ impl ConformanceScreen {
 
         let filtered_count = indices.len();
         let filter_suffix = self.filter_label_suffix();
-        // Round-15: show lifetime `total_seen` alongside the buffered
-        // count so a 656k-request run doesn't look like "only 256".
-        let seen_suffix = if self.total_seen as usize > self.total {
-            format!(", {} seen total", self.total_seen)
+        // Round-15: lifetime `total_seen` alongside the buffered count
+        // so a 656k-request run doesn't look like "only 256".
+        // Round-17.1: also surface `total_ok` (conformant requests) so
+        // the user sees the real pass/fail ratio. Format chosen to
+        // stay short — N violations / M ok = N+M total validated.
+        let seen_suffix = if self.total_seen as usize > self.total || self.total_ok > 0 {
+            let validated = self.total_seen + self.total_ok;
+            format!(", {}/{} validated failed", self.total_seen, validated)
         } else {
             String::new()
         };

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -1335,14 +1335,21 @@ pub async fn get_conformance_violations(
     let snap = mockforge_foundation::conformance_violations::snapshot();
     let total = snap.len();
     let total_seen = mockforge_foundation::conformance_violations::total_seen();
+    let total_ok = mockforge_foundation::conformance_violations::total_ok();
     let limit: Option<usize> = q.get("limit").and_then(|s| s.parse().ok());
     let limited: Vec<_> = match limit {
         Some(n) => snap.into_iter().take(n).collect(),
         None => snap,
     };
     // `total` = entries currently in the 256-cap ring buffer;
-    // `total_seen` = lifetime count since server start (Issue #79 r15).
-    Json(json!({"violations": limited, "total": total, "total_seen": total_seen}))
+    // `total_seen` = lifetime count of violations (Issue #79 r15);
+    // `total_ok` = lifetime count of conformant requests (round 17.1).
+    Json(json!({
+        "violations": limited,
+        "total": total,
+        "total_seen": total_seen,
+        "total_ok": total_ok,
+    }))
 }
 
 /// Clear the server-side conformance violation ring buffer.


### PR DESCRIPTION
## Summary

First slice of round 17 (the larger \"complete conformance view\" arc from Srikanth's reply). Two contained user-visible changes:

### (c-i) Clipboard copy from the TUI detail view

Pressing **\`c\`** in the violation detail view (after \`Enter\`) copies the selected violation to the system clipboard as pretty-printed JSON. Uses \`arboard\` with default features — works on X11, Wayland (via \`wayland-data-control\`), macOS NSPasteboard, and Win32 without per-platform setup. On a clipboard-less TTY the failure surfaces in the flash strip rather than silently no-op'ing.

The detail view title and status hint now advertise the keystroke:

\`\`\`
 Violation Detail (Esc:close  j/k:scroll  c:copy)
\`\`\`

### (f) \`total_ok\` lifetime counter

New companion to the round-15 \`total_seen\` (lifetime violations). \`run_validation_with_recording\` now bumps a \`TOTAL_OK\` atomic on the \`Ok\` branch, and the admin API returns it as \`total_ok\`. The TUI title surfaces the real pass/fail ratio:

\`\`\`
Conformance Violations (256 buffered, 256 shown, 517498/522830 validated failed)
\`\`\`

Resolves Srikanth's (f) follow-up — \"is there a way to know the conformance ratio?\".

## Test plan

- [x] \`cargo clippy -p mockforge-tui -p mockforge-foundation -p mockforge-openapi -p mockforge-ui --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p mockforge-tui --lib\` — 291 pass
- [x] \`cargo test -p mockforge-foundation --lib conformance_violations\` — 2 pass
- [x] \`cargo fmt --all --check\` — clean

Workspace 0.3.152 → 0.3.153.

Next: round 17.2–4 (schema-driven negatives + security probes + spec audits) in a separate PR.