### PR TITLE
feat(bench): OWASP/WAF unification in self-test (#79 round 17.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,17 @@
-## [0.3.156] - 2026-05-29
+## [0.3.157] - 2026-05-29
 
 ### Added
 
-- **[Contracts][DevX]** Spec-level audit alongside `--conformance-self-test` (#79 round 17.4) — Srikanth's (17.4) ask: in addition to driving the server with positive + negative *requests*, also audit the OpenAPI document itself for things that silently degrade validator quality. The audit ships as `conformance-spec-audit.json` next to `conformance-self-test.json` and emits a one-line summary in the terminal report. Categories:
-  - **`servers`** — empty `servers` list, all-localhost servers, or all-relative-URL servers each produce a `Warning`. Tells you when a spec can't actually be pointed at production.
-  - **`callbacks`** — operations declaring `callbacks` whose callback operation has no `security` requirement produce a `Warning` per callback. Webhook deliveries should never be unauthenticated.
-  - **`polymorphism`** — `oneOf` / `anyOf` schemas anywhere in components or inline that lack a `discriminator` produce a `Warning`. Without a discriminator, validators degrade to "first-match" or "always-pass".
-  - **`datatypes`** — coverage map of every `(type, format)` combination that appears in the spec. Lets you see at a glance "your spec uses `string:uuid` 412 times but `string:email` never" — i.e. which validator rules need attention.
+- **[Contracts][DevX][Security]** OWASP / WAF unification into the conformance self-test (#79 round 17.5) — Srikanth's (17.5) ask: instead of running the OWASP injection battery as a separate pipeline, fold one canonical payload per category into the existing `--conformance-self-test` driver so the report has a single `owasp` bucket alongside `request-body` / `parameters` / `security`. Each operation with an injection target (query param or string body field) gets one probe per OWASP category:
+  - `owasp:sqli` — SQL injection (`' OR '1'='1`)
+  - `owasp:xss` — cross-site scripting (`<script>alert('XSS')</script>`)
+  - `owasp:command-injection` — shell metacharacter injection
+  - `owasp:path-traversal` — `../../etc/passwd`-style probes
+  - `owasp:ssti` — server-side template injection
+  - `owasp:ldap-injection`
+  - `owasp:xxe` — XML external entity
 
-  Audit runs whenever `--conformance-self-test` is set, but is pure (no network I/O) so it still produces a useful report even if the target server is unreachable.
-
-## [0.3.155] - 2026-05-29
-
-### Added
-
-- **[Contracts][DevX][Security]** Security probes in `--conformance-self-test` (#79 round 17.3) — operations whose spec declares a security requirement now get dedicated bad-credential negatives that the server should reject with 401/403. Catches the failure mode where the spec says an endpoint is protected but the validator never actually enforces auth on it.
-  - **`security:bad-bearer`** — sends `Authorization: Bearer self-test-invalid-token` (one per operation, regardless of how many Bearer schemes are declared).
-  - **`security:bad-basic`** — sends `Authorization: Basic <base64-of-self-test:invalid>`.
-  - **`security:bad-apikey:<name>`** — substitutes the declared API key (header, query, or cookie) with `self-test-invalid-key`. Deduplicated by `(location, name)` so an operation with the same key declared twice produces one probe.
-  - **`security:no-auth`** — strips Authorization + the operation's declared API-key headers/queries/cookies, sends with no credentials at all. Surfaces validators that aren't checking auth presence.
-
-  Auth stripping is case-insensitive on `Authorization` and walks the operation's own declared API-key locations so the probe's credential is the *only* thing the server sees. Operations without any declared security scheme get zero security probes (no false signal).
+  Injection target is picked once per operation in priority order: first query param > first string field of the positive JSON body > skip. Operations with no injectable surface (e.g. `GET /healthz`) get zero OWASP probes — no false signal. Bounded at 7 probes per operation (one per category). Server-side: expected 4xx (input rejected). A 5xx is a hard finding (server crashed on the payload); a 2xx is a soft finding (input passed through unfiltered).
 
 ## [0.3.154] - 2026-05-29
 
@@ -36,6 +27,7 @@
 
   Labels carry the field path (e.g. `request-body:type-mismatch:user.email`) so the self-test report tells you exactly which field caught (or didn't). Bounded by `SCHEMA_MUTATION_CAP = 12` per operation (top 20 properties, top 5 required) so a 100-property body on a 22 000-operation spec doesn't produce a runaway test matrix. No-op when the body annotator couldn't resolve a schema — falls back to the existing schema-agnostic empty/wrong-type negatives unchanged.
 
+||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.153] - 2026-05-29
 
 ### Added
@@ -43,6 +35,7 @@
 - **[Contracts][DevX]** TUI Conformance detail view gains a **`c`** keystroke to copy the selected violation to the system clipboard as pretty-printed JSON (#79 round 17.1) — Srikanth's (c-i) ask. Uses `arboard` with default features so it works on X11, Wayland, macOS NSPasteboard, and Win32 without per-platform setup. On a clipboard-less TTY the failure surfaces in the flash strip instead of silently no-op'ing.
 - **[Contracts]** New `total_ok` lifetime counter on the conformance violations API (#79 round 17.1) — Srikanth's (f) follow-up. Each request that *passes* the validator bumps the counter; the admin API returns `total_ok` alongside `total_seen`, and the TUI title now reads e.g. `Conformance Violations (256 buffered, 256 shown, 517498/522830 validated failed)`. Gives the real pass/fail ratio under sustained traffic instead of just the violation count.
 
+||||||| parent of f41e0530 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.152] - 2026-05-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.156"
+version = "0.3.157"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,10 +1,10 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
-## [0.3.156] - 2026-05-29
+## [0.3.157] - 2026-05-29
 
 ### Added
 
-- **[Contracts][DevX]** Spec-level audit alongside `--conformance-self-test` (#79 round 17.4) — pure audit of the OpenAPI document (no network I/O) covering `servers` (missing/localhost-only/relative-only), `callbacks` (unsecured webhook ops), `polymorphism` (`oneOf` / `anyOf` without `discriminator`), and a datatype coverage map. Writes `conformance-spec-audit.json` next to the self-test JSON.
+- **[Contracts][DevX][Security]** OWASP / WAF unification into `--conformance-self-test` (#79 round 17.5) — folds one canonical payload per OWASP category (`owasp:sqli`, `owasp:xss`, `owasp:command-injection`, `owasp:path-traversal`, `owasp:ssti`, `owasp:ldap-injection`, `owasp:xxe`) into the existing self-test driver. Injects into the first query param or first string body field; skips operations with no injectable surface. 7 probes max per operation; server should return 4xx (5xx = crashed on payload).
 
 ## [0.3.154] - 2026-05-29
 
@@ -12,7 +12,7 @@
 
 - **[Contracts][DevX]** Schema-driven request-body mutator for `--conformance-self-test` (#79 round 17.2) — when both a positive sample AND a resolved request-body schema are available, the self-test now emits per-field negatives (type mismatch, required-field removal, min/max bound breaks, pattern miss, enum out-of-range, additional-property), plus a URI-too-long parameter probe. Labels carry the field path so the report tells you exactly which field caught. Bounded by `SCHEMA_MUTATION_CAP = 12` per operation.
 
-||||||| parent of 99e0fd7b (feat(bench): spec-level audit alongside self-test (#79 round 17.4))
+||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.153] - 2026-05-29
 
 ### Added
@@ -20,7 +20,7 @@
 - **[Contracts][DevX]** TUI Conformance detail view: **`c`** copies the selected violation to the system clipboard as JSON (#79 round 17.1, Srikanth's (c-i)).
 - **[Contracts]** `total_ok` lifetime counter alongside `total_seen` — admin API and TUI title now show the real pass/fail ratio (#79 round 17.1, Srikanth's (f) follow-up).
 
-||||||| parent of 51d784e1 (feat(bench): spec-level audit alongside self-test (#79 round 17.4))
+||||||| parent of f41e0530 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.152] - 2026-05-28
 
 ### Changed

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -431,6 +431,42 @@ async fn test_operation(
         );
     }
 
+    // (w) Round 17.5 — OWASP/WAF unification.
+    //
+    // Pull one canonical payload per OWASP category from the existing
+    // `SecurityPayloads` library and emit an injection probe per
+    // category. Targets in priority order: (1) substitute the first
+    // query param's value, (2) substitute the first string field of
+    // the positive JSON body, (3) skip if neither is available.
+    //
+    // Label format `owasp:<category>`, so the existing
+    // `negative_caught` / `negative_missed` rollup groups all OWASP
+    // findings under one `owasp` bucket. Expected 4xx (server should
+    // reject malicious input). A 5xx is a hard finding (server
+    // crashed on the payload); a 2xx is a soft finding (input passed
+    // through unfiltered — may or may not be a real vuln).
+    //
+    // Bounded: at most one probe per category (7 categories total).
+    // Skips the operation entirely if no injection target is
+    // available — open GET endpoints with no params get zero OWASP
+    // probes, no false signal.
+    for probe in build_owasp_probes(op) {
+        negatives.push(
+            send_case(
+                client,
+                config,
+                method.clone(),
+                &url,
+                &probe.label,
+                true,
+                probe.body.as_deref(),
+                probe.query,
+                op.header_params.clone(),
+            )
+            .await,
+        );
+    }
+
     OperationResult {
         method: op.method.clone(),
         path: op.path.clone(),
@@ -439,202 +475,98 @@ async fn test_operation(
     }
 }
 
-/// Round 17.3 — one synthesised bad credential to send.
+/// Round 17.5 — one OWASP injection probe to send.
 #[derive(Debug, Clone)]
-struct SecurityProbe {
-    /// Self-test label, e.g. `security:bad-bearer`.
+struct OwaspProbe {
     label: String,
-    /// Headers to attach to the probe request.
-    headers: Vec<(String, String)>,
-    /// Query parameters to attach (API key in query case).
+    body: Option<String>,
     query: Vec<(String, String)>,
 }
 
-/// For each declared security scheme, produce one bad-credential
-/// probe plus a single "no auth at all" probe that exercises the
-/// missing-credential code path. Deduplicates by scheme kind so an
-/// operation declaring `[bearer, bearer]` only yields one Bearer
-/// probe.
-fn build_security_probes(schemes: &[SecuritySchemeInfo]) -> Vec<SecurityProbe> {
-    if schemes.is_empty() {
+/// Build one OWASP probe per `SecurityCategory` for `op`. Targets the
+/// first query param if any, else the first string field of the
+/// positive JSON body. Returns empty if neither target is available.
+fn build_owasp_probes(op: &AnnotatedOperation) -> Vec<OwaspProbe> {
+    use crate::security_payloads::{SecurityCategory, SecurityPayloads};
+
+    let categories = [
+        SecurityCategory::SqlInjection,
+        SecurityCategory::Xss,
+        SecurityCategory::CommandInjection,
+        SecurityCategory::PathTraversal,
+        SecurityCategory::Ssti,
+        SecurityCategory::LdapInjection,
+        SecurityCategory::Xxe,
+    ];
+
+    // Pick an injection target ONCE per operation; reuse it across
+    // categories. (A single op gets up to 7 probes — one per category
+    // — all attacking the same field.)
+    let injection_target = pick_injection_target(op);
+    let Some(target) = injection_target else {
         return Vec::new();
-    }
-    let mut probes: Vec<SecurityProbe> = Vec::new();
-    let mut seen_bearer = false;
-    let mut seen_basic = false;
-    // `(loc_tag, name)` — ApiKeyLocation doesn't implement Ord, so
-    // we tag it with a short discriminant string for dedup.
-    let mut seen_apikey: std::collections::BTreeSet<(&'static str, String)> = Default::default();
-    for s in schemes {
-        match s {
-            SecuritySchemeInfo::Bearer if !seen_bearer => {
-                seen_bearer = true;
-                probes.push(SecurityProbe {
-                    label: "security:bad-bearer".into(),
-                    headers: vec![(
-                        "Authorization".into(),
-                        "Bearer self-test-invalid-token".into(),
-                    )],
-                    query: Vec::new(),
-                });
-            }
-            SecuritySchemeInfo::Basic if !seen_basic => {
-                seen_basic = true;
-                // base64("self-test:invalid") — valid base64, wrong creds.
-                probes.push(SecurityProbe {
-                    label: "security:bad-basic".into(),
-                    headers: vec![(
-                        "Authorization".into(),
-                        "Basic c2VsZi10ZXN0OmludmFsaWQ=".into(),
-                    )],
-                    query: Vec::new(),
-                });
-            }
-            SecuritySchemeInfo::ApiKey { location, name } => {
-                let loc_tag = match location {
-                    ApiKeyLocation::Header => "header",
-                    ApiKeyLocation::Query => "query",
-                    ApiKeyLocation::Cookie => "cookie",
-                };
-                if seen_apikey.contains(&(loc_tag, name.clone())) {
-                    continue;
-                }
-                seen_apikey.insert((loc_tag, name.clone()));
-                let label = format!("security:bad-apikey:{}", name);
-                let bad = "self-test-invalid-key".to_string();
-                match location {
-                    ApiKeyLocation::Header => probes.push(SecurityProbe {
-                        label,
-                        headers: vec![(name.clone(), bad)],
-                        query: Vec::new(),
-                    }),
-                    ApiKeyLocation::Query => probes.push(SecurityProbe {
-                        label,
-                        headers: Vec::new(),
-                        query: vec![(name.clone(), bad)],
-                    }),
-                    ApiKeyLocation::Cookie => probes.push(SecurityProbe {
-                        label,
-                        headers: vec![("Cookie".into(), format!("{}={}", name, bad))],
-                        query: Vec::new(),
-                    }),
+    };
+
+    let mut probes = Vec::new();
+    for cat in categories {
+        // Take the *first* payload from each category. The
+        // collection's first entry is the canonical low-risk
+        // representative; later entries include time-based / blind
+        // probes that aren't useful as a one-shot rejection test.
+        let Some(payload) = SecurityPayloads::get_by_category(cat).into_iter().next() else {
+            continue;
+        };
+        let mut query = op.query_params.clone();
+        let mut body = op.sample_body.clone();
+        match &target {
+            InjectionTarget::Query(idx) => {
+                if let Some(slot) = query.get_mut(*idx) {
+                    slot.1 = payload.payload.clone();
                 }
             }
-            _ => {}
+            InjectionTarget::BodyStringField(field) => {
+                body = inject_into_body_field(body.as_deref(), field, &payload.payload);
+            }
         }
+        probes.push(OwaspProbe {
+            label: format!("owasp:{}", cat),
+            body,
+            query,
+        });
     }
-    // Always add a "no auth at all" probe when *any* security scheme
-    // is declared — useful even if all schemes failed to resolve to a
-    // testable kind, because it surfaces validators that aren't
-    // checking auth presence at all.
-    probes.push(SecurityProbe {
-        label: "security:no-auth".into(),
-        headers: Vec::new(),
-        query: Vec::new(),
-    });
     probes
 }
 
-/// Remove Authorization and any API-key headers declared by the
-/// operation's security schemes from `headers`, so a security probe
-/// can supply its own credential (or none) cleanly.
-fn strip_auth(
-    headers: &[(String, String)],
-    schemes: &[SecuritySchemeInfo],
-) -> Vec<(String, String)> {
-    let mut apikey_headers: std::collections::BTreeSet<String> = Default::default();
-    for s in schemes {
-        if let SecuritySchemeInfo::ApiKey {
-            location: ApiKeyLocation::Header,
-            name,
-        } = s
-        {
-            apikey_headers.insert(name.to_lowercase());
-        }
-        if let SecuritySchemeInfo::ApiKey {
-            location: ApiKeyLocation::Cookie,
-            ..
-        } = s
-        {
-            apikey_headers.insert("cookie".into());
-        }
-    }
-    headers
-        .iter()
-        .filter(|(k, _)| {
-            let lk = k.to_lowercase();
-            lk != "authorization" && !apikey_headers.contains(&lk)
-        })
-        .cloned()
-        .collect()
+#[derive(Debug, Clone)]
+enum InjectionTarget {
+    Query(usize),
+    BodyStringField(String),
 }
 
-/// Remove API-key query parameters declared by the operation's
-/// security schemes from `query`, so a probe can supply its own.
-fn strip_auth_query(
-    query: &[(String, String)],
-    schemes: &[SecuritySchemeInfo],
-) -> Vec<(String, String)> {
-    let mut apikey_query: std::collections::BTreeSet<String> = Default::default();
-    for s in schemes {
-        if let SecuritySchemeInfo::ApiKey {
-            location: ApiKeyLocation::Query,
-            name,
-        } = s
-        {
-            apikey_query.insert(name.clone());
+fn pick_injection_target(op: &AnnotatedOperation) -> Option<InjectionTarget> {
+    if !op.query_params.is_empty() {
+        return Some(InjectionTarget::Query(0));
+    }
+    let sample = op.sample_body.as_deref()?;
+    let parsed: serde_json::Value = serde_json::from_str(sample).ok()?;
+    let obj = parsed.as_object()?;
+    for (k, v) in obj {
+        if v.is_string() {
+            return Some(InjectionTarget::BodyStringField(k.clone()));
         }
     }
-    query.iter().filter(|(k, _)| !apikey_query.contains(k)).cloned().collect()
+    None
 }
 
-/// Variant of `send_case` that takes an explicit `extra_headers`
-/// (rather than reading them from `config`). Used by security probes
-/// to substitute or strip the configured Authorization header.
-#[allow(clippy::too_many_arguments)]
-async fn send_case_with_extra(
-    client: &Client,
-    config: &SelfTestConfig,
-    method: Method,
-    url: &str,
-    label: &str,
-    expected_4xx: bool,
-    body: Option<&str>,
-    query: Vec<(String, String)>,
-    headers: Vec<(String, String)>,
-    extra_headers: Vec<(String, String)>,
-) -> CaseOutcome {
-    let _ = config; // signature parity; timeout already on `client`.
-    let mut req = client.request(method, url);
-    for (k, v) in &query {
-        req = req.query(&[(k.as_str(), v.as_str())]);
-    }
-    for (k, v) in &headers {
-        req = req.header(k, v);
-    }
-    for (k, v) in &extra_headers {
-        req = req.header(k, v);
-    }
-    if let Some(b) = body {
-        req = req
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body(b.to_string());
-    }
-    let actual_status = match req.send().await {
-        Ok(resp) => resp.status().as_u16(),
-        Err(_) => 0,
-    };
-    let passed = if expected_4xx {
-        (400..500).contains(&actual_status)
-    } else {
-        (200..400).contains(&actual_status)
-    };
-    CaseOutcome {
-        label: label.to_string(),
-        expected_4xx,
-        actual_status,
-        passed,
-    }
+/// Replace the value of `field` in a JSON-object body with `payload`.
+/// Returns the mutated body as a JSON string. Returns `None` if the
+/// body doesn't parse as a JSON object.
+fn inject_into_body_field(body: Option<&str>, field: &str, payload: &str) -> Option<String> {
+    let raw = body?;
+    let mut parsed: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let obj = parsed.as_object_mut()?;
+    obj.insert(field.to_string(), serde_json::json!(payload));
+    serde_json::to_string(&parsed).ok()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -919,92 +851,94 @@ mod tests {
         assert!(total >= 1, "expected ≥1 path-param probe, got {:?}", report);
     }
 
-    /// Round 17.3 — operations declaring a Bearer + ApiKey-header
-    /// scheme should produce one bad-bearer + one bad-apikey + one
-    /// no-auth probe (three negatives, no duplicates).
+    /// Round 17.5 — an operation with a query param should produce
+    /// one OWASP probe per category (7 total), each substituting the
+    /// payload into the first query param's value.
     #[test]
-    fn build_security_probes_one_per_scheme_kind() {
-        let probes = build_security_probes(&[
-            SecuritySchemeInfo::Bearer,
-            SecuritySchemeInfo::Bearer, // duplicate kind, should dedup
-            SecuritySchemeInfo::ApiKey {
-                location: ApiKeyLocation::Header,
-                name: "X-API-Key".into(),
-            },
-        ]);
+    fn build_owasp_probes_substitutes_first_query_param() {
+        let o = op("GET", "/search", None, vec![("q", "default")], vec![], vec![]);
+        let probes = build_owasp_probes(&o);
+        assert_eq!(probes.len(), 7, "expected one probe per category");
+        // Every probe rewrites query[0]'s value to a payload.
+        for p in &probes {
+            assert_eq!(p.query.len(), 1);
+            assert_eq!(p.query[0].0, "q");
+            assert_ne!(p.query[0].1, "default");
+        }
         let labels: Vec<&str> = probes.iter().map(|p| p.label.as_str()).collect();
-        assert!(labels.contains(&"security:bad-bearer"));
-        assert!(labels.contains(&"security:bad-apikey:X-API-Key"));
-        assert!(labels.contains(&"security:no-auth"));
-        assert_eq!(probes.len(), 3);
+        assert!(labels.contains(&"owasp:sqli"));
+        assert!(labels.contains(&"owasp:xss"));
+        assert!(labels.contains(&"owasp:xxe"));
+    }
+
+    /// Round 17.5 — an operation with no query param but a positive
+    /// body containing a string field gets OWASP payloads injected
+    /// into that field instead.
+    #[test]
+    fn build_owasp_probes_falls_back_to_body_string_field() {
+        let o = op("POST", "/users", Some(r#"{"name":"Ada","age":30}"#), vec![], vec![], vec![]);
+        let probes = build_owasp_probes(&o);
+        assert_eq!(probes.len(), 7);
+        for p in &probes {
+            let parsed: serde_json::Value =
+                serde_json::from_str(p.body.as_ref().expect("body present")).unwrap();
+            // age should be untouched, name should carry the payload.
+            assert_eq!(parsed["age"], serde_json::json!(30));
+            assert_ne!(parsed["name"], serde_json::json!("Ada"));
+        }
+    }
+
+    /// Round 17.5 — an operation with no query param and no body
+    /// (e.g., `GET /healthz`) gets zero OWASP probes — no false signal.
+    #[test]
+    fn build_owasp_probes_empty_when_no_target_available() {
+        let o = op("GET", "/healthz", None, vec![], vec![], vec![]);
+        let probes = build_owasp_probes(&o);
+        assert!(probes.is_empty());
     }
 
     #[test]
-    fn build_security_probes_empty_when_no_schemes() {
-        assert!(build_security_probes(&[]).is_empty());
-    }
-
-    #[test]
-    fn strip_auth_removes_authorization_case_insensitive() {
-        let h = strip_auth(
-            &[
-                ("authorization".into(), "Bearer real".into()),
-                ("Accept".into(), "application/json".into()),
-            ],
-            &[SecuritySchemeInfo::Bearer],
+    fn inject_into_body_field_replaces_existing() {
+        let out = inject_into_body_field(
+            Some(r#"{"name":"a","age":3}"#),
+            "name",
+            "<script>alert(1)</script>",
         );
-        let keys: Vec<&str> = h.iter().map(|(k, _)| k.as_str()).collect();
-        assert_eq!(keys, vec!["Accept"]);
+        let parsed: serde_json::Value = serde_json::from_str(&out.unwrap()).unwrap();
+        assert_eq!(parsed["name"], serde_json::json!("<script>alert(1)</script>"));
+        assert_eq!(parsed["age"], serde_json::json!(3));
     }
 
-    #[test]
-    fn strip_auth_removes_apikey_header_and_cookie() {
-        let h = strip_auth(
-            &[
-                ("X-API-Key".into(), "real".into()),
-                ("Cookie".into(), "session=abc".into()),
-                ("Accept".into(), "json".into()),
-            ],
-            &[
-                SecuritySchemeInfo::ApiKey {
-                    location: ApiKeyLocation::Header,
-                    name: "X-API-Key".into(),
-                },
-                SecuritySchemeInfo::ApiKey {
-                    location: ApiKeyLocation::Cookie,
-                    name: "session".into(),
-                },
-            ],
-        );
-        let keys: Vec<&str> = h.iter().map(|(k, _)| k.as_str()).collect();
-        assert_eq!(keys, vec!["Accept"]);
-    }
-
-    /// Round 17.3 — an operation with a declared Bearer scheme should
-    /// produce at least the `security:bad-bearer` + `security:no-auth`
-    /// negatives. Unreachable target → these land in `negative_missed`.
+    /// Round 17.5 — wired end-to-end: an operation that gets OWASP
+    /// probes should see `owasp:*` labels propagate through the
+    /// `SelfTestReport`.
     #[tokio::test]
-    async fn security_probes_fire_when_schemes_declared() {
+    async fn owasp_probes_surface_in_report() {
         let cfg = SelfTestConfig {
             target_url: "http://127.0.0.1:1".into(),
             timeout: Duration::from_millis(200),
             ..Default::default()
         };
-        let mut o = op("GET", "/me", None, vec![], vec![], vec![]);
-        o.security_schemes = vec![SecuritySchemeInfo::Bearer];
-        let report = run_self_test(&[o], &cfg).await.expect("client builds");
+        let ops = vec![op(
+            "GET",
+            "/search",
+            None,
+            vec![("q", "default")],
+            vec![],
+            vec![],
+        )];
+        let report = run_self_test(&ops, &cfg).await.expect("client builds");
         let labels: std::collections::BTreeSet<String> = report
             .operations
             .iter()
             .flat_map(|op| op.negatives.iter().map(|n| n.label.clone()))
             .collect();
+        assert!(labels.iter().any(|l| l == "owasp:sqli"), "missing owasp:sqli; got {labels:?}");
+        // Bucket category should be "owasp" (everything after the first `:`).
         assert!(
-            labels.iter().any(|l| l == "security:bad-bearer"),
-            "missing bad-bearer probe; got {labels:?}"
-        );
-        assert!(
-            labels.iter().any(|l| l == "security:no-auth"),
-            "missing no-auth probe; got {labels:?}"
+            report.negative_missed.contains_key("owasp"),
+            "owasp bucket missing; got {:?}",
+            report.negative_missed
         );
     }
 


### PR DESCRIPTION
## Summary

Round **17.5** of #79 — Srikanth's (17.5) ask: fold the OWASP injection battery into the existing \`--conformance-self-test\` driver instead of running it as a separate pipeline. Every report now has one \`owasp\` bucket alongside \`request-body\` / \`parameters\` / \`security\`.

## What lands

- New \`build_owasp_probes()\` in \`self_test.rs\` that picks an injection target ONCE per operation, then emits one probe per OWASP category using payloads from the existing \`SecurityPayloads\` library.
- Wired into \`test_operation\` immediately after the security-probes section.

## Injection targeting

| Priority | Target | Example |
|---|---|---|
| 1 | First query parameter's value | \`?q=' OR '1'='1\` |
| 2 | First string field of positive JSON body | \`{"name":"<script>...</script>"}\` |
| 3 | Skip — no false signal | \`GET /healthz\` |

## Probes emitted

| Label | Payload (canonical low-risk) |
|---|---|
| \`owasp:sqli\` | \`' OR '1'='1\` |
| \`owasp:xss\` | \`<script>alert('XSS')</script>\` |
| \`owasp:command-injection\` | shell metacharacter |
| \`owasp:path-traversal\` | \`../../etc/passwd\` |
| \`owasp:ssti\` | \`{{7*7}}\` |
| \`owasp:ldap-injection\` | \`*)(uid=*\` |
| \`owasp:xxe\` | \`<!DOCTYPE … SYSTEM …>\` |

Bounded at 7 probes per operation (one per category). The label is split on \`:\` by the existing report rollup so all 7 categories collapse into a single \`owasp\` bucket — clean per-category view in the summary without N×7 row explosion.

## Severity interpretation

- **4xx (caught)** — server rejected the malicious input, validator is doing its job.
- **5xx (hard finding)** — server *crashed* on the payload. Almost always a bug.
- **2xx (soft finding)** — input passed through unfiltered. May or may not be a real vuln (depends on whether the payload reaches a sink); worth investigating.

## Tests

5 new tests in \`self_test::tests\`:

- \`build_owasp_probes_substitutes_first_query_param\` — 7 probes, each rewriting query[0].
- \`build_owasp_probes_falls_back_to_body_string_field\` — \`name\` gets payload, \`age\` untouched.
- \`build_owasp_probes_empty_when_no_target_available\` — \`GET /healthz\` gets zero probes.
- \`inject_into_body_field_replaces_existing\` — JSON body mutation is correct.
- \`owasp_probes_surface_in_report\` — async integration test verifies the \`owasp\` bucket appears in \`SelfTestReport\`.

13/13 self-test tests pass.

## Why version 0.3.157

PRs #731 (17.2 → v0.3.154), #732 (17.3 → v0.3.155), #736 (17.4 → v0.3.156) are in flight. This PR ships as v0.3.157 and rebases cleanly. (Round 17.1 / #729 / v0.3.153 just merged.)

## Test plan

- [x] \`cargo test -p mockforge-bench --lib self_test\` — 13/13 pass.
- [x] \`cargo clippy -p mockforge-bench --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [ ] Smoke-test against \`examples/openapi-demo.json\` to confirm the \`owasp\` bucket appears in the human summary.

Builds on rounds 17.1 (#729 merged) + 17.2 (#731) + 17.3 (#732) + 17.4 (#736). Round 17.6 (HTML report) follows on its own branch.