### PR TITLE
feat(registry,ui): annual billing — backend routing + monthly/annual toggle (#747)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7737,7 +7737,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7759,7 +7759,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7796,7 +7796,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7837,7 +7837,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7853,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7979,7 +7979,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7989,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8087,7 +8087,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8120,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8176,7 +8176,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8200,7 +8200,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8226,7 +8226,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8307,7 +8307,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8388,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8406,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8435,7 +8435,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8519,7 +8519,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8544,7 +8544,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8567,7 +8567,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8593,7 +8593,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8609,7 +8609,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8688,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8717,7 +8717,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8732,7 +8732,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8796,7 +8796,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8814,7 +8814,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8833,7 +8833,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8858,7 +8858,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8876,7 +8876,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8910,7 +8910,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8948,7 +8948,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9025,7 +9025,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9045,7 +9045,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9058,7 +9058,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9080,7 +9080,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9145,7 +9145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9175,7 +9175,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9225,14 +9225,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9292,7 +9292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9310,7 +9310,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9334,7 +9334,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9365,7 +9365,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9417,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9452,7 +9452,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9463,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9480,7 +9480,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15318,7 +15318,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.153"
+version = "0.3.154"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/crates/mockforge-registry-server/src/config.rs
+++ b/crates/mockforge-registry-server/src/config.rs
@@ -57,11 +57,22 @@ pub struct Config {
     /// Stripe secret key for billing
     pub stripe_secret_key: Option<String>,
 
-    /// Stripe price ID for Pro plan
+    /// Stripe price ID for Pro plan (monthly cadence)
     pub stripe_price_id_pro: Option<String>,
 
-    /// Stripe price ID for Team plan
+    /// Stripe price ID for Team plan (monthly cadence)
     pub stripe_price_id_team: Option<String>,
+
+    /// Stripe price ID for the Pro plan billed annually. The "2 months free"
+    /// discount is encoded in this Stripe price (set to 10× the monthly
+    /// amount), so there is no discount math in code. `None` means annual Pro
+    /// isn't offered and annual checkout for Pro is rejected rather than
+    /// silently charged monthly.
+    pub stripe_price_id_pro_annual: Option<String>,
+
+    /// Stripe price ID for the Team plan billed annually. Same semantics as
+    /// [`Config::stripe_price_id_pro_annual`].
+    pub stripe_price_id_team_annual: Option<String>,
 
     /// Stripe webhook secret for verifying webhook signatures
     pub stripe_webhook_secret: Option<String>,
@@ -177,6 +188,8 @@ impl Config {
             stripe_secret_key: std::env::var("STRIPE_SECRET_KEY").ok(),
             stripe_price_id_pro: std::env::var("STRIPE_PRICE_ID_PRO").ok(),
             stripe_price_id_team: std::env::var("STRIPE_PRICE_ID_TEAM").ok(),
+            stripe_price_id_pro_annual: std::env::var("STRIPE_PRICE_ID_PRO_ANNUAL").ok(),
+            stripe_price_id_team_annual: std::env::var("STRIPE_PRICE_ID_TEAM_ANNUAL").ok(),
             stripe_webhook_secret: std::env::var("STRIPE_WEBHOOK_SECRET").ok(),
             stripe_trial_period_days: std::env::var("STRIPE_TRIAL_PERIOD_DAYS")
                 .ok()

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -28,6 +28,10 @@ pub struct BillingConfigResponse {
     /// trials are disabled and checkout charges immediately — UI should
     /// hide trial-related copy in that case.
     pub trial_period_days: u32,
+    /// Whether annual billing is offered (i.e. at least one annual Stripe
+    /// price ID is configured). The pricing/billing UI uses this to decide
+    /// whether to render the monthly/annual toggle.
+    pub annual_billing_available: bool,
 }
 
 /// Public billing config (no auth required).
@@ -41,6 +45,8 @@ pub async fn get_billing_config(
 ) -> ApiResult<Json<BillingConfigResponse>> {
     Ok(Json(BillingConfigResponse {
         trial_period_days: state.config.stripe_trial_period_days,
+        annual_billing_available: state.config.stripe_price_id_pro_annual.is_some()
+            || state.config.stripe_price_id_team_annual.is_some(),
     }))
 }
 
@@ -77,6 +83,19 @@ pub async fn get_subscription(
             .as_ref()
             .map(|s| s.status().to_string())
             .unwrap_or_else(|| "free".to_string()),
+        // Derived from the stored Stripe price ID (no dedicated column) — annual
+        // subs are recognised by matching the configured annual price IDs.
+        billing_interval: subscription
+            .as_ref()
+            .map(|s| {
+                interval_label_from_price_id(
+                    &s.price_id,
+                    state.config.stripe_price_id_pro_annual.as_deref(),
+                    state.config.stripe_price_id_team_annual.as_deref(),
+                )
+                .to_string()
+            })
+            .unwrap_or_else(|| BillingInterval::Monthly.as_str().to_string()),
         cancel_at_period_end: subscription
             .as_ref()
             .map(|s| s.cancel_at_period_end)
@@ -117,6 +136,9 @@ pub struct SubscriptionResponse {
     pub org_id: Uuid,
     pub plan: String,
     pub status: String,
+    /// Billing cadence of the active subscription: "month" or "year".
+    /// Defaults to "month" for free orgs / when no subscription exists.
+    pub billing_interval: String,
     pub cancel_at_period_end: bool,
     pub current_period_start: Option<chrono::DateTime<chrono::Utc>>,
     pub current_period_end: Option<chrono::DateTime<chrono::Utc>>,
@@ -136,11 +158,57 @@ pub struct UsageStats {
     pub ai_tokens_limit: i64,
 }
 
+/// Billing cadence requested at checkout. The annual price carries the
+/// "2 months free" discount (encoded in the Stripe annual price = 10× monthly),
+/// so nothing in code computes a discount — we only route to the right price.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BillingInterval {
+    Monthly,
+    Annual,
+}
+
+impl BillingInterval {
+    /// Parse the optional `billing_interval` request field. Absent → Monthly
+    /// (keeps existing clients working). Returns `None` for unrecognised
+    /// values so the caller can 400 rather than guess.
+    fn parse(s: Option<&str>) -> Option<Self> {
+        match s {
+            None | Some("month") | Some("monthly") => Some(Self::Monthly),
+            Some("year") | Some("annual") | Some("yearly") => Some(Self::Annual),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Monthly => "month",
+            Self::Annual => "year",
+        }
+    }
+}
+
+/// Pick the Stripe price ID for the requested cadence from a plan's
+/// (monthly, annual) pair. Returns `None` when the requested cadence isn't
+/// configured — the caller turns that into a clear error so an annual checkout
+/// never silently falls back to (and charges) the monthly price.
+fn select_price_id<'a>(
+    interval: BillingInterval,
+    monthly: Option<&'a str>,
+    annual: Option<&'a str>,
+) -> Option<&'a str> {
+    match interval {
+        BillingInterval::Monthly => monthly,
+        BillingInterval::Annual => annual,
+    }
+}
+
 /// Create Stripe checkout session
 /// This would typically redirect to Stripe Checkout
 #[derive(Debug, Deserialize)]
 pub struct CreateCheckoutRequest {
     pub plan: String, // "pro" or "team"
+    /// Billing cadence: "month" (default) or "year". Absent = monthly.
+    pub billing_interval: Option<String>,
     pub success_url: Option<String>,
     pub cancel_url: Option<String>,
 }
@@ -181,20 +249,42 @@ pub async fn create_checkout(
         .ok_or_else(|| ApiError::InvalidRequest("Stripe not configured".to_string()))?;
     let client = Client::new(stripe_secret);
 
-    // Get price ID for the plan
-    let price_id = match plan {
-        Plan::Pro => state.config.stripe_price_id_pro.as_ref().ok_or_else(|| {
-            ApiError::InvalidRequest("Stripe Pro price ID not configured".to_string())
-        })?,
-        Plan::Team => state.config.stripe_price_id_team.as_ref().ok_or_else(|| {
-            ApiError::InvalidRequest("Stripe Team price ID not configured".to_string())
-        })?,
+    // Resolve the requested billing cadence (monthly default).
+    let interval =
+        BillingInterval::parse(request.billing_interval.as_deref()).ok_or_else(|| {
+            ApiError::InvalidRequest(
+                "Invalid billing_interval. Must be 'month' or 'year'".to_string(),
+            )
+        })?;
+
+    // Get the (monthly, annual) price-ID pair for the plan, then pick by cadence.
+    let (monthly, annual) = match plan {
+        Plan::Pro => (
+            state.config.stripe_price_id_pro.as_deref(),
+            state.config.stripe_price_id_pro_annual.as_deref(),
+        ),
+        Plan::Team => (
+            state.config.stripe_price_id_team.as_deref(),
+            state.config.stripe_price_id_team_annual.as_deref(),
+        ),
         Plan::Free => {
             return Err(ApiError::InvalidRequest(
                 "Cannot create checkout for free plan".to_string(),
             ))
         }
     };
+    // `None` here means the requested cadence isn't configured. Erroring (rather
+    // than falling back to the other cadence) guarantees we never charge a
+    // customer monthly when they asked for annual, or vice versa.
+    let price_id = select_price_id(interval, monthly, annual)
+        .ok_or_else(|| {
+            ApiError::InvalidRequest(format!(
+                "{} billing is not configured for the {} plan",
+                interval.as_str(),
+                plan
+            ))
+        })?
+        .to_string();
 
     // Build success and cancel URLs
     let success_url = request.success_url.unwrap_or_else(|| {
@@ -221,6 +311,7 @@ pub async fn create_checkout(
     checkout_params.metadata = Some(std::collections::HashMap::from([
         ("org_id".to_string(), org_id_str.clone()),
         ("plan".to_string(), plan_str.clone()),
+        ("billing_interval".to_string(), interval.as_str().to_string()),
     ]));
 
     // Add line item with price
@@ -261,9 +352,10 @@ pub async fn create_checkout(
             org_ctx.org_id,
             Some(user_id),
             AuditEventType::BillingCheckout,
-            format!("Checkout session created for {} plan", request.plan),
+            format!("Checkout session created for {} plan ({})", request.plan, interval.as_str()),
             Some(serde_json::json!({
                 "plan": request.plan,
+                "billing_interval": interval.as_str(),
                 "session_id": session.id.to_string(),
             })),
             ip_address,
@@ -933,6 +1025,18 @@ fn determine_plan_from_price_id(price_id: &str, config: &crate::config::Config) 
         }
     }
 
+    // Annual price IDs map to the same plan as their monthly counterpart.
+    if let Some(pro_annual) = &config.stripe_price_id_pro_annual {
+        if price_id == pro_annual {
+            return Plan::Pro;
+        }
+    }
+    if let Some(team_annual) = &config.stripe_price_id_team_annual {
+        if price_id == team_annual {
+            return Plan::Team;
+        }
+    }
+
     // Fallback: heuristic matching (for development/testing)
     if price_id.contains("pro") || price_id.contains("Pro") {
         tracing::warn!("Using heuristic matching for price_id: {} (Pro)", price_id);
@@ -947,4 +1051,77 @@ fn determine_plan_from_price_id(price_id: &str, config: &crate::config::Config) 
     // Default to Free if unknown
     tracing::warn!("Unknown price_id: {}, defaulting to Free", price_id);
     Plan::Free
+}
+
+/// Derive the billing cadence label ("month" / "year") of an active
+/// subscription from its stored Stripe price ID. Annual subscriptions are
+/// identified by matching the configured annual price IDs; everything else
+/// (including unknown / legacy IDs) is treated as monthly. This avoids
+/// persisting a redundant column — the stored `price_id` is the source of truth.
+fn interval_label_from_price_id(
+    price_id: &str,
+    pro_annual: Option<&str>,
+    team_annual: Option<&str>,
+) -> &'static str {
+    if Some(price_id) == pro_annual || Some(price_id) == team_annual {
+        BillingInterval::Annual.as_str()
+    } else {
+        BillingInterval::Monthly.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn billing_interval_parses_aliases_and_defaults_to_monthly() {
+        assert_eq!(BillingInterval::parse(None), Some(BillingInterval::Monthly));
+        assert_eq!(BillingInterval::parse(Some("month")), Some(BillingInterval::Monthly));
+        assert_eq!(BillingInterval::parse(Some("monthly")), Some(BillingInterval::Monthly));
+        assert_eq!(BillingInterval::parse(Some("year")), Some(BillingInterval::Annual));
+        assert_eq!(BillingInterval::parse(Some("annual")), Some(BillingInterval::Annual));
+        assert_eq!(BillingInterval::parse(Some("yearly")), Some(BillingInterval::Annual));
+        // Unrecognised values are rejected (caller 400s) rather than guessed.
+        assert_eq!(BillingInterval::parse(Some("biennial")), None);
+        assert_eq!(BillingInterval::parse(Some("")), None);
+    }
+
+    #[test]
+    fn select_price_id_routes_by_cadence() {
+        let monthly = Some("price_monthly");
+        let annual = Some("price_annual");
+        assert_eq!(
+            select_price_id(BillingInterval::Monthly, monthly, annual),
+            Some("price_monthly")
+        );
+        assert_eq!(select_price_id(BillingInterval::Annual, monthly, annual), Some("price_annual"));
+    }
+
+    #[test]
+    fn select_price_id_annual_unconfigured_returns_none_not_monthly() {
+        // The critical safety property: requesting annual when it isn't
+        // configured must NOT silently fall back to the monthly price.
+        let monthly = Some("price_monthly");
+        assert_eq!(select_price_id(BillingInterval::Annual, monthly, None), None);
+        // ...and vice versa.
+        assert_eq!(select_price_id(BillingInterval::Monthly, None, Some("price_annual")), None);
+    }
+
+    #[test]
+    fn interval_label_recognises_annual_price_ids() {
+        let pro_annual = Some("price_pro_year");
+        let team_annual = Some("price_team_year");
+        assert_eq!(interval_label_from_price_id("price_pro_year", pro_annual, team_annual), "year");
+        assert_eq!(
+            interval_label_from_price_id("price_team_year", pro_annual, team_annual),
+            "year"
+        );
+        // Monthly / unknown / legacy IDs → monthly.
+        assert_eq!(
+            interval_label_from_price_id("price_pro_month", pro_annual, team_annual),
+            "month"
+        );
+        assert_eq!(interval_label_from_price_id("price_legacy", None, None), "month");
+    }
 }

--- a/crates/mockforge-ui/ui/src/pages/BillingPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/BillingPage.tsx
@@ -32,6 +32,7 @@ interface Subscription {
     | 'unpaid'
     | 'incomplete'
     | 'incomplete_expired';
+  billing_interval?: 'month' | 'year';
   cancel_at_period_end?: boolean;
   current_period_start?: string;
   current_period_end?: string;
@@ -62,14 +63,37 @@ interface UsageStats {
   ai_tokens_limit: number;
 }
 
+type BillingInterval = 'month' | 'year';
+
 interface CreateCheckoutRequest {
   plan: 'pro' | 'team';
+  billing_interval?: BillingInterval;
   success_url?: string;
   cancel_url?: string;
 }
 
 interface CreateCheckoutResponse {
   checkout_url: string;
+}
+
+// Public billing config — `annual_billing_available` gates the monthly/annual
+// toggle so we never offer annual when the operator hasn't configured the
+// annual Stripe prices (backend would reject that checkout anyway).
+interface BillingConfig {
+  trial_period_days: number;
+  annual_billing_available: boolean;
+}
+
+// Plan list prices in whole dollars. Annual = 10x monthly (i.e. "2 months
+// free"), matching the configured Stripe annual prices and the pricing page.
+const PLAN_PRICING: Record<'pro' | 'team', Record<BillingInterval, number>> = {
+  pro: { month: 29, year: 290 },
+  team: { month: 99, year: 990 },
+};
+
+/** Per-month-equivalent dollars for an annual plan, rounded for display. */
+function annualMonthlyEquivalent(plan: 'pro' | 'team'): number {
+  return Math.round(PLAN_PRICING[plan].year / 12);
 }
 
 interface CreatePortalResponse {
@@ -145,6 +169,14 @@ async function fetchInvoices(): Promise<ListInvoicesResponse> {
   return response.json();
 }
 
+async function fetchBillingConfig(): Promise<BillingConfig> {
+  const response = await fetch(`${API_BASE}/billing/config`);
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response, 'Failed to fetch billing config'));
+  }
+  return response.json();
+}
+
 async function createPortalSession(): Promise<CreatePortalResponse> {
   const response = await authenticatedFetch(`${API_BASE}/billing/portal`, {
     method: 'POST',
@@ -163,6 +195,23 @@ export function BillingPage() {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
   const [selectedPlan, setSelectedPlan] = useState<'pro' | 'team' | null>(null);
+  // Preselect the cadence from `?interval=year` so a choice made on the
+  // (pre-auth) pricing page carries through the login → billing redirect.
+  const [billingInterval, setBillingInterval] = useState<BillingInterval>(() =>
+    new URLSearchParams(window.location.search).get('interval') === 'year' ? 'year' : 'month'
+  );
+
+  // Annual availability gates the toggle. Soft-fail to monthly-only if the
+  // endpoint is unreachable rather than blocking the page.
+  const { data: billingConfig } = useQuery({
+    queryKey: ['billing-config'],
+    queryFn: fetchBillingConfig,
+    staleTime: 5 * 60_000,
+    retry: 1,
+  });
+  const annualAvailable = billingConfig?.annual_billing_available ?? false;
+  // Don't leave the user on an annual selection we can't fulfill.
+  const effectiveInterval: BillingInterval = annualAvailable ? billingInterval : 'month';
 
   // Fetch subscription
   const {
@@ -219,6 +268,7 @@ export function BillingPage() {
     setSelectedPlan(plan);
     checkoutMutation.mutate({
       plan,
+      billing_interval: effectiveInterval,
       success_url: `${window.location.origin}/billing?success=true`,
       cancel_url: `${window.location.origin}/billing?canceled=true`,
     });
@@ -374,6 +424,11 @@ export function BillingPage() {
                     <div className="text-sm text-muted-foreground mt-1">
                       {subscription.cancel_at_period_end ? 'Ends on ' : 'Renews on '}
                       {new Date(subscription.current_period_end).toLocaleDateString()}
+                    </div>
+                  )}
+                  {subscription.plan !== 'free' && subscription.billing_interval && (
+                    <div className="text-sm text-muted-foreground mt-1">
+                      Billed {subscription.billing_interval === 'year' ? 'annually' : 'monthly'}
                     </div>
                   )}
                 </div>
@@ -693,6 +748,45 @@ export function BillingPage() {
 
         {/* Plans Tab */}
         <TabsContent value="plans" className="space-y-4">
+          {annualAvailable && (
+            <div className="flex justify-center">
+              <div
+                role="radiogroup"
+                aria-label="Billing interval"
+                className="inline-flex items-center rounded-full border bg-muted/50 p-1 text-sm"
+              >
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={effectiveInterval === 'month'}
+                  onClick={() => setBillingInterval('month')}
+                  className={`rounded-full px-4 py-1.5 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${
+                    effectiveInterval === 'month'
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  Monthly
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={effectiveInterval === 'year'}
+                  onClick={() => setBillingInterval('year')}
+                  className={`flex items-center rounded-full px-4 py-1.5 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${
+                    effectiveInterval === 'year'
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  Annual
+                  <span className="ml-1.5 rounded-full bg-success-500/15 px-1.5 py-0.5 text-xs font-semibold text-success-600 dark:text-success-400">
+                    2 months free
+                  </span>
+                </button>
+              </div>
+            </div>
+          )}
           <div className="grid gap-4 md:grid-cols-3">
             {/* Free Plan */}
             <Card className={subscription.plan === 'free' ? 'border-primary' : ''}>
@@ -744,8 +838,7 @@ export function BillingPage() {
             <Card className={subscription.plan === 'pro' ? 'border-primary' : ''}>
               <CardHeader>
                 <CardTitle>Pro</CardTitle>
-                <div className="text-3xl font-bold">$29</div>
-                <CardDescription>per month</CardDescription>
+                <PlanPrice plan="pro" interval={effectiveInterval} />
               </CardHeader>
               <CardContent className="space-y-4">
                 <ul className="space-y-2 text-sm">
@@ -794,8 +887,7 @@ export function BillingPage() {
             <Card className={subscription.plan === 'team' ? 'border-primary' : ''}>
               <CardHeader>
                 <CardTitle>Team</CardTitle>
-                <div className="text-3xl font-bold">$99</div>
-                <CardDescription>per month</CardDescription>
+                <PlanPrice plan="team" interval={effectiveInterval} />
               </CardHeader>
               <CardContent className="space-y-4">
                 <ul className="space-y-2 text-sm">
@@ -843,6 +935,31 @@ export function BillingPage() {
         </TabsContent>
       </Tabs>
     </div>
+  );
+}
+
+/** Interval-aware price block for a paid plan card (Plans tab). */
+function PlanPrice({ plan, interval }: { plan: 'pro' | 'team'; interval: BillingInterval }) {
+  const price = PLAN_PRICING[plan][interval];
+  if (interval === 'year') {
+    return (
+      <>
+        <div className="text-3xl font-bold">${price}</div>
+        <CardDescription>
+          per year ·{' '}
+          <span className="font-medium text-success-600 dark:text-success-400">2 months free</span>
+        </CardDescription>
+        <div className="mt-0.5 text-xs text-muted-foreground">
+          ≈ ${annualMonthlyEquivalent(plan)}/mo, billed annually
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      <div className="text-3xl font-bold">${price}</div>
+      <CardDescription>per month</CardDescription>
+    </>
   );
 }
 

--- a/crates/mockforge-ui/ui/src/pages/PricingPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/PricingPage.tsx
@@ -1,13 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/button';
 import { CheckCircle2, XCircle, ArrowRight } from 'lucide-react';
 
 // Public billing-config endpoint. Returns trial length so the pricing
-// CTA copy can stay in sync with the operator-set
-// STRIPE_TRIAL_PERIOD_DAYS env var without redeploying the UI.
-type BillingConfig = { trial_period_days: number };
+// CTA copy can stay in sync with the operator-set STRIPE_TRIAL_PERIOD_DAYS
+// env var, plus whether annual billing is offered (gates the toggle).
+type BillingConfig = { trial_period_days: number; annual_billing_available: boolean };
+
+type BillingInterval = 'month' | 'year';
+
+// Annual = 10× monthly ("2 months free"), matching the configured Stripe
+// annual prices and the BillingPage display.
+const PLAN_PRICING: Record<'pro' | 'team', Record<BillingInterval, number>> = {
+  pro: { month: 29, year: 290 },
+  team: { month: 99, year: 990 },
+};
 
 async function fetchBillingConfig(): Promise<BillingConfig> {
   const res = await fetch('/api/v1/billing/config');
@@ -32,15 +41,20 @@ export function PricingPage() {
   const trialSubtitle = hasTrial ? `${trialDays}-day free trial · no commitment` : null;
   const paidCtaLabel = hasTrial ? 'Start free trial' : 'Upgrade';
 
+  const annualAvailable = billingConfig?.annual_billing_available ?? false;
+  const [billingInterval, setBillingInterval] = useState<BillingInterval>('month');
+  const interval: BillingInterval = annualAvailable ? billingInterval : 'month';
+
   const handleGetStarted = () => {
     // Navigate to sign up or login
     window.location.href = '/signup';
   };
 
-  const handleUpgrade = (plan: 'pro' | 'team') => {
-    // Navigate to billing page (requires auth)
-    // If not authenticated, redirect to login first
-    window.location.href = '/login?redirect=/billing';
+  const handleUpgrade = (_plan: 'pro' | 'team') => {
+    // Checkout requires auth, so route through login → billing. Carry the
+    // chosen cadence so BillingPage can preselect it.
+    const dest = interval === 'year' ? '/billing?interval=year' : '/billing';
+    window.location.href = `/login?redirect=${encodeURIComponent(dest)}`;
   };
 
   return (
@@ -51,6 +65,45 @@ export function PricingPage() {
         <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
           Choose the plan that's right for you. Start free, upgrade when you need more.
         </p>
+        {annualAvailable && (
+          <div className="mt-6 flex justify-center">
+            <div
+              role="radiogroup"
+              aria-label="Billing interval"
+              className="inline-flex items-center rounded-full border bg-muted/50 p-1 text-sm"
+            >
+              <button
+                type="button"
+                role="radio"
+                aria-checked={interval === 'month'}
+                onClick={() => setBillingInterval('month')}
+                className={`rounded-full px-4 py-1.5 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${
+                  interval === 'month'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Monthly
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={interval === 'year'}
+                onClick={() => setBillingInterval('year')}
+                className={`flex items-center rounded-full px-4 py-1.5 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${
+                  interval === 'year'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Annual
+                <span className="ml-1.5 rounded-full bg-success-500/15 px-1.5 py-0.5 text-xs font-semibold text-success-600 dark:text-success-400">
+                  2 months free
+                </span>
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Pricing Cards */}
@@ -113,10 +166,7 @@ export function PricingPage() {
           </div>
           <CardHeader>
             <CardTitle className="text-2xl">Pro</CardTitle>
-            <div className="mt-4">
-              <span className="text-4xl font-bold">$29</span>
-              <span className="text-muted-foreground">/month</span>
-            </div>
+            <PriceBlock plan="pro" interval={interval} />
             {trialSubtitle && (
               <p className="text-sm text-success-600 font-medium mt-1">{trialSubtitle}</p>
             )}
@@ -168,10 +218,7 @@ export function PricingPage() {
         <Card className="relative">
           <CardHeader>
             <CardTitle className="text-2xl">Team</CardTitle>
-            <div className="mt-4">
-              <span className="text-4xl font-bold">$99</span>
-              <span className="text-muted-foreground">/month</span>
-            </div>
+            <PriceBlock plan="team" interval={interval} />
             {trialSubtitle && (
               <p className="text-sm text-success-600 font-medium mt-1">{trialSubtitle}</p>
             )}
@@ -348,6 +395,27 @@ export function PricingPage() {
           <ArrowRight className="ml-2 h-4 w-4" />
         </Button>
       </div>
+    </div>
+  );
+}
+
+/** Interval-aware price for a paid plan card. */
+function PriceBlock({ plan, interval }: { plan: 'pro' | 'team'; interval: BillingInterval }) {
+  const price = PLAN_PRICING[plan][interval];
+  if (interval === 'year') {
+    const perMo = Math.round(PLAN_PRICING[plan].year / 12);
+    return (
+      <div className="mt-4">
+        <span className="text-4xl font-bold">${price}</span>
+        <span className="text-muted-foreground">/year</span>
+        <p className="text-sm text-muted-foreground mt-1">≈ ${perMo}/mo, billed annually</p>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-4">
+      <span className="text-4xl font-bold">${price}</span>
+      <span className="text-muted-foreground">/month</span>
     </div>
   );
 }

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -104,8 +104,10 @@ These variables configure the MockForge Plugin Registry server.
 |----------|---------|-------------|
 | `STRIPE_SECRET_KEY` | None | Stripe API secret key |
 | `STRIPE_WEBHOOK_SECRET` | None | Stripe webhook signing secret |
-| `STRIPE_PRICE_ID_PRO` | None | Stripe price ID for Pro plan |
-| `STRIPE_PRICE_ID_TEAM` | None | Stripe price ID for Team plan |
+| `STRIPE_PRICE_ID_PRO` | None | Stripe price ID for Pro plan (monthly) |
+| `STRIPE_PRICE_ID_TEAM` | None | Stripe price ID for Team plan (monthly) |
+| `STRIPE_PRICE_ID_PRO_ANNUAL` | None | Stripe price ID for Pro billed annually. Set the Stripe price to 10× monthly to honor "2 months free". Unset = annual Pro not offered (annual checkout rejected, never charged monthly). |
+| `STRIPE_PRICE_ID_TEAM_ANNUAL` | None | Stripe price ID for Team billed annually (same semantics as the Pro annual var). |
 
 ### Deployment
 


### PR DESCRIPTION
Closes #747 (pending the Stripe ops config below).

Delivers annual billing end to end: customers can choose annual and get '2 months free'. Two commits — backend (correctness-critical) + UI (the toggle).

## Backend (no DB migration — interval derives from the stored Stripe `price_id`)
- Config: `STRIPE_PRICE_ID_PRO_ANNUAL` / `STRIPE_PRICE_ID_TEAM_ANNUAL`. The '2 months free' discount is encoded in the Stripe annual price (10× monthly) — **no discount math in code**.
- `create_checkout`: accepts `billing_interval` (`"month"` default | `"year"`), routes to the matching price. **If annual is requested but unconfigured, it 400s — never silently charges the monthly price.** Interval flows into checkout metadata + audit log.
- `determine_plan_from_price_id`: annual IDs map to the same plan (webhook sync works for annual subs).
- `get_subscription` surfaces `billing_interval`; `get_billing_config` exposes `annual_billing_available`.
- Backwards compatible: absent `billing_interval` = monthly.

## UI
- **BillingPage** (Plans tab): monthly/annual segmented toggle gated on `annual_billing_available`; sends `billing_interval` to checkout; prices switch to annual ($290/$990) with per-month equivalent + '2 months free' badge; Current Plan card shows 'Billed annually/monthly'.
- **PricingPage** (pre-auth splash): same toggle; carries the choice through login → billing via `?interval=year`.
- Both soft-fail to monthly-only when annual isn't available, so the UI never offers a cadence the backend rejects.

## Verification
- `cargo clippy -p mockforge-registry-server --all-targets --all-features -- -D warnings` — clean
- `cargo test -p mockforge-registry-server --lib` — green incl. 4 new unit tests (parse, routing, **no-silent-fallback safety**, interval derivation)
- `cargo fmt --all --check` clean; UI `tsc --noEmit` + `eslint` clean on both pages
- **Live visual verification pending** a preview env with annual Stripe prices configured (gating means the toggle only renders once the env vars are set).

## Remaining ops step to fully close #747
Configure the annual prices in Stripe (set to 10× monthly) and set the two env vars. Until then the toggle stays hidden and annual checkout is safely rejected.