### PR TITLE
fix: clear unused_qualifications errors failing the --all-features clippy ratchet on main

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -2196,10 +2196,9 @@ impl BenchCommand {
                 "Self-test mode: driving {} operations with positive + per-category negative cases",
                 ops.len()
             ));
-            let report =
-                crate::conformance::self_test::run_self_test(&ops, &cfg).await.map_err(|e| {
-                    crate::error::BenchError::Other(format!("self-test client error: {e}"))
-                })?;
+            let report = crate::conformance::self_test::run_self_test(&ops, &cfg)
+                .await
+                .map_err(|e| BenchError::Other(format!("self-test client error: {e}")))?;
             TerminalReporter::print_progress(&report.render_summary());
             // Persist the JSON report alongside the regular conformance
             // report so it's grep-able next to the buffer dump from the

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2366,7 +2366,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Ok(path) = std::env::var("MOCKFORGE_ANALYTICS_DB") {
         if !path.is_empty() {
             let cfg = mockforge_analytics::AnalyticsConfig {
-                database_path: std::path::PathBuf::from(&path),
+                database_path: PathBuf::from(&path),
                 ..Default::default()
             };
             match mockforge_analytics::init(cfg).await {

--- a/crates/mockforge-http/src/management/mod.rs
+++ b/crates/mockforge-http/src/management/mod.rs
@@ -1210,7 +1210,7 @@ pub async fn dynamic_mock_fallback(
                 // not realistic response shapes.
                 (
                     StatusCode::OK,
-                    [(axum::http::header::CONTENT_TYPE, "application/json")],
+                    [(http::header::CONTENT_TYPE, "application/json")],
                     r#"{"shadow":true,"matched":false}"#,
                 )
                     .into_response()

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -1362,9 +1362,7 @@ pub async fn clear_conformance_violations() -> impl IntoResponse {
 /// Issue #79 round 13 — feed of requests for paths the loaded OpenAPI
 /// spec doesn't know about. Surfaces server/client spec drift (Srikanth's
 /// (a) ask). Backed by `mockforge_foundation::unknown_paths`.
-pub async fn get_unknown_paths(
-    axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
-) -> impl IntoResponse {
+pub async fn get_unknown_paths(Query(q): Query<HashMap<String, String>>) -> impl IntoResponse {
     let snap = mockforge_foundation::unknown_paths::snapshot();
     let total = snap.len();
     let total_seen = mockforge_foundation::unknown_paths::total_seen();


### PR DESCRIPTION
While babysitting the CI queue I found the actual cause of the red **Warning Ratchet** lane on every open PR: **main itself fails** the warning gate.

CI runs (`.github/workflows/ci.yml:135`):
```
cargo clippy --workspace --exclude mockforge-desktop --lib --bins --all-features \
  -- -D clippy::correctness -D unused_qualifications
```
Six redundant path qualifications had accumulated (only surfaced under `--all-features`), so the lane is red on `main` and shows as failing on #735/#739/#745 and any other open PR.

### Fix (machine-applicable `clippy --fix`)
| file | change |
|------|--------|
| `mockforge-bench/src/command.rs:2201` | `crate::error::BenchError` → `BenchError` (already imported at L6) |
| `mockforge-cli/src/main.rs` | `std::path::PathBuf` → `PathBuf` |
| `mockforge-http/src/management/mod.rs:1213` | `axum::http::header::CONTENT_TYPE` → `http::header::CONTENT_TYPE` |
| `mockforge-ui/src/handlers.rs:1366` | `axum::extract::Query<std::collections::HashMap<..>>` → `Query<HashMap<..>>` (×3) |

### Verification
- The exact CI ratchet command now finishes **clean (0 errors)** — confirmed locally.
- `cargo fmt --check` clean on all four crates (qualifier shortening can let rustfmt recollapse lines — re-formatted + checked, per prior CI burns).

No behavior change; pure lint hygiene. Unblocks the warning gate for the open PR queue.

### Related (found during the same investigation)
- #764 — `mockforge-desktop` `build_router` call is out of sync (broken on main, hidden by CI `--exclude mockforge-desktop`).