### PR TITLE
ci(registry-e2e): skip-aware gate so the lane can be a required check

### DIFF
--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -8,13 +8,13 @@ on:
       - 'crates/mockforge-registry-core/**'
       - 'docker-compose.e2e.yml'
       - '.github/workflows/registry-e2e.yml'
+  # No `paths:` filter on pull_request — the workflow runs on EVERY PR so the
+  # required "Registry E2E (Postgres + MinIO)" check always reports a status.
+  # The `changes` job below gates the heavy work: non-registry PRs get a fast
+  # skipped job (which branch protection counts as success) instead of a
+  # never-reported check that would block the merge. Mirrors ci.yml's pattern.
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'crates/mockforge-registry-server/**'
-      - 'crates/mockforge-registry-core/**'
-      - 'docker-compose.e2e.yml'
-      - '.github/workflows/registry-e2e.yml'
   workflow_dispatch:
 
 env:
@@ -32,8 +32,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Cheap scope gate on ubuntu-latest (not the busy self-hosted Rust runners).
+  # Lets the heavy registry-e2e job below be skipped (= success for branch
+  # protection) on PRs that don't touch the registry, so this can be a required
+  # check without blocking unrelated PRs. Non-PR events always run the suite.
+  changes:
+    name: Detect registry scope
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.filter.outputs.registry }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Determine whether registry files changed
+        id: filter
+        env:
+          # Routed through env (not interpolated into the script) per workflow
+          # injection best practice. Both are GitHub-controlled values anyway.
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Non-PR event ($EVENT_NAME): running registry E2E."
+            echo "registry=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+          echo "Changed files:"; printf '%s\n' "$files"
+          registry=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              crates/mockforge-registry-server/*|crates/mockforge-registry-core/*|docker-compose.e2e.yml|.github/workflows/registry-e2e.yml) registry=true ;;
+            esac
+          done <<< "$files"
+          echo "Registry E2E required: registry=$registry"
+          echo "registry=$registry" >> "$GITHUB_OUTPUT"
+
   registry-e2e:
     name: Registry E2E (Postgres + MinIO)
+    needs: changes
+    if: ${{ needs.changes.outputs.registry == 'true' }}
     runs-on: [self-hosted, linux, x64, rust]
     timeout-minutes: 45
 


### PR DESCRIPTION
## Why
The registry-e2e lane is now **green in ~11 min** (debug build, #765). To make it actually *gate* registry changes, it needs to be a required status check — but it currently uses a **workflow-level `paths:` filter**, which is a branch-protection footgun: a required check that never reports (because the workflow didn't trigger) blocks the PR forever. The repo has many non-registry PRs that would jam.

## Change (mirrors ci.yml's blessed pattern)
- Drop the `pull_request` `paths:` filter → workflow runs on every PR, so the **"Registry E2E (Postgres + MinIO)"** check always reports.
- Add a cheap **`changes`** job on `ubuntu-latest` (off the busy self-hosted Rust runners) that detects whether registry files changed.
- Gate the heavy `registry-e2e` job on `needs.changes.outputs.registry`. Non-registry PRs **skip** it → branch protection counts a skipped required check as success → no block. ci.yml documents this exact behavior.

`push` keeps its `paths:` filter (main pushes only run the suite when the registry changes).

## After merge
Add **"Registry E2E (Postgres + MinIO)"** to main's required status checks — completing the gate that would have caught #724. (Currently only `Security Audit` is required.)

Validated: YAML parses; this PR touches the workflow so it triggers a real debug-build e2e run (~11 min) to confirm green before merge.