### PR TITLE
test(registry): green the registry-e2e lane (paid_flow + workspace_content)

### DIFF
--- a/crates/mockforge-registry-server/tests/paid_flow_e2e.rs
+++ b/crates/mockforge-registry-server/tests/paid_flow_e2e.rs
@@ -147,6 +147,12 @@ impl PaidFlowHelper {
                     "object": "subscription",
                     "customer": self.customer_id,
                     "status": status,
+                    // `async-stripe`'s `Subscription` requires these (no serde
+                    // default); real Stripe events always include them. Without
+                    // them `Webhook::construct_event` fails with "error parsing
+                    // event object" after the signature check passes.
+                    "livemode": false,
+                    "automatic_tax": { "enabled": false },
                     "current_period_start": now,
                     "current_period_end": now + 30 * 86400,
                     "cancel_at_period_end": event_type == "customer.subscription.deleted",

--- a/crates/mockforge-registry-server/tests/workspace_content_e2e.rs
+++ b/crates/mockforge-registry-server/tests/workspace_content_e2e.rs
@@ -93,7 +93,10 @@ async fn register_and_setup(base_url: &str) -> E2e {
     let res = client
         .post(format!("{}/api/v1/organizations", base_url))
         .header("Authorization", format!("Bearer {}", access_token))
-        .json(&json!({ "name": format!("WS-Content Test Org {}", ts), "slug": org_slug }))
+        // These tests create multiple workspaces in one org to exercise
+        // cross-workspace isolation; the Free plan caps an org at 1 workspace
+        // (max_projects), so provision a Team org which is uncapped.
+        .json(&json!({ "name": format!("WS-Content Test Org {}", ts), "slug": org_slug, "plan": "team" }))
         .send()
         .await
         .expect("create org failed");


### PR DESCRIPTION
## Why
`registry-e2e.yml` runs all 7 registry e2e targets (Postgres + MinIO + live registry on the self-hosted runner) but has been **red on every run for days** and is **not a required check** — so it gave zero signal, and that's how #724 (marketplace search returning empty) shipped straight through it.

Two pre-existing **test-fixture** failures kept it red. Neither is a product bug:

### 1. `paid_flow_e2e::test_paid_flow_e2e`
The synthetic Stripe `customer.subscription.*` event omitted `livemode` and `automatic_tax` on the subscription object. `async-stripe` 0.41's `Subscription` requires both (no serde default), so `Webhook::construct_event` failed with "error parsing event object" **after** the signature check passed. Real Stripe events always include these → production is fine. Added both to the fixture builder.

### 2. `workspace_content_e2e` (2 tests)
Both create a **second** workspace in one org to exercise cross-workspace isolation, but the Free plan caps an org at 1 workspace (`max_projects`, added in #449 after these tests were written). The org is now provisioned as Team (uncapped) via the org-create `plan` field.

## Verification
Clean-room run (fresh Postgres+MinIO via `docker-compose.e2e.yml`, CI's exact command) — **all 7 targets green**:
```
cloud_ai_contract_diff(4)  cloud_conformance(2)  cloud_verification(2)
marketplace(5)  paid_flow(1)  signup_flow(3)  workspace_content(4)
```
The lane will run on this PR (it touches `mockforge-registry-server`) — that's the real-CI proof.

## Important follow-up
Fixing #2 surfaced a real billing-bypass bug: **#733** — org-create honors a client-supplied `plan` with no entitlement check (any user can self-provision Team for free). When #733 is fixed, the `plan: "team"` test shortcut must be replaced with a legitimate upgrade path (noted in #733).

## Next (separate, after this merges)
Make "Registry E2E (Postgres + MinIO)" a **required status check** so this class of regression actually blocks merges.