### PR TITLE
fix(bench): OWASP coverage table explains the "-" rows (#79 round 18.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,8 @@
-## [0.3.157] - 2026-05-29
+## [0.3.161] - 2026-05-29
 
-### Added
+### Changed
 
-- **[Contracts][DevX][Security]** OWASP / WAF unification into the conformance self-test (#79 round 17.5) — Srikanth's (17.5) ask: instead of running the OWASP injection battery as a separate pipeline, fold one canonical payload per category into the existing `--conformance-self-test` driver so the report has a single `owasp` bucket alongside `request-body` / `parameters` / `security`. Each operation with an injection target (query param or string body field) gets one probe per OWASP category:
-  - `owasp:sqli` — SQL injection (`' OR '1'='1`)
-  - `owasp:xss` — cross-site scripting (`<script>alert('XSS')</script>`)
-  - `owasp:command-injection` — shell metacharacter injection
-  - `owasp:path-traversal` — `../../etc/passwd`-style probes
-  - `owasp:ssti` — server-side template injection
-  - `owasp:ldap-injection`
-  - `owasp:xxe` — XML external entity
-
-  Injection target is picked once per operation in priority order: first query param > first string field of the positive JSON body > skip. Operations with no injectable surface (e.g. `GET /healthz`) get zero OWASP probes — no false signal. Bounded at 7 probes per operation (one per category). Server-side: expected 4xx (input rejected). A 5xx is a hard finding (server crashed on the payload); a 2xx is a soft finding (input passed through unfiltered).
-
-## [0.3.154] - 2026-05-29
-
-### Added
-
-- **[Contracts][DevX]** Schema-driven request-body mutator for the `--conformance-self-test` driver (#79 round 17.2) — Srikanth's (17.2) ask: positive + negative coverage that's actually informed by the spec instead of just "send an empty body". When both a positive sample AND a resolved request-body schema are available, the self-test now produces per-field negatives that the server should reject with 4xx:
-  - **Type mismatch** per field (`string` field gets a number, `integer` gets a string, `object` gets an array) plus a top-level `$root` shape probe.
-  - **Required-field removal** — drops each required field one at a time (up to 5), so a validator that's only enforcing the root shape but not requiredness is caught.
-  - **String constraint breaks** — too-short, too-long, pattern miss, enum-out-of-range when the schema declares those bounds.
-  - **Numeric bound breaks** — `minimum`/`maximum` violations plus an "integer as float" probe for `integer` fields.
-  - **Additional-property** probe when the schema explicitly sets `additionalProperties: false`.
-  - **URI-too-long** parameter probe — appends a 9 KiB query string so deployments behind a tight reverse-proxy URI cap surface as a `parameters:uri-too-long` negative.
-
-  Labels carry the field path (e.g. `request-body:type-mismatch:user.email`) so the self-test report tells you exactly which field caught (or didn't). Bounded by `SCHEMA_MUTATION_CAP = 12` per operation (top 20 properties, top 5 required) so a 100-property body on a 22 000-operation spec doesn't produce a runaway test matrix. No-op when the body annotator couldn't resolve a schema — falls back to the existing schema-agnostic empty/wrong-type negatives unchanged.
+- **[Contracts][DevX]** OWASP coverage table now explains the "-" rows with actionable hints (#79 round 18.4) — Srikanth ran `--conformance-categories "security,request-bodies,parameters"` and reported "Not Working" when 5 of 10 OWASP categories showed `-`. The output was actually correct: those 3 categories map to exactly API1/API2/API4/API8, leaving API3/5/6/7/9/10 untouched. The confusing UX has been fixed by appending an "Untested OWASP categories" footer that tells the user exactly which `--conformance-categories` value to add for each uncovered OWASP category (e.g. `API3:2023 — add constraints (required/property checks)`, `API10:2023 — add response-validation`). API6 (Sensitive Business Flows) and API7 (SSRF) honestly say "no single category — requires custom scenario flows / URL-injection custom checks" rather than pretending coverage exists.
 
 ||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.153] - 2026-05-29

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.157"
+version = "0.3.161"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,16 +1,10 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
-## [0.3.157] - 2026-05-29
+## [0.3.161] - 2026-05-29
 
-### Added
+### Changed
 
-- **[Contracts][DevX][Security]** OWASP / WAF unification into `--conformance-self-test` (#79 round 17.5) — folds one canonical payload per OWASP category (`owasp:sqli`, `owasp:xss`, `owasp:command-injection`, `owasp:path-traversal`, `owasp:ssti`, `owasp:ldap-injection`, `owasp:xxe`) into the existing self-test driver. Injects into the first query param or first string body field; skips operations with no injectable surface. 7 probes max per operation; server should return 4xx (5xx = crashed on payload).
-
-## [0.3.154] - 2026-05-29
-
-### Added
-
-- **[Contracts][DevX]** Schema-driven request-body mutator for `--conformance-self-test` (#79 round 17.2) — when both a positive sample AND a resolved request-body schema are available, the self-test now emits per-field negatives (type mismatch, required-field removal, min/max bound breaks, pattern miss, enum out-of-range, additional-property), plus a URI-too-long parameter probe. Labels carry the field path so the report tells you exactly which field caught. Bounded by `SCHEMA_MUTATION_CAP = 12` per operation.
+- **[Contracts][DevX]** OWASP coverage table now appends an "Untested OWASP categories" footer that tells you exactly which `--conformance-categories` value to add for each uncovered OWASP category (#79 round 18.4). Removes the "Not Working" confusion when a user-selected subset of categories doesn't cover the full OWASP Top 10.
 
 ||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.153] - 2026-05-29

--- a/crates/mockforge-bench/src/conformance/report.rs
+++ b/crates/mockforge-bench/src/conformance/report.rs
@@ -710,7 +710,8 @@ impl ConformanceReport {
         println!("{}", "OWASP API Security Top 10 Coverage".bold());
         println!("{}", "=".repeat(64).bright_green());
 
-        for entry in self.owasp_coverage_data() {
+        let entries = self.owasp_coverage_data();
+        for entry in &entries {
             let (status, via) = if !entry.tested {
                 ("-".bright_black(), String::new())
             } else {
@@ -723,6 +724,31 @@ impl ConformanceReport {
             };
 
             println!("  {:<12} {:<40} {}{}", entry.id, entry.name, status, via);
+        }
+
+        // Round 18.4 — Srikanth's confusion: he saw 5 OWASP rows
+        // show "-" after `--conformance-categories
+        // "security,request-bodies,parameters"` and read it as "not
+        // working". Actually it was working perfectly — his selected
+        // categories simply don't map to the 5 untouched OWASP
+        // categories. Print a footer that explains which conformance
+        // category to add to exercise each untested OWASP category.
+        let untested: Vec<&OwaspCoverageEntry> = entries.iter().filter(|e| !e.tested).collect();
+        if !untested.is_empty() {
+            println!();
+            println!(
+                "{}",
+                "  Untested OWASP categories — add the listed --conformance-categories to exercise:".bright_black()
+            );
+            for entry in untested {
+                let suggestion = suggest_conformance_category_for_owasp(&entry.id);
+                println!(
+                    "    {} {:<40} {}",
+                    entry.id.bright_black(),
+                    entry.name.bright_black(),
+                    suggestion.bright_black()
+                );
+            }
         }
     }
 
@@ -744,9 +770,44 @@ impl ConformanceReport {
     }
 }
 
+/// Round 18.4 — pair each OWASP category with the conformance
+/// category that exercises it. Used by the report footer when a
+/// category is untested to tell the user *how* to test it.
+fn suggest_conformance_category_for_owasp(owasp_id: &str) -> &'static str {
+    match owasp_id {
+        "API1:2023" => "add `parameters` (path-param probes)",
+        "API2:2023" => "add `security` (auth probes)",
+        "API3:2023" => "add `constraints` (required/property checks)",
+        "API4:2023" => "add `request-bodies` or `constraints` (min/max/pattern/enum)",
+        "API5:2023" => "add `http-methods` (method-by-method coverage)",
+        "API6:2023" => "no single category — requires custom scenario flows",
+        "API7:2023" => "no built-in coverage — requires URL-injection custom checks",
+        "API8:2023" => "add any of `parameters` / `request-bodies` / `schema-types` / `string-formats` / `composition` / `response-codes` / `content-types` / `response-validation`",
+        "API9:2023" => "add `response-codes` or `http-methods`",
+        "API10:2023" => "add `response-validation`",
+        _ => "no mapping",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Round 18.4 — every OWASP category that the suggestion helper
+    /// is asked about should return a non-empty hint, so the footer
+    /// in the coverage table never prints an empty cell.
+    #[test]
+    fn suggest_conformance_category_returns_a_hint_for_every_owasp() {
+        for category in OwaspCategory::all() {
+            let suggestion = suggest_conformance_category_for_owasp(category.identifier());
+            assert!(
+                !suggestion.is_empty() && suggestion != "no mapping",
+                "no suggestion for {} ({})",
+                category.identifier(),
+                category.short_name()
+            );
+        }
+    }
 
     #[test]
     fn test_parse_conformance_report() {


### PR DESCRIPTION
## Summary

Srikanth ran:
\`\`\`
mockforge bench --conformance --conformance-categories "security,request-bodies,parameters" ...
\`\`\`
and reported "Not Working" when 5 of 10 OWASP categories showed \`-\` in the coverage table.

## Why it was correct, but confusing

The output was working as designed. The 3 conformance categories he selected map to exactly:

| CLI category | OWASP categories |
|---|---|
| \`security\` | API2 |
| \`request-bodies\` | API4, API8 |
| \`parameters\` | API1, API8 |
| **Union** | **API1, API2, API4, API8 = 4 of 10** ✓ |

The remaining 6 OWASP rows (API3, API5, API6, API7, API9, API10) map to other conformance categories he didn't select. The table gave no indication what would unlock them.

## Fix

Append an "Untested OWASP categories" footer to the OWASP coverage table that, for each \`-\` row, prints exactly which \`--conformance-categories\` value to add:

\`\`\`
Untested OWASP categories — add the listed --conformance-categories to exercise:
  API3:2023   Broken Object Property Authorization     add \`constraints\` (required/property checks)
  API5:2023   Broken Function Authorization            add \`http-methods\` (method-by-method coverage)
  API6:2023   Sensitive Business Flows                 no single category — requires custom scenario flows
  API7:2023   SSRF                                     no built-in coverage — requires URL-injection custom checks
  API9:2023   Improper Inventory Management            add \`response-codes\` or \`http-methods\`
  API10:2023  Unsafe API Consumption                   add \`response-validation\`
\`\`\`

API6 and API7 honestly say "no single category — requires custom scenario flows / URL-injection custom checks" rather than pretending coverage exists.

## Tests

1 new unit test asserts that every OWASP category from \`OwaspCategory::all()\` has a non-empty hint, so the footer never prints a blank cell.

## Test plan

- [x] \`cargo test -p mockforge-bench --lib conformance::report\` — 4/4 pass.
- [x] \`cargo clippy -p mockforge-bench --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [ ] Smoke-test the original \`--conformance-categories "security,request-bodies,parameters"\` run to confirm the footer renders correctly.

## Why version 0.3.161

Follows in sequence after #729 (17.1), #731-738 (17.2-17.6), #740 (18.1+18.2), #741 (18.3). Last in the current 17.x/18.x chain before I cut a unified release.