### PR TITLE
fix(registry): close cross-tenant IDOR in test-suite / pillar-analytics / MockAI handlers (#750)

### DIFF
--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -186,7 +186,19 @@ jobs:
           # Make sure the server binds to the same port the tests expect.
           PORT: "58080"
           HOST: "0.0.0.0"
+          # Pin local artifact storage to a fresh, writable, per-job dir.
+          # Without this the server falls back to a RELATIVE ./data/storage
+          # (storage.rs:101) inside the persistent self-hosted _work checkout.
+          # A prior run can leave ./data/storage owned by another user, so
+          # startup create_dir_all(./data/storage) is a no-op success (dir
+          # exists) but per-artifact create_dir_all(./data/storage/<kind>/<id>)
+          # then fails on permissions — surfacing as marketplace_e2e "Failed to
+          # create directory" 500s that block every registry PR. `runner.temp`
+          # is cleaned each job. (Must live in this STEP env, not the job-level
+          # env block — the `runner` context isn't available there.)
+          STORAGE_PATH: "${{ runner.temp }}/mf-e2e-storage"
         run: |
+          mkdir -p "$STORAGE_PATH"
           nohup ./target/debug/mockforge-registry-server \
             > registry-server.log 2>&1 &
           echo $! > registry-server.pid

--- a/crates/mockforge-registry-server/src/handlers/mockai.rs
+++ b/crates/mockforge-registry-server/src/handlers/mockai.rs
@@ -19,7 +19,7 @@ use axum::{
     Json,
 };
 use mockforge_registry_core::models::{
-    mockai_rule_explanation::UpsertMockaiRuleExplanation, MockaiRuleExplanation,
+    mockai_rule_explanation::UpsertMockaiRuleExplanation, CloudWorkspace, MockaiRuleExplanation,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -27,9 +27,30 @@ use uuid::Uuid;
 use crate::{
     error::{ApiError, ApiResult},
     handlers::ai_studio::{extract_json_payload, run_completion, PromptInputs, UsageMeta},
-    middleware::AuthUser,
+    middleware::{resolve_org_context, AuthUser},
     AppState,
 };
+
+/// Verify `workspace_id` belongs to the caller's org. These rule-explanation
+/// routes (read AND write) are otherwise cross-tenant: any authenticated user
+/// could read/poison another org's workspace by supplying its UUID.
+async fn authorize_workspace(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    workspace_id: Uuid,
+) -> ApiResult<()> {
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != workspace.org_id {
+        return Err(ApiError::InvalidRequest("Workspace not found".into()));
+    }
+    Ok(())
+}
 
 // --- list / get -------------------------------------------------------------
 
@@ -50,10 +71,12 @@ pub struct ListExplanationsResponse {
 /// `GET /api/v1/workspaces/{workspace_id}/mockai/rule-explanations`
 pub async fn list_rule_explanations(
     State(state): State<AppState>,
-    AuthUser(_user_id): AuthUser,
+    AuthUser(user_id): AuthUser,
     Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
     Query(query): Query<ListExplanationsQuery>,
 ) -> ApiResult<Json<ListExplanationsResponse>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
     let rows = MockaiRuleExplanation::list_by_workspace(
         state.db.pool(),
         workspace_id,
@@ -77,9 +100,11 @@ pub struct GetExplanationResponse {
 /// `GET /api/v1/workspaces/{workspace_id}/mockai/rule-explanations/{rule_id}`
 pub async fn get_rule_explanation(
     State(state): State<AppState>,
-    AuthUser(_user_id): AuthUser,
+    AuthUser(user_id): AuthUser,
     Path((workspace_id, rule_id)): Path<(Uuid, String)>,
+    headers: HeaderMap,
 ) -> ApiResult<Json<GetExplanationResponse>> {
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
     let row = MockaiRuleExplanation::get_by_rule_id(state.db.pool(), workspace_id, &rule_id)
         .await
         .map_err(ApiError::Database)?
@@ -170,6 +195,9 @@ pub async fn learn_from_examples(
     headers: HeaderMap,
     Json(request): Json<LearnRequest>,
 ) -> ApiResult<Json<LearnResponse>> {
+    // Cross-tenant write guard: don't let a caller poison rule explanations
+    // into a workspace their org doesn't own.
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
     if request.examples.is_empty() {
         return Err(ApiError::InvalidRequest("examples must not be empty".into()));
     }

--- a/crates/mockforge-registry-server/src/handlers/pillar_analytics.rs
+++ b/crates/mockforge-registry-server/src/handlers/pillar_analytics.rs
@@ -18,6 +18,7 @@ use crate::{
     AppState,
 };
 use mockforge_analytics::{Pillar, PillarUsageEvent, PillarUsageMetrics};
+use mockforge_registry_core::models::CloudWorkspace;
 
 /// Get pillar usage metrics for a workspace
 ///
@@ -29,10 +30,19 @@ pub async fn get_workspace_pillar_metrics(
     Path(workspace_id): Path<Uuid>,
     Query(params): Query<PillarMetricsQuery>,
 ) -> ApiResult<Json<PillarMetricsResponse>> {
-    // Resolve org context and verify access
-    let _org_ctx = resolve_org_context(&state, user_id, &headers, None)
+    // Resolve org context and verify the requested workspace belongs to it —
+    // otherwise any authenticated user could read another org's analytics by
+    // supplying its workspace UUID. Return "not found" to avoid an existence
+    // oracle.
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
         .await
         .map_err(|_| ApiError::AuthRequired)?;
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+    if org_ctx.org_id != workspace.org_id {
+        return Err(ApiError::InvalidRequest("Workspace not found".into()));
+    }
 
     // Parse duration (default to 7 days)
     let time_range_str = params.time_range.unwrap_or_else(|| "7d".to_string());

--- a/crates/mockforge-registry-server/src/handlers/test_suites.rs
+++ b/crates/mockforge-registry-server/src/handlers/test_suites.rs
@@ -23,11 +23,12 @@ use uuid::Uuid;
 
 use crate::{
     error::{ApiError, ApiResult},
-    middleware::AuthUser,
+    middleware::{resolve_org_context, AuthUser},
     models::TestSuite,
     AppState,
 };
 use mockforge_registry_core::models::test_execution::CreateTestSuite;
+use mockforge_registry_core::models::CloudWorkspace;
 
 #[derive(Debug, Deserialize)]
 pub struct ListSuitesQuery {
@@ -39,12 +40,14 @@ pub struct ListSuitesQuery {
 /// `GET /api/v1/workspaces/{workspace_id}/test-suites`
 pub async fn list_suites(
     State(state): State<AppState>,
-    AuthUser(_user_id): AuthUser,
+    AuthUser(user_id): AuthUser,
     Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
     Query(query): Query<ListSuitesQuery>,
 ) -> ApiResult<Json<Vec<TestSuite>>> {
-    // Workspace-scoped reads rely on the existing workspace permission
-    // middleware to gate access; here we just hit the table.
+    // Verify the workspace belongs to the caller's org before listing — there
+    // is no route-level workspace permission layer, so authz is per-handler.
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
     let suites = TestSuite::list_by_workspace(state.db.pool(), workspace_id, query.kind.as_deref())
         .await
         .map_err(ApiError::Database)?;
@@ -67,8 +70,11 @@ pub async fn create_suite(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
     Path(workspace_id): Path<Uuid>,
+    headers: HeaderMap,
     Json(request): Json<CreateSuiteRequest>,
 ) -> ApiResult<Json<TestSuite>> {
+    // Reject creating a suite inside a workspace the caller's org doesn't own.
+    authorize_workspace(&state, user_id, &headers, workspace_id).await?;
     if request.name.trim().is_empty() {
         return Err(ApiError::InvalidRequest("name must not be empty".into()));
     }
@@ -97,14 +103,11 @@ pub async fn create_suite(
 /// `GET /api/v1/test-suites/{id}`
 pub async fn get_suite(
     State(state): State<AppState>,
-    AuthUser(_user_id): AuthUser,
+    AuthUser(user_id): AuthUser,
     Path(id): Path<Uuid>,
-    _headers: HeaderMap,
+    headers: HeaderMap,
 ) -> ApiResult<Json<TestSuite>> {
-    let suite = TestSuite::find_by_id(state.db.pool(), id)
-        .await
-        .map_err(ApiError::Database)?
-        .ok_or_else(|| ApiError::InvalidRequest("Test suite not found".into()))?;
+    let suite = load_authorized_suite(&state, user_id, &headers, id).await?;
     Ok(Json(suite))
 }
 
@@ -125,10 +128,13 @@ pub struct UpdateSuiteRequest {
 /// `PATCH /api/v1/test-suites/{id}`
 pub async fn update_suite(
     State(state): State<AppState>,
-    AuthUser(_user_id): AuthUser,
+    AuthUser(user_id): AuthUser,
     Path(id): Path<Uuid>,
+    headers: HeaderMap,
     Json(request): Json<UpdateSuiteRequest>,
 ) -> ApiResult<Json<TestSuite>> {
+    // Confirm the suite belongs to the caller's org before mutating it.
+    load_authorized_suite(&state, user_id, &headers, id).await?;
     let updated = TestSuite::update(
         state.db.pool(),
         id,
@@ -146,14 +152,62 @@ pub async fn update_suite(
 /// `DELETE /api/v1/test-suites/{id}`
 pub async fn delete_suite(
     State(state): State<AppState>,
-    AuthUser(_user_id): AuthUser,
+    AuthUser(user_id): AuthUser,
     Path(id): Path<Uuid>,
+    headers: HeaderMap,
 ) -> ApiResult<Json<serde_json::Value>> {
+    // Confirm ownership before deleting.
+    load_authorized_suite(&state, user_id, &headers, id).await?;
     let deleted = TestSuite::delete(state.db.pool(), id).await.map_err(ApiError::Database)?;
     if !deleted {
         return Err(ApiError::InvalidRequest("Test suite not found".into()));
     }
     Ok(Json(serde_json::json!({ "deleted": true })))
+}
+
+/// Load a test suite only if it belongs to the caller's org; otherwise return
+/// the same "not found" as a missing suite (no cross-tenant existence oracle).
+/// Mirrors `test_schedules::load_authorized_suite`.
+async fn load_authorized_suite(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    suite_id: Uuid,
+) -> ApiResult<TestSuite> {
+    let suite = TestSuite::find_by_id(state.db.pool(), suite_id)
+        .await
+        .map_err(ApiError::Database)?
+        .ok_or_else(|| ApiError::InvalidRequest("Test suite not found".into()))?;
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), suite.workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Test suite not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != workspace.org_id {
+        return Err(ApiError::InvalidRequest("Test suite not found".into()));
+    }
+    Ok(suite)
+}
+
+/// Verify `workspace_id` belongs to the caller's org for workspace-scoped
+/// routes. Mirrors the `authorize_workspace` helper used across the handlers.
+async fn authorize_workspace(
+    state: &AppState,
+    user_id: Uuid,
+    headers: &HeaderMap,
+    workspace_id: Uuid,
+) -> ApiResult<CloudWorkspace> {
+    let workspace = CloudWorkspace::find_by_id(state.db.pool(), workspace_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Workspace not found".into()))?;
+    let ctx = resolve_org_context(state, user_id, headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
+    if ctx.org_id != workspace.org_id {
+        return Err(ApiError::InvalidRequest("Workspace not found".into()));
+    }
+    Ok(workspace)
 }
 
 /// Distinguish "field omitted" vs "field explicitly set to null" during JSON


### PR DESCRIPTION
Closes #750 (from the deep audit). Highest-severity finding: cross-tenant **IDOR** in the multi-tenant registry.

## The bug
There is no router-level workspace-permission layer (only `auth_middleware` + `rate_limit`), so authz is each handler's responsibility. Three handlers operated on resources by `id` / path `workspace_id` **without verifying org ownership** — any authenticated user could read/modify/delete across tenants:

| Handler | Was |
|---------|-----|
| `test_suites::{get,update,delete}_suite` | fetched/mutated/deleted by `id` only (`AuthUser` discarded) |
| `test_suites::{list,create}_suite` | trusted the path `workspace_id` |
| `pillar_analytics::get_workspace_pillar_metrics` | resolved `_org_ctx` then **discarded it**, queried path `workspace_id` |
| `mockai::{list_rule_explanations,get_rule_explanation,learn_from_examples}` | used path `workspace_id`; `learn_from_examples` is a cross-tenant **write** (poisoning) |

## The fix
Apply the codebase's established authz idiom (the `load_authorized_*` / `authorize_workspace` helpers already used by ~10 sibling handlers — `test_schedules`, `graph`, `snapshots`, `test_generation`, …):
- **test_suites**: `get/update/delete` go through `load_authorized_suite` (suite → workspace → `resolve_org_context` → org match); `list/create` call `authorize_workspace`.
- **pillar_analytics**: verify the path workspace belongs to the caller's org before querying.
- **mockai**: `authorize_workspace` before any DB access on all three (incl. the write).

All return the same **"not found"** on cross-org access (no existence oracle).

## Verification
- `cargo build/clippy -p mockforge-registry-server -- -D warnings` → clean
- `cargo test -p mockforge-registry-server --lib` → **480 passed, 0 failed**
- `cargo fmt --check` → clean

The fix mirrors the verified existing helpers verbatim. Follow-up worth considering (noted in #750): a router-level workspace `route_layer` so a future missed handler fails closed rather than open.