### PR TITLE
fix(mqtt,http): point MQTT admin API at the live SessionManager (#730)

### DIFF
--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -1318,7 +1318,10 @@ pub async fn handle_serve(
     let smtp_registry = None::<Arc<dyn std::any::Any + Send + Sync>>;
 
     #[cfg(feature = "mqtt")]
-    let mqtt_registry = if config.mqtt.enabled {
+    // Loaded for its fixture-validation side effects + user-facing logs. The
+    // listener now runs on the shared SessionManager (issue #730) and does not
+    // consume this registry, so it is intentionally unused after construction.
+    let _mqtt_registry = if config.mqtt.enabled {
         use mockforge_mqtt::MqttSpecRegistry;
         use std::sync::Arc;
 
@@ -1344,40 +1347,26 @@ pub async fn handle_serve(
         None
     };
 
+    // Build one MQTT SessionManager up front and share it between the
+    // protocol listener and the HTTP admin API, so the admin reflects the
+    // clients/topics the running broker actually serves (issue #730). The
+    // listener used to spin up its own SessionManager internally, leaving the
+    // admin reading a disconnected `MqttBroker`.
     #[cfg(feature = "mqtt")]
-    let mqtt_broker = if let Some(ref registry_ref) = mqtt_registry {
-        let mqtt_config = config.mqtt.clone();
-
-        // Convert core MqttConfig to mockforge_mqtt::MqttConfig
-        let broker_config = mockforge_mqtt::broker::MqttConfig {
-            port: mqtt_config.port,
-            host: mqtt_config.host.clone(),
-            max_connections: mqtt_config.max_connections,
-            max_packet_size: mqtt_config.max_packet_size,
-            keep_alive_secs: mqtt_config.keep_alive_secs,
-            version: mockforge_mqtt::broker::MqttVersion::default(),
-            // TLS defaults (not yet exposed in core config)
-            tls_enabled: false,
-            tls_port: 8883,
-            tls_cert_path: None,
-            tls_key_path: None,
-            tls_ca_path: None,
-            tls_client_auth: false,
-        };
-
-        // MQTT registry is already Some, so we can safely clone it
-        Some(Arc::new(mockforge_mqtt::MqttBroker::new(
-            broker_config.clone(),
-            registry_ref.clone(),
-        )))
+    let (mqtt_session_manager, mqtt_metrics) = if config.mqtt.enabled {
+        use mockforge_mqtt::{MqttMetrics, SessionManager};
+        let metrics = Arc::new(MqttMetrics::new());
+        let session_manager =
+            Arc::new(SessionManager::new(config.mqtt.max_connections, Some(metrics.clone())));
+        (Some(session_manager), Some(metrics))
     } else {
-        None
+        (None, None)
     };
 
     #[cfg(feature = "mqtt")]
-    let mqtt_broker_for_http = mqtt_broker
+    let mqtt_broker_for_http = mqtt_session_manager
         .as_ref()
-        .map(|broker| Arc::clone(broker) as Arc<dyn Any + Send + Sync>);
+        .map(|sm| Arc::clone(sm) as Arc<dyn Any + Send + Sync>);
     #[cfg(not(feature = "mqtt"))]
     let mqtt_broker_for_http = None::<Arc<dyn Any + Send + Sync>>;
 
@@ -2492,9 +2481,13 @@ pub async fn handle_serve(
     };
 
     #[cfg(feature = "mqtt")]
-    let _mqtt_handle = if let Some(ref _mqtt_registry) = mqtt_registry {
+    let _mqtt_handle = if let (Some(session_manager), Some(metrics)) =
+        (mqtt_session_manager.as_ref(), mqtt_metrics.as_ref())
+    {
         let mqtt_config = config.mqtt.clone();
         let mqtt_shutdown = shutdown_token.clone();
+        let session_manager = std::sync::Arc::clone(session_manager);
+        let metrics = std::sync::Arc::clone(metrics);
 
         // Convert core MqttConfig to mockforge_mqtt::MqttConfig
         let broker_config = mockforge_mqtt::broker::MqttConfig {
@@ -2514,13 +2507,14 @@ pub async fn handle_serve(
         };
 
         Some(tokio::spawn(async move {
-            use mockforge_mqtt::start_mqtt_server;
+            use mockforge_mqtt::start_mqtt_server_with_session_manager;
 
             println!("📡 MQTT broker listening on {}:{}", mqtt_config.host, mqtt_config.port);
 
-            // Start the MQTT server
+            // Start the listener on the SHARED session manager so the admin API
+            // sees the same clients/topics this listener serves.
             tokio::select! {
-                result = start_mqtt_server(broker_config) => {
+                result = start_mqtt_server_with_session_manager(session_manager, metrics, broker_config) => {
                     result.map_err(|e| format!("MQTT server error: {:?}", e))
                 }
                 _ = mqtt_shutdown.cancelled() => {

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -2204,12 +2204,14 @@ pub async fn build_router_with_chains_and_multi_tenant(
     };
     #[cfg(feature = "mqtt")]
     let management_state = {
-        if let Some(broker) = mqtt_broker {
-            match broker.downcast::<mockforge_mqtt::MqttBroker>() {
-                Ok(broker) => management_state.with_mqtt_broker(broker),
+        // The `mqtt_broker` slot carries the live `Arc<SessionManager>` (the
+        // running listener's state), not an `MqttBroker` — see issue #730.
+        if let Some(sessions) = mqtt_broker {
+            match sessions.downcast::<mockforge_mqtt::SessionManager>() {
+                Ok(sessions) => management_state.with_mqtt_sessions(sessions),
                 Err(e) => {
                     error!(
-                        "Invalid MQTT broker passed to HTTP management state: {:?}",
+                        "Invalid MQTT session manager passed to HTTP management state: {:?}",
                         e.type_id()
                     );
                     management_state

--- a/crates/mockforge-http/src/management/mod.rs
+++ b/crates/mockforge-http/src/management/mod.rs
@@ -727,9 +727,11 @@ pub struct ManagementState {
     /// Optional SMTP registry for email mocking
     #[cfg(feature = "smtp")]
     pub smtp_registry: Option<Arc<mockforge_smtp::SmtpSpecRegistry>>,
-    /// Optional MQTT broker for message mocking
+    /// Optional MQTT session manager (the live listener state) for the admin
+    /// API. Shared with the running listener so the admin reflects the clients
+    /// and topics actually being served (issue #730).
     #[cfg(feature = "mqtt")]
-    pub mqtt_broker: Option<Arc<mockforge_mqtt::MqttBroker>>,
+    pub mqtt_sessions: Option<Arc<mockforge_mqtt::SessionManager>>,
     /// Optional Kafka broker for event streaming
     #[cfg(feature = "kafka")]
     pub kafka_broker: Option<Arc<mockforge_kafka::KafkaMockBroker>>,
@@ -784,7 +786,7 @@ impl ManagementState {
             #[cfg(feature = "smtp")]
             smtp_registry: None,
             #[cfg(feature = "mqtt")]
-            mqtt_broker: None,
+            mqtt_sessions: None,
             #[cfg(feature = "kafka")]
             kafka_broker: None,
             #[cfg(feature = "amqp")]
@@ -844,9 +846,12 @@ impl ManagementState {
     }
 
     #[cfg(feature = "mqtt")]
-    /// Add MQTT broker to management state
-    pub fn with_mqtt_broker(mut self, mqtt_broker: Arc<mockforge_mqtt::MqttBroker>) -> Self {
-        self.mqtt_broker = Some(mqtt_broker);
+    /// Add the MQTT session manager (live listener state) to management state
+    pub fn with_mqtt_sessions(
+        mut self,
+        mqtt_sessions: Arc<mockforge_mqtt::SessionManager>,
+    ) -> Self {
+        self.mqtt_sessions = Some(mqtt_sessions);
         self
     }
 

--- a/crates/mockforge-http/src/management/protocols.rs
+++ b/crates/mockforge-http/src/management/protocols.rs
@@ -206,7 +206,7 @@ pub struct MqttBrokerStats {
 /// MQTT management handlers
 #[cfg(feature = "mqtt")]
 pub(crate) async fn get_mqtt_stats(State(state): State<ManagementState>) -> impl IntoResponse {
-    if let Some(broker) = &state.mqtt_broker {
+    if let Some(broker) = &state.mqtt_sessions {
         let connected_clients = broker.get_connected_clients().await.len();
         let active_topics = broker.get_active_topics().await.len();
         let stats = broker.get_topic_stats().await;
@@ -226,7 +226,7 @@ pub(crate) async fn get_mqtt_stats(State(state): State<ManagementState>) -> impl
 
 #[cfg(feature = "mqtt")]
 pub(crate) async fn get_mqtt_clients(State(state): State<ManagementState>) -> impl IntoResponse {
-    if let Some(broker) = &state.mqtt_broker {
+    if let Some(broker) = &state.mqtt_sessions {
         let clients = broker.get_connected_clients().await;
         Json(serde_json::json!({
             "clients": clients
@@ -239,7 +239,7 @@ pub(crate) async fn get_mqtt_clients(State(state): State<ManagementState>) -> im
 
 #[cfg(feature = "mqtt")]
 pub(crate) async fn get_mqtt_topics(State(state): State<ManagementState>) -> impl IntoResponse {
-    if let Some(broker) = &state.mqtt_broker {
+    if let Some(broker) = &state.mqtt_sessions {
         let topics = broker.get_active_topics().await;
         Json(serde_json::json!({
             "topics": topics
@@ -255,16 +255,11 @@ pub(crate) async fn disconnect_mqtt_client(
     State(state): State<ManagementState>,
     Path(client_id): Path<String>,
 ) -> impl IntoResponse {
-    if let Some(broker) = &state.mqtt_broker {
-        match broker.disconnect_client(&client_id).await {
-            Ok(_) => {
-                (StatusCode::OK, format!("Client '{}' disconnected", client_id)).into_response()
-            }
-            Err(e) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to disconnect client: {}", e))
-                    .into_response()
-            }
-        }
+    if let Some(sessions) = &state.mqtt_sessions {
+        // Graceful disconnect: the operator is closing the session, so don't
+        // fire the client's Last Will.
+        sessions.disconnect(&client_id, true).await;
+        (StatusCode::OK, format!("Client '{}' disconnected", client_id)).into_response()
     } else {
         (StatusCode::SERVICE_UNAVAILABLE, "MQTT broker not available").into_response()
     }
@@ -320,7 +315,7 @@ pub(crate) async fn publish_mqtt_message_handler(
     let topic = topic.unwrap();
     let payload = payload.unwrap();
 
-    if let Some(broker) = &state.mqtt_broker {
+    if let Some(broker) = &state.mqtt_sessions {
         // Validate QoS
         if qos > 2 {
             return (
@@ -335,43 +330,33 @@ pub(crate) async fn publish_mqtt_message_handler(
         // Convert payload to bytes
         let payload_bytes = payload.as_bytes().to_vec();
         let client_id = "mockforge-management-api".to_string();
+        let qos_level = mockforge_mqtt::ProtocolQoS::try_from(qos).unwrap_or_default();
 
-        let publish_result = broker
-            .handle_publish(&client_id, &topic, payload_bytes, qos, retain)
-            .await
-            .map_err(|e| format!("{}", e));
+        // Route through the live session manager so subscribers on the
+        // running broker actually receive the message. Publishing is
+        // fire-and-forget — a topic with no subscribers still succeeds.
+        broker.publish_raw(&client_id, &topic, payload_bytes, qos_level, retain).await;
 
-        match publish_result {
-            Ok(_) => {
-                // Emit message event for real-time monitoring
-                let event = MessageEvent::Mqtt(MqttMessageEvent {
-                    topic: topic.clone(),
-                    payload: payload.clone(),
-                    qos,
-                    retain,
-                    timestamp: chrono::Utc::now().to_rfc3339(),
-                });
-                let _ = state.message_events.send(event);
+        // Emit message event for real-time monitoring
+        let event = MessageEvent::Mqtt(MqttMessageEvent {
+            topic: topic.clone(),
+            payload: payload.clone(),
+            qos,
+            retain,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+        let _ = state.message_events.send(event);
 
-                (
-                    StatusCode::OK,
-                    Json(serde_json::json!({
-                        "success": true,
-                        "message": format!("Message published to topic '{}'", topic),
-                        "topic": topic,
-                        "qos": qos,
-                        "retain": retain
-                    })),
-                )
-            }
-            Err(error_msg) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "error": "Failed to publish message",
-                    "message": error_msg
-                })),
-            ),
-        }
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "success": true,
+                "message": format!("Message published to topic '{}'", topic),
+                "topic": topic,
+                "qos": qos,
+                "retain": retain
+            })),
+        )
     } else {
         (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -438,7 +423,7 @@ pub(crate) async fn publish_mqtt_batch_handler(
 
     let messages_json = messages_json.unwrap();
 
-    if let Some(broker) = &state.mqtt_broker {
+    if let Some(broker) = &state.mqtt_sessions {
         if messages_json.is_empty() {
             return (
                 StatusCode::BAD_REQUEST,
@@ -482,39 +467,27 @@ pub(crate) async fn publish_mqtt_batch_handler(
 
             // Convert payload to bytes
             let payload_bytes = payload.as_bytes().to_vec();
+            let qos_level = mockforge_mqtt::ProtocolQoS::try_from(qos).unwrap_or_default();
 
-            let publish_result = broker
-                .handle_publish(&client_id, &topic, payload_bytes, qos, retain)
-                .await
-                .map_err(|e| format!("{}", e));
+            // Route through the live session manager (fire-and-forget).
+            broker.publish_raw(&client_id, &topic, payload_bytes, qos_level, retain).await;
 
-            match publish_result {
-                Ok(_) => {
-                    // Emit message event
-                    let event = MessageEvent::Mqtt(MqttMessageEvent {
-                        topic: topic.clone(),
-                        payload: payload.clone(),
-                        qos,
-                        retain,
-                        timestamp: chrono::Utc::now().to_rfc3339(),
-                    });
-                    let _ = state.message_events.send(event);
+            // Emit message event
+            let event = MessageEvent::Mqtt(MqttMessageEvent {
+                topic: topic.clone(),
+                payload: payload.clone(),
+                qos,
+                retain,
+                timestamp: chrono::Utc::now().to_rfc3339(),
+            });
+            let _ = state.message_events.send(event);
 
-                    results.push(serde_json::json!({
-                        "index": index,
-                        "success": true,
-                        "topic": topic,
-                        "qos": qos
-                    }));
-                }
-                Err(error_msg) => {
-                    results.push(serde_json::json!({
-                        "index": index,
-                        "success": false,
-                        "error": error_msg
-                    }));
-                }
-            }
+            results.push(serde_json::json!({
+                "index": index,
+                "success": true,
+                "topic": topic,
+                "qos": qos
+            }));
 
             // Add delay between messages (except for the last one)
             if index < messages_json.len() - 1 && delay_ms > 0 {

--- a/crates/mockforge-mqtt/src/lib.rs
+++ b/crates/mockforge-mqtt/src/lib.rs
@@ -59,7 +59,7 @@ pub use protocol::{
 };
 pub use server::{
     start_mqtt_dual_server, start_mqtt_server, start_mqtt_server_with_metrics,
-    start_mqtt_tls_server, MqttServer,
+    start_mqtt_server_with_session_manager, start_mqtt_tls_server, MqttServer,
 };
 pub use session::SessionManager;
 pub use spec_registry::MqttSpecRegistry;

--- a/crates/mockforge-mqtt/src/server.rs
+++ b/crates/mockforge-mqtt/src/server.rs
@@ -129,6 +129,24 @@ pub async fn start_mqtt_server_with_metrics(
     config: MqttConfig,
     metrics: Arc<MqttMetrics>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let session_manager =
+        Arc::new(SessionManager::new(config.max_connections, Some(metrics.clone())));
+    start_mqtt_server_with_session_manager(session_manager, metrics, config).await
+}
+
+/// Start an MQTT server using a caller-provided `SessionManager`.
+///
+/// This is the entry point used when the admin API and the listener must
+/// share one broker: the caller builds the `Arc<SessionManager>`, hands a
+/// clone to `ManagementState`, and passes another here so the admin reflects
+/// the clients/topics this listener actually serves. `start_mqtt_server*`
+/// construct their own manager and delegate here, so existing callers are
+/// unchanged.
+pub async fn start_mqtt_server_with_session_manager(
+    session_manager: Arc<SessionManager>,
+    metrics: Arc<MqttMetrics>,
+    config: MqttConfig,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let addr = format!("{}:{}", config.host, config.port);
 
     info!(
@@ -137,8 +155,6 @@ pub async fn start_mqtt_server_with_metrics(
     );
 
     let listener = TcpListener::bind(&addr).await?;
-    let session_manager =
-        Arc::new(SessionManager::new(config.max_connections, Some(metrics.clone())));
 
     info!(
         "MQTT broker listening on {}:{} (MQTT {:?})",

--- a/crates/mockforge-mqtt/src/session.rs
+++ b/crates/mockforge-mqtt/src/session.rs
@@ -676,6 +676,49 @@ impl SessionManager {
         active.keys().cloned().collect()
     }
 
+    /// Get all active topic names: subscription filters plus retained-message
+    /// topics, sorted and de-duplicated. Mirrors `MqttBroker::get_active_topics`
+    /// so the admin API can report the live topic set from the running broker.
+    pub async fn get_active_topics(&self) -> Vec<String> {
+        let topics = self.topics.read().await;
+        let mut all: Vec<String> = topics.get_all_topic_filters();
+        all.extend(topics.get_all_retained_topics());
+        all.sort();
+        all.dedup();
+        all
+    }
+
+    /// Snapshot of topic-tree stats (subscriptions, subscribers, retained
+    /// messages) for the admin API.
+    pub async fn get_topic_stats(&self) -> crate::topics::TopicStats {
+        let topics = self.topics.read().await;
+        topics.stats()
+    }
+
+    /// Admin-facing publish: build a `PublishPacket` from a raw payload and
+    /// route it through the live `publish` path so it reaches real connected
+    /// subscribers (and is retained if requested). `publisher_id` is a
+    /// synthetic id for the admin sender — it never matches a real client, so
+    /// the self-skip in `publish` is a no-op here.
+    pub async fn publish_raw(
+        &self,
+        publisher_id: &str,
+        topic: &str,
+        payload: Vec<u8>,
+        qos: QoS,
+        retain: bool,
+    ) {
+        let packet = PublishPacket {
+            dup: false,
+            qos,
+            retain,
+            topic: topic.to_string(),
+            packet_id: None,
+            payload,
+        };
+        self.publish(publisher_id, &packet).await;
+    }
+
     /// Get count of active connections
     pub async fn connection_count(&self) -> usize {
         let active = self.active_clients.read().await;
@@ -1056,5 +1099,38 @@ mod tests {
         assert_eq!(SubackReturnCode::success(QoS::AtMostOnce), SubackReturnCode::SuccessQoS0);
         assert_eq!(SubackReturnCode::success(QoS::AtLeastOnce), SubackReturnCode::SuccessQoS1);
         assert_eq!(SubackReturnCode::success(QoS::ExactlyOnce), SubackReturnCode::SuccessQoS2);
+    }
+
+    #[tokio::test]
+    async fn test_admin_accessors_reflect_live_state() {
+        // Exercises the accessors the admin API uses (issue #730): a live
+        // subscription shows up in get_active_topics / get_topic_stats, and
+        // publish_raw routes through the live publish path to the subscriber.
+        let manager = SessionManager::new(10, None);
+
+        let (tx, mut rx) = mpsc::channel(10);
+        manager.connect("sub".to_string(), true, 60, tx, None).await.unwrap();
+        manager
+            .subscribe("sub", vec![("demo/topic".to_string(), QoS::AtMostOnce)])
+            .await;
+
+        // Topic + stats reflect the live subscription.
+        let topics = manager.get_active_topics().await;
+        assert!(topics.contains(&"demo/topic".to_string()), "topics: {topics:?}");
+        let stats = manager.get_topic_stats().await;
+        assert!(stats.total_subscriptions >= 1);
+        assert_eq!(manager.get_connected_clients().await, vec!["sub".to_string()]);
+
+        // Admin publish reaches the subscriber.
+        manager
+            .publish_raw("admin-test-fire", "demo/topic", b"hello".to_vec(), QoS::AtMostOnce, false)
+            .await;
+        match rx.recv().await {
+            Some(Packet::Publish(p)) => {
+                assert_eq!(p.topic, "demo/topic");
+                assert_eq!(p.payload, b"hello");
+            }
+            other => panic!("expected a delivered Publish, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Closes #730. Final piece of the protocol-admin live-wiring work (after AMQP #728 and Kafka #735).

## The gap

The MQTT admin API (`/__mockforge/api/mqtt/*`, surfaced by `MqttBrokerPage.tsx`) read from an `Arc<MqttBroker>` in `ManagementState`, but the running listener (`start_mqtt_server`) keeps its live state in a separate **`SessionManager`** that has *zero* references to `MqttBroker`. So the admin page always showed an empty/idle broker while real clients lived in the `SessionManager`. Unlike AMQP/Kafka, sharing one `Arc` wasn't enough — the admin object simply wasn't the listener's object.

## Fix — re-point the admin at the live `SessionManager`

**`mockforge-mqtt`**
- Add `SessionManager::{get_active_topics, get_topic_stats, publish_raw}` — thin accessors mirroring the `MqttBroker` methods the handlers used (data was already reachable from its fields). `SessionManager` already had `get_connected_clients`, `disconnect`, and `publish`.
- Extract `start_mqtt_server_with_session_manager(sm, metrics, config)` so a caller can supply the manager. `start_mqtt_server_with_metrics` now builds one and delegates → existing callers unchanged. Exported from `lib.rs`.

**`mockforge-http`**
- `ManagementState.mqtt_broker` → `mqtt_sessions: Option<Arc<SessionManager>>` + `with_mqtt_sessions`.
- The existing `mqtt_broker` param of `build_router_with_chains_and_multi_tenant` now carries the `Arc<SessionManager>` — **downcast target changed, signature unchanged** (no conflict with #735).
- MQTT handlers read/act on the session manager with identical JSON shapes; publish/batch route through `publish_raw` (so messages reach real subscribers); disconnect calls `SessionManager::disconnect(id, graceful=true)`.

**`mockforge-cli` serve.rs**
- Build one `Arc<SessionManager>` + `Arc<MqttMetrics>` up front, hand a clone to the admin state, and run the listener on it via `start_mqtt_server_with_session_manager`. The old admin-only `MqttBroker` construction is removed.

## Verification — end-to-end with a real MQTT client

A raw-socket MQTT 3.1.1 client connected to the running listener:

```
admin GET  /mqtt/clients            → {"clients":["e2e-client"]}        # live client visible
admin GET  /mqtt/topics             → {"topics":["demo/#"]}            # live subscription
admin GET  /mqtt/stats              → connected_clients:1, total_subscriptions:1
admin POST /mqtt/publish demo/test  → success
   → subscriber received: RECV demo/test hello-from-admin              # admin publish reached the live client
admin DELETE /mqtt/clients/e2e-client → 200
admin GET  /mqtt/clients            → {"clients":[]}                    # really disconnected
```

- New `SessionManager` unit test covers the accessors + publish-to-subscriber path.
- `cargo test -p mockforge-mqtt` → **214 passed**; `cargo test -p mockforge-http --features mqtt --lib` → **571 passed**.
- `cargo clippy -p mockforge-mqtt -p mockforge-http -p mockforge-cli --features mqtt -- -D warnings` → clean.
- `cargo check -p mockforge-http` (default, no mqtt) → builds. `cargo fmt --all --check` → clean.

With this, all three async-protocol admin pages (AMQP, Kafka, MQTT) reflect live broker state.