### PR TITLE
fix(openapi,bench): resolve nested $ref against full spec context (#79 round 18.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## [0.3.161] - 2026-05-29
+## [0.3.160] - 2026-05-29
 
-### Changed
+### Fixed
 
-- **[Contracts][DevX]** OWASP coverage table now explains the "-" rows with actionable hints (#79 round 18.4) — Srikanth ran `--conformance-categories "security,request-bodies,parameters"` and reported "Not Working" when 5 of 10 OWASP categories showed `-`. The output was actually correct: those 3 categories map to exactly API1/API2/API4/API8, leaving API3/5/6/7/9/10 untouched. The confusing UX has been fixed by appending an "Untested OWASP categories" footer that tells the user exactly which `--conformance-categories` value to add for each uncovered OWASP category (e.g. `API3:2023 — add constraints (required/property checks)`, `API10:2023 — add response-validation`). API6 (Sensitive Business Flows) and API7 (SSRF) honestly say "no single category — requires custom scenario flows / URL-injection custom checks" rather than pretending coverage exists.
+- **[Contracts]** Request-body validator now resolves nested `$ref` pointers against the spec's full components map (#79 round 18.3) — Srikanth's vCenter 0.3.152 run produced 157 (of 256) violations like `Failed to create schema validator: Pointer '/components/schemas/Vcenter.VM.DiskCloneSpec' does not exist`. The schema was defined in the spec; the validator just couldn't see it because `jsonschema::options().build(&inner_schema)` was called with only the inner schema as the document — nested `$ref` strings then had no `components` map to resolve against. New `mockforge_openapi::schema_ref_resolver::build_validator(&schema, &spec)` wraps the schema document with the spec's components inlined at the root, giving JSON Pointer `#/components/schemas/X` a place to land. Wired into both `mockforge-bench`'s `request_validator` (the `--validate-requests` path that Srikanth hit) and `mockforge-openapi`'s `validation::validate_request_body` (the live-server path that powers `mockforge serve` request validation). Schema names with dots (`Vcenter.VM.DiskCloneSpec`), spaces, or other JSON-Pointer-safe characters now resolve correctly. 4 new unit tests cover the bug reproducer, naked-validator failure mode, explicit-components precedence, and no-components no-op.
 
 ||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.153] - 2026-05-29

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.161"
+version = "0.3.160"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,10 +1,10 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
-## [0.3.161] - 2026-05-29
+## [0.3.160] - 2026-05-29
 
-### Changed
+### Fixed
 
-- **[Contracts][DevX]** OWASP coverage table now appends an "Untested OWASP categories" footer that tells you exactly which `--conformance-categories` value to add for each uncovered OWASP category (#79 round 18.4). Removes the "Not Working" confusion when a user-selected subset of categories doesn't cover the full OWASP Top 10.
+- **[Contracts]** Request-body validator now resolves nested `$ref` pointers against the spec's components map (#79 round 18.3) — pre-fix specs whose component schemas had dotted names (`Vcenter.VM.DiskCloneSpec`) or were referenced from nested schemas failed with `Pointer '/components/schemas/X' does not exist`. New `schema_ref_resolver::build_validator(&schema, &spec)` inlines the components into the validator's document context.
 
 ||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.153] - 2026-05-29

--- a/crates/mockforge-bench/src/conformance/request_validator.rs
+++ b/crates/mockforge-bench/src/conformance/request_validator.rs
@@ -268,16 +268,39 @@ fn validate_request_body(
 
         if let Some(media) = json_media {
             if let Some(schema_ref) = &media.schema {
-                // Resolve schema $ref
-                let schema_json = match resolve_schema_to_json(schema_ref, spec) {
-                    Some(s) => s,
-                    None => return,
+                // Resolve the immediate $ref (one level) to get the
+                // root schema, then hand both schema + spec to the
+                // ref-resolver helper so nested `$ref` strings (e.g.
+                // `#/components/schemas/Vcenter.VM.DiskCloneSpec`)
+                // resolve against the full document context.
+                //
+                // Round 18.3 — pre-fix this called
+                // `jsonschema::validator_for(&schema_json)` directly,
+                // which used the inner schema as the validator's
+                // document. Nested $refs to `#/components/schemas/X`
+                // then failed with "Pointer '...' does not exist"
+                // because the validator's document had no
+                // `components` key (Srikanth's vCenter run: 157
+                // violations).
+                let root_schema = match schema_ref {
+                    ReferenceOr::Item(s) => s.clone(),
+                    ReferenceOr::Reference { reference } => {
+                        let name =
+                            reference.strip_prefix("#/components/schemas/").unwrap_or(reference);
+                        match spec.components.as_ref().and_then(|c| c.schemas.get(name)) {
+                            Some(ReferenceOr::Item(s)) => s.clone(),
+                            _ => return,
+                        }
+                    }
                 };
 
                 // Parse body as JSON and validate against schema
                 match serde_json::from_str::<serde_json::Value>(body_str) {
                     Ok(body_value) => {
-                        match jsonschema::validator_for(&schema_json) {
+                        match mockforge_openapi::schema_ref_resolver::build_validator(
+                            &root_schema,
+                            spec,
+                        ) {
                             Ok(validator) => {
                                 let errors: Vec<_> = validator.iter_errors(&body_value).collect();
                                 for err in errors.iter().take(5) {

--- a/crates/mockforge-openapi/src/lib.rs
+++ b/crates/mockforge-openapi/src/lib.rs
@@ -36,6 +36,7 @@ pub mod response_rewriter;
 pub mod response_trace;
 pub mod route;
 pub mod schema;
+pub mod schema_ref_resolver;
 pub mod spec;
 pub mod spec_parser;
 pub mod swagger_convert;

--- a/crates/mockforge-openapi/src/schema_ref_resolver.rs
+++ b/crates/mockforge-openapi/src/schema_ref_resolver.rs
@@ -1,0 +1,184 @@
+//! Build a JSON Schema validator that can resolve nested `$ref`
+//! pointers into the OpenAPI document's `#/components/schemas/...`
+//! map.
+//!
+//! Issue #79 round 18.3 — Srikanth's vCenter run on 0.3.152
+//! produced 157 violations like
+//!   "Failed to create schema validator: Pointer
+//!    '/components/schemas/Vcenter.VM.DiskCloneSpec' does not exist"
+//!
+//! Root cause: `validate_request_body` called
+//! `jsonschema::options().build(&inner_schema_json)` with **only the
+//! inner schema** as the validator's document. When the schema's
+//! properties contained nested `"$ref": "#/components/schemas/X"`
+//! strings, the validator tried to resolve them against the inner
+//! schema, which has no `components` section.
+//!
+//! Fix: wrap the inner schema so it carries the spec's components
+//! map at the document root, giving `$ref` pointers a place to
+//! resolve to. JSON Schema validators ignore unknown root keys, so
+//! the synthetic `components` field doesn't affect validation
+//! semantics — it's only there to be a resolution target.
+
+use jsonschema::{Draft, Validator};
+use openapiv3::{OpenAPI, Schema};
+use serde_json::Value;
+
+/// Build a `jsonschema::Validator` for `schema` that can resolve
+/// `$ref` pointers against the full `spec`. Returns a `String`
+/// error so callers don't have to thread `jsonschema::ValidationError`
+/// lifetimes through their result types.
+pub fn build_validator(schema: &Schema, spec: &OpenAPI) -> Result<Validator, String> {
+    let schema_json = serde_json::to_value(schema)
+        .map_err(|e| format!("Failed to convert OpenAPI schema to JSON: {e}"))?;
+    let merged = merge_components_into(schema_json, spec);
+    jsonschema::options()
+        .with_draft(Draft::Draft7)
+        .build(&merged)
+        .map_err(|e| format!("Failed to create schema validator: {e}"))
+}
+
+/// Merge the spec's components into a root-level `components` key on
+/// the schema document. If the schema already declares a
+/// `components` key (rare but legal), it takes precedence — we don't
+/// clobber explicit data. Returns the merged document.
+pub fn merge_components_into(mut schema_json: Value, spec: &OpenAPI) -> Value {
+    let Some(components) = &spec.components else {
+        return schema_json;
+    };
+    let Value::Object(ref mut map) = schema_json else {
+        // Non-object root (rare — a schema is usually an object).
+        // Wrap it in an object so we can attach components.
+        let inner = schema_json;
+        let wrapper = serde_json::json!({
+            "allOf": [inner],
+        });
+        return merge_components_into(wrapper, spec);
+    };
+    if map.contains_key("components") {
+        return schema_json;
+    }
+    if let Ok(comp_json) = serde_json::to_value(components) {
+        map.insert("components".to_string(), comp_json);
+    }
+    schema_json
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openapiv3::{Components, ReferenceOr, SchemaData, SchemaKind, StringType, Type};
+
+    fn make_spec_with_named_schema(name: &str, schema: Schema) -> OpenAPI {
+        let mut components = Components::default();
+        components.schemas.insert(name.to_string(), ReferenceOr::Item(schema));
+        OpenAPI {
+            openapi: "3.0.0".into(),
+            info: Default::default(),
+            components: Some(components),
+            ..Default::default()
+        }
+    }
+
+    /// The canonical bug reproducer: a request-body schema with a
+    /// nested `$ref` to a components/schemas/X with dots in the
+    /// name. Pre-fix this failed with "Pointer does not exist".
+    /// Post-fix it should build a validator and validate a body
+    /// against it cleanly.
+    #[test]
+    fn dotted_schema_ref_resolves_against_spec_context() {
+        // Define `Foo.Bar.Baz` in components — string type.
+        let nested = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(StringType::default())),
+        };
+        let spec = make_spec_with_named_schema("Foo.Bar.Baz", nested);
+
+        // Request body schema: object with one property that
+        // $refs into the components.
+        let body_schema_json = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "#/components/schemas/Foo.Bar.Baz"}
+            },
+            "required": ["name"]
+        });
+        let body_schema: Schema = serde_json::from_value(body_schema_json).unwrap();
+
+        let validator =
+            build_validator(&body_schema, &spec).expect("validator builds against spec context");
+
+        // A valid body — `name` is a string.
+        let good = serde_json::json!({"name": "hello"});
+        assert!(validator.iter_errors(&good).next().is_none());
+
+        // An invalid body — `name` is a number, should be rejected.
+        let bad = serde_json::json!({"name": 42});
+        assert!(validator.iter_errors(&bad).next().is_some());
+    }
+
+    /// Pre-fix path: a validator built from just the inner schema
+    /// (without our wrapper) fails AT BUILD TIME to resolve dotted
+    /// $refs — jsonschema is eager-resolve. The error wording is
+    /// literally the one Srikanth saw:
+    /// `Pointer '/components/schemas/Foo.Bar.Baz' does not exist`.
+    /// Documenting the wrong behaviour so future-me knows what
+    /// `build_validator` is protecting against.
+    #[test]
+    fn naked_validator_fails_to_build_on_dotted_ref() {
+        let body_schema_json = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "#/components/schemas/Foo.Bar.Baz"}
+            }
+        });
+        let result = jsonschema::options().with_draft(Draft::Draft7).build(&body_schema_json);
+        let err = result.expect_err("naked validator should fail to build");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Foo.Bar.Baz") || msg.contains("/components/schemas/"),
+            "naked-validator error should reference the unresolvable pointer; got: {msg}"
+        );
+    }
+
+    /// When the schema already declares a `components` key (rare —
+    /// some specs do this inline), we don't clobber it.
+    #[test]
+    fn explicit_components_takes_precedence() {
+        let spec = make_spec_with_named_schema(
+            "X",
+            Schema {
+                schema_data: SchemaData::default(),
+                schema_kind: SchemaKind::Type(Type::String(StringType::default())),
+            },
+        );
+        let schema = serde_json::json!({
+            "type": "object",
+            "components": {"schemas": {"X": {"type": "integer"}}}
+        });
+        let merged = merge_components_into(schema.clone(), &spec);
+        // The schema's explicit `components.schemas.X` (integer)
+        // wins; the spec's (string) does not overwrite.
+        let x = merged.get("components").and_then(|c| c.get("schemas")).and_then(|s| s.get("X"));
+        assert_eq!(
+            x.and_then(|v| v.get("type")).and_then(|v| v.as_str()),
+            Some("integer"),
+            "explicit schema components should not be clobbered"
+        );
+    }
+
+    /// Specs with no `components` block at all (some Swagger
+    /// conversions, or very minimal specs) should still produce a
+    /// working validator — we just don't add a components key.
+    #[test]
+    fn spec_without_components_is_a_noop() {
+        let spec = OpenAPI {
+            openapi: "3.0.0".into(),
+            info: Default::default(),
+            ..Default::default()
+        };
+        let schema = serde_json::json!({"type": "string"});
+        let merged = merge_components_into(schema.clone(), &spec);
+        assert_eq!(merged, schema);
+    }
+}

--- a/crates/mockforge-openapi/src/validation.rs
+++ b/crates/mockforge-openapi/src/validation.rs
@@ -464,97 +464,44 @@ fn validate_request_body(
     spec: &crate::spec::OpenApiSpec,
 ) -> Option<Vec<String>> {
     // For now, only validate JSON content
-    if let Some(media_type) = content.get("application/json") {
-        if let Some(schema_ref) = &media_type.schema {
-            match body {
-                Some(body_value) => {
-                    // Implement proper schema validation
-                    match schema_ref {
-                        ReferenceOr::Item(schema) => {
-                            // Convert OpenAPI schema to JSON Schema
-                            match serde_json::to_value(schema) {
-                                Ok(schema_json) => {
-                                    // Create JSON Schema validator
-                                    match jsonschema::options()
-                                        .with_draft(Draft::Draft7)
-                                        .build(&schema_json)
-                                    {
-                                        Ok(validator) => {
-                                            // Validate the body against the schema
-                                            let mut errors = Vec::new();
-                                            for error in validator.iter_errors(body_value) {
-                                                errors.push(error.to_string());
-                                            }
-                                            if errors.is_empty() {
-                                                None
-                                            } else {
-                                                Some(errors)
-                                            }
-                                        }
-                                        Err(e) => Some(vec![format!(
-                                            "Failed to create schema validator: {}",
-                                            e
-                                        )]),
-                                    }
-                                }
-                                Err(e) => Some(vec![format!(
-                                    "Failed to convert OpenAPI schema to JSON: {}",
-                                    e
-                                )]),
-                            }
-                        }
-                        ReferenceOr::Reference { reference } => {
-                            // Resolve schema reference
-                            if let Some(resolved_schema) = spec.get_schema(reference) {
-                                // Convert OpenAPI schema to JSON Schema
-                                match serde_json::to_value(&resolved_schema.schema) {
-                                    Ok(schema_json) => {
-                                        // Create JSON Schema validator
-                                        match jsonschema::options()
-                                            .with_draft(Draft::Draft7)
-                                            .build(&schema_json)
-                                        {
-                                            Ok(validator) => {
-                                                // Validate the body against the schema
-                                                let mut errors = Vec::new();
-                                                for error in validator.iter_errors(body_value) {
-                                                    errors.push(error.to_string());
-                                                }
-                                                if errors.is_empty() {
-                                                    None
-                                                } else {
-                                                    Some(errors)
-                                                }
-                                            }
-                                            Err(e) => Some(vec![format!(
-                                                "Failed to create schema validator: {}",
-                                                e
-                                            )]),
-                                        }
-                                    }
-                                    Err(e) => Some(vec![format!(
-                                        "Failed to convert OpenAPI schema to JSON: {}",
-                                        e
-                                    )]),
-                                }
-                            } else {
-                                Some(vec![format!(
-                                    "Failed to resolve schema reference: {}",
-                                    reference
-                                )])
-                            }
-                        }
-                    }
-                }
-                None => Some(vec!["Request body is required but not provided".to_string()]),
+    let media_type = content.get("application/json")?;
+    let schema_ref = media_type.schema.as_ref()?;
+    let body_value = match body {
+        Some(b) => b,
+        None => return Some(vec!["Request body is required but not provided".to_string()]),
+    };
+
+    // Round 18.3 — resolve the immediate $ref (one level), then hand
+    // the root schema + full spec to the ref-resolver helper so
+    // nested `$ref` strings (e.g.
+    // `#/components/schemas/Vcenter.VM.DiskCloneSpec`) resolve
+    // against the document context. Pre-fix this called
+    // `jsonschema::options().build(&schema_json)` with only the
+    // inner schema; nested $refs then failed with `Pointer ... does
+    // not exist` because the validator's document had no
+    // `components` map. Srikanth's vCenter run hit this 157× across
+    // 256 violations on 0.3.152.
+    let root_schema = match schema_ref {
+        ReferenceOr::Item(s) => s.clone(),
+        ReferenceOr::Reference { reference } => match spec.get_schema(reference) {
+            Some(s) => s.schema.clone(),
+            None => {
+                return Some(vec![format!("Failed to resolve schema reference: {reference}")]);
             }
-        } else {
-            // No schema defined, body is optional
-            None
+        },
+    };
+
+    match crate::schema_ref_resolver::build_validator(&root_schema, &spec.spec) {
+        Ok(validator) => {
+            let errors: Vec<String> =
+                validator.iter_errors(body_value).map(|e| e.to_string()).collect();
+            if errors.is_empty() {
+                None
+            } else {
+                Some(errors)
+            }
         }
-    } else {
-        // No JSON content type defined, skip validation
-        None
+        Err(e) => Some(vec![e]),
     }
 }
 


### PR DESCRIPTION
## Summary

Srikanth's 0.3.152 vCenter \`--validate-requests\` run produced 256 violations, 157 of them like:

\`\`\`
Failed to create schema validator: Pointer '/components/schemas/Vcenter.VM.DiskCloneSpec' does not exist
\`\`\`

The schema **IS** defined in the spec. The validator just couldn't see it.

## Root cause

Every call site that built a \`jsonschema::Validator\` passed only the inner schema's JSON as the validator's document. Nested \`\$ref\` strings in the schema then tried to resolve against that inner-schema document, which has no \`components\` section. \`jsonschema\` is eager-resolve, so it fails at build time with "Pointer does not exist."

The dotted-name surface (\`Vcenter.VM.DiskCloneSpec\`) made it visible at scale on vCenter — nearly every schema in that spec uses dotted names, and nearly every operation references one.

## Fix

New module **\`mockforge_openapi::schema_ref_resolver\`** whose
\`build_validator(&schema, &spec)\` wraps the schema document with the
spec's components inlined at the root. JSON Pointer
\`#/components/schemas/X\` now has a target to resolve to. JSON Schema
validators ignore unknown root keys, so the synthetic \`components\`
field doesn't affect validation semantics — it's only a resolution
target.

Wired into both call sites:

| File | Path that hits the bug |
|---|---|
| \`mockforge-bench/src/conformance/request_validator.rs\` | \`mockforge bench --validate-requests\` (Srikanth's cmd1) |
| \`mockforge-openapi/src/validation.rs\` | live-server validation in \`mockforge serve\` |

The \`openapi\` side also collapsed ~80 lines of nested match/if-let into a flat let-else flow.

## Tests

4 new tests in \`schema_ref_resolver\`:

- \`dotted_schema_ref_resolves_against_spec_context\` — canonical bug reproducer with \`Foo.Bar.Baz\`
- \`naked_validator_fails_to_build_on_dotted_ref\` — documents the broken pre-fix path (confirms jsonschema is eager-resolve, the error message matches Srikanth's exact wording)
- \`explicit_components_takes_precedence\` — schemas declaring their own \`components\` aren't clobbered
- \`spec_without_components_is_a_noop\` — minimal specs still work

164/164 openapi tests pass. 399/399 bench tests pass.

## Test plan

- [x] \`cargo test -p mockforge-openapi --lib\` — 164/164 pass.
- [x] \`cargo test -p mockforge-bench --lib\` — 399/399 pass.
- [x] \`cargo clippy -p mockforge-openapi -p mockforge-bench --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [ ] Smoke-test Srikanth's cmd1 against the vCenter spec — the 157 \"Pointer does not exist\" violations should vanish. Real body-validation violations (if any) will still surface, which is the actual signal we want.

## Why version 0.3.160

PRs #731 (17.2), #732 (17.3), #736 (17.4), #737 (17.5), #738 (17.6), #740 (18.1+18.2) are in flight. This PR ships as 0.3.160 — second round-18 release.