### PR TITLE
ci(registry-e2e): debug build so the lane can survive the shared runner

### DIFF
--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -108,11 +108,16 @@ jobs:
           env-vars: "CARGO_HOME"
 
       - name: Build registry-server
-        # Retry once under shared-runner resource pressure, same as the sibling workflow.
+        # Debug build (not --release): this is a behavioral E2E lane, not a perf
+        # benchmark, so an optimized build buys nothing but costs ~3-5x more CPU
+        # time and disk. The runner host is heavily shared; a lighter/faster build
+        # is far less likely to be starved or reclaimed mid-job (the lane
+        # historically died before the build even finished). Retry once under
+        # shared-runner resource pressure, same as the sibling workflow.
         run: |
-          cargo build -p mockforge-registry-server --release \
+          cargo build -p mockforge-registry-server \
             || (echo "::warning::first build failed, retrying once" \
-                && cargo build -p mockforge-registry-server --release)
+                && cargo build -p mockforge-registry-server)
 
       - name: Start Postgres + MinIO
         run: |
@@ -141,7 +146,7 @@ jobs:
           PORT: "58080"
           HOST: "0.0.0.0"
         run: |
-          nohup ./target/release/mockforge-registry-server \
+          nohup ./target/debug/mockforge-registry-server \
             > registry-server.log 2>&1 &
           echo $! > registry-server.pid
           echo "Waiting for registry-server on :${REGISTRY_PORT}..."


### PR DESCRIPTION
## Why
Forensics on `registry-e2e`: it has **never** reached its build/test steps — every run (main, PRs, reruns) dies right after `Cache dependencies`, with `Build registry-server` / `Run E2E tests` showing `never-ran`. The lane being red for days was **infra**, not tests (the test-fixture bugs were fixed separately in #734).

Root cause: the self-hosted runner host is heavily oversubscribed (~12 runners across 6 repos on one ~8-vCPU box, disk ~82–85% so the 30-min cleanup churns constantly). The repo's heaviest job — an **optimized** `registry-server` build + Postgres + MinIO — gets starved/reclaimed during the long `--release` build before it finishes.

## Change
Switch the e2e build from `--release` to **debug**. This is a behavioral E2E lane, not a perf benchmark, so an optimized build buys nothing but costs ~3–5× more CPU/disk. Debug (verified locally to pass all 7 targets) shrinks the window in which contention/cleanup can kill the job.

> Note: this does **not** fix the underlying capacity problem — more runner headroom / fewer co-located runners is the real fix. It gives the lane a realistic chance of completing so it can become a gating signal.

## After this merges
A main-push `registry-e2e` run will use the debug build. If it completes green, the next step is to add `Registry E2E (Postgres + MinIO)` to main's required checks (the gate).