### PR TITLE
fix(registry): gate Admin role to the Team plan (#749)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7737,7 +7737,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7759,7 +7759,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7796,7 +7796,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7837,7 +7837,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7853,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7979,7 +7979,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7989,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8087,7 +8087,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8120,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8176,7 +8176,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8200,7 +8200,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8226,7 +8226,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8307,7 +8307,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8388,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8406,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8435,7 +8435,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8519,7 +8519,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8544,7 +8544,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8567,7 +8567,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8593,7 +8593,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8609,7 +8609,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8688,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8717,7 +8717,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8732,7 +8732,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8796,7 +8796,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8814,7 +8814,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8833,7 +8833,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8858,7 +8858,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8876,7 +8876,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8910,7 +8910,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8948,7 +8948,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9025,7 +9025,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9045,7 +9045,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9058,7 +9058,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9080,7 +9080,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9145,7 +9145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9175,7 +9175,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9225,14 +9225,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9292,7 +9292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9310,7 +9310,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9334,7 +9334,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9365,7 +9365,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9417,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9452,7 +9452,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9463,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9480,7 +9480,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15318,7 +15318,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/crates/mockforge-registry-server/src/handlers/organizations.rs
+++ b/crates/mockforge-registry-server/src/handlers/organizations.rs
@@ -201,6 +201,23 @@ pub async fn get_organization_members(
     Ok(Json(member_responses))
 }
 
+/// RBAC entitlement gate (#749): assigning the `Admin` role is a Team-plan
+/// feature — it's marketed as "SSO / RBAC" on the Team tier, so it must not be
+/// grantable on Free/Pro. `Owner` and `Member` remain available on every plan.
+///
+/// This blocks *new* Admin grants only; members who already hold Admin on a
+/// lower plan are grandfathered (no forced downgrade).
+fn require_role_allowed_on_plan(role: OrgRole, plan: Plan) -> ApiResult<()> {
+    if matches!(role, OrgRole::Admin) && plan != Plan::Team {
+        return Err(ApiError::InvalidRequest(
+            "The Admin role requires the Team plan. Upgrade to delegate \
+             administration, or assign the 'member' role."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Add a member to an organization
 pub async fn add_organization_member(
     State(state): State<AppState>,
@@ -293,6 +310,9 @@ pub async fn add_organization_member(
             ))
         }
     };
+
+    // RBAC entitlement: Admin role is Team-only (#749).
+    require_role_allowed_on_plan(role, org.plan())?;
 
     // Add member
     let member = state.store.create_org_member(org_id, target_user.id, role).await?;
@@ -465,6 +485,9 @@ pub async fn update_organization_member_role(
             ))
         }
     };
+
+    // RBAC entitlement: promoting to Admin is Team-only (#749).
+    require_role_allowed_on_plan(new_role, org.plan())?;
 
     // Update role
     state.store.update_org_member_role(org_id, member_user_id, new_role).await?;
@@ -837,6 +860,11 @@ pub async fn create_invitation(
         .ok_or(ApiError::OrganizationNotFound)?;
 
     require_org_admin(&state, &org, user_id).await?;
+
+    // RBAC entitlement: don't let lower plans mint Admin invitations (#749).
+    if role == "admin" {
+        require_role_allowed_on_plan(OrgRole::Admin, org.plan())?;
+    }
 
     use base64::Engine;
     use rand::RngCore;
@@ -1225,4 +1253,25 @@ pub async fn mark_user_verified_admin(
         "email": user.email,
         "is_verified": user.is_verified,
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admin_role_requires_team_plan() {
+        // Admin is gated to Team across every lower plan.
+        assert!(require_role_allowed_on_plan(OrgRole::Admin, Plan::Free).is_err());
+        assert!(require_role_allowed_on_plan(OrgRole::Admin, Plan::Pro).is_err());
+        assert!(require_role_allowed_on_plan(OrgRole::Admin, Plan::Team).is_ok());
+    }
+
+    #[test]
+    fn owner_and_member_roles_allowed_on_every_plan() {
+        for plan in [Plan::Free, Plan::Pro, Plan::Team] {
+            assert!(require_role_allowed_on_plan(OrgRole::Member, plan).is_ok());
+            assert!(require_role_allowed_on_plan(OrgRole::Owner, plan).is_ok());
+        }
+    }
 }


### PR DESCRIPTION
Closes #749.

## Problem
The pricing page markets **RBAC** as a Team-tier feature (the "SSO / RBAC" cell), but the **Admin** role could be assigned on *any* plan — Free/Pro orgs could mint Admins with no entitlement check. This undercut the Team value prop and was inconsistent with how every other limit (collaborators, hosted mocks, custom domains) is plan-gated.

## Fix
Added `require_role_allowed_on_plan(role, plan)` and applied it at **all three role-choice points**:
- `add_organization_member`
- `update_organization_member_role` (promotion)
- `create_invitation` (so lower plans can't mint Admin invites)

`Owner` and `Member` remain available on every plan; only **new Admin grants** now require Team. Returns the same `InvalidRequest` "upgrade" shape used by the existing `max_collaborators` gate.

### Deliberate scope choices
- **Existing admins on lower plans are grandfathered** — no forced downgrade. The gate blocks new grants only.
- `accept_invitation` is left ungated: it honors an invite that was validly created on Team (the gate is at creation time). The grandfather-on-downgrade edge case is intentional, matching the existing-admin behavior.

## Verification
- `cargo clippy -p mockforge-registry-server --all-targets --all-features -- -D warnings` — clean
- `cargo test -p mockforge-registry-server --lib` — **473 passed, 0 failed** (incl. new `admin_role_requires_team_plan` / `owner_and_member_roles_allowed_on_every_plan` unit tests)
- `cargo fmt --all --check` — clean
- No existing test/e2e assigns the Admin role, so the gate introduces no regressions.

Also syncs `Cargo.lock` to the `0.3.154` workspace version (was stale on main).

Pairs with #746 (SSO, the other half of the same pricing cell). Once both land, marketing copy (mockforge.dev#20) becomes accurate.