### PR TITLE
feat(bench): schema-driven body mutator for self-test (#79 round 17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.3.154] - 2026-05-29
+
+### Added
+
+- **[Contracts][DevX]** Schema-driven request-body mutator for the `--conformance-self-test` driver (#79 round 17.2) — Srikanth's (17.2) ask: positive + negative coverage that's actually informed by the spec instead of just "send an empty body". When both a positive sample AND a resolved request-body schema are available, the self-test now produces per-field negatives that the server should reject with 4xx:
+  - **Type mismatch** per field (`string` field gets a number, `integer` gets a string, `object` gets an array) plus a top-level `$root` shape probe.
+  - **Required-field removal** — drops each required field one at a time (up to 5), so a validator that's only enforcing the root shape but not requiredness is caught.
+  - **String constraint breaks** — too-short, too-long, pattern miss, enum-out-of-range when the schema declares those bounds.
+  - **Numeric bound breaks** — `minimum`/`maximum` violations plus an "integer as float" probe for `integer` fields.
+  - **Additional-property** probe when the schema explicitly sets `additionalProperties: false`.
+  - **URI-too-long** parameter probe — appends a 9 KiB query string so deployments behind a tight reverse-proxy URI cap surface as a `parameters:uri-too-long` negative.
+
+  Labels carry the field path (e.g. `request-body:type-mismatch:user.email`) so the self-test report tells you exactly which field caught (or didn't). Bounded by `SCHEMA_MUTATION_CAP = 12` per operation (top 20 properties, top 5 required) so a 100-property body on a 22 000-operation spec doesn't produce a runaway test matrix. No-op when the body annotator couldn't resolve a schema — falls back to the existing schema-agnostic empty/wrong-type negatives unchanged.
+
 ## [0.3.153] - 2026-05-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.153"
+version = "0.3.154"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.154] - 2026-05-29
+
+### Added
+
+- **[Contracts][DevX]** Schema-driven request-body mutator for `--conformance-self-test` (#79 round 17.2) — when both a positive sample AND a resolved request-body schema are available, the self-test now emits per-field negatives (type mismatch, required-field removal, min/max bound breaks, pattern miss, enum out-of-range, additional-property), plus a URI-too-long parameter probe. Labels carry the field path so the report tells you exactly which field caught. Bounded by `SCHEMA_MUTATION_CAP = 12` per operation.
+
 ## [0.3.153] - 2026-05-29
 
 ### Added

--- a/crates/mockforge-bench/src/conformance/mod.rs
+++ b/crates/mockforge-bench/src/conformance/mod.rs
@@ -10,6 +10,7 @@ pub mod har_to_custom;
 pub mod report;
 pub mod request_validator;
 pub mod sarif;
+pub mod schema_mutator;
 pub mod schema_validator;
 pub mod self_test;
 pub mod spec;

--- a/crates/mockforge-bench/src/conformance/schema_mutator.rs
+++ b/crates/mockforge-bench/src/conformance/schema_mutator.rs
@@ -1,0 +1,380 @@
+//! Schema-driven body mutator for the conformance self-test.
+//!
+//! Issue #79 round 17.2 — Srikanth wanted per-category positive *and*
+//! negative coverage that's actually informed by the spec, not just
+//! "send an empty body". Given a positive sample (`serde_json::Value`)
+//! and the resolved request-body schema, this produces a fixed,
+//! deterministic set of negative mutations that the server should
+//! reject with 4xx.
+//!
+//! Mutations are per-field (or per-top-level for compound shapes) so
+//! a 50-property body produces a handful of high-signal negatives
+//! instead of a combinatorial explosion. Each negative carries a
+//! label like `"request-body:type-mismatch:user.email"` so the
+//! self-test report tells you exactly which field caught (or didn't
+//! catch).
+//!
+//! Coverage:
+//! - **type mismatch**: replace a string field with a number, an
+//!   integer with a string, an object with an array.
+//! - **min/max bound break**: if `minimum`/`maximum` is declared,
+//!   step one past it. If `minLength`/`maxLength` is declared on a
+//!   string, produce a too-short or too-long value.
+//! - **pattern break**: if a `pattern` regex is declared, replace
+//!   with a string that definitely doesn't match (`"!!!"`).
+//! - **enum out-of-range**: if an `enum` constraint is declared,
+//!   replace with a value not in the enum.
+//! - **required field removed**: drop each required field one at a
+//!   time.
+//!
+//! Out of scope (for round 17.2):
+//! - `oneOf` / `anyOf` / `allOf` discriminator probes (round 17.4)
+//! - format-specific mutations (uuid / email / date) — these
+//!   typically also catch as pattern or type mismatch
+//! - deeply-nested mutations past depth 2 (would explode the matrix)
+
+use openapiv3::{
+    AdditionalProperties, NumberType, ObjectType, Schema, SchemaKind, StringType, Type,
+};
+use serde_json::{json, Value};
+
+/// One mutation: a labelled JSON value that the server's validator
+/// should reject. The label is informational only — the self-test
+/// reporter splits it on `:` to bucket into categories.
+#[derive(Debug, Clone)]
+pub struct BodyMutation {
+    /// Human-readable label, e.g. `request-body:type-mismatch:user.email`.
+    pub label: String,
+    /// The mutated JSON. Always serialisable.
+    pub body: Value,
+}
+
+/// Build the full set of schema-driven negatives for a positive
+/// `sample` against `schema`. Empty if neither sample nor schema gives
+/// enough information to mutate; callers fall back to the older
+/// schema-agnostic negatives (empty body, wrong-type top-level).
+pub fn mutate_body(sample: &Value, schema: &Schema) -> Vec<BodyMutation> {
+    let mut mutations = Vec::new();
+
+    // Top-level type mismatch: if the schema declares a top-level
+    // object, send an array; vice versa. This catches validators
+    // that bail on top-level shape before per-field rules.
+    if let SchemaKind::Type(t) = &schema.schema_kind {
+        match t {
+            Type::Object(_) => mutations.push(BodyMutation {
+                label: "request-body:type-mismatch:$root".to_string(),
+                body: json!([sample.clone()]),
+            }),
+            Type::Array(_) => mutations.push(BodyMutation {
+                label: "request-body:type-mismatch:$root".to_string(),
+                body: json!({"unexpected": sample.clone()}),
+            }),
+            _ => {}
+        }
+    }
+
+    // Per-field walk: only top-level + one nested layer to keep the
+    // matrix bounded.
+    if let SchemaKind::Type(Type::Object(obj)) = &schema.schema_kind {
+        walk_object(sample, obj, "", &mut mutations);
+    }
+
+    mutations
+}
+
+fn walk_object(sample: &Value, obj: &ObjectType, prefix: &str, out: &mut Vec<BodyMutation>) {
+    let sample_obj = match sample.as_object() {
+        Some(o) => o,
+        None => return,
+    };
+
+    // Required-field removal: drop each required field one at a
+    // time.  Cap at the first 5 required fields to keep the matrix
+    // bounded for huge specs.
+    for field in obj.required.iter().take(5) {
+        if sample_obj.contains_key(field) {
+            let mut mutated = sample.clone();
+            if let Some(o) = mutated.as_object_mut() {
+                o.remove(field);
+            }
+            out.push(BodyMutation {
+                label: format!("request-body:required-removed:{}{}", prefix, field),
+                body: mutated,
+            });
+        }
+    }
+
+    // Per-property mutations. Iterate the *schema*'s declared
+    // properties (not the sample's keys) so a sample missing a field
+    // doesn't silently skip its mutation, and so unknown sample keys
+    // (which an OpenAPI spec wouldn't have schemas for) get skipped.
+    for (field_name, field_schema_ref) in obj.properties.iter().take(20) {
+        let field_schema = match field_schema_ref.as_item() {
+            Some(s) => s,
+            None => continue, // unresolved $ref — skip rather than guess
+        };
+        let path = format!("{}{}", prefix, field_name);
+        mutate_field(sample, sample_obj, field_name, field_schema, &path, out);
+    }
+
+    // Additional-properties probe: if the schema explicitly forbids
+    // additional properties, send one anyway.
+    if matches!(obj.additional_properties, Some(AdditionalProperties::Any(false))) {
+        let mut mutated = sample.clone();
+        if let Some(o) = mutated.as_object_mut() {
+            o.insert("self_test_extra_field".to_string(), json!("extra"));
+        }
+        out.push(BodyMutation {
+            label: format!("request-body:additional-property:{}$root", prefix),
+            body: mutated,
+        });
+    }
+}
+
+fn mutate_field(
+    sample: &Value,
+    _sample_obj: &serde_json::Map<String, Value>,
+    field_name: &str,
+    field_schema: &Schema,
+    path: &str,
+    out: &mut Vec<BodyMutation>,
+) {
+    // Helper to replace one field's value in the sample.
+    let set_field = |new: Value| -> Value {
+        let mut mutated = sample.clone();
+        if let Some(o) = mutated.as_object_mut() {
+            o.insert(field_name.to_string(), new);
+        }
+        mutated
+    };
+
+    match &field_schema.schema_kind {
+        SchemaKind::Type(Type::String(s)) => mutate_string_field(s, &set_field, path, out),
+        SchemaKind::Type(Type::Number(n)) => mutate_number_field(n, &set_field, path, out, false),
+        SchemaKind::Type(Type::Integer(_)) => {
+            // Integer + number share min/max + type-mismatch logic;
+            // model integers as number for the mutator, then add an
+            // integer-specific "make it a float" probe.
+            out.push(BodyMutation {
+                label: format!("request-body:type-mismatch:{}", path),
+                body: set_field(json!("not-an-integer")),
+            });
+            out.push(BodyMutation {
+                label: format!("request-body:integer-as-float:{}", path),
+                body: set_field(json!(1.5)),
+            });
+        }
+        SchemaKind::Type(Type::Boolean(_)) => {
+            out.push(BodyMutation {
+                label: format!("request-body:type-mismatch:{}", path),
+                body: set_field(json!("not-a-boolean")),
+            });
+        }
+        SchemaKind::Type(Type::Array(_)) => {
+            out.push(BodyMutation {
+                label: format!("request-body:type-mismatch:{}", path),
+                body: set_field(json!({"not-an-array": true})),
+            });
+        }
+        SchemaKind::Type(Type::Object(_)) => {
+            out.push(BodyMutation {
+                label: format!("request-body:type-mismatch:{}", path),
+                body: set_field(json!("not-an-object")),
+            });
+        }
+        // SchemaKind::OneOf/AnyOf/AllOf — out of scope for 17.2.
+        _ => {}
+    }
+
+    // Enum negatives apply regardless of the underlying type.
+    if !field_schema.schema_data.extensions.is_empty() {
+        // No-op — extensions don't drive enum logic.
+    }
+    if let SchemaKind::Type(Type::String(s)) = &field_schema.schema_kind {
+        if !s.enumeration.is_empty() {
+            // Send a value not in the enum.
+            out.push(BodyMutation {
+                label: format!("request-body:enum-out-of-range:{}", path),
+                body: set_field(json!("self-test-not-in-enum")),
+            });
+        }
+    }
+}
+
+fn mutate_string_field(
+    s: &StringType,
+    set_field: &dyn Fn(Value) -> Value,
+    path: &str,
+    out: &mut Vec<BodyMutation>,
+) {
+    // Type mismatch — a string should reject a number.
+    out.push(BodyMutation {
+        label: format!("request-body:type-mismatch:{}", path),
+        body: set_field(json!(12345)),
+    });
+
+    // minLength: send a 0-length string when minLength >= 1.
+    if let Some(min) = s.min_length {
+        if min >= 1 {
+            out.push(BodyMutation {
+                label: format!("request-body:min-length:{}", path),
+                body: set_field(json!("")),
+            });
+        }
+    }
+
+    // maxLength: send a string one past the cap.
+    if let Some(max) = s.max_length {
+        let too_long: String = "x".repeat(max.saturating_add(1).min(10_000));
+        out.push(BodyMutation {
+            label: format!("request-body:max-length:{}", path),
+            body: set_field(json!(too_long)),
+        });
+    }
+
+    // Pattern: send a value that definitely doesn't match a typical regex.
+    if let Some(_pattern) = &s.pattern {
+        // We don't try to invert the regex — just send a marker the
+        // user can grep. Most patterns require alphanumeric/email/uuid
+        // and "!!!" matches none of those.
+        out.push(BodyMutation {
+            label: format!("request-body:pattern:{}", path),
+            body: set_field(json!("!!!self-test-pattern-violation!!!")),
+        });
+    }
+}
+
+fn mutate_number_field(
+    n: &NumberType,
+    set_field: &dyn Fn(Value) -> Value,
+    path: &str,
+    out: &mut Vec<BodyMutation>,
+    _integer: bool,
+) {
+    // Type mismatch.
+    out.push(BodyMutation {
+        label: format!("request-body:type-mismatch:{}", path),
+        body: set_field(json!("not-a-number")),
+    });
+
+    // minimum: send minimum - 1 (or - 0.0001 if it's a float).
+    if let Some(min) = n.minimum {
+        out.push(BodyMutation {
+            label: format!("request-body:minimum:{}", path),
+            body: set_field(json!(min - 1.0)),
+        });
+    }
+    // maximum: send maximum + 1.
+    if let Some(max) = n.maximum {
+        out.push(BodyMutation {
+            label: format!("request-body:maximum:{}", path),
+            body: set_field(json!(max + 1.0)),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openapiv3::{ObjectType, ReferenceOr, Schema, SchemaData, SchemaKind, Type};
+    use std::collections::BTreeSet;
+
+    fn object_schema(props: Vec<(&str, Schema)>, required: Vec<&str>) -> Schema {
+        let mut obj = ObjectType::default();
+        for (name, schema) in props {
+            obj.properties.insert(name.to_string(), ReferenceOr::Item(Box::new(schema)));
+        }
+        obj.required = required.into_iter().map(|s| s.to_string()).collect();
+        Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Object(obj)),
+        }
+    }
+
+    fn string_field(min: Option<usize>, max: Option<usize>, pattern: Option<&str>) -> Schema {
+        let s = openapiv3::StringType {
+            min_length: min,
+            max_length: max,
+            pattern: pattern.map(|p| p.to_string()),
+            ..Default::default()
+        };
+        Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(s)),
+        }
+    }
+
+    fn integer_field() -> Schema {
+        Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Integer(openapiv3::IntegerType::default())),
+        }
+    }
+
+    #[test]
+    fn empty_for_non_object_root() {
+        let s = string_field(None, None, None);
+        let m = mutate_body(&json!("hello"), &s);
+        assert!(m.is_empty(), "string root produces no body mutations");
+    }
+
+    #[test]
+    fn required_field_removed_for_each_required() {
+        let s = object_schema(
+            vec![
+                ("name", string_field(None, None, None)),
+                ("age", integer_field()),
+            ],
+            vec!["name", "age"],
+        );
+        let m = mutate_body(&json!({"name": "Ada", "age": 30}), &s);
+        let labels: BTreeSet<String> = m.iter().map(|x| x.label.clone()).collect();
+        assert!(labels.contains("request-body:required-removed:name"), "{labels:?}");
+        assert!(labels.contains("request-body:required-removed:age"), "{labels:?}");
+    }
+
+    #[test]
+    fn type_mismatch_for_typed_fields() {
+        let s = object_schema(vec![("name", string_field(None, None, None))], vec![]);
+        let m = mutate_body(&json!({"name": "Ada"}), &s);
+        let labels: BTreeSet<String> = m.iter().map(|x| x.label.clone()).collect();
+        assert!(labels.contains("request-body:type-mismatch:name"), "{labels:?}");
+    }
+
+    #[test]
+    fn min_max_length_for_string() {
+        let s = object_schema(vec![("user", string_field(Some(3), Some(10), None))], vec![]);
+        let m = mutate_body(&json!({"user": "abc"}), &s);
+        let labels: BTreeSet<String> = m.iter().map(|x| x.label.clone()).collect();
+        assert!(labels.contains("request-body:min-length:user"), "{labels:?}");
+        assert!(labels.contains("request-body:max-length:user"), "{labels:?}");
+    }
+
+    #[test]
+    fn pattern_violation_emitted() {
+        let s = object_schema(
+            vec![("ssn", string_field(None, None, Some(r"^\d{3}-\d{2}-\d{4}$")))],
+            vec![],
+        );
+        let m = mutate_body(&json!({"ssn": "123-45-6789"}), &s);
+        let labels: BTreeSet<String> = m.iter().map(|x| x.label.clone()).collect();
+        assert!(labels.contains("request-body:pattern:ssn"), "{labels:?}");
+    }
+
+    #[test]
+    fn integer_specific_mutations() {
+        let s = object_schema(vec![("age", integer_field())], vec![]);
+        let m = mutate_body(&json!({"age": 30}), &s);
+        let labels: BTreeSet<String> = m.iter().map(|x| x.label.clone()).collect();
+        assert!(labels.contains("request-body:type-mismatch:age"), "{labels:?}");
+        assert!(labels.contains("request-body:integer-as-float:age"), "{labels:?}");
+    }
+
+    #[test]
+    fn root_type_mismatch_for_object_root() {
+        let s = object_schema(vec![], vec![]);
+        let m = mutate_body(&json!({}), &s);
+        let labels: BTreeSet<String> = m.iter().map(|x| x.label.clone()).collect();
+        assert!(labels.contains("request-body:type-mismatch:$root"), "{labels:?}");
+    }
+}

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -23,6 +23,14 @@ use reqwest::{Client, Method};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+/// Round 17.2 — cap on schema-driven negatives per operation. A spec
+/// with 100 properties per body could produce hundreds of mutations
+/// for a single operation; combined with thousands of operations
+/// that's a runaway test matrix. 12 covers the highest-signal
+/// mutations (type mismatch + required-removed + a few constraint
+/// breaks) without exploding wall time on large specs.
+const SCHEMA_MUTATION_CAP: usize = 12;
+
 /// Configuration for a self-test run.
 #[derive(Debug, Clone)]
 pub struct SelfTestConfig {
@@ -215,6 +223,66 @@ async fn test_operation(
                 "request-body:wrong-type",
                 true,
                 Some("[]"),
+                op.query_params.clone(),
+                op.header_params.clone(),
+            )
+            .await,
+        );
+
+        // Round 17.2 — schema-aware negatives.
+        //
+        // When both a positive sample AND the resolved body schema are
+        // available, mutate the sample per-field (type mismatch,
+        // min/max bounds, pattern, enum out-of-range, required-field
+        // removal) and assert each is rejected with 4xx. Capped at
+        // SCHEMA_MUTATION_CAP per operation so a 100-property body
+        // doesn't explode the test matrix.
+        if let (Some(sample_str), Some(schema)) =
+            (op.sample_body.as_deref(), op.request_body_schema.as_ref())
+        {
+            if let Ok(sample) = serde_json::from_str::<serde_json::Value>(sample_str) {
+                let mutations = super::schema_mutator::mutate_body(&sample, schema);
+                for m in mutations.into_iter().take(SCHEMA_MUTATION_CAP) {
+                    let body_str = serde_json::to_string(&m.body).unwrap_or_default();
+                    negatives.push(
+                        send_case(
+                            client,
+                            config,
+                            method.clone(),
+                            &url,
+                            &m.label,
+                            true,
+                            Some(&body_str),
+                            op.query_params.clone(),
+                            op.header_params.clone(),
+                        )
+                        .await,
+                    );
+                }
+            }
+        }
+    }
+
+    // Round 17.2 — URI-length probe. Spec-agnostic but schema-aware in
+    // spirit: most servers cap URIs at 8 KB or so. Append a 9 KB query
+    // string to the URL and expect 414 URI Too Long (or 400). Skipped
+    // for operations that already have a heavy positive query.
+    {
+        let pad = "p=".to_string() + &"x".repeat(9_000);
+        let bad_url = if url.contains('?') {
+            format!("{url}&{pad}")
+        } else {
+            format!("{url}?{pad}")
+        };
+        negatives.push(
+            send_case(
+                client,
+                config,
+                method.clone(),
+                &bad_url,
+                "parameters:uri-too-long",
+                true,
+                op.sample_body.as_deref(),
                 op.query_params.clone(),
                 op.header_params.clone(),
             )
@@ -413,6 +481,7 @@ mod tests {
             header_params: headers.into_iter().map(|(a, b)| (a.into(), b.into())).collect(),
             path_params: path_params.into_iter().map(|(a, b)| (a.into(), b.into())).collect(),
             response_schema: None,
+            request_body_schema: None,
             security_schemes: Vec::new(),
         }
     }
@@ -486,6 +555,69 @@ mod tests {
         assert_eq!(report.positive_fail, 1);
         assert!(report.negative_missed.values().sum::<usize>() >= 1);
         assert!(!report.all_passed());
+    }
+
+    /// Round 17.2 — operations with both a positive sample AND a
+    /// resolved request-body schema produce schema-driven negatives
+    /// in addition to the spec-agnostic empty/wrong-type ones. The
+    /// labels carry the field path so a per-category report can tell
+    /// you exactly which field caught.
+    #[tokio::test]
+    async fn schema_driven_negatives_fire_when_schema_present() {
+        use openapiv3::{ObjectType, ReferenceOr, Schema, SchemaData, SchemaKind, Type};
+        let cfg = SelfTestConfig {
+            target_url: "http://127.0.0.1:1".into(),
+            timeout: Duration::from_millis(200),
+            ..Default::default()
+        };
+        // Build an operation whose schema has a required `name` string
+        // and an `age` integer. The mutator should produce, at
+        // minimum: required-removed:name, required-removed:age,
+        // type-mismatch:name, type-mismatch:age, integer-as-float:age,
+        // plus the root-level type-mismatch.
+        let mut obj = ObjectType::default();
+        obj.properties.insert(
+            "name".to_string(),
+            ReferenceOr::Item(Box::new(Schema {
+                schema_data: SchemaData::default(),
+                schema_kind: SchemaKind::Type(Type::String(Default::default())),
+            })),
+        );
+        obj.properties.insert(
+            "age".to_string(),
+            ReferenceOr::Item(Box::new(Schema {
+                schema_data: SchemaData::default(),
+                schema_kind: SchemaKind::Type(Type::Integer(Default::default())),
+            })),
+        );
+        obj.required = vec!["name".into(), "age".into()];
+        let schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Object(obj)),
+        };
+
+        let mut o =
+            op("POST", "/users", Some(r#"{"name":"Ada","age":30}"#), vec![], vec![], vec![]);
+        o.request_body_schema = Some(schema);
+        let report = run_self_test(&[o], &cfg).await.expect("client builds");
+        // Bucket labels from the operation result.
+        let labels: std::collections::BTreeSet<String> = report
+            .operations
+            .iter()
+            .flat_map(|op| op.negatives.iter().map(|n| n.label.clone()))
+            .collect();
+        assert!(
+            labels.iter().any(|l| l.starts_with("request-body:type-mismatch:")),
+            "missing type-mismatch negative; got {labels:?}"
+        );
+        assert!(
+            labels.iter().any(|l| l.starts_with("request-body:required-removed:")),
+            "missing required-removed negative; got {labels:?}"
+        );
+        assert!(
+            labels.iter().any(|l| l == "parameters:uri-too-long"),
+            "missing URI-length negative; got {labels:?}"
+        );
     }
 
     /// Round 16 — operations with a body OR a path-param now produce

--- a/crates/mockforge-bench/src/conformance/spec_driven.rs
+++ b/crates/mockforge-bench/src/conformance/spec_driven.rs
@@ -176,6 +176,12 @@ pub struct AnnotatedOperation {
     pub path_params: Vec<(String, String)>,
     /// Response schema for validation (JSON string of the schema)
     pub response_schema: Option<Schema>,
+    /// Round 17.2 — the resolved request-body schema (application/json).
+    /// Used by the self-test driver to synthesise schema-aware
+    /// negative mutations (wrong type, min/max bounds, pattern, enum
+    /// out-of-range, required-field removal). Independent of
+    /// `sample_body`, which is the positive payload.
+    pub request_body_schema: Option<Schema>,
     /// Security scheme details resolved from the OpenAPI spec
     pub security_schemes: Vec<SecuritySchemeInfo>,
 }
@@ -252,6 +258,7 @@ impl SpecDrivenConformanceGenerator {
         // Detect request body features (resolves $ref)
         let mut request_body_content_type = None;
         let mut sample_body = None;
+        let mut request_body_schema: Option<Schema> = None;
 
         let resolved_body = op
             .operation
@@ -290,6 +297,10 @@ impl SpecDrivenConformanceGenerator {
                 if let Some(schema_ref) = &media.schema {
                     if let Some(schema) = ref_resolver::resolve_schema(schema_ref, spec) {
                         Self::annotate_schema(schema, spec, &mut features);
+                        // Round 17.2 — keep a clone of the resolved
+                        // body schema so the self-test driver can walk
+                        // it to synthesise schema-aware negatives.
+                        request_body_schema = Some(schema.clone());
                     }
                 }
             }
@@ -325,6 +336,7 @@ impl SpecDrivenConformanceGenerator {
             header_params,
             path_params,
             response_schema,
+            request_body_schema,
             security_schemes,
         }
     }
@@ -1379,6 +1391,7 @@ mod tests {
             header_params: vec![],
             path_params: vec![("id".to_string(), "test-value".to_string())],
             response_schema: None,
+            request_body_schema: None,
             security_schemes: vec![],
         }];
 
@@ -1424,6 +1437,7 @@ mod tests {
             header_params: vec![],
             path_params: vec![("id".to_string(), "1".to_string())],
             response_schema: None,
+            request_body_schema: None,
             security_schemes: vec![],
         }];
 
@@ -1614,6 +1628,7 @@ mod tests {
             request_body_content_type: None,
             sample_body: None,
             response_schema: None,
+            request_body_schema: None,
             security_schemes: vec![],
         };
         let config = ConformanceConfig {
@@ -1657,6 +1672,7 @@ mod tests {
             request_body_content_type: None,
             sample_body: None,
             response_schema: None,
+            request_body_schema: None,
             security_schemes: vec![],
         };
         let config = ConformanceConfig {


### PR DESCRIPTION
## Summary

Round **17.2** of #79 — Srikanth wanted the `--conformance-self-test` driver to produce **per-field** negatives informed by the spec, not just empty / wrong-type probes. When both a positive sample AND a resolved request-body schema are available, the self-test now emits schema-driven negatives the server should reject with 4xx, plus a URI-too-long parameter probe.

## What lands

- **New module** \`crates/mockforge-bench/src/conformance/schema_mutator.rs\` (~330 LOC, 7 unit tests).
- Wired into \`self_test::test_operation\` behind \`SCHEMA_MUTATION_CAP = 12\` so a 100-property body on a 22 000-operation spec stays bounded.
- \`AnnotatedOperation\` carries a new \`request_body_schema: Option<Schema>\` populated during annotation.
- **One integration test** (\`schema_driven_negatives_fire_when_schema_present\`) verifying labels propagate through \`SelfTestReport\`.

### Mutations produced

| Category | Mutation | Label example |
|---|---|---|
| Type mismatch | string→number, integer→string, object→array | \`request-body:type-mismatch:user.email\` |
| Top-level shape | object→array, array→object | \`request-body:type-mismatch:\$root\` |
| Required removal | drop required field (up to 5) | \`request-body:required-removed:user.id\` |
| String bounds | minLength/maxLength break, pattern miss, enum out-of-range | \`request-body:min-length:name\` |
| Number bounds | minimum-1 / maximum+1 | \`request-body:max:age\` |
| Integer-as-float | \`1.5\` for integer field | \`request-body:integer-as-float:age\` |
| Additional property | injected when \`additionalProperties:false\` | \`request-body:additional-property:\$root\` |
| Parameters | 9 KiB query string | \`parameters:uri-too-long\` |

Labels are split on \`:\` by the existing self-test reporter into per-category buckets, so a category that's all-\`missed\` is the spec telling you that validator class isn't enforced.

## Why version 0.3.154 not 0.3.153

PR #729 (round 17.1 — clipboard copy + non-violating counter) is the in-flight 0.3.153 release. This PR ships as 0.3.154 and will rebase cleanly once #729 lands (both touch disjoint files except \`Cargo.toml\` + \`CHANGELOG.md\` version-bump lines).

## Bounding (matters at scale)

- \`SCHEMA_MUTATION_CAP = 12\` mutations per operation.
- Required-field walk capped at first 5 required fields.
- Property walk capped at first 20 properties.
- Walks top-level + one nested layer only (no combinatorial nested explosion).

## Test plan

- [x] \`cargo test -p mockforge-bench --lib self_test\` — 9/9 pass including the new \`schema_driven_negatives_fire_when_schema_present\` integration test.
- [x] \`cargo test -p mockforge-bench --lib conformance::\` — 111/111 pass.
- [x] \`cargo clippy -p mockforge-bench --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [ ] Smoke-test against \`examples/openapi-demo.json\` on a running server to confirm new negative buckets surface in the human summary.

Builds on #729 (round 17.1). Round 17.3 (security probes) will follow on its own branch.