### PR TITLE
ci: trim per-PR self-hosted runner load (4 workflows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,15 +457,11 @@ jobs:
 
   typos:
     name: Spell Check
-    runs-on: [self-hosted, linux, x64, rust]
+    # GitHub-hosted: a pure text check needs no Rust toolchain, and the repo is
+    # public so standard runners are free. Keeps the contended self-hosted Rust
+    # slot for jobs that actually compile. (No per-runner CARGO_HOME needed.)
+    runs-on: ubuntu-latest
     steps:
-    - name: Set per-runner CARGO_HOME
-      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
-      # (GH Actions context: `runner.*` is step-scoped). Writing to
-      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
-      # including the rust-toolchain composite action and rust-cache.
-      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
-
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -474,25 +470,24 @@ jobs:
 
   changelog-validation:
     name: Changelog Validation
-    runs-on: [self-hosted, linux, x64, rust]
+    # GitHub-hosted: a git-diff + shell check needs no Rust toolchain; public
+    # repo → free standard runner, and it frees the self-hosted Rust slot.
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-    - name: Set per-runner CARGO_HOME
-      # `runner.name` is unavailable in workflow- or job-level `env:` blocks
-      # (GH Actions context: `runner.*` is step-scoped). Writing to
-      # `$GITHUB_ENV` here exports it to every subsequent step in this job,
-      # including the rust-toolchain composite action and rust-cache.
-      run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
-
     - name: Checkout repository
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Validate changelog pillar tags
+      # base_ref is the PR target branch name; route it through env rather than
+      # interpolating into the shell to avoid any expression-injection surface.
+      env:
+        BASE_REF: ${{ github.base_ref }}
       run: |
         # Check if CHANGELOG.md was modified in this PR
-        if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "CHANGELOG.md"; then
+        if git diff --name-only "origin/${BASE_REF}...HEAD" | grep -q "CHANGELOG.md"; then
           echo "CHANGELOG.md modified, validating pillar tags..."
           # Make script executable
           chmod +x scripts/check-changelog.sh

--- a/.github/workflows/contract-diff.yml
+++ b/.github/workflows/contract-diff.yml
@@ -1,11 +1,21 @@
 name: Contract Diff Verification
 
 on:
+  # Narrowed from repo-wide **/*.{json,yaml,yml}. This job does a full
+  # `--release --features all-protocols` CLI build BEFORE it detects whether any
+  # OpenAPI spec changed, so the old globs paid that build on every incidental
+  # JSON/YAML edit (tsconfig, package.json, Cargo configs, CI yaml, test
+  # fixtures) only to self-skip. OpenAPI specs in this repo live under
+  # examples/ and specs/; the job's own find-step still scans the whole tree, so
+  # no committed spec escapes analysis once the workflow is triggered.
   pull_request:
     paths:
-      - '**/*.yaml'
-      - '**/*.yml'
-      - '**/*.json'
+      - 'examples/**/*.json'
+      - 'examples/**/*.yaml'
+      - 'examples/**/*.yml'
+      - 'specs/**'
+      - 'openapi.yaml'
+      - 'openapi.json'
       - 'crates/mockforge-core/src/ai_contract_diff/**'
       - 'crates/mockforge-cli/src/contract_diff_commands.rs'
       - '.github/workflows/contract-diff.yml'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -135,8 +135,7 @@ jobs:
       # `--skip protocols::` excludes the e2e protocol tests from THIS
       # step — they spawn real mockforge processes that race on ports
       # under parallel test execution (find_available_port TOCTOU).
-      # The dedicated `e2e-tests` job below runs them with
-      # --test-threads=1.
+      # The E2E phase later in this job runs them with --test-threads=1.
       - name: Run integration tests (non-ignored)
         run: |
           cargo test --package mockforge-integration-tests --test '*' -- --nocapture --skip 'protocols::'
@@ -151,62 +150,20 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  e2e-tests:
-    name: E2E Tests
-    runs-on: [self-hosted, linux, x64, rust]
-    # Serialize after integration-tests. Both jobs build the workspace
-    # in release mode and share the self-hosted runner's target/ and
-    # ~/.cargo dirs. When they ran in parallel the rustc process could
-    # vanish mid-compile (one job's cache restore / cargo-cache action
-    # stepping on the other's toolchain), producing "No such file or
-    # directory" on an rlib rustc had just launched. `needs:` forces a
-    # happens-before ordering and also lets E2E reuse what Integration
-    # Tests just built.
-    needs: integration-tests
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Set per-runner CARGO_HOME
-        # `runner.name` is unavailable in workflow- or job-level `env:` blocks
-        # (GH Actions context: `runner.*` is step-scoped). Writing to
-        # `$GITHUB_ENV` here exports it to every subsequent step in this job,
-        # including the rust-toolchain composite action and rust-cache.
-        run: echo "CARGO_HOME=/tmp/cargo-mockforge-${{ runner.name }}" >> "$GITHUB_ENV"
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: ./.github/actions/rust-toolchain
-
-      # See integration-tests job: heal any stale rustup default pin
-      # left by another repo's workflow on this shared runner.
-      - name: Ensure rustup default = stable
-        run: rustup default stable
-
-      - name: Install protoc (protobuf compiler)
-        run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'
-
-      # No cache step here: e2e-tests runs `needs: integration-tests` on
-      # the same self-hosted runner, so target/ and ~/.cargo are already
-      # warm from that job. `actions/cache@v4` would serialize a ~20GB
-      # target/ to/from the cache API on every run — wasted bytes, and
-      # the wholesale overwrite is what let the prior run push the disk
-      # to 100%.
-      - name: Build MockForge
-        # Should be a cache hit from integration-tests; re-run is cheap.
-        # Same retry guard as the integration-tests build step.
-        run: |
-          cargo build --release --bin mockforge --features all-protocols \
-            || (echo "::warning::first build failed, retrying once" \
-                && cargo build --release --bin mockforge --features all-protocols)
-
-      # See note on the integration-tests job: env: PATH doesn't expand
-      # $PATH. GITHUB_PATH is the supported way to prepend to PATH.
-      - name: Prepend target/release to PATH
-        run: echo "${{ github.workspace }}/target/release" >> "$GITHUB_PATH"
-
+      # --- E2E phase (formerly a separate `e2e-tests` job) -------------------
+      # Merged into this job so the release binary built above is reused
+      # directly — the old split paid a second queue slot on the saturated
+      # single-slot self-hosted runner plus duplicate checkout/toolchain/protoc
+      # setup, and relied on the second job landing on the SAME physical runner
+      # to find target/ warm. As steps in one job this is strictly serial (the
+      # original reason for the split was to avoid parallel rustc on a shared
+      # runner — `needs:` ordering, now subsumed) and the binary is guaranteed
+      # warm: no rebuild step at all.
+      #
+      # E2E runs only on PRs and main (the former job's `if:` gate) — skipped
+      # on develop pushes and manual dispatch.
       - name: Run E2E tests
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
         # Target the `e2e` integration-test binary (tests/tests/e2e.rs) and
         # filter to each protocol module. The prior form
         # `... -- e2e::protocols::<foo>` ran against every test binary and
@@ -222,9 +179,9 @@ jobs:
           cargo test --package mockforge-integration-tests --release --test e2e -- --test-threads=1 protocols::websocket_e2e_tests
           cargo test --package mockforge-integration-tests --release --test e2e -- --test-threads=1 protocols::grpc_e2e_tests
 
-      - name: Upload test results
+      - name: Upload E2E test results
+        if: failure() && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v7
-        if: failure()
         with:
           name: e2e-test-results
           path: target/test-results/

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -1,20 +1,20 @@
 name: Load Testing & Performance Regression
 
-# Cron disabled — runner queue contention; manual workflow_dispatch still works.
+# Load tests run on main-push + manual dispatch only — NOT per-PR. Load testing
+# and perf benchmarks as PR merge-gates burned a full release build + k6 run on
+# every code PR against a single self-hosted runner, for a signal we don't gate
+# merges on (none of these jobs are required checks). The regression we actually
+# act on is "did this regress after landing on main", so they run post-merge.
+# Nightly cron stays disabled (runner queue contention); use workflow_dispatch
+# for on-demand runs.
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'crates/**'
-      - 'tests/load/**'
-      - 'Cargo.toml'
-      - '.github/workflows/load-testing.yml'
   push:
     branches: [main]
     paths:
       - 'crates/**'
       - 'tests/load/**'
       - 'Cargo.toml'
+      - '.github/workflows/load-testing.yml'
   workflow_dispatch:
     inputs:
       test_type:
@@ -27,18 +27,18 @@ on:
           - extended
           - stress
 
-# Push-on-main retained — Extended Load Test + Performance Benchmarks gate on
-# refs/heads/main. Concurrency keys are GitHub-internal context, safe to interpolate.
+# All load/perf jobs run on refs/heads/main (post-merge) or manual dispatch.
+# Concurrency keys are GitHub-internal context, safe to interpolate.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   standard-load-test:
     name: Standard Load Test
     runs-on: [self-hosted, linux, x64, rust]
     if: |
-      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.test_type == 'standard')
 
     steps:
@@ -138,7 +138,6 @@ jobs:
     name: Performance Benchmarks
     runs-on: [self-hosted, linux, x64, rust]
     if: |
-      github.event_name == 'pull_request' ||
       github.ref == 'refs/heads/main' ||
       github.event_name == 'workflow_dispatch'
 


### PR DESCRIPTION
## Why

The single-slot self-hosted Rust runner has been saturated (20-deep queue), partly because several **heavy, non-required** jobs gate *every* code PR. Branch protection requires only **Security Audit** and **Registry E2E**, so moving the others off the PR critical path costs no merge safety — it just stops burning the contended runner on signals we don't gate merges on.

Audit context: of 26 workflows, only 4 actually gate a typical code PR. This trims those 4.

## Changes

| Workflow | Before (per PR) | After |
|---|---|---|
| **load-testing** | 2–3 heavy release builds + k6 on every PR | main-push + `workflow_dispatch` only (post-merge regression signal) |
| **integration-tests** | 2 jobs, 2 queue slots, duplicate setup, relied on same-runner warm cache | 1 sequential job; E2E reuses the built binary with **zero rebuild** |
| **ci.yml** `typos` + `changelog-validation` | self-hosted Rust slot | `ubuntu-latest` (free on public repo; no toolchain needed) |
| **contract-diff** | full `--release --features all-protocols` CLI build on **any** `*.json`/`*.yaml`/`*.yml` change | triggers only on `examples/**` + `specs/**` + contract-diff sources |

Details:
- **load-testing** — nightly cron stays disabled (the documented runner-contention decision); `extended-load-test` was already main/schedule-only.
- **integration-tests** — merging into one job is strictly *more* serial than the old `needs:` ordering, so the anti-parallel-rustc reason for the split is subsumed. E2E still gated to PR/main via a step-level `if:`.
- **ci.yml** — also routed `github.base_ref` through `env:` in the changelog step to remove an expression-injection surface.
- **contract-diff** — the job's own find-step still scans the whole tree, so no committed spec escapes analysis once triggered.

## Safety / scope

- No required check is moved off PRs (only Security Audit + Registry E2E are required, both unchanged).
- Takes effect once merged to main — helps **future** PRs, not the currently-queued ones.
- Validated with `actionlint` (no new findings; only pre-existing custom-`rust`-label noise) + YAML parse.

## Not done (left as a question)

The 5 SDK publishers (go/maven/npm/nuget/python) cost nothing on PRs but are only worth keeping if those packages are actually published — left untouched pending confirmation.