### PR TITLE
feat(observability): export Kafka/AMQP/MQTT broker metrics to Prometheus + dashboards (#684)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,6 +1376,8 @@ Admin API endpoints are namespaced under `__mockforge`:
   - `GET /__mockforge/metrics`
   - `GET /__mockforge/fixtures`
   - `POST /__mockforge/config/*`
+
+> **Prometheus & Grafana:** enable the Prometheus endpoint with `--metrics` (or `observability.prometheus` in config); it exports `mockforge_*` series including per-protocol gauges (`mockforge_{http,ws,kafka,mqtt,amqp,smtp}_*`). Ready-to-import Grafana dashboards live in [`grafana/dashboards/`](grafana/) — see [`grafana/README.md`](grafana/README.md) for the catalogue (service overview, async protocols, chaos, workspace, marketplace).
 - Embedded under a mount path (e.g., `/admin`):
   - `GET /admin/__mockforge/dashboard`
   - `GET /admin/__mockforge/health`

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -2196,10 +2196,9 @@ impl BenchCommand {
                 "Self-test mode: driving {} operations with positive + per-category negative cases",
                 ops.len()
             ));
-            let report =
-                crate::conformance::self_test::run_self_test(&ops, &cfg).await.map_err(|e| {
-                    crate::error::BenchError::Other(format!("self-test client error: {e}"))
-                })?;
+            let report = crate::conformance::self_test::run_self_test(&ops, &cfg)
+                .await
+                .map_err(|e| BenchError::Other(format!("self-test client error: {e}")))?;
             TerminalReporter::print_progress(&report.render_summary());
             // Persist the JSON report alongside the regular conformance
             // report so it's grep-able next to the buffer dump from the

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2366,7 +2366,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Ok(path) = std::env::var("MOCKFORGE_ANALYTICS_DB") {
         if !path.is_empty() {
             let cfg = mockforge_analytics::AnalyticsConfig {
-                database_path: std::path::PathBuf::from(&path),
+                database_path: PathBuf::from(&path),
                 ..Default::default()
             };
             match mockforge_analytics::init(cfg).await {

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -6,7 +6,7 @@ use mockforge_chaos::api::create_chaos_api_router;
 use mockforge_chaos::config::ChaosConfig;
 use mockforge_core::encryption::init_key_store;
 use mockforge_core::ServerConfig;
-use mockforge_observability::prometheus::{prometheus_router, MetricsRegistry};
+use mockforge_observability::prometheus::prometheus_router;
 use mockforge_openapi::OpenApiSpec;
 use std::any::Any;
 use std::net::SocketAddr;
@@ -2193,8 +2193,12 @@ pub async fn handle_serve(
 
     println!("💡 Press Ctrl+C to stop");
 
-    // Create metrics registry (use global registry)
-    let metrics_registry = Arc::new(MetricsRegistry::new());
+    // Serve the GLOBAL metrics registry — the same instance the HTTP/drift/
+    // coverage middleware, the system-metrics collector, and the protocol
+    // updaters below all record into. A fresh `MetricsRegistry::new()` here
+    // would export an empty registry while real metrics went to the global
+    // one (#743).
+    let metrics_registry = mockforge_observability::get_global_registry_arc();
 
     // Start system metrics collector if Prometheus is enabled
     if config.observability.prometheus.enabled {
@@ -2208,6 +2212,69 @@ pub async fn handle_serve(
             system_metrics_config,
         );
         println!("📈 System metrics collector started (interval: 15s)");
+
+        // Export async-protocol broker metrics to Prometheus by periodically
+        // snapshotting each running broker's internal counters into the global
+        // registry's gauges (#684). Each broker exposes Arc-internal atomics, so
+        // a 5s snapshot is cheap and lock-light.
+        #[cfg(feature = "kafka")]
+        if let Some(broker) = kafka_broker.as_ref() {
+            let m = Arc::clone(broker.metrics());
+            tokio::spawn(async move {
+                let reg = get_global_registry();
+                let mut ticker = tokio::time::interval(Duration::from_secs(5));
+                loop {
+                    ticker.tick().await;
+                    let s = m.snapshot();
+                    reg.kafka_connections_active.set(s.connections_active as i64);
+                    reg.kafka_messages_produced_total.set(s.messages_produced_total as i64);
+                    reg.kafka_messages_consumed_total.set(s.messages_consumed_total as i64);
+                    reg.kafka_topics_total
+                        .set(s.topics_created_total.saturating_sub(s.topics_deleted_total) as i64);
+                    reg.kafka_partitions_total.set(s.partitions_total as i64);
+                    reg.kafka_consumer_groups_total.set(s.consumer_groups_total as i64);
+                    reg.kafka_errors_total.set(s.errors_total as i64);
+                }
+            });
+        }
+
+        #[cfg(feature = "amqp")]
+        if let Some(broker) = amqp_broker.as_ref() {
+            let m = broker.metrics();
+            tokio::spawn(async move {
+                let reg = get_global_registry();
+                let mut ticker = tokio::time::interval(Duration::from_secs(5));
+                loop {
+                    ticker.tick().await;
+                    let s = m.snapshot();
+                    reg.amqp_connections_active.set(s.connections_active as i64);
+                    reg.amqp_channels_active.set(s.channels_active as i64);
+                    reg.amqp_messages_published_total.set(s.messages_published_total as i64);
+                    reg.amqp_messages_consumed_total.set(s.messages_consumed_total as i64);
+                    reg.amqp_messages_acked_total.set(s.messages_acked_total as i64);
+                    reg.amqp_queues_total.set(s.queues_total as i64);
+                    reg.amqp_exchanges_total.set(s.exchanges_total as i64);
+                    reg.amqp_bindings_total.set(s.bindings_total as i64);
+                    reg.amqp_errors_total.set(s.errors_total as i64);
+                }
+            });
+        }
+
+        #[cfg(feature = "mqtt")]
+        if let Some(m) = mqtt_metrics.clone() {
+            tokio::spawn(async move {
+                let reg = get_global_registry();
+                let mut ticker = tokio::time::interval(Duration::from_secs(5));
+                loop {
+                    ticker.tick().await;
+                    let s = m.snapshot();
+                    reg.mqtt_connections_active.set(s.connections_active as i64);
+                    reg.mqtt_topics_active.set(s.topics_total as i64);
+                    reg.mqtt_subscriptions_active.set(s.subscriptions_active as i64);
+                    reg.mqtt_retained_messages.set(s.retained_messages_total as i64);
+                }
+            });
+        }
     }
 
     // Create a cancellation token for graceful shutdown
@@ -2510,8 +2577,8 @@ pub async fn handle_serve(
     {
         let mqtt_config = config.mqtt.clone();
         let mqtt_shutdown = shutdown_token.clone();
-        let session_manager = std::sync::Arc::clone(session_manager);
-        let metrics = std::sync::Arc::clone(metrics);
+        let session_manager = Arc::clone(session_manager);
+        let metrics = Arc::clone(metrics);
 
         // Convert core MqttConfig to mockforge_mqtt::MqttConfig
         let broker_config = mockforge_mqtt::broker::MqttConfig {

--- a/crates/mockforge-http/src/management/mod.rs
+++ b/crates/mockforge-http/src/management/mod.rs
@@ -1215,7 +1215,7 @@ pub async fn dynamic_mock_fallback(
                 // not realistic response shapes.
                 (
                     StatusCode::OK,
-                    [(axum::http::header::CONTENT_TYPE, "application/json")],
+                    [(http::header::CONTENT_TYPE, "application/json")],
                     r#"{"shadow":true,"matched":false}"#,
                 )
                     .into_response()

--- a/crates/mockforge-observability/src/lib.rs
+++ b/crates/mockforge-observability/src/lib.rs
@@ -28,7 +28,9 @@ pub mod tracing_integration;
 
 // Re-export commonly used items
 pub use logging::{init_logging, init_logging_with_otel, LoggingConfig};
-pub use prometheus::{get_global_registry, DriftEvaluationSample, MetricsRegistry};
+pub use prometheus::{
+    get_global_registry, get_global_registry_arc, DriftEvaluationSample, MetricsRegistry,
+};
 #[cfg(feature = "sentry")]
 pub use sentry_init::init_sentry;
 pub use system_metrics::{start_system_metrics_collector, SystemMetricsConfig};

--- a/crates/mockforge-observability/src/prometheus/metrics.rs
+++ b/crates/mockforge-observability/src/prometheus/metrics.rs
@@ -81,6 +81,28 @@ pub struct MetricsRegistry {
     pub mqtt_retained_messages: IntGauge,
     pub mqtt_errors_total: IntCounterVec,
 
+    // Kafka specific metrics. Driven by a periodic snapshot of the broker's
+    // internal `KafkaMetrics`, so these are IntGauges set to the absolute
+    // current value each tick (the `_total` ones are monotonic in practice).
+    pub kafka_connections_active: IntGauge,
+    pub kafka_messages_produced_total: IntGauge,
+    pub kafka_messages_consumed_total: IntGauge,
+    pub kafka_topics_total: IntGauge,
+    pub kafka_partitions_total: IntGauge,
+    pub kafka_consumer_groups_total: IntGauge,
+    pub kafka_errors_total: IntGauge,
+
+    // AMQP specific metrics (periodic snapshot of the broker's `AmqpMetrics`).
+    pub amqp_connections_active: IntGauge,
+    pub amqp_channels_active: IntGauge,
+    pub amqp_messages_published_total: IntGauge,
+    pub amqp_messages_consumed_total: IntGauge,
+    pub amqp_messages_acked_total: IntGauge,
+    pub amqp_queues_total: IntGauge,
+    pub amqp_exchanges_total: IntGauge,
+    pub amqp_bindings_total: IntGauge,
+    pub amqp_errors_total: IntGauge,
+
     // System metrics
     pub memory_usage_bytes: Gauge,
     pub cpu_usage_percent: Gauge,
@@ -379,6 +401,72 @@ impl MetricsRegistry {
         )
         .expect("Failed to create mqtt_errors_total metric");
 
+        // Kafka metrics
+        let kafka_connections_active = IntGauge::new(
+            "mockforge_kafka_connections_active",
+            "Number of active Kafka client connections",
+        )
+        .expect("Failed to create kafka_connections_active metric");
+        let kafka_messages_produced_total = IntGauge::new(
+            "mockforge_kafka_messages_produced_total",
+            "Total number of Kafka messages produced",
+        )
+        .expect("Failed to create kafka_messages_produced_total metric");
+        let kafka_messages_consumed_total = IntGauge::new(
+            "mockforge_kafka_messages_consumed_total",
+            "Total number of Kafka messages consumed",
+        )
+        .expect("Failed to create kafka_messages_consumed_total metric");
+        let kafka_topics_total =
+            IntGauge::new("mockforge_kafka_topics_total", "Number of Kafka topics")
+                .expect("Failed to create kafka_topics_total metric");
+        let kafka_partitions_total =
+            IntGauge::new("mockforge_kafka_partitions_total", "Number of Kafka partitions")
+                .expect("Failed to create kafka_partitions_total metric");
+        let kafka_consumer_groups_total = IntGauge::new(
+            "mockforge_kafka_consumer_groups_total",
+            "Number of Kafka consumer groups",
+        )
+        .expect("Failed to create kafka_consumer_groups_total metric");
+        let kafka_errors_total =
+            IntGauge::new("mockforge_kafka_errors_total", "Total number of Kafka errors")
+                .expect("Failed to create kafka_errors_total metric");
+
+        // AMQP metrics
+        let amqp_connections_active =
+            IntGauge::new("mockforge_amqp_connections_active", "Number of active AMQP connections")
+                .expect("Failed to create amqp_connections_active metric");
+        let amqp_channels_active =
+            IntGauge::new("mockforge_amqp_channels_active", "Number of active AMQP channels")
+                .expect("Failed to create amqp_channels_active metric");
+        let amqp_messages_published_total = IntGauge::new(
+            "mockforge_amqp_messages_published_total",
+            "Total number of AMQP messages published",
+        )
+        .expect("Failed to create amqp_messages_published_total metric");
+        let amqp_messages_consumed_total = IntGauge::new(
+            "mockforge_amqp_messages_consumed_total",
+            "Total number of AMQP messages consumed",
+        )
+        .expect("Failed to create amqp_messages_consumed_total metric");
+        let amqp_messages_acked_total = IntGauge::new(
+            "mockforge_amqp_messages_acked_total",
+            "Total number of AMQP messages acknowledged",
+        )
+        .expect("Failed to create amqp_messages_acked_total metric");
+        let amqp_queues_total =
+            IntGauge::new("mockforge_amqp_queues_total", "Number of AMQP queues")
+                .expect("Failed to create amqp_queues_total metric");
+        let amqp_exchanges_total =
+            IntGauge::new("mockforge_amqp_exchanges_total", "Number of AMQP exchanges")
+                .expect("Failed to create amqp_exchanges_total metric");
+        let amqp_bindings_total =
+            IntGauge::new("mockforge_amqp_bindings_total", "Number of AMQP bindings")
+                .expect("Failed to create amqp_bindings_total metric");
+        let amqp_errors_total =
+            IntGauge::new("mockforge_amqp_errors_total", "Total number of AMQP errors")
+                .expect("Failed to create amqp_errors_total metric");
+
         // System metrics
         let memory_usage_bytes =
             Gauge::new("mockforge_memory_usage_bytes", "Memory usage in bytes")
@@ -669,6 +757,28 @@ impl MetricsRegistry {
         registry
             .register(Box::new(mqtt_errors_total.clone()))
             .expect("Failed to register mqtt_errors_total");
+        for m in [
+            &kafka_connections_active,
+            &kafka_messages_produced_total,
+            &kafka_messages_consumed_total,
+            &kafka_topics_total,
+            &kafka_partitions_total,
+            &kafka_consumer_groups_total,
+            &kafka_errors_total,
+            &amqp_connections_active,
+            &amqp_channels_active,
+            &amqp_messages_published_total,
+            &amqp_messages_consumed_total,
+            &amqp_messages_acked_total,
+            &amqp_queues_total,
+            &amqp_exchanges_total,
+            &amqp_bindings_total,
+            &amqp_errors_total,
+        ] {
+            registry
+                .register(Box::new(m.clone()))
+                .expect("Failed to register kafka/amqp protocol metric");
+        }
         registry
             .register(Box::new(memory_usage_bytes.clone()))
             .expect("Failed to register memory_usage_bytes");
@@ -777,6 +887,22 @@ impl MetricsRegistry {
             mqtt_subscriptions_active,
             mqtt_retained_messages,
             mqtt_errors_total,
+            kafka_connections_active,
+            kafka_messages_produced_total,
+            kafka_messages_consumed_total,
+            kafka_topics_total,
+            kafka_partitions_total,
+            kafka_consumer_groups_total,
+            kafka_errors_total,
+            amqp_connections_active,
+            amqp_channels_active,
+            amqp_messages_published_total,
+            amqp_messages_consumed_total,
+            amqp_messages_acked_total,
+            amqp_queues_total,
+            amqp_exchanges_total,
+            amqp_bindings_total,
+            amqp_errors_total,
             memory_usage_bytes,
             cpu_usage_percent,
             thread_count,
@@ -1187,12 +1313,24 @@ impl Default for MetricsRegistry {
     }
 }
 
-/// Global metrics registry instance
-static GLOBAL_REGISTRY: Lazy<MetricsRegistry> = Lazy::new(MetricsRegistry::new);
+/// Global metrics registry instance.
+///
+/// Held as an `Arc` so the same instance can be both written to (via
+/// `get_global_registry()`) AND served at `GET /metrics` (via
+/// `get_global_registry_arc()`). Previously the metrics endpoint was handed a
+/// *separate* `MetricsRegistry::new()`, so nothing that recorded metrics was
+/// ever exported (#743).
+static GLOBAL_REGISTRY: Lazy<Arc<MetricsRegistry>> = Lazy::new(|| Arc::new(MetricsRegistry::new()));
 
-/// Get the global metrics registry
+/// Get a shared reference to the global metrics registry (for recording).
 pub fn get_global_registry() -> &'static MetricsRegistry {
     &GLOBAL_REGISTRY
+}
+
+/// Get an owned `Arc` handle to the global metrics registry, e.g. to mount the
+/// Prometheus `/metrics` endpoint on the same instance everything records into.
+pub fn get_global_registry_arc() -> Arc<MetricsRegistry> {
+    Arc::clone(&GLOBAL_REGISTRY)
 }
 
 #[cfg(test)]

--- a/crates/mockforge-observability/src/prometheus/mod.rs
+++ b/crates/mockforge-observability/src/prometheus/mod.rs
@@ -11,7 +11,9 @@ mod exporter;
 mod metrics;
 
 pub use exporter::{metrics_handler, prometheus_router};
-pub use metrics::{get_global_registry, DriftEvaluationSample, MetricsRegistry};
+pub use metrics::{
+    get_global_registry, get_global_registry_arc, DriftEvaluationSample, MetricsRegistry,
+};
 
 // Re-export prometheus types for users who need to access metrics directly
 pub use prometheus;

--- a/crates/mockforge-ui/src/handlers.rs
+++ b/crates/mockforge-ui/src/handlers.rs
@@ -1362,9 +1362,7 @@ pub async fn clear_conformance_violations() -> impl IntoResponse {
 /// Issue #79 round 13 — feed of requests for paths the loaded OpenAPI
 /// spec doesn't know about. Surfaces server/client spec drift (Srikanth's
 /// (a) ask). Backed by `mockforge_foundation::unknown_paths`.
-pub async fn get_unknown_paths(
-    axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
-) -> impl IntoResponse {
+pub async fn get_unknown_paths(Query(q): Query<HashMap<String, String>>) -> impl IntoResponse {
     let snap = mockforge_foundation::unknown_paths::snapshot();
     let total = snap.len();
     let total_seen = mockforge_foundation::unknown_paths::total_seen();

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -14,6 +14,9 @@ Per the 2026-05-23 go-live readiness audit, this is one piece of observability b
 |---|---|---|
 | [Service Overview](dashboards/mockforge-service-overview.json) | `mockforge-service-overview` | Request rate, error rate, latency p50/p95/p99, in-flight requests — all by protocol and pillar. Top-10 paths by rate and latency. The default landing page for "is MockForge healthy right now?" |
 | [Marketplace](dashboards/mockforge-marketplace.json) | `mockforge-marketplace` | Publish / download / search operations on the plugin/template/scenario marketplace. Operation rates, p95 durations, errors by code, total items. Spike in `errors_total` is the canary for the kind of bugs that drove PRs #621 / #624. |
+| [Async Protocols](dashboards/mockforge-async-protocols.json) | `mockforge-async-protocols` | Kafka, MQTT, AMQP, WebSocket and SMTP brokers — connection counts, message throughput (`rate(...)`), and broker gauges (Kafka topics/partitions/consumer-groups, AMQP queues/exchanges/bindings, MQTT topics/retained). Backed by `mockforge_{kafka,amqp,mqtt,ws,smtp}_*` (#684). |
+| [Chaos & Resilience](dashboards/mockforge-chaos.json) | `mockforge-chaos` | Chaos triggers, drift budget / breaking-change tracking, error-budget burn, scenario mode. |
+| [Workspace](dashboards/mockforge-workspace.json) | `mockforge-workspace` | Per-workspace request rate, error rate, p95 latency and active routes — for per-tenant SLOs. |
 
 ## Metric sources
 

--- a/grafana/dashboards/mockforge-async-protocols.json
+++ b/grafana/dashboards/mockforge-async-protocols.json
@@ -10,24 +10,55 @@
     }
   ],
   "__requires": [
-    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
-    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
-    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
-    { "type": "panel", "id": "stat", "name": "Stat", "version": "" }
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
   ],
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "description": "Async protocol brokers (Kafka, MQTT, AMQP, WebSocket, SMTP). Visualises connection counts, message throughput, and broker-specific gauges (MQTT topics / retained messages, WS connections). Pair with service-overview when async traffic is part of the system under test.",
   "editable": true,
   "graphTooltip": 1,
   "id": null,
   "uid": "mockforge-async-protocols",
-  "title": "MockForge — Async Protocols",
-  "tags": ["mockforge", "kafka", "mqtt", "amqp", "websocket"],
+  "title": "MockForge \u2014 Async Protocols",
+  "tags": [
+    "mockforge",
+    "kafka",
+    "mqtt",
+    "amqp",
+    "websocket"
+  ],
   "timezone": "browser",
   "schemaVersion": 38,
-  "version": 1,
+  "version": 2,
   "refresh": "30s",
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "templating": {
     "list": [
       {
@@ -45,106 +76,1049 @@
     {
       "type": "stat",
       "title": "WS connections",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
-      "targets": [{ "expr": "mockforge_ws_connections_active", "refId": "A" }],
-      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] } } },
-      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "mockforge_ws_connections_active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
     {
       "type": "stat",
       "title": "MQTT connections",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
-      "targets": [{ "expr": "mockforge_mqtt_connections_active", "refId": "A" }],
-      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] } } },
-      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "mockforge_mqtt_connections_active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
     {
       "type": "stat",
       "title": "MQTT topics",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
-      "targets": [{ "expr": "mockforge_mqtt_topics_active", "refId": "A" }],
-      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] } } },
-      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "mockforge_mqtt_topics_active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
     {
       "type": "stat",
       "title": "SMTP connections",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
-      "targets": [{ "expr": "mockforge_smtp_connections_active", "refId": "A" }],
-      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } } },
-      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "mockforge_smtp_connections_active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "WebSocket: messages sent / received (rate)",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "targets": [
-        { "expr": "sum(rate(mockforge_ws_messages_sent[5m]))", "legendFormat": "sent", "refId": "A" },
-        { "expr": "sum(rate(mockforge_ws_messages_received[5m]))", "legendFormat": "received", "refId": "B" }
+        {
+          "expr": "sum(rate(mockforge_ws_messages_sent[5m]))",
+          "legendFormat": "sent",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(mockforge_ws_messages_received[5m]))",
+          "legendFormat": "received",
+          "refId": "B"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "drawStyle": "line"
+          }
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "MQTT: messages published / received (rate)",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "targets": [
-        { "expr": "sum(rate(mockforge_mqtt_messages_published_total[5m]))", "legendFormat": "published", "refId": "A" },
-        { "expr": "sum(rate(mockforge_mqtt_messages_received_total[5m]))", "legendFormat": "received", "refId": "B" }
+        {
+          "expr": "sum(rate(mockforge_mqtt_messages_published_total[5m]))",
+          "legendFormat": "published",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(mockforge_mqtt_messages_received_total[5m]))",
+          "legendFormat": "received",
+          "refId": "B"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "drawStyle": "line"
+          }
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "SMTP: messages received / stored (rate)",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
       "targets": [
-        { "expr": "sum(rate(mockforge_smtp_messages_received_total[5m]))", "legendFormat": "received", "refId": "A" },
-        { "expr": "sum(rate(mockforge_smtp_messages_stored_total[5m]))", "legendFormat": "stored", "refId": "B" }
+        {
+          "expr": "sum(rate(mockforge_smtp_messages_received_total[5m]))",
+          "legendFormat": "received",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(mockforge_smtp_messages_stored_total[5m]))",
+          "legendFormat": "stored",
+          "refId": "B"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "drawStyle": "line"
+          }
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "Async errors (rate)",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
       "targets": [
-        { "expr": "sum(rate(mockforge_ws_errors_total[5m]))", "legendFormat": "ws", "refId": "A" },
-        { "expr": "sum(rate(mockforge_mqtt_errors_total[5m]))", "legendFormat": "mqtt", "refId": "B" },
-        { "expr": "sum(rate(mockforge_smtp_errors_total[5m]))", "legendFormat": "smtp", "refId": "C" }
+        {
+          "expr": "sum(rate(mockforge_ws_errors_total[5m]))",
+          "legendFormat": "ws",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(mockforge_mqtt_errors_total[5m]))",
+          "legendFormat": "mqtt",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(mockforge_smtp_errors_total[5m]))",
+          "legendFormat": "smtp",
+          "refId": "C"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "drawStyle": "line"
+          }
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "MQTT retained messages + subscriptions",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
       "targets": [
-        { "expr": "mockforge_mqtt_retained_messages", "legendFormat": "retained", "refId": "A" },
-        { "expr": "mockforge_mqtt_subscriptions_active", "legendFormat": "subscriptions", "refId": "B" }
+        {
+          "expr": "mockforge_mqtt_retained_messages",
+          "legendFormat": "retained",
+          "refId": "A"
+        },
+        {
+          "expr": "mockforge_mqtt_subscriptions_active",
+          "legendFormat": "subscriptions",
+          "refId": "B"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "drawStyle": "line"
+          }
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "WS connection durations (p50 / p95 / p99)",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
       "targets": [
-        { "expr": "histogram_quantile(0.50, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))", "legendFormat": "p50", "refId": "A" },
-        { "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))", "legendFormat": "p95", "refId": "B" },
-        { "expr": "histogram_quantile(0.99, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))", "legendFormat": "p99", "refId": "C" }
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(mockforge_ws_connection_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "line" } } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "drawStyle": "line"
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Kafka",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Kafka connections",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 29
+      },
+      "targets": [
+        {
+          "expr": "mockforge_kafka_connections_active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Kafka topics",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 29
+      },
+      "targets": [
+        {
+          "expr": "mockforge_kafka_topics_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Kafka partitions",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 29
+      },
+      "targets": [
+        {
+          "expr": "mockforge_kafka_partitions_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Kafka consumer groups",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 29
+      },
+      "targets": [
+        {
+          "expr": "mockforge_kafka_consumer_groups_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Kafka throughput (msgs/sec)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "targets": [
+        {
+          "expr": "rate(mockforge_kafka_messages_produced_total[5m])",
+          "legendFormat": "produced",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(mockforge_kafka_messages_consumed_total[5m])",
+          "legendFormat": "consumed",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Kafka errors",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 33
+      },
+      "targets": [
+        {
+          "expr": "mockforge_kafka_errors_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Kafka messages produced (total)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 33
+      },
+      "targets": [
+        {
+          "expr": "mockforge_kafka_messages_produced_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "AMQP",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "AMQP connections",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 42
+      },
+      "targets": [
+        {
+          "expr": "mockforge_amqp_connections_active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "AMQP channels",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 42
+      },
+      "targets": [
+        {
+          "expr": "mockforge_amqp_channels_active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "AMQP queues",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 42
+      },
+      "targets": [
+        {
+          "expr": "mockforge_amqp_queues_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "AMQP exchanges",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 42
+      },
+      "targets": [
+        {
+          "expr": "mockforge_amqp_exchanges_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "AMQP delivery (msgs/sec)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "targets": [
+        {
+          "expr": "rate(mockforge_amqp_messages_published_total[5m])",
+          "legendFormat": "published",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(mockforge_amqp_messages_consumed_total[5m])",
+          "legendFormat": "consumed",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(mockforge_amqp_messages_acked_total[5m])",
+          "legendFormat": "acked",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "AMQP bindings",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 46
+      },
+      "targets": [
+        {
+          "expr": "mockforge_amqp_bindings_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "AMQP errors",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 46
+      },
+      "targets": [
+        {
+          "expr": "mockforge_amqp_errors_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
The long-term observability fix — completes the async-protocol metrics story and makes `/metrics` actually export what's recorded. **Self-contained & CI-green**: folds in #745 (served-registry) and #766 (ratchet cleanup) so it can land independently of the queue.

## 1. Served registry (#743)
`/metrics` was handed a fresh empty `MetricsRegistry` while the middleware/system-metrics recorded into the global singleton. `GLOBAL_REGISTRY` is now `Lazy<Arc<MetricsRegistry>>` + `get_global_registry_arc()`, and serve.rs mounts the endpoint on that shared instance.

## 2. Protocol metric export (#684)
- `MetricsRegistry` gains 7 `kafka_*` + 9 `amqp_*` `IntGauge` series, registered next to the existing mqtt/ws/smtp.
- serve.rs spawns a 5s updater per enabled broker that snapshots the broker's internal atomics into the gauges — Kafka (#735), AMQP (#728), MQTT (#739 SessionManager metrics). Stateless absolute `.set()`, lock-light.

## 3. Dashboards + docs (#684 acceptance)
- `mockforge-async-protocols.json`: added **Kafka** + **AMQP** rows (throughput via `rate()`, connections, topics/partitions/queues/exchanges/bindings, errors).
- `grafana/README.md`: catalogued the 3 previously-unlisted dashboards (async-protocols, chaos, workspace); main README now points to `grafana/dashboards/`.

## 4. Ratchet cleanup (#766)
Cleared the 6 `unused_qualifications` that fail the `--all-features` clippy gate on main (bench/cli/http/ui) + the new serve.rs code.

## Verification (end-to-end)
`serve --metrics` with kafka+amqp+mqtt; produced 3 Kafka messages via the admin API + connected a raw MQTT client; then `GET /metrics`:
```
mockforge_kafka_messages_produced_total 3
mockforge_mqtt_connections_active 1
mockforge_mqtt_subscriptions_active 1
mockforge_amqp_*  (exported; populated by real AMQP protocol traffic)
```
- `cargo build -p mockforge-cli --features kafka,amqp,mqtt` → clean
- exact CI ratchet `cargo clippy --workspace --exclude mockforge-desktop --lib --bins --all-features -- -D clippy::correctness -D unused_qualifications` → **clean**
- `cargo fmt --check` → clean

Closes #684. Supersedes #745 and #766 (folded in; whichever merges first, the overlap no-ops). Refs #743.