### PR TITLE
fix(registry): hosted-mock overage keeps responding (soft quota) + 100% usage alert (#748)

### DIFF
--- a/crates/mockforge-registry-server/src/deployment/router.rs
+++ b/crates/mockforge-registry-server/src/deployment/router.rs
@@ -33,6 +33,20 @@ const DEFAULT_MOCK_REQUEST_BODY_MB: i64 = 10;
 /// Same rationale as the body cap default.
 const DEFAULT_MOCK_RPS_LIMIT: i64 = 100;
 
+/// Default overage-ceiling multiplier for hosted-mock monthly request quotas.
+///
+/// `0` means **no monthly cutoff**: once an org passes its `requests_per_30d`
+/// allotment its mocks keep responding. This matches the public pricing
+/// promise — "mocks keep responding if you exceed your request limit
+/// (notification sent but no cutoff)". Usage is still metered and the
+/// 75/90/100% usage alerts still fire (the "notification sent" half), while the
+/// per-second RPS cap and request-body cap remain the always-on infra floors.
+///
+/// Operators can re-introduce a hard ceiling for abuse protection by setting
+/// `MOCKFORGE_HOSTED_OVERAGE_CEILING_MULT` to a positive integer N, which cuts
+/// off proxy traffic once monthly usage reaches `N ×` the plan limit.
+const DEFAULT_OVERAGE_CEILING_MULT: i64 = 0;
+
 /// Multitenant router that routes requests to deployed mock services
 pub struct MultitenantRouter;
 
@@ -74,9 +88,10 @@ impl MultitenantRouter {
             return Err(StatusCode::SERVICE_UNAVAILABLE);
         }
 
-        // Enforce the org's monthly `requests_per_30d` plan limit (#449).
-        // Returns 429 with the spec'd `usage_limit_exceeded` body if the
-        // deployment's owning org has already burnt through its monthly quota.
+        // Soft-enforce the org's monthly `requests_per_30d` plan limit (#449,
+        // #748). Default policy is "no cutoff" — mocks keep responding past the
+        // allotment; only an opt-in abuse ceiling
+        // (MOCKFORGE_HOSTED_OVERAGE_CEILING_MULT) produces a 429.
         if let Err(response) = enforce_monthly_quota(&state, deployment.org_id).await {
             return Ok(response);
         }
@@ -150,7 +165,8 @@ pub async fn custom_domain_fallback(
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    // Enforce the org's monthly `requests_per_30d` plan limit before forwarding.
+    // Soft-enforce the org's monthly `requests_per_30d` plan limit before
+    // forwarding (#748: no cutoff by default; opt-in abuse ceiling only).
     if let Err(response) = enforce_monthly_quota(&state, deployment.org_id).await {
         return Ok(response);
     }
@@ -314,15 +330,54 @@ fn monthly_request_limit(limits_json: &serde_json::Value) -> Option<i64> {
     }
 }
 
-/// Enforce the owning org's `requests_per_30d` plan limit on a hosted-mock
-/// proxy request. Returns a 429 `Response` carrying the spec'd
-/// `usage_limit_exceeded` body (#449 criterion 1) when the org has already
-/// exhausted its monthly allotment.
+/// Read the configured hosted-mock overage-ceiling multiplier from
+/// `MOCKFORGE_HOSTED_OVERAGE_CEILING_MULT`. Unset / unparsable / non-positive
+/// values mean "no cutoff" (the default that honors the published pricing copy).
+fn overage_ceiling_mult() -> i64 {
+    std::env::var("MOCKFORGE_HOSTED_OVERAGE_CEILING_MULT")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_OVERAGE_CEILING_MULT)
+}
+
+/// Given the plan's monthly request limit and the configured overage-ceiling
+/// multiplier, return the hard cutoff threshold, or `None` for "no cutoff".
 ///
-/// Fail-open semantics on DB/Redis hiccups: a transient infra failure must
-/// not take the proxy offline. The body cap and per-second RPS check (added
-/// in #450) remain absolute safety floors regardless.
+/// A multiplier `<= 0` disables the cutoff entirely (mocks keep responding past
+/// the plan limit). A positive `mult` caps proxy traffic at `mult × limit`,
+/// saturating instead of overflowing on extreme inputs.
+fn overage_cutoff(limit: i64, ceiling_mult: i64) -> Option<i64> {
+    if ceiling_mult <= 0 {
+        None
+    } else {
+        Some(limit.saturating_mul(ceiling_mult))
+    }
+}
+
+/// Soft-enforce the owning org's `requests_per_30d` plan limit on a hosted-mock
+/// proxy request.
+///
+/// Per the public pricing promise — "mocks keep responding if you exceed your
+/// request limit (notification sent but no cutoff)" — the monthly plan quota is
+/// a **soft limit by default**: traffic is metered (so the usage dashboard and
+/// the 75/90/100% threshold alerts work) but is **not** cut off when the org
+/// passes its allotment. A hard cutoff is only applied when an operator opts in
+/// via `MOCKFORGE_HOSTED_OVERAGE_CEILING_MULT > 0`, at which point this returns
+/// a 429 `usage_limit_exceeded` response (#449 body shape) once usage reaches
+/// `mult ×` the plan limit — an abuse ceiling, not the plan limit itself.
+///
+/// Fail-open semantics on DB/Redis hiccups: a transient infra failure must not
+/// take the proxy offline. The body cap and per-second RPS check (added in
+/// #450) remain absolute safety floors regardless of this soft quota.
 async fn enforce_monthly_quota(state: &AppState, org_id: Uuid) -> Result<(), Response> {
+    // No ceiling configured → no cutoff, and no need to touch the DB on the
+    // hot path. This is the default that matches the pricing copy.
+    let mult = overage_ceiling_mult();
+    if mult <= 0 {
+        return Ok(());
+    }
+
     let org = match Organization::find_by_id(state.db.pool(), org_id).await {
         Ok(Some(org)) => org,
         Ok(None) => {
@@ -336,7 +391,11 @@ async fn enforce_monthly_quota(state: &AppState, org_id: Uuid) -> Result<(), Res
     };
 
     let Some(limit) = monthly_request_limit(&org.limits_json) else {
-        return Ok(()); // unlimited
+        return Ok(()); // unlimited plan (Team)
+    };
+
+    let Some(cutoff) = overage_cutoff(limit, mult) else {
+        return Ok(());
     };
 
     let used = match UsageCounter::get_or_create_current(state.db.pool(), org_id).await {
@@ -347,12 +406,19 @@ async fn enforce_monthly_quota(state: &AppState, org_id: Uuid) -> Result<(), Res
         }
     };
 
-    if used >= limit {
-        tracing::info!("Monthly request quota exhausted for org {}: {}/{}", org_id, used, limit);
+    if used >= cutoff {
+        tracing::warn!(
+            "Hosted-mock overage ceiling reached for org {}: {}/{} ({}× plan limit {})",
+            org_id,
+            used,
+            cutoff,
+            mult,
+            limit
+        );
         Err(ApiError::UsageLimitExceeded {
             limit_type: "requests".to_string(),
             current: used,
-            max: limit,
+            max: cutoff,
             period: current_month_period(),
         }
         .into_response())
@@ -540,6 +606,32 @@ mod tests {
             monthly_request_limit(&json!({ "requests_per_30d": "250000" })),
             Some(DEFAULT_REQUESTS_PER_30D)
         );
+    }
+
+    // ───────────────── #748 soft overage / no-cutoff ─────────────────
+
+    #[test]
+    fn overage_cutoff_disabled_by_default() {
+        // mult <= 0 → no cutoff: mocks keep responding past the plan limit,
+        // honoring the "no cutoff" pricing promise.
+        assert_eq!(overage_cutoff(10_000, DEFAULT_OVERAGE_CEILING_MULT), None);
+        assert_eq!(overage_cutoff(10_000, 0), None);
+        assert_eq!(overage_cutoff(10_000, -5), None);
+    }
+
+    #[test]
+    fn overage_cutoff_positive_multiplier_caps_at_multiple() {
+        // A positive ceiling caps at mult × plan limit — an abuse ceiling well
+        // above the plan allotment, not the allotment itself.
+        assert_eq!(overage_cutoff(10_000, 10), Some(100_000));
+        assert_eq!(overage_cutoff(250_000, 2), Some(500_000));
+        assert_eq!(overage_cutoff(1_000_000, 1), Some(1_000_000));
+    }
+
+    #[test]
+    fn overage_cutoff_saturates_on_overflow() {
+        // Hostile/extreme inputs saturate rather than wrap.
+        assert_eq!(overage_cutoff(i64::MAX, 2), Some(i64::MAX));
     }
 
     // ───────────────── #450 body cap + RPS ─────────────────

--- a/crates/mockforge-registry-server/src/email.rs
+++ b/crates/mockforge-registry-server/src/email.rs
@@ -865,6 +865,43 @@ Privacy: https://mockforge.dev/privacy
         limit_pretty: &str,
         threshold_pct: u16,
     ) -> EmailMessage {
+        // At/over 100% the org has entered overage. For request mocks there is
+        // no hard cutoff (#748) — the message must inform, not warn of an
+        // impending limit that's already been reached.
+        let is_over = threshold_pct >= 100;
+        let headline = if is_over {
+            "Usage Limit Reached"
+        } else {
+            "Usage Approaching Limit"
+        };
+        let crossed_html = if is_over {
+            format!(
+                "Your MockForge Cloud organization has reached <strong>{threshold_pct}%</strong> of its <strong>{metric_label}</strong> allotment for the current billing period."
+            )
+        } else {
+            format!(
+                "Your MockForge Cloud organization has crossed <strong>{threshold_pct}%</strong> of its <strong>{metric_label}</strong> limit on the current billing period."
+            )
+        };
+        let crossed_text = if is_over {
+            format!(
+                "Your MockForge Cloud organization has reached {threshold_pct}% of its {metric_label} allotment for the current billing period."
+            )
+        } else {
+            format!(
+                "Your MockForge Cloud organization has crossed {threshold_pct}% of its {metric_label} limit on the current billing period."
+            )
+        };
+        let guidance = if is_over {
+            "You've used your full allotment for this period. Upgrade for a higher limit, or contact us if you expect a temporary spike."
+        } else {
+            "If you continue at the current rate, you may hit your plan limit before the end of the period. Consider upgrading or contacting us if you expect a temporary spike."
+        };
+        let subject = if is_over {
+            format!("MockForge: {} limit reached on {} plan", metric_label, plan)
+        } else {
+            format!("MockForge: {}% of {} used on {} plan", threshold_pct, metric_label, plan)
+        };
         let html_body = format!(
             r#"
 <!DOCTYPE html>
@@ -882,17 +919,17 @@ Privacy: https://mockforge.dev/privacy
 </head>
 <body>
     <div class="header">
-        <h1>Usage Approaching Limit</h1>
+        <h1>{headline}</h1>
     </div>
     <div class="content">
         <p>Hi {username},</p>
-        <p>Your MockForge Cloud organization has crossed <strong>{threshold_pct}%</strong> of its <strong>{metric_label}</strong> limit on the current billing period.</p>
+        <p>{crossed_html}</p>
         <div class="info-box">
             <p><strong>Metric:</strong> {metric_label}</p>
             <p><strong>Plan:</strong> {plan}</p>
             <p><strong>Used:</strong> {used_pretty} of {limit_pretty}</p>
         </div>
-        <p>If you continue at the current rate, you may hit your plan limit before the end of the period. Consider upgrading or contacting us if you expect a temporary spike.</p>
+        <p>{guidance}</p>
         <p style="text-align: center;">
             <a href="https://app.mockforge.dev/usage" class="button">View Usage</a>
         </p>
@@ -906,28 +943,30 @@ Privacy: https://mockforge.dev/privacy
 </body>
 </html>
 "#,
+            headline = headline,
             username = username,
+            crossed_html = crossed_html,
             plan = plan,
             metric_label = metric_label,
             used_pretty = used_pretty,
             limit_pretty = limit_pretty,
-            threshold_pct = threshold_pct,
+            guidance = guidance,
             year = chrono::Utc::now().year()
         );
 
         let text_body = format!(
             r#"
-Usage Approaching Limit
+{headline}
 
 Hi {username},
 
-Your MockForge Cloud organization has crossed {threshold_pct}% of its {metric_label} limit on the current billing period.
+{crossed_text}
 
 Metric: {metric_label}
 Plan: {plan}
 Used: {used_pretty} of {limit_pretty}
 
-If you continue at the current rate, you may hit your plan limit before the end of the period. Consider upgrading or contact us if you expect a temporary spike.
+{guidance}
 
 View usage: https://app.mockforge.dev/usage
 
@@ -936,21 +975,20 @@ The MockForge Team
 
 © {year} MockForge. All rights reserved.
 "#,
+            headline = headline,
             username = username,
+            crossed_text = crossed_text,
             plan = plan,
             metric_label = metric_label,
             used_pretty = used_pretty,
             limit_pretty = limit_pretty,
-            threshold_pct = threshold_pct,
+            guidance = guidance,
             year = chrono::Utc::now().year()
         );
 
         EmailMessage {
             to: vec![email.to_string()],
-            subject: format!(
-                "MockForge: {}% of {} used on {} plan",
-                threshold_pct, metric_label, plan
-            ),
+            subject,
             html_body,
             text_body,
             ..Default::default()

--- a/crates/mockforge-registry-server/src/workers/usage_threshold_checker.rs
+++ b/crates/mockforge-registry-server/src/workers/usage_threshold_checker.rs
@@ -1,11 +1,15 @@
 //! Background worker that scans every org's current-month usage against its
 //! effective limits (plan + custom quota) and inserts a `usage_alerts` row the
-//! first time a 75% or 90% band is crossed. Inserts are idempotent on the
-//! unique index, so the worker is safe to re-run on any cadence.
+//! first time a 75%, 90%, or 100% band is crossed. Inserts are idempotent on
+//! the unique index, so the worker is safe to re-run on any cadence.
+//!
+//! The 100% band is the "notification sent" half of the hosted-mock overage
+//! promise (#748): request mocks keep responding past the plan allotment (no
+//! cutoff by default), but the owner is emailed the moment they enter overage.
 //!
 //! On a newly inserted alert, the worker emails the org owner (gated on
-//! `users.email_notifications`). Both bands can be inserted in a single run if
-//! usage hops past them between checks; only the highest newly-inserted band
+//! `users.email_notifications`). Multiple bands can be inserted in a single run
+//! if usage hops past them between checks; only the highest newly-inserted band
 //! per (org, metric) triggers an email so users are not double-pinged.
 
 use std::time::Duration;
@@ -21,7 +25,7 @@ use crate::{
 };
 
 const DEFAULT_INTERVAL_SECS: u64 = 30 * 60; // 30 minutes
-const BANDS: [i16; 2] = [75, 90];
+const BANDS: [i16; 3] = [75, 90, 100];
 
 /// Start the usage-threshold checker. Interval can be overridden by the
 /// `USAGE_THRESHOLD_CHECK_INTERVAL_SECS` env var; falls back to 30 minutes.


### PR DESCRIPTION
Closes #748.

## Problem
The pricing page promises **"mocks keep responding if you exceed your request limit (notification sent but no cutoff)"**, but the hosted-mock proxy (`deployment/router.rs::enforce_monthly_quota`) hard-returned **HTTP 429** the moment an org hit its monthly `requests_per_30d` allotment. To a customer who was told their mocks keep responding, that reads as an outage on their side.

## Fix
**Honor the published policy (soft limit), keep the infra floors.**

- **`deployment/router.rs`** — the monthly plan quota is now a *soft limit*. By default (`MOCKFORGE_HOSTED_OVERAGE_CEILING_MULT=0`) mocks keep responding past the allotment; a hard cutoff is only applied when an operator opts into an abuse ceiling of `N ×` the plan limit. The per-second **RPS cap** and **request-body cap** (#450) remain the always-on infra floors, so removing the monthly cutoff does not expose the proxy to runaway cost. Bonus: when no ceiling is configured we skip the usage-counter DB read on the proxy hot path entirely.
- **`workers/usage_threshold_checker.rs`** — added a **100% band** (alongside the existing 75/90%) so the org owner is emailed the moment they enter overage. This is the **"notification sent"** half of the promise.
- **`email.rs`** — the threshold email is now band-aware: `>=100%` renders **"Usage Limit Reached"** with accurate overage copy instead of "Approaching Limit / you may hit your limit". This also corrects the pre-existing **200% Fly-spend alert**, which previously said "approaching" while already at 2× spend.

## Deliberately out of scope
- The **control-plane API limiter** (`middleware/org_rate_limit.rs`) is unchanged — the pricing promise is about *mocks*, not the management API. (There's a separate worth-noting UX wrinkle: a customer who blows their quota could be 429'd out of the dashboard they'd use to upgrade — flagged for follow-up, not fixed here.)
- If the business actually intends a **hard cutoff**, the alternative is a copy change on the pricing FAQ instead — that path is noted in #748.

## Verification
- `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` — clean
- `cargo test -p mockforge-registry-server --lib` — **474 passed, 0 failed** (incl. new `overage_cutoff` unit tests)
- `cargo fmt --all --check` — clean

## Config
| Env var | Default | Effect |
|---|---|---|
| `MOCKFORGE_HOSTED_OVERAGE_CEILING_MULT` | `0` | `0`/unset = no monthly cutoff (matches pricing copy). `N>0` = cut off at `N ×` plan limit (abuse ceiling). |