### PR TITLE
fix(observability): serve the global metrics registry at /metrics (#743)

### DIFF
--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -6,7 +6,7 @@ use mockforge_chaos::api::create_chaos_api_router;
 use mockforge_chaos::config::ChaosConfig;
 use mockforge_core::encryption::init_key_store;
 use mockforge_core::ServerConfig;
-use mockforge_observability::prometheus::{prometheus_router, MetricsRegistry};
+use mockforge_observability::prometheus::prometheus_router;
 use mockforge_openapi::OpenApiSpec;
 use std::any::Any;
 use std::net::SocketAddr;
@@ -2180,8 +2180,11 @@ pub async fn handle_serve(
 
     println!("💡 Press Ctrl+C to stop");
 
-    // Create metrics registry (use global registry)
-    let metrics_registry = Arc::new(MetricsRegistry::new());
+    // Serve the GLOBAL metrics registry — the same instance the HTTP/drift/
+    // coverage middleware and the system-metrics collector record into. Using a
+    // fresh `MetricsRegistry::new()` here meant `/metrics` exported an empty
+    // registry while all real metrics went to the global one (#743).
+    let metrics_registry = mockforge_observability::get_global_registry_arc();
 
     // Start system metrics collector if Prometheus is enabled
     if config.observability.prometheus.enabled {

--- a/crates/mockforge-observability/src/lib.rs
+++ b/crates/mockforge-observability/src/lib.rs
@@ -28,7 +28,9 @@ pub mod tracing_integration;
 
 // Re-export commonly used items
 pub use logging::{init_logging, init_logging_with_otel, LoggingConfig};
-pub use prometheus::{get_global_registry, DriftEvaluationSample, MetricsRegistry};
+pub use prometheus::{
+    get_global_registry, get_global_registry_arc, DriftEvaluationSample, MetricsRegistry,
+};
 #[cfg(feature = "sentry")]
 pub use sentry_init::init_sentry;
 pub use system_metrics::{start_system_metrics_collector, SystemMetricsConfig};

--- a/crates/mockforge-observability/src/prometheus/metrics.rs
+++ b/crates/mockforge-observability/src/prometheus/metrics.rs
@@ -1187,12 +1187,27 @@ impl Default for MetricsRegistry {
     }
 }
 
-/// Global metrics registry instance
-static GLOBAL_REGISTRY: Lazy<MetricsRegistry> = Lazy::new(MetricsRegistry::new);
+/// Global metrics registry instance.
+///
+/// Held as an `Arc` so the same instance can be both written to (via
+/// `get_global_registry()`, used by the HTTP/drift/coverage middleware and the
+/// system-metrics collector) AND served at `GET /metrics` (via
+/// `get_global_registry_arc()`). Previously the metrics endpoint was handed a
+/// *separate* `MetricsRegistry::new()` instance, so nothing that recorded
+/// metrics was ever exported (#743).
+static GLOBAL_REGISTRY: Lazy<Arc<MetricsRegistry>> = Lazy::new(|| Arc::new(MetricsRegistry::new()));
 
-/// Get the global metrics registry
+/// Get a shared reference to the global metrics registry (for recording).
 pub fn get_global_registry() -> &'static MetricsRegistry {
     &GLOBAL_REGISTRY
+}
+
+/// Get an owned `Arc` handle to the global metrics registry.
+///
+/// Use this to mount the Prometheus `/metrics` endpoint so it serves the same
+/// instance that everything records into.
+pub fn get_global_registry_arc() -> Arc<MetricsRegistry> {
+    Arc::clone(&GLOBAL_REGISTRY)
 }
 
 #[cfg(test)]

--- a/crates/mockforge-observability/src/prometheus/mod.rs
+++ b/crates/mockforge-observability/src/prometheus/mod.rs
@@ -11,7 +11,9 @@ mod exporter;
 mod metrics;
 
 pub use exporter::{metrics_handler, prometheus_router};
-pub use metrics::{get_global_registry, DriftEvaluationSample, MetricsRegistry};
+pub use metrics::{
+    get_global_registry, get_global_registry_arc, DriftEvaluationSample, MetricsRegistry,
+};
 
 // Re-export prometheus types for users who need to access metrics directly
 pub use prometheus;


### PR DESCRIPTION
Foundational fix for #743 (and the data side of #684).

## Bug

`MetricsRegistry` holds its own private `prometheus::Registry`. There were **two instances** at runtime:
- the **global singleton** (`get_global_registry()`) that the HTTP metrics middleware, drift tracking, coverage, and the system-metrics collector all record into; and
- a **fresh `MetricsRegistry::new()`** that `serve.rs` handed to `prometheus_router` for `GET /metrics`.

So `/metrics` served an instance **nothing ever wrote to** — `mockforge_requests_total`, latency histograms, ws/mqtt/smtp gauges, and system metrics were recorded but never exported. (The call-site comment literally said *"use global registry"* while constructing a new one.)

## Fix

- Hold `GLOBAL_REGISTRY` as `Lazy<Arc<MetricsRegistry>>` and add `get_global_registry_arc()`.
- `serve.rs` mounts the metrics endpoint on that shared `Arc` — the same instance everything records into.
- `get_global_registry()` is unchanged (still `&'static MetricsRegistry`), so existing recording callers are untouched.

Four files: `metrics.rs`, `prometheus/mod.rs`, `lib.rs` (re-exports), `serve.rs`.

## Verification (end-to-end)

`serve --metrics --metrics-port 9096`, made 5 HTTP requests, then `GET /metrics`:

```
mockforge_requests_total{method="GET",pillar="unknown",protocol="http",status="404"} 5
mockforge_requests_in_flight{protocol="http"} 0
mockforge_request_duration_seconds_bucket/_count/_sum ...
mockforge_cpu_usage_percent / memory_usage_bytes / uptime_seconds / thread_count ...
mockforge_mqtt_* / smtp_* / ws_* gauges ...
```

**40 `mockforge_*` series exported** — where the served instance previously exported none of them.

- `cargo test -p mockforge-observability` → 51 passed
- `cargo clippy -p mockforge-observability -p mockforge-cli --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean

## Follow-up (tracked)

This unblocks the protocol-metrics work: exporting `mockforge_kafka_*` / `mockforge_amqp_*` via periodic broker-snapshot updaters + the #684 async-protocol dashboard panels. Those need serve.rs to hold shared broker handles, which arrive with #735 (Kafka) and #739 (MQTT). I'll land them once those merge. Refs #743, #684.