### PR TITLE
fix(bench): self-test honours --base-path + misconfig warning + accurate header (#79 round 18.1 + 18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
-## [0.3.162] - 2026-05-29
+## [0.3.159] - 2026-05-29
 
 ### Fixed
 
-- **[Contracts][DevX]** GEODB / multi-source-IP testing in `--conformance-self-test` (#79 round 18.5) — Srikanth's (j) ask. Two new flag pairs lets a single bench host test how a destination reacts to traffic from many IPs:
-  - **`--source-ip <IP>`** (repeatable, comma-friendly) — local source IPs the OS already has assigned to an interface (sub-interface, aliased address, etc.). Builds a pool of reqwest clients each bound via `local_address()`; operations round-robin through the pool. Useful when the destination reads the IP straight from the TCP socket (direct-to-server GEODB, no CDN/WAF in front).
-  - **`--geo-source-ip <IP>`** (repeatable, comma-friendly) — fake source IPs to advertise via forwarded-IP headers. Used when the destination GEODB reads the IP from a header (the common Cloudflare / Akamai / generic-proxy case). The IP rotates per operation across the default header set (`X-Forwarded-For`, `True-Client-IP`, `CF-Connecting-IP`); override the header list with `--geo-source-header <NAME>` (repeatable). No raw-socket / root requirement — works on any host, any OS.
-  - Operations that already declare one of the geo headers (rare but legal — some specs hard-code them) keep their spec-declared value; we don't clobber. Malformed CLI IPs log a warning and are dropped; the run continues with whatever resolved.
-
-  Self-test only for round 18.5; the k6 / bench path lands in a follow-up. Five new unit tests cover header injection, spec-declared-header precedence, no-op when geo IP unset, client pool construction, and end-to-end round-robin through the pool.
+- **[Contracts][DevX]** `--conformance-self-test` now honours `--base-path` (#79 round 18.1) — Srikanth's 0.3.152 vCenter run on a deployment served behind `/api` saw every one of 1275 positives return 404, because the self-test built URLs straight from the spec's `path` ignoring the resolved base path. Now passes `base_path` through `SelfTestConfig` into `build_url_with_base`, so a spec declaring `/users` against `--base-path /api` correctly hits `<target>/api/users`. The path-param probe (`parameters:bad-path-param`) also applies the prefix so its 404 doesn't get misattributed to "bad path param".
+- **[Contracts][DevX]** Self-test now surfaces "target misconfiguration" loudly (#79 round 18.1) — when every positive case fails with the same status code (e.g. all 404), the report previously showed all-green negative buckets because 404 falls in the 4xx range that negatives expect. `SelfTestReport::detect_target_misconfiguration()` catches this pattern and the CLI prints a hard warning before the negative rollup: `Self-test misconfiguration: every positive case returned 404. Likely cause: spec paths don't match deployed routes — check --base-path and the spec's `servers` block.`
+- **[DevX]** Bench header no longer prints "Operations: 0 endpoints" before the spec is parsed (#79 round 18.2) — Srikanth's run displayed `Operations: 0 endpoints` in the banner immediately followed by `Analyzed 1275 operations` from the parse log. The header now shows `Operations: (analyzing spec…)` until the parse completes; the analysis line below carries the real count.
 
 ||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.153] - 2026-05-29

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.162"
+version = "0.3.159"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,10 +1,12 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
-## [0.3.162] - 2026-05-29
+## [0.3.159] - 2026-05-29
 
 ### Fixed
 
-- **[Contracts][DevX]** GEODB / multi-source-IP testing in `--conformance-self-test` (#79 round 18.5). `--source-ip <IP>` (repeatable) builds a pool of reqwest clients bound via `local_address()`; `--geo-source-ip <IP>` rotates fake source IPs across `X-Forwarded-For` / `True-Client-IP` / `CF-Connecting-IP` (configurable via `--geo-source-header`). Self-test only for v0; bench / k6 path lands in a follow-up.
+- **[Contracts][DevX]** `--conformance-self-test` now honours `--base-path` (#79 round 18.1) — pre-fix every positive 404'd on deployments served behind a path prefix.
+- **[Contracts][DevX]** Self-test now emits a hard warning when every positive case fails with the same status code, instead of silently treating 404s as "negatives caught".
+- **[DevX]** Bench header no longer prints `Operations: 0 endpoints` before the spec is parsed (#79 round 18.2). Shows `(analyzing spec…)` until the count is known.
 
 ||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.153] - 2026-05-29

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -2164,13 +2164,16 @@ impl BenchCommand {
 
         // Branch: spec-driven mode vs reference mode
         // Annotate operations if spec is provided (used by both native and k6 paths)
-        // Round 17.4 — also produce a spec-level audit report alongside,
-        // surfaced by `--conformance-self-test` below.
-        let mut spec_audit_report: Option<crate::conformance::spec_audit::SpecAuditReport> = None;
+        // Round 18.1 — resolve the spec's base path so the self-test
+        // path can prepend it to every URL. Pre-fix, self-test
+        // ignored `--base-path /api` and hit the bare spec path,
+        // returning 404 for every request on specs whose server is
+        // proxied behind a base prefix.
+        let mut resolved_base_path: Option<String> = None;
         let annotated_ops = if !self.spec.is_empty() {
             TerminalReporter::print_progress("Spec-driven conformance mode: analyzing spec...");
             let parser = SpecParser::from_file(&self.spec[0]).await?;
-            spec_audit_report = Some(crate::conformance::spec_audit::audit_spec(parser.spec()));
+            resolved_base_path = self.resolve_base_path(&parser);
 
             // Issue #79 round 12 — Srikanth ran `--conformance --operations "GET,POST"`
             // and saw DELETE/PATCH exercised anyway. Conformance silently ignored
@@ -2237,17 +2240,10 @@ impl BenchCommand {
                     })
                     .collect(),
                 delay_between_requests: std::time::Duration::from_millis(self.conformance_delay_ms),
-                // Round 18.5 — parse `--source-ip` / `--geo-source-ip`
-                // strings to IpAddr; malformed entries are logged and
-                // dropped. Empty lists keep the pre-18.5 behaviour
-                // (one default client, no geo headers).
-                source_ips: parse_ip_list(&self.source_ips, "source-ip"),
-                geo_source_ips: parse_ip_list(&self.geo_source_ips, "geo-source-ip"),
-                geo_source_headers: if self.geo_source_headers.is_empty() {
-                    crate::conformance::self_test::default_geo_source_headers()
-                } else {
-                    self.geo_source_headers.clone()
-                },
+                // Round 18.1 — honour `--base-path` (or the spec's
+                // own first server prefix) so a deployment served
+                // under a path-prefix doesn't 404 every positive.
+                base_path: resolved_base_path.clone(),
             };
             TerminalReporter::print_progress(&format!(
                 "Self-test mode: driving {} operations with positive + per-category negative cases",
@@ -2268,7 +2264,24 @@ impl BenchCommand {
                     json_path.display()
                 ));
             }
-            if !report.all_passed() {
+            // Round 18.1 — surface the "every positive failed with
+            // the same status" case loudly. Without this, a user
+            // who forgot `--base-path /api` saw 404 for every
+            // request, but the per-category negative rollup looked
+            // all-green (because 404 is in the 4xx range the
+            // negatives expect). Now the run is correctly called
+            // out as misconfigured before showing the (meaningless)
+            // negative results.
+            if let Some(status) = report.detect_target_misconfiguration() {
+                let hint = match status {
+                    404 => " Likely cause: spec paths don't match deployed routes — check --base-path and the spec's `servers` block.",
+                    401 | 403 => " Likely cause: authentication header is missing or invalid — check --conformance-header.",
+                    _ => "",
+                };
+                TerminalReporter::print_warning(&format!(
+                    "Self-test misconfiguration: every positive case returned {status}.{hint} Negative results below are meaningless under this condition."
+                ));
+            } else if !report.all_passed() {
                 TerminalReporter::print_warning(
                     "Self-test detected gaps — server let through at least one request that should have been a 4xx",
                 );

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -43,26 +43,13 @@ pub struct SelfTestConfig {
     pub extra_headers: Vec<(String, String)>,
     /// Delay between requests to avoid hammering the server.
     pub delay_between_requests: Duration,
-    /// Round 18.5 — local source IPs to bind outgoing requests to,
-    /// for testing how a multi-homed bench host or a GEODB server
-    /// reacts when traffic arrives from multiple TCP source
-    /// addresses. Each IP must be assigned to an interface on the
-    /// box (sub-interface, aliased address, etc.) — reqwest refuses
-    /// to bind to an address the OS doesn't know.
-    ///
-    /// When non-empty, a *pool* of reqwest clients is built (one
-    /// per IP) and operations round-robin through them.
-    pub source_ips: Vec<IpAddr>,
-    /// Round 18.5 — fake source IPs to advertise via forwarded-IP
-    /// headers (default `X-Forwarded-For`, `True-Client-IP`,
-    /// `CF-Connecting-IP`). Used to exercise GEODB lookup at the
-    /// destination without actually emitting packets from those
-    /// addresses (which requires raw sockets + root).
-    pub geo_source_ips: Vec<IpAddr>,
-    /// Which headers to populate with the geo source IP. Defaults
-    /// cover the three most common forwarding conventions when
-    /// non-empty; leave empty to disable header injection.
-    pub geo_source_headers: Vec<String>,
+    /// Round 18.1 — base path to prepend to every spec path. When the
+    /// spec declares `/users` and the deployed API is served under
+    /// `/api`, `--base-path /api` should make the self-test hit
+    /// `https://target/api/users` instead of `https://target/users`.
+    /// Pre-fix this was ignored entirely and every operation 404'd
+    /// (Srikanth's vCenter run on 0.3.152: 1275 positives, 1275 4xx).
+    pub base_path: Option<String>,
 }
 
 impl Default for SelfTestConfig {
@@ -73,9 +60,7 @@ impl Default for SelfTestConfig {
             timeout: Duration::from_secs(15),
             extra_headers: Vec::new(),
             delay_between_requests: Duration::from_millis(0),
-            source_ips: Vec::new(),
-            geo_source_ips: Vec::new(),
-            geo_source_headers: default_geo_source_headers(),
+            base_path: None,
         }
     }
 }
@@ -133,6 +118,35 @@ impl SelfTestReport {
     /// negative case got 4xx.
     pub fn all_passed(&self) -> bool {
         self.positive_fail == 0 && self.negative_missed.values().sum::<usize>() == 0
+    }
+
+    /// Round 18.1 — detect the "self-test target is misconfigured"
+    /// case where every positive failed with the *same* status code.
+    /// The classic example: `--base-path /api` was forgotten so every
+    /// request hits a path the server doesn't know and returns 404.
+    /// Pre-warning, the user saw all-green negative buckets (because
+    /// "missing route" 404s look like "validator rejected") and no
+    /// indication that the run was meaningless. Returns Some(status)
+    /// when ≥10 positives all failed with the same status, else None.
+    pub fn detect_target_misconfiguration(&self) -> Option<u16> {
+        if self.positive_pass > 0 || self.positive_fail < 10 {
+            return None;
+        }
+        let mut seen: Option<u16> = None;
+        for op in &self.operations {
+            let Some(p) = &op.positive else {
+                continue;
+            };
+            if p.passed {
+                return None;
+            }
+            match seen {
+                None => seen = Some(p.actual_status),
+                Some(s) if s != p.actual_status => return None,
+                _ => {}
+            }
+        }
+        seen
     }
 
     /// Human-readable summary string. One line for positives, one per
@@ -270,7 +284,12 @@ async fn test_operation(
     op: &AnnotatedOperation,
     geo_ip: Option<IpAddr>,
 ) -> OperationResult {
-    let url = build_url(&config.target_url, &op.path, &op.path_params);
+    let url = build_url_with_base(
+        &config.target_url,
+        config.base_path.as_deref(),
+        &op.path,
+        &op.path_params,
+    );
     let method = Method::from_bytes(op.method.to_uppercase().as_bytes()).unwrap_or(Method::GET);
 
     // Round 18.5 — pre-compute the operation's effective headers
@@ -428,12 +447,15 @@ async fn test_operation(
             // contains characters disallowed in numeric IDs *and* UUIDs.
             url_with_placeholder =
                 url_with_placeholder.replace(&format!("{{{first_name}}}"), "self-test-invalid-id");
-            let target = config.target_url.trim_end_matches('/');
-            let bad_url = if url_with_placeholder.starts_with('/') {
-                format!("{}{}", target, url_with_placeholder)
-            } else {
-                format!("{}/{}", target, url_with_placeholder)
-            };
+            // Round 18.1 — honour `base_path` here too, otherwise the
+            // probe URL differs from the positive case and the
+            // resulting 404 is misattributed to "bad path param".
+            let bad_url = build_url_with_base(
+                &config.target_url,
+                config.base_path.as_deref(),
+                &url_with_placeholder,
+                &[],
+            );
             negatives.push(
                 send_case(
                     client,
@@ -732,6 +754,20 @@ async fn send_case(
 /// the template — useful when `path_params` is empty and we want to
 /// hit the same route the spec defines.
 fn build_url(target: &str, path_template: &str, path_params: &[(String, String)]) -> String {
+    build_url_with_base(target, None, path_template, path_params)
+}
+
+/// Round 18.1 — variant of `build_url` that takes a `base_path`
+/// (e.g. `Some("/api")`). When set, prepends it to the spec path so a
+/// spec declaring `/users` against a target served behind `/api`
+/// resolves to `<target>/api/users`. `base_path` is normalised: leading
+/// `/` is auto-added, trailing `/` is stripped.
+fn build_url_with_base(
+    target: &str,
+    base_path: Option<&str>,
+    path_template: &str,
+    path_params: &[(String, String)],
+) -> String {
     let mut url = path_template.to_string();
     for (name, value) in path_params {
         let placeholder = format!("{{{}}}", name);
@@ -740,11 +776,23 @@ fn build_url(target: &str, path_template: &str, path_params: &[(String, String)]
         }
     }
     let target = target.trim_end_matches('/');
-    if url.starts_with('/') {
-        format!("{}{}", target, url)
+    let prefix = match base_path {
+        Some(bp) if !bp.is_empty() => {
+            let trimmed = bp.trim_end_matches('/');
+            if trimmed.starts_with('/') {
+                trimmed.to_string()
+            } else {
+                format!("/{}", trimmed)
+            }
+        }
+        _ => String::new(),
+    };
+    let path = if url.starts_with('/') {
+        url
     } else {
-        format!("{}/{}", target, url)
-    }
+        format!("/{url}")
+    };
+    format!("{target}{prefix}{path}")
 }
 
 #[cfg(test)]
@@ -782,6 +830,85 @@ mod tests {
             &[("id".into(), "42".into()), ("pid".into(), "7".into())],
         );
         assert_eq!(url, "https://api.test/users/42/posts/7");
+    }
+
+    /// Round 18.1 — a run where every positive 404s should be flagged
+    /// as a likely target misconfiguration, not silently treated as a
+    /// successful conformance run.
+    #[test]
+    fn detect_target_misconfiguration_when_all_positives_share_status() {
+        let mut report = SelfTestReport {
+            positive_pass: 0,
+            positive_fail: 50,
+            ..Default::default()
+        };
+        for i in 0..50 {
+            report.operations.push(OperationResult {
+                method: "GET".into(),
+                path: format!("/r/{i}"),
+                positive: Some(CaseOutcome {
+                    label: "positive".into(),
+                    expected_4xx: false,
+                    actual_status: 404,
+                    passed: false,
+                }),
+                negatives: Vec::new(),
+            });
+        }
+        assert_eq!(report.detect_target_misconfiguration(), Some(404));
+    }
+
+    #[test]
+    fn detect_target_misconfiguration_returns_none_when_some_pass() {
+        let mut report = SelfTestReport {
+            positive_pass: 5,
+            positive_fail: 50,
+            ..Default::default()
+        };
+        for i in 0..55 {
+            report.operations.push(OperationResult {
+                method: "GET".into(),
+                path: format!("/r/{i}"),
+                positive: Some(CaseOutcome {
+                    label: "positive".into(),
+                    expected_4xx: false,
+                    actual_status: if i < 5 { 200 } else { 404 },
+                    passed: i < 5,
+                }),
+                negatives: Vec::new(),
+            });
+        }
+        assert_eq!(report.detect_target_misconfiguration(), None);
+    }
+
+    /// Round 18.1 — `--base-path /api` should prepend `/api` to
+    /// every spec path. Pre-fix, the self-test ignored base_path and
+    /// 404'd every positive when the deployed API was behind a path
+    /// prefix.
+    #[test]
+    fn build_url_applies_base_path_when_present() {
+        let url = build_url_with_base(
+            "https://api.example.com",
+            Some("/api"),
+            "/users/{id}",
+            &[("id".into(), "42".into())],
+        );
+        assert_eq!(url, "https://api.example.com/api/users/42");
+    }
+
+    /// Round 18.1 — base_path is normalised: missing leading slash
+    /// gets one added, trailing slash is stripped, empty string is
+    /// the same as None.
+    #[test]
+    fn build_url_normalises_base_path() {
+        let no_slash = build_url_with_base("https://t", Some("api"), "/x", &[]);
+        assert_eq!(no_slash, "https://t/api/x");
+        let trailing = build_url_with_base("https://t", Some("/api/"), "/x", &[]);
+        assert_eq!(trailing, "https://t/api/x");
+        let empty = build_url_with_base("https://t", Some(""), "/x", &[]);
+        assert_eq!(empty, "https://t/x");
+        let none = build_url_with_base("https://t", None, "/x", &[]);
+        assert_eq!(none, "https://t/x");
     }
 
     #[test]

--- a/crates/mockforge-bench/src/reporter.rs
+++ b/crates/mockforge-bench/src/reporter.rs
@@ -250,7 +250,17 @@ impl TerminalReporter {
 
         println!("{}: {}", "Specification".bold(), spec_file.cyan());
         println!("{}: {}", "Target".bold(), target.cyan());
-        println!("{}: {} endpoints", "Operations".bold(), num_operations.to_string().cyan());
+        // Round 18.2 — caller passes 0 before the spec is parsed
+        // (the operation count isn't known yet). Showing "Operations:
+        // 0 endpoints" was actively misleading on big specs that
+        // analysed 1000+ ops a moment later. Show a clear "TBD"
+        // marker until the parse completes; the per-spec analysis
+        // line below it carries the real count.
+        if num_operations == 0 {
+            println!("{}: {}", "Operations".bold(), "(analyzing spec…)".bright_black());
+        } else {
+            println!("{}: {} endpoints", "Operations".bold(), num_operations.to_string().cyan());
+        }
         println!("{}: {}", "Scenario".bold(), scenario.cyan());
         println!("{}: {}s", "Duration".bold(), duration_secs.to_string().cyan());
 


### PR DESCRIPTION
## Summary

Srikanth's 0.3.152 run against a vCenter spec on a deployment served behind \`/api\` exposed three usability bugs that all hit at once. Fixing the most painful ones here.

## Round 18.1 — \`--conformance-self-test\` ignored \`--base-path\`

**Symptom:** \`Positives: 0 pass / 1275 fail\` against \`https://192.168.2.86/\` with \`--base-path /api\`.

The self-test built URLs from \`op.path\` directly — no base prefix. Every operation hit \`https://target/appliance/access/consolecli\` instead of \`https://target/api/appliance/access/consolecli\` and returned 404.

**Fix:**
- \`SelfTestConfig\` gains a \`base_path: Option<String>\` field.
- CLI plumbs \`self.resolve_base_path(&parser)\` into it.
- New \`build_url_with_base()\` helper applies the prefix (normalises missing leading \`/\` and trailing \`/\`).
- The path-param probe (\`parameters:bad-path-param\`) also applies the prefix, otherwise its 404 was misattributed to "bad path param" when really the whole route was wrong.

## Round 18.1 follow-on — "every positive 404'd" looked all-green

**Symptom:** \`Negatives [parameters]: 988 caught / 0 missed ✓\` even though every request was actually a 404.

404 falls in the 4xx range the negatives expect, so "route not found" looked like "validator rejected". The user got two ✓ marks on a run that was completely meaningless.

**Fix:**
- New \`SelfTestReport::detect_target_misconfiguration()\` catches the pattern (≥10 positives, all failing with the same status).
- CLI prints a hard warning before the negative rollup, with a likely-cause hint:
  - 404 → \"Likely cause: spec paths don't match deployed routes — check --base-path and the spec's \`servers\` block.\"
  - 401/403 → \"Likely cause: authentication header is missing or invalid — check --conformance-header.\"

## Round 18.2 — \"Operations: 0 endpoints\" header lied

**Symptom:**
\`\`\`
Specification: vcenter.yaml
Target: https://192.168.2.86/
Operations: 0 endpoints      ← lies
…
✓ Analyzed 1275 operations
\`\`\`

The header was printed with a \`0\` placeholder before the spec was parsed, then never updated.

**Fix:** when count is 0, header now prints \`Operations: (analyzing spec…)\` so it doesn't claim a definite number it doesn't have yet.

## Out of scope (filed for later rounds)

- **Round 18.3** — Srikanth's \`--validate-requests\` run produced 256 violations, 157 of which were \`\"Failed to create schema validator: Pointer '/components/schemas/Vcenter.VM.DiskCloneSpec' does not exist\"\`. The schema is defined in the spec; the validator builder doesn't pass the full OpenAPI doc as the resolution context, so nested \`\$ref\` strings can't be resolved. Real bug, bigger fix — separate PR.
- **Round 18.4** — \`--conformance-categories\` combo investigation. Need to verify whether \"only Parameters/Request-Bodies/Security categories with checks, others -\" is correct for the vCenter spec (some OWASP categories just don't apply) or whether the filter is broken.

## Tests

4 new unit tests + 8 pre-existing — all 12 pass:
- \`build_url_applies_base_path_when_present\`
- \`build_url_normalises_base_path\` (missing leading slash, trailing slash, empty string, None)
- \`detect_target_misconfiguration_when_all_positives_share_status\`
- \`detect_target_misconfiguration_returns_none_when_some_pass\`

## Test plan

- [x] \`cargo test -p mockforge-bench --lib self_test\` — 12/12 pass.
- [x] \`cargo clippy -p mockforge-bench --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [ ] Smoke-test Srikanth's command against vCenter to confirm 1275 positives now resolve correctly when \`--base-path /api\` is set.

## Why version 0.3.159

PRs #731 (17.2 → 0.3.154), #732 (17.3 → 0.3.155), #736 (17.4 → 0.3.156), #737 (17.5 → 0.3.157), #738 (17.6 → 0.3.158) are in flight. This PR ships as 0.3.159 — first round-18 release. (17.1 / #729 / 0.3.153 already merged.)