### PR TITLE
feat(registry,ui): complete SSO — SAML login loop + OIDC + domain-verified cross-tenant security (#746)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,7 @@ dependencies = [
  "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
- "p256",
+ "p256 0.11.1",
  "percent-encoding",
  "ring",
  "sha2 0.10.9",
@@ -1709,6 +1709,12 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base32"
@@ -3251,8 +3257,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4061,9 +4069,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
  "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4107,16 +4129,37 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
+ "group 0.12.1",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
+ "generic-array",
+ "group 0.13.0",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4425,6 +4468,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -4957,6 +5010,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -5484,7 +5538,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -8986,6 +9051,7 @@ dependencies = [
  "mockforge-registry-core",
  "mockforge-scenarios",
  "oauth2",
+ "openidconnect",
  "opentelemetry-proto 0.32.0",
  "prometheus",
  "prost 0.14.3",
@@ -10430,6 +10496,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "openidconnect"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "http 0.2.12",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256 0.13.2",
+ "p384",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10808,8 +10906,32 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -11618,6 +11740,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -12721,6 +12852,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13340,10 +13481,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -13643,6 +13798,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,9 @@ oauth2 = "4.4"
 # the workspace's reqwest config.
 openidconnect = { version = "3.5", default-features = false, features = ["reqwest", "rustls-tls"] }
 ring = "0.17"
+# Async DNS resolver (tokio runtime). Used by the registry server for SSO
+# domain-ownership verification (TXT lookups) and tunnel DNS checks.
+hickory-resolver = { version = "0.26", default-features = false, features = ["tokio", "system-config"] }
 
 # Encryption libraries
 aes-gcm = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,10 @@ parking_lot = "0.12"
 # Authentication libraries
 jsonwebtoken = "9.0"
 oauth2 = "4.4"
+# OIDC (OpenID Connect) for SSO ID-token validation. 3.x depends on oauth2 4.x
+# (compatible with the dep above). rustls-tls keeps us off native-tls to match
+# the workspace's reqwest config.
+openidconnect = { version = "3.5", default-features = false, features = ["reqwest", "rustls-tls"] }
 ring = "0.17"
 
 # Encryption libraries

--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -92,6 +92,11 @@ pub enum AuditEventType {
     PlatformSigningKeyRevoked,
     // Admin actions
     AdminImpersonation,
+    // Authentication
+    // Successful SSO login (SAML ACS or OIDC callback). `metadata` carries
+    // the `provider` ("saml" | "oidc"). Mirror migration:
+    // 20250101000080_sso_login_audit_event.sql.
+    SsoLogin,
 }
 
 impl AuditEventType {
@@ -162,6 +167,7 @@ impl AuditEventType {
             "platform_signing_key_retired" => Some(Self::PlatformSigningKeyRetired),
             "platform_signing_key_revoked" => Some(Self::PlatformSigningKeyRevoked),
             "admin_impersonation" => Some(Self::AdminImpersonation),
+            "sso_login" => Some(Self::SsoLogin),
             _ => None,
         }
     }
@@ -233,6 +239,7 @@ impl AuditEventType {
             Self::PlatformSigningKeyRetired => "platform_signing_key_retired",
             Self::PlatformSigningKeyRevoked => "platform_signing_key_revoked",
             Self::AdminImpersonation => "admin_impersonation",
+            Self::SsoLogin => "sso_login",
         }
     }
 }

--- a/crates/mockforge-registry-core/src/models/mod.rs
+++ b/crates/mockforge-registry-core/src/models/mod.rs
@@ -100,7 +100,7 @@ pub use scenario_promotion::{PromotionStatus, ScenarioEnvironmentVersion, Scenar
 pub use settings::{BYOKConfig, OrgAiSettings, OrgSetting};
 pub use showcase::ShowcaseEntry;
 pub use snapshot::Snapshot;
-pub use sso::{SSOConfiguration, SSOSession};
+pub use sso::{normalize_email_domain, SSOConfiguration, SSOSession};
 pub use subscription::{Subscription, SubscriptionStatus, UsageAlert, UsageCounter};
 pub use user::User;
 

--- a/crates/mockforge-registry-core/src/models/sso.rs
+++ b/crates/mockforge-registry-core/src/models/sso.rs
@@ -58,6 +58,12 @@ pub struct SSOConfiguration {
     // Email-domain discovery
     pub email_domain: Option<String>,
 
+    // Domain-ownership verification (DNS TXT). `domain_verified` gates whether
+    // `email_domain` may be trusted for SSO login routing; the token is the
+    // value the org admin publishes in a DNS TXT record.
+    pub domain_verified: bool,
+    pub domain_verification_token: Option<String>,
+
     // Attribute mapping
     pub attribute_mapping: serde_json::Value,
 
@@ -116,6 +122,8 @@ impl SSOConfiguration {
         oidc_client_id: Option<&str>,
         oidc_client_secret: Option<&str>,
         email_domain: Option<&str>,
+        domain_verified: bool,
+        domain_verification_token: Option<&str>,
     ) -> sqlx::Result<Self> {
         let attribute_mapping = attribute_mapping.unwrap_or_else(|| serde_json::json!({}));
 
@@ -125,9 +133,13 @@ impl SSOConfiguration {
                 org_id, provider, saml_entity_id, saml_sso_url, saml_slo_url,
                 saml_x509_cert, saml_name_id_format, attribute_mapping,
                 require_signed_assertions, require_signed_responses, allow_unsolicited_responses,
-                oidc_issuer_url, oidc_client_id, oidc_client_secret, email_domain
+                oidc_issuer_url, oidc_client_id, oidc_client_secret, email_domain,
+                domain_verified, domain_verification_token
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+                $16, $17
+            )
             ON CONFLICT (org_id) DO UPDATE SET
                 provider = EXCLUDED.provider,
                 saml_entity_id = EXCLUDED.saml_entity_id,
@@ -143,6 +155,8 @@ impl SSOConfiguration {
                 oidc_client_id = EXCLUDED.oidc_client_id,
                 oidc_client_secret = EXCLUDED.oidc_client_secret,
                 email_domain = EXCLUDED.email_domain,
+                domain_verified = EXCLUDED.domain_verified,
+                domain_verification_token = EXCLUDED.domain_verification_token,
                 updated_at = NOW()
             RETURNING *
             "#,
@@ -162,8 +176,21 @@ impl SSOConfiguration {
         .bind(oidc_client_id)
         .bind(oidc_client_secret)
         .bind(email_domain)
+        .bind(domain_verified)
+        .bind(domain_verification_token)
         .fetch_one(pool)
         .await
+    }
+
+    /// Mark the organization's SSO email domain as verified.
+    pub async fn mark_domain_verified(pool: &sqlx::PgPool, org_id: Uuid) -> sqlx::Result<()> {
+        sqlx::query(
+            "UPDATE sso_configurations SET domain_verified = TRUE, updated_at = NOW() WHERE org_id = $1",
+        )
+        .bind(org_id)
+        .execute(pool)
+        .await?;
+        Ok(())
     }
 
     /// Look up (org_slug, provider) by email domain for SSO discovery.

--- a/crates/mockforge-registry-core/src/models/sso.rs
+++ b/crates/mockforge-registry-core/src/models/sso.rs
@@ -112,6 +112,10 @@ impl SSOConfiguration {
         require_signed_assertions: bool,
         require_signed_responses: bool,
         allow_unsolicited_responses: bool,
+        oidc_issuer_url: Option<&str>,
+        oidc_client_id: Option<&str>,
+        oidc_client_secret: Option<&str>,
+        email_domain: Option<&str>,
     ) -> sqlx::Result<Self> {
         let attribute_mapping = attribute_mapping.unwrap_or_else(|| serde_json::json!({}));
 
@@ -121,9 +125,9 @@ impl SSOConfiguration {
                 org_id, provider, saml_entity_id, saml_sso_url, saml_slo_url,
                 saml_x509_cert, saml_name_id_format, attribute_mapping,
                 require_signed_assertions, require_signed_responses, allow_unsolicited_responses,
-                email_domain
+                oidc_issuer_url, oidc_client_id, oidc_client_secret, email_domain
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
             ON CONFLICT (org_id) DO UPDATE SET
                 provider = EXCLUDED.provider,
                 saml_entity_id = EXCLUDED.saml_entity_id,
@@ -135,6 +139,10 @@ impl SSOConfiguration {
                 require_signed_assertions = EXCLUDED.require_signed_assertions,
                 require_signed_responses = EXCLUDED.require_signed_responses,
                 allow_unsolicited_responses = EXCLUDED.allow_unsolicited_responses,
+                oidc_issuer_url = EXCLUDED.oidc_issuer_url,
+                oidc_client_id = EXCLUDED.oidc_client_id,
+                oidc_client_secret = EXCLUDED.oidc_client_secret,
+                email_domain = EXCLUDED.email_domain,
                 updated_at = NOW()
             RETURNING *
             "#,
@@ -150,6 +158,10 @@ impl SSOConfiguration {
         .bind(require_signed_assertions)
         .bind(require_signed_responses)
         .bind(allow_unsolicited_responses)
+        .bind(oidc_issuer_url)
+        .bind(oidc_client_id)
+        .bind(oidc_client_secret)
+        .bind(email_domain)
         .fetch_one(pool)
         .await
     }

--- a/crates/mockforge-registry-core/src/models/sso.rs
+++ b/crates/mockforge-registry-core/src/models/sso.rs
@@ -55,6 +55,9 @@ pub struct SSOConfiguration {
     pub oidc_client_id: Option<String>,
     pub oidc_client_secret: Option<String>,
 
+    // Email-domain discovery
+    pub email_domain: Option<String>,
+
     // Attribute mapping
     pub attribute_mapping: serde_json::Value,
 
@@ -117,9 +120,10 @@ impl SSOConfiguration {
             INSERT INTO sso_configurations (
                 org_id, provider, saml_entity_id, saml_sso_url, saml_slo_url,
                 saml_x509_cert, saml_name_id_format, attribute_mapping,
-                require_signed_assertions, require_signed_responses, allow_unsolicited_responses
+                require_signed_assertions, require_signed_responses, allow_unsolicited_responses,
+                email_domain
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL)
             ON CONFLICT (org_id) DO UPDATE SET
                 provider = EXCLUDED.provider,
                 saml_entity_id = EXCLUDED.saml_entity_id,
@@ -148,6 +152,30 @@ impl SSOConfiguration {
         .bind(allow_unsolicited_responses)
         .fetch_one(pool)
         .await
+    }
+
+    /// Look up (org_slug, provider) by email domain for SSO discovery.
+    ///
+    /// Matches `lower(email_domain) = lower($1)` and `enabled = true` so
+    /// only active configurations are returned.
+    pub async fn find_org_slug_by_email_domain(
+        pool: &sqlx::PgPool,
+        domain: &str,
+    ) -> sqlx::Result<Option<(String, String)>> {
+        let row: Option<(String, String)> = sqlx::query_as(
+            r#"
+            SELECT o.slug, sc.provider
+            FROM sso_configurations sc
+            JOIN organizations o ON o.id = sc.org_id
+            WHERE lower(sc.email_domain) = lower($1)
+              AND sc.enabled = TRUE
+            LIMIT 1
+            "#,
+        )
+        .bind(domain)
+        .fetch_optional(pool)
+        .await?;
+        Ok(row)
     }
 
     /// Enable SSO for an organization
@@ -179,6 +207,17 @@ impl SSOConfiguration {
             .execute(pool)
             .await?;
         Ok(())
+    }
+}
+
+/// Extract the lowercased domain from an email address, or None if malformed.
+pub fn normalize_email_domain(email: &str) -> Option<String> {
+    let (_, domain) = email.split_once('@')?;
+    let domain = domain.trim().to_lowercase();
+    if domain.is_empty() {
+        None
+    } else {
+        Some(domain)
     }
 }
 
@@ -244,5 +283,17 @@ impl SSOSession {
             .execute(pool)
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_email_domain;
+
+    #[test]
+    fn email_domain_normalization() {
+        assert_eq!(normalize_email_domain("Jo@Acme.com"), Some("acme.com".to_string()));
+        assert_eq!(normalize_email_domain("no-at-sign"), None);
+        assert_eq!(normalize_email_domain("a@"), None);
     }
 }

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1403,6 +1403,10 @@ pub trait RegistryStore: Send + Sync + 'static {
     async fn enable_sso_config(&self, org_id: Uuid) -> StoreResult<()>;
     async fn disable_sso_config(&self, org_id: Uuid) -> StoreResult<()>;
     async fn delete_sso_config(&self, org_id: Uuid) -> StoreResult<()>;
+    async fn find_org_slug_by_email_domain(
+        &self,
+        domain: &str,
+    ) -> StoreResult<Option<(String, String)>>;
 
     // ---------------------------------------------------------------------
     // SAML replay prevention

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1398,6 +1398,10 @@ pub trait RegistryStore: Send + Sync + 'static {
         require_signed_assertions: bool,
         require_signed_responses: bool,
         allow_unsolicited_responses: bool,
+        oidc_issuer_url: Option<&str>,
+        oidc_client_id: Option<&str>,
+        oidc_client_secret: Option<&str>,
+        email_domain: Option<&str>,
     ) -> StoreResult<SSOConfiguration>;
 
     async fn enable_sso_config(&self, org_id: Uuid) -> StoreResult<()>;

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1402,7 +1402,12 @@ pub trait RegistryStore: Send + Sync + 'static {
         oidc_client_id: Option<&str>,
         oidc_client_secret: Option<&str>,
         email_domain: Option<&str>,
+        domain_verified: bool,
+        domain_verification_token: Option<&str>,
     ) -> StoreResult<SSOConfiguration>;
+
+    /// Mark the organization's SSO email domain as verified (DNS TXT proof).
+    async fn mark_sso_domain_verified(&self, org_id: Uuid) -> StoreResult<()>;
 
     async fn enable_sso_config(&self, org_id: Uuid) -> StoreResult<()>;
     async fn disable_sso_config(&self, org_id: Uuid) -> StoreResult<()>;

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -1127,6 +1127,8 @@ impl RegistryStore for PgRegistryStore {
         oidc_client_id: Option<&str>,
         oidc_client_secret: Option<&str>,
         email_domain: Option<&str>,
+        domain_verified: bool,
+        domain_verification_token: Option<&str>,
     ) -> StoreResult<SSOConfiguration> {
         SSOConfiguration::upsert(
             &self.pool,
@@ -1145,9 +1147,17 @@ impl RegistryStore for PgRegistryStore {
             oidc_client_id,
             oidc_client_secret,
             email_domain,
+            domain_verified,
+            domain_verification_token,
         )
         .await
         .map_err(Into::into)
+    }
+
+    async fn mark_sso_domain_verified(&self, org_id: Uuid) -> StoreResult<()> {
+        SSOConfiguration::mark_domain_verified(&self.pool, org_id)
+            .await
+            .map_err(Into::into)
     }
 
     async fn enable_sso_config(&self, org_id: Uuid) -> StoreResult<()> {

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -1154,6 +1154,15 @@ impl RegistryStore for PgRegistryStore {
         SSOConfiguration::delete(&self.pool, org_id).await.map_err(Into::into)
     }
 
+    async fn find_org_slug_by_email_domain(
+        &self,
+        domain: &str,
+    ) -> StoreResult<Option<(String, String)>> {
+        SSOConfiguration::find_org_slug_by_email_domain(&self.pool, domain)
+            .await
+            .map_err(Into::into)
+    }
+
     async fn is_saml_assertion_used(&self, assertion_id: &str, org_id: Uuid) -> StoreResult<bool> {
         SAMLAssertionId::is_used(&self.pool, assertion_id, org_id)
             .await

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -1123,6 +1123,10 @@ impl RegistryStore for PgRegistryStore {
         require_signed_assertions: bool,
         require_signed_responses: bool,
         allow_unsolicited_responses: bool,
+        oidc_issuer_url: Option<&str>,
+        oidc_client_id: Option<&str>,
+        oidc_client_secret: Option<&str>,
+        email_domain: Option<&str>,
     ) -> StoreResult<SSOConfiguration> {
         SSOConfiguration::upsert(
             &self.pool,
@@ -1137,6 +1141,10 @@ impl RegistryStore for PgRegistryStore {
             require_signed_assertions,
             require_signed_responses,
             allow_unsolicited_responses,
+            oidc_issuer_url,
+            oidc_client_id,
+            oidc_client_secret,
+            email_domain,
         )
         .await
         .map_err(Into::into)

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -1905,7 +1905,14 @@ impl RegistryStore for SqliteRegistryStore {
         oidc_client_id: Option<&str>,
         oidc_client_secret: Option<&str>,
         email_domain: Option<&str>,
+        domain_verified: bool,
+        domain_verification_token: Option<&str>,
     ) -> StoreResult<SSOConfiguration> {
+        Err(StoreError::NotFound)
+    }
+
+    #[allow(unused_variables)]
+    async fn mark_sso_domain_verified(&self, org_id: Uuid) -> StoreResult<()> {
         Err(StoreError::NotFound)
     }
 

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -1901,6 +1901,10 @@ impl RegistryStore for SqliteRegistryStore {
         require_signed_assertions: bool,
         require_signed_responses: bool,
         allow_unsolicited_responses: bool,
+        oidc_issuer_url: Option<&str>,
+        oidc_client_id: Option<&str>,
+        oidc_client_secret: Option<&str>,
+        email_domain: Option<&str>,
     ) -> StoreResult<SSOConfiguration> {
         Err(StoreError::NotFound)
     }

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -1921,6 +1921,14 @@ impl RegistryStore for SqliteRegistryStore {
     }
 
     #[allow(unused_variables)]
+    async fn find_org_slug_by_email_domain(
+        &self,
+        domain: &str,
+    ) -> StoreResult<Option<(String, String)>> {
+        Ok(None)
+    }
+
+    #[allow(unused_variables)]
     async fn is_saml_assertion_used(&self, assertion_id: &str, org_id: Uuid) -> StoreResult<bool> {
         Ok(false)
     }

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -110,7 +110,7 @@ uuid = { version = "1.23", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 cron = "0.15"
-hickory-resolver = { version = "0.26", default-features = false, features = ["tokio", "system-config"] }
+hickory-resolver = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rust_decimal = "1.42"

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -67,8 +67,8 @@ email = ["dep:lettre"]
 # OAuth 2.0 social login (Google, GitHub, etc.).
 oauth = ["dep:oauth2"]
 
-# SAML 2.0 SSO for enterprise customers.
-saml = ["dep:quick-xml", "dep:x509-parser", "dep:rustls-pemfile"]
+# SAML 2.0 SSO + OIDC SSO for enterprise customers.
+saml = ["dep:quick-xml", "dep:x509-parser", "dep:rustls-pemfile", "dep:openidconnect"]
 
 # Redis cache for sessions, rate limiting, and hot data.
 cache-redis = ["dep:redis"]
@@ -204,6 +204,11 @@ lettre = { version = "0.11", features = ["tokio1-native-tls", "builder", "smtp-t
 
 # OAuth 2.0 (feature: `oauth`)
 oauth2 = { version = "4.4", features = ["reqwest"], optional = true }
+
+# OIDC / OpenID Connect (feature: `saml`) — discovery, ID-token validation
+# (signature via JWKS, iss/aud/exp/nonce checks). Sourced from the workspace
+# so it locks onto the same oauth2 4.x line as the dep above.
+openidconnect = { workspace = true, optional = true }
 
 # Stripe payments (feature: `stripe`)
 async-stripe = { version = "0.41", default-features = false, features = ["runtime-tokio-hyper", "checkout", "webhook-events", "billing", "connect"], optional = true }

--- a/crates/mockforge-registry-server/migrations/20250101000079_sso_email_domain.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000079_sso_email_domain.sql
@@ -1,0 +1,9 @@
+-- Email-domain discovery for SSO: map a work-email domain to the org's IdP.
+ALTER TABLE sso_configurations
+    ADD COLUMN IF NOT EXISTS email_domain VARCHAR(255);
+
+-- One domain maps to at most one org (deterministic discovery). Partial unique
+-- index so it only applies to rows that set a domain.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sso_email_domain
+    ON sso_configurations (lower(email_domain))
+    WHERE email_domain IS NOT NULL;

--- a/crates/mockforge-registry-server/migrations/20250101000080_sso_login_audit_event.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000080_sso_login_audit_event.sql
@@ -1,0 +1,11 @@
+-- Successful SSO login audit event (Issue #746).
+--
+-- Written by both the SAML ACS handler and the OIDC callback handler in
+-- `mockforge-registry-server/src/handlers/{sso,oidc}.rs` after JIT
+-- provisioning succeeds. The `metadata` payload carries `provider`
+-- ("saml" | "oidc").
+--
+-- The Rust mirror is `AuditEventType::SsoLogin` in
+-- `crates/mockforge-registry-core/src/models/audit_log.rs`; the round-trip
+-- test in that file guarantees the snake_case literal below matches.
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'sso_login';

--- a/crates/mockforge-registry-server/migrations/20250101000081_sso_domain_verification.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000081_sso_domain_verification.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sso_configurations
+    ADD COLUMN IF NOT EXISTS domain_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS domain_verification_token VARCHAR(255);

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -29,6 +29,7 @@ pub mod mockai;
 pub mod notification_channels;
 pub mod oauth;
 pub mod observability;
+pub mod oidc;
 pub mod org_templates;
 pub mod organization_settings;
 pub mod organizations;

--- a/crates/mockforge-registry-server/src/handlers/oidc.rs
+++ b/crates/mockforge-registry-server/src/handlers/oidc.rs
@@ -15,8 +15,8 @@ use axum::{
 };
 use openidconnect::{
     core::{CoreAuthenticationFlow, CoreClient, CoreProviderMetadata},
-    reqwest::async_http_client,
-    AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce, RedirectUrl, Scope,
+    url, AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce, RedirectUrl,
+    Scope,
 };
 use serde::Deserialize;
 
@@ -74,12 +74,13 @@ async fn build_oidc_client(
     let issuer_url = IssuerUrl::new(issuer.to_string())
         .map_err(|e| ApiError::InvalidRequest(format!("Invalid OIDC issuer URL: {}", e)))?;
 
-    let provider_metadata = CoreProviderMetadata::discover_async(issuer_url, async_http_client)
-        .await
-        .map_err(|e| {
-            tracing::warn!("OIDC discovery failed for issuer {}: {}", issuer, e);
-            ApiError::InvalidRequest("OIDC provider discovery failed".to_string())
-        })?;
+    let provider_metadata =
+        CoreProviderMetadata::discover_async(issuer_url, http_client_with_timeout)
+            .await
+            .map_err(|e| {
+                tracing::warn!("OIDC discovery failed for issuer {}: {}", issuer, e);
+                ApiError::InvalidRequest("OIDC provider discovery failed".to_string())
+            })?;
 
     let redirect_uri = RedirectUrl::new(format!(
         "{}/api/v1/sso/oidc/callback/{}",
@@ -146,6 +147,11 @@ pub async fn oidc_login(
     State(state): State<AppState>,
     Path(org_slug): Path<String>,
 ) -> Result<Response, ApiError> {
+    let app_base_url = state.config.app_base_url.clone();
+    let err_redirect = |code: &str| {
+        Ok(Redirect::to(&format!("{}/login?sso_error={}", app_base_url, code)).into_response())
+    };
+
     let org = state
         .store
         .find_organization_by_slug(&org_slug)
@@ -153,6 +159,31 @@ pub async fn oidc_login(
         .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
 
     let config = load_oidc_config(&state, &org).await?;
+
+    // SECURITY (#746): fail early — SSO login is only safe once the org has
+    // proven ownership of its email_domain. Without a verified domain the
+    // callback would reject every assertion anyway, so refuse before the IdP
+    // round-trip.
+    if config.email_domain.is_none() || !config.domain_verified {
+        return err_redirect("sso_domain_not_verified");
+    }
+
+    // SECURITY (#746, M4): the issuer URL is tenant-controlled and fetched
+    // server-side during discovery. Block SSRF (loopback/private/link-local/
+    // metadata addresses, non-HTTPS) before any outbound request.
+    match config.oidc_issuer_url.as_deref() {
+        Some(issuer) => match url::Url::parse(issuer) {
+            Ok(parsed) => {
+                if validate_public_https_url(&parsed).await.is_err() {
+                    tracing::warn!("OIDC issuer URL blocked by SSRF guard for org {}", org_slug);
+                    return err_redirect("issuer_blocked");
+                }
+            }
+            Err(_) => return err_redirect("issuer_blocked"),
+        },
+        None => return err_redirect("issuer_blocked"),
+    }
+
     let client = build_oidc_client(&state, &config, &org_slug).await?;
 
     let (auth_url, csrf_token, nonce) = client
@@ -268,6 +299,19 @@ pub async fn oidc_callback(
             return err_redirect("token_invalid");
         }
     };
+
+    // SECURITY (#746, M4): re-validate the tenant-controlled issuer URL before
+    // any server-side fetch (discovery + token exchange) — SSRF guard.
+    match config.oidc_issuer_url.as_deref().and_then(|i| url::Url::parse(i).ok()) {
+        Some(parsed) => {
+            if validate_public_https_url(&parsed).await.is_err() {
+                tracing::warn!("OIDC issuer URL blocked by SSRF guard for org {}", org_slug);
+                return err_redirect("issuer_blocked");
+            }
+        }
+        None => return err_redirect("issuer_blocked"),
+    }
+
     let client = match build_oidc_client(&state, &config, &org_slug).await {
         Ok(c) => c,
         Err(e) => {
@@ -279,7 +323,7 @@ pub async fn oidc_callback(
     // 4. Exchange the authorization code for tokens.
     let token_response = match client
         .exchange_code(AuthorizationCode::new(code))
-        .request_async(async_http_client)
+        .request_async(http_client_with_timeout)
         .await
     {
         Ok(t) => t,
@@ -313,6 +357,18 @@ pub async fn oidc_callback(
         Ok(pair) => pair,
         Err(_) => return err_redirect("no_email"),
     };
+
+    // 6b. SECURITY (#746): the IdP can assert ANY email. Only trust an asserted
+    // email whose domain matches the org's *verified* email_domain. This is the
+    // cross-tenant takeover guard — it MUST run before provisioning.
+    if let Err(e) = crate::handlers::sso::assert_email_in_verified_domain(&email, &config) {
+        let code = match &e {
+            ApiError::InvalidRequest(m) => m.clone(),
+            _ => "domain_mismatch".to_string(),
+        };
+        tracing::warn!("OIDC domain-trust check failed for org {}: {:?}", org_slug, e);
+        return err_redirect(&code);
+    }
 
     // 7. JIT-provision the user + issue a short-lived redirect token.
     let user = find_or_create_sso_user(&state, &email, username.as_deref(), &org).await?;
@@ -352,6 +408,164 @@ fn extract_identity(
     });
 
     Ok((email, username))
+}
+
+// ---------------------------------------------------------------------------
+// SSRF guard + timeout HTTP client (#746 M4)
+// ---------------------------------------------------------------------------
+
+/// Reject a non-global IPv4 address (loopback / private / link-local /
+/// unspecified / broadcast / CGNAT 100.64/10). `is_private` covers 10/8,
+/// 172.16/12, 192.168/16; the rest std doesn't fold into one helper on stable.
+fn is_blocked_ipv4(ip: std::net::Ipv4Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local() // 169.254/16, incl. 169.254.169.254 metadata
+        || ip.is_unspecified()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        // 100.64.0.0/10 — carrier-grade NAT, not publicly routable.
+        || (ip.octets()[0] == 100 && (ip.octets()[1] & 0xC0) == 0x40)
+}
+
+/// Reject a non-global IPv6 address (loopback / unspecified / link-local /
+/// unique-local fc00::/7). Also reject IPv4-mapped addresses whose embedded
+/// v4 is blocked.
+fn is_blocked_ipv6(ip: std::net::Ipv6Addr) -> bool {
+    if ip.is_loopback() || ip.is_unspecified() {
+        return true;
+    }
+    let seg = ip.segments();
+    // fe80::/10 link-local.
+    if (seg[0] & 0xffc0) == 0xfe80 {
+        return true;
+    }
+    // fc00::/7 unique-local.
+    if (seg[0] & 0xfe00) == 0xfc00 {
+        return true;
+    }
+    // IPv4-mapped (::ffff:0:0/96) — defer to the v4 rules.
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return is_blocked_ipv4(v4);
+    }
+    false
+}
+
+fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => is_blocked_ipv4(v4),
+        std::net::IpAddr::V6(v6) => is_blocked_ipv6(v6),
+    }
+}
+
+/// SECURITY (#746, M4): validate a tenant-controlled URL before fetching it
+/// server-side. Requires HTTPS and a *public* host: IP literals are checked
+/// directly; hostnames are resolved and rejected if **any** resolved address
+/// is loopback/private/link-local/metadata/unique-local/unspecified. This is
+/// the primary SSRF defense against issuer URLs pointing at internal services
+/// or the cloud metadata endpoint (169.254.169.254).
+async fn validate_public_https_url(url: &url::Url) -> Result<(), ApiError> {
+    if url.scheme() != "https" {
+        return Err(ApiError::InvalidRequest("issuer_must_be_https".into()));
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| ApiError::InvalidRequest("issuer_no_host".into()))?;
+
+    // IP literal? Check it directly without DNS.
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        if is_blocked_ip(ip) {
+            return Err(ApiError::InvalidRequest("issuer_blocked".into()));
+        }
+        return Ok(());
+    }
+
+    // Hostname: resolve and reject if ANY address is non-public.
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addrs = tokio::net::lookup_host((host, port)).await.map_err(|e| {
+        tracing::warn!("OIDC issuer host resolution failed for {}: {}", host, e);
+        ApiError::InvalidRequest("issuer_unresolvable".into())
+    })?;
+
+    let mut saw_any = false;
+    for sa in addrs {
+        saw_any = true;
+        if is_blocked_ip(sa.ip()) {
+            return Err(ApiError::InvalidRequest("issuer_blocked".into()));
+        }
+    }
+    if !saw_any {
+        return Err(ApiError::InvalidRequest("issuer_unresolvable".into()));
+    }
+
+    Ok(())
+}
+
+/// Shared reqwest client for OIDC discovery + token exchange, built once with a
+/// 10s timeout and redirects disabled (following redirects re-opens the SSRF
+/// hole the `validate_public_https_url` pre-check closes).
+fn oidc_http_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            // Fall back to the default client if the builder somehow fails;
+            // the SSRF pre-check is the primary defense regardless.
+            .unwrap_or_default()
+    })
+}
+
+/// Timeout-bounded async HTTP client matching openidconnect's
+/// `FnOnce(HttpRequest) -> Future<Result<HttpResponse, _>>` contract, backed by
+/// [`oidc_http_client`]. Mirrors `oauth2::reqwest::async_http_client` but reuses
+/// a shared client carrying a 10s timeout + no-redirect policy.
+///
+/// openidconnect 3.5 / oauth2 4.4 model their `HttpRequest`/`HttpResponse` on
+/// `http` 0.2, while reqwest 0.12 speaks `http` 1.x — so method/header/status
+/// values are bridged across the two versions via their byte/string forms.
+async fn http_client_with_timeout(
+    request: openidconnect::HttpRequest,
+) -> Result<openidconnect::HttpResponse, openidconnect::reqwest::Error<reqwest::Error>> {
+    use openidconnect::reqwest::Error;
+
+    let client = oidc_http_client();
+
+    // Bridge http 0.2 Method -> reqwest (http 1.x) Method via its str form.
+    let method = reqwest::Method::from_bytes(request.method.as_str().as_bytes())
+        .map_err(|e| Error::Other(format!("invalid HTTP method: {e}")))?;
+
+    let mut request_builder = client.request(method, request.url.as_str()).body(request.body);
+    for (name, value) in &request.headers {
+        request_builder = request_builder.header(name.as_str(), value.as_bytes());
+    }
+    let req = request_builder.build().map_err(Error::Reqwest)?;
+
+    let response = client.execute(req).await.map_err(Error::Reqwest)?;
+
+    // Bridge reqwest (http 1.x) StatusCode -> http 0.2 StatusCode.
+    let status_code = openidconnect::http::StatusCode::from_u16(response.status().as_u16())
+        .map_err(|e| Error::Other(format!("invalid status code: {e}")))?;
+
+    // Bridge reqwest (http 1.x) headers -> http 0.2 HeaderMap.
+    let mut headers = openidconnect::http::HeaderMap::new();
+    for (name, value) in response.headers() {
+        if let (Ok(n), Ok(v)) = (
+            openidconnect::http::header::HeaderName::from_bytes(name.as_str().as_bytes()),
+            openidconnect::http::HeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            headers.append(n, v);
+        }
+    }
+
+    let chunks = response.bytes().await.map_err(Error::Reqwest)?;
+    Ok(openidconnect::HttpResponse {
+        status_code,
+        headers,
+        body: chunks.to_vec(),
+    })
 }
 
 #[cfg(test)]
@@ -399,5 +613,57 @@ mod tests {
         let claims = base_claims("user-3");
         let result = extract_identity(&claims);
         assert!(result.is_err(), "missing email claim must be an error");
+    }
+
+    // ---- SSRF guard (#746 M4) ----
+
+    fn ip(s: &str) -> std::net::IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn ssrf_blocks_loopback_private_linklocal_metadata() {
+        assert!(is_blocked_ip(ip("127.0.0.1")));
+        assert!(is_blocked_ip(ip("10.0.0.5")));
+        assert!(is_blocked_ip(ip("172.16.4.2")));
+        assert!(is_blocked_ip(ip("192.168.1.1")));
+        assert!(is_blocked_ip(ip("169.254.169.254"))); // cloud metadata
+        assert!(is_blocked_ip(ip("0.0.0.0")));
+        assert!(is_blocked_ip(ip("100.64.0.1"))); // CGNAT
+        assert!(is_blocked_ip(ip("::1"))); // ipv6 loopback
+        assert!(is_blocked_ip(ip("fc00::1"))); // ULA
+        assert!(is_blocked_ip(ip("fe80::1"))); // ipv6 link-local
+        assert!(is_blocked_ip(ip("::ffff:127.0.0.1"))); // ipv4-mapped loopback
+    }
+
+    #[test]
+    fn ssrf_allows_public_ips() {
+        assert!(!is_blocked_ip(ip("8.8.8.8")));
+        assert!(!is_blocked_ip(ip("1.1.1.1")));
+        assert!(!is_blocked_ip(ip("2606:4700:4700::1111")));
+    }
+
+    #[tokio::test]
+    async fn ssrf_rejects_non_https_scheme() {
+        let u = url::Url::parse("http://idp.example.com/").unwrap();
+        assert!(validate_public_https_url(&u).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn ssrf_rejects_https_ip_literal_loopback() {
+        let u = url::Url::parse("https://127.0.0.1/").unwrap();
+        assert!(validate_public_https_url(&u).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn ssrf_rejects_https_metadata_literal() {
+        let u = url::Url::parse("https://169.254.169.254/latest/meta-data").unwrap();
+        assert!(validate_public_https_url(&u).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn ssrf_allows_https_public_ip_literal() {
+        let u = url::Url::parse("https://8.8.8.8/").unwrap();
+        assert!(validate_public_https_url(&u).await.is_ok());
     }
 }

--- a/crates/mockforge-registry-server/src/handlers/oidc.rs
+++ b/crates/mockforge-registry-server/src/handlers/oidc.rs
@@ -1,0 +1,403 @@
+//! OIDC (OpenID Connect) SSO handlers
+//!
+//! Implements the OIDC authorization-code flow for Team-plan organizations:
+//! discovery → authorize redirect → callback → **ID-token validation**
+//! (signature via discovered JWKS, plus `iss` / `aud` / `exp` / `nonce`) →
+//! JIT user provisioning → short-lived redirect token.
+//!
+//! Mirrors the Redis CSRF-state pattern in `handlers/oauth.rs` and the
+//! Team-plan gate + final redirect shape in `handlers/sso.rs` (SAML).
+
+use axum::{
+    extract::{Path, Query, State},
+    http::HeaderMap,
+    response::{IntoResponse, Redirect, Response},
+};
+use openidconnect::{
+    core::{CoreAuthenticationFlow, CoreClient, CoreProviderMetadata},
+    reqwest::async_http_client,
+    AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce, RedirectUrl, Scope,
+};
+use serde::Deserialize;
+
+use crate::{
+    error::ApiError,
+    handlers::sso::{find_or_create_sso_user, record_sso_login_audit},
+    models::Plan,
+    AppState,
+};
+
+/// Redis TTL for a pending OIDC authorization (CSRF state + nonce), in seconds.
+/// Mirrors the 15-minute window oauth.rs uses for its CSRF state.
+const OIDC_STATE_TTL_SECS: u64 = 900;
+
+/// Value stored in Redis under `oidc:state:{state}` while the user is at the IdP.
+/// Serialized as JSON so the callback can recover the nonce + org binding.
+#[derive(Debug, serde::Serialize, Deserialize)]
+struct PendingOidcAuth {
+    nonce: String,
+    org_slug: String,
+}
+
+/// Query params on the IdP callback (`?code=...&state=...`).
+#[derive(Debug, Deserialize)]
+pub struct OidcCallbackParams {
+    pub code: Option<String>,
+    pub state: Option<String>,
+}
+
+/// Build the OIDC client for an organization via discovery.
+///
+/// Performs `.well-known/openid-configuration` discovery against the issuer,
+/// then constructs a [`CoreClient`] with the configured client id/secret and
+/// the callback redirect URI. The redirect URI is an **API** URL
+/// (`{app_base_url}/api/v1/sso/oidc/callback/{org_slug}`) using the same base
+/// the SAML ACS URL is built from in `handlers/sso.rs`.
+async fn build_oidc_client(
+    state: &AppState,
+    config: &crate::models::SSOConfiguration,
+    org_slug: &str,
+) -> Result<CoreClient, ApiError> {
+    let issuer = config
+        .oidc_issuer_url
+        .as_deref()
+        .ok_or_else(|| ApiError::InvalidRequest("OIDC issuer URL not configured".to_string()))?;
+    let client_id = config
+        .oidc_client_id
+        .as_deref()
+        .ok_or_else(|| ApiError::InvalidRequest("OIDC client ID not configured".to_string()))?;
+    let client_secret = config
+        .oidc_client_secret
+        .as_deref()
+        .ok_or_else(|| ApiError::InvalidRequest("OIDC client secret not configured".to_string()))?;
+
+    let issuer_url = IssuerUrl::new(issuer.to_string())
+        .map_err(|e| ApiError::InvalidRequest(format!("Invalid OIDC issuer URL: {}", e)))?;
+
+    let provider_metadata = CoreProviderMetadata::discover_async(issuer_url, async_http_client)
+        .await
+        .map_err(|e| {
+            tracing::warn!("OIDC discovery failed for issuer {}: {}", issuer, e);
+            ApiError::InvalidRequest("OIDC provider discovery failed".to_string())
+        })?;
+
+    let redirect_uri = RedirectUrl::new(format!(
+        "{}/api/v1/sso/oidc/callback/{}",
+        state.config.app_base_url, org_slug
+    ))
+    .map_err(|e| ApiError::Internal(anyhow::anyhow!("Invalid OIDC redirect URI: {}", e)))?;
+
+    let client = CoreClient::from_provider_metadata(
+        provider_metadata,
+        ClientId::new(client_id.to_string()),
+        Some(ClientSecret::new(client_secret.to_string())),
+    )
+    .set_redirect_uri(redirect_uri);
+
+    Ok(client)
+}
+
+/// Load the org's SSO config and assert it's an enabled, fully-configured OIDC
+/// setup on a Team plan. Mirrors the SAML login gate.
+async fn load_oidc_config(
+    state: &AppState,
+    org: &crate::models::Organization,
+) -> Result<crate::models::SSOConfiguration, ApiError> {
+    // Team-plan gate (identical to SAML login / SSO-config handlers).
+    if org.plan() != Plan::Team {
+        return Err(ApiError::InvalidRequest("SSO is only available for Team plans".to_string()));
+    }
+
+    let config = state.store.find_sso_config_by_org(org.id).await?.ok_or_else(|| {
+        ApiError::InvalidRequest("SSO not configured for this organization".to_string())
+    })?;
+
+    if !config.enabled {
+        return Err(ApiError::InvalidRequest(
+            "SSO is not enabled for this organization".to_string(),
+        ));
+    }
+
+    if config.provider != "oidc" {
+        return Err(ApiError::InvalidRequest(
+            "This organization is not configured for OIDC SSO".to_string(),
+        ));
+    }
+
+    if config.oidc_issuer_url.is_none()
+        || config.oidc_client_id.is_none()
+        || config.oidc_client_secret.is_none()
+    {
+        return Err(ApiError::InvalidRequest(
+            "OIDC configuration is incomplete (issuer URL, client ID, and client secret are required)"
+                .to_string(),
+        ));
+    }
+
+    Ok(config)
+}
+
+/// `GET /api/v1/sso/oidc/login/{org_slug}` — initiate the OIDC login flow.
+///
+/// Discovers the IdP, builds the authorization URL with a random CSRF state +
+/// nonce, persists `{nonce, org_slug}` in Redis keyed by the state value, and
+/// redirects the browser to the IdP.
+pub async fn oidc_login(
+    State(state): State<AppState>,
+    Path(org_slug): Path<String>,
+) -> Result<Response, ApiError> {
+    let org = state
+        .store
+        .find_organization_by_slug(&org_slug)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    let config = load_oidc_config(&state, &org).await?;
+    let client = build_oidc_client(&state, &config, &org_slug).await?;
+
+    let (auth_url, csrf_token, nonce) = client
+        .authorize_url(
+            CoreAuthenticationFlow::AuthorizationCode,
+            CsrfToken::new_random,
+            Nonce::new_random,
+        )
+        .add_scope(Scope::new("email".to_string()))
+        .add_scope(Scope::new("profile".to_string()))
+        .url();
+
+    // Persist the nonce + org binding keyed by the CSRF state. Redis is
+    // required here for the same reason as oauth.rs: without it we cannot
+    // securely tie the callback back to this request (CSRF / nonce replay).
+    let pending = PendingOidcAuth {
+        nonce: nonce.secret().to_string(),
+        org_slug: org_slug.clone(),
+    };
+    let state_key = format!("oidc:state:{}", csrf_token.secret());
+    let state_value = serde_json::to_string(&pending)
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to encode OIDC state: {}", e)))?;
+
+    if let Some(redis) = &state.redis {
+        redis
+            .set_with_expiry(&state_key, &state_value, OIDC_STATE_TTL_SECS)
+            .await
+            .map_err(|e| {
+                ApiError::Internal(anyhow::anyhow!("Failed to store OIDC state: {}", e))
+            })?;
+    } else {
+        return Err(ApiError::Internal(anyhow::anyhow!(
+            "OIDC SSO requires Redis for CSRF protection. Please configure REDIS_URL."
+        )));
+    }
+
+    Ok(Redirect::to(auth_url.as_str()).into_response())
+}
+
+/// `GET /api/v1/sso/oidc/callback/{org_slug}` — complete the OIDC flow.
+///
+/// Verifies the CSRF state against Redis (one-time use), exchanges the code,
+/// **validates the ID token** (signature + iss/aud/exp + nonce), provisions
+/// the user, audits the login, and redirects to the same frontend URL shape
+/// as SAML: `{app_base_url}/auth/sso/callback?token=...&org_slug=...`.
+///
+/// On any auth/crypto failure it redirects to `{app_base_url}/login?sso_error=...`
+/// with a coarse error code — the underlying error is only ever logged, never
+/// surfaced to the user.
+pub async fn oidc_callback(
+    State(state): State<AppState>,
+    Path(org_slug): Path<String>,
+    headers: HeaderMap,
+    Query(params): Query<OidcCallbackParams>,
+) -> Result<Response, ApiError> {
+    let app_base_url = state.config.app_base_url.clone();
+    let err_redirect = |code: &str| {
+        Ok(Redirect::to(&format!("{}/login?sso_error={}", app_base_url, code)).into_response())
+    };
+
+    // 1. Required query params.
+    let (code, csrf_state) = match (params.code, params.state) {
+        (Some(c), Some(s)) => (c, s),
+        _ => return err_redirect("invalid_state"),
+    };
+
+    // 2. Recover + consume the pending auth from Redis (one-time use).
+    let Some(redis) = &state.redis else {
+        tracing::error!("OIDC callback hit with no Redis configured");
+        return err_redirect("invalid_state");
+    };
+    let state_key = format!("oidc:state:{}", csrf_state);
+    let stored = match redis.get(&state_key).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("OIDC state lookup failed: {}", e);
+            return err_redirect("invalid_state");
+        }
+    };
+    let Some(stored) = stored else {
+        return err_redirect("invalid_state");
+    };
+    // Consume immediately to prevent replay regardless of what follows.
+    let _ = redis.delete(&state_key).await;
+
+    let pending: PendingOidcAuth = match serde_json::from_str(&stored) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("OIDC state decode failed: {}", e);
+            return err_redirect("invalid_state");
+        }
+    };
+
+    // Path org_slug must match the one bound at login time.
+    if pending.org_slug != org_slug {
+        tracing::warn!(
+            "OIDC callback org_slug mismatch: path={} state={}",
+            org_slug,
+            pending.org_slug
+        );
+        return err_redirect("invalid_state");
+    }
+
+    // 3. Reload org + config and rebuild the client.
+    let org = match state.store.find_organization_by_slug(&org_slug).await? {
+        Some(o) => o,
+        None => return err_redirect("invalid_state"),
+    };
+    let config = match load_oidc_config(&state, &org).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("OIDC callback config load failed for org {}: {:?}", org_slug, e);
+            return err_redirect("token_invalid");
+        }
+    };
+    let client = match build_oidc_client(&state, &config, &org_slug).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("OIDC client build failed for org {}: {:?}", org_slug, e);
+            return err_redirect("token_invalid");
+        }
+    };
+
+    // 4. Exchange the authorization code for tokens.
+    let token_response = match client
+        .exchange_code(AuthorizationCode::new(code))
+        .request_async(async_http_client)
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("OIDC code exchange failed for org {}: {}", org_slug, e);
+            return err_redirect("token_invalid");
+        }
+    };
+
+    // 5. Validate the ID token: signature (JWKS from discovery), iss, aud,
+    //    exp, and nonce. Never leak the crypto error to the user.
+    let id_token = match openidconnect::TokenResponse::id_token(&token_response) {
+        Some(t) => t,
+        None => {
+            tracing::warn!("OIDC token response missing id_token for org {}", org_slug);
+            return err_redirect("token_invalid");
+        }
+    };
+
+    let nonce = Nonce::new(pending.nonce);
+    let claims = match id_token.claims(&client.id_token_verifier(), &nonce) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("OIDC ID-token validation failed for org {}: {}", org_slug, e);
+            return err_redirect("token_invalid");
+        }
+    };
+
+    // 6. Extract identity from the validated claims.
+    let (email, username) = match extract_identity(claims) {
+        Ok(pair) => pair,
+        Err(_) => return err_redirect("no_email"),
+    };
+
+    // 7. JIT-provision the user + issue a short-lived redirect token.
+    let user = find_or_create_sso_user(&state, &email, username.as_deref(), &org).await?;
+
+    record_sso_login_audit(&state, &org, &user, "oidc", &headers).await;
+
+    let token = crate::auth::create_token(&user.id.to_string(), &state.config.jwt_secret)
+        .map_err(ApiError::Internal)?;
+
+    // 8. Redirect to the app — SAME shape as the SAML ACS success path.
+    let redirect_url =
+        format!("{}/auth/sso/callback?token={}&org_slug={}", app_base_url, token, org_slug);
+    Ok(Redirect::to(&redirect_url).into_response())
+}
+
+/// Pull `(email, username)` out of validated OIDC ID-token claims.
+///
+/// Email is **required** (it's the JIT-provisioning key) — absence is an
+/// error. Username is best-effort: `preferred_username` then `name`, else
+/// `None` (the provisioner falls back to the email local-part).
+fn extract_identity(
+    claims: &openidconnect::IdTokenClaims<
+        openidconnect::EmptyAdditionalClaims,
+        openidconnect::core::CoreGenderClaim,
+    >,
+) -> Result<(String, Option<String>), ApiError> {
+    let email = claims
+        .email()
+        .map(|e| e.as_str().to_string())
+        .ok_or_else(|| ApiError::InvalidRequest("OIDC ID token missing email claim".to_string()))?;
+
+    let username = claims.preferred_username().map(|u| u.as_str().to_string()).or_else(|| {
+        claims
+            .name()
+            .and_then(|localized| localized.get(None))
+            .map(|n| n.as_str().to_string())
+    });
+
+    Ok((email, username))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openidconnect::{
+        core::CoreIdTokenClaims, Audience, EmptyAdditionalClaims, EndUserUsername, IssuerUrl,
+        StandardClaims, SubjectIdentifier,
+    };
+
+    fn base_claims(sub: &str) -> CoreIdTokenClaims {
+        CoreIdTokenClaims::new(
+            IssuerUrl::new("https://idp.example.com".to_string()).unwrap(),
+            vec![Audience::new("client-123".to_string())],
+            chrono::Utc::now() + chrono::Duration::hours(1),
+            chrono::Utc::now(),
+            StandardClaims::new(SubjectIdentifier::new(sub.to_string())),
+            EmptyAdditionalClaims {},
+        )
+    }
+
+    #[test]
+    fn extract_identity_returns_email_and_preferred_username() {
+        let claims = base_claims("user-1")
+            .set_email(Some(openidconnect::EndUserEmail::new("jane@example.com".to_string())))
+            .set_preferred_username(Some(EndUserUsername::new("jane".to_string())));
+
+        let (email, username) = extract_identity(&claims).expect("email present => Ok");
+        assert_eq!(email, "jane@example.com");
+        assert_eq!(username.as_deref(), Some("jane"));
+    }
+
+    #[test]
+    fn extract_identity_username_is_optional() {
+        let claims = base_claims("user-2")
+            .set_email(Some(openidconnect::EndUserEmail::new("noname@example.com".to_string())));
+
+        let (email, username) = extract_identity(&claims).expect("email present => Ok");
+        assert_eq!(email, "noname@example.com");
+        assert_eq!(username, None);
+    }
+
+    #[test]
+    fn extract_identity_errors_when_email_absent() {
+        let claims = base_claims("user-3");
+        let result = extract_identity(&claims);
+        assert!(result.is_err(), "missing email claim must be an error");
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -3,7 +3,7 @@
 //! Handles SAML 2.0 SSO setup and authentication for Team plan organizations
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::HeaderMap,
     response::{IntoResponse, Redirect, Response},
     Form, Json,
@@ -1272,4 +1272,60 @@ fn validate_saml_timestamps(user_info: &SAMLUserInfo) -> Result<(), ApiError> {
 
     tracing::debug!("SAML timestamp validation passed");
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// SSO discovery endpoint
+// ---------------------------------------------------------------------------
+
+/// Query parameters for `GET /api/v1/sso/discover`.
+#[derive(Debug, Deserialize)]
+pub struct SsoDiscoverQuery {
+    pub email: String,
+}
+
+/// Response body for a successful SSO discovery lookup.
+#[derive(Debug, Serialize)]
+pub struct SsoDiscoverResponse {
+    pub org_slug: String,
+    pub provider: String,
+}
+
+/// `GET /api/v1/sso/discover?email=<email>` — public, no auth required.
+///
+/// Maps a work email address to the organisation's configured IdP so the
+/// login page can redirect directly to the correct SSO flow.
+///
+/// Returns 404 with a **generic** message on any non-match (missing domain,
+/// no enabled config, or unparsable email) to prevent email-domain
+/// enumeration by unauthenticated callers.
+pub async fn discover_sso(
+    State(state): State<AppState>,
+    Query(params): Query<SsoDiscoverQuery>,
+) -> ApiResult<Json<SsoDiscoverResponse>> {
+    let domain = crate::models::normalize_email_domain(&params.email)
+        .ok_or_else(|| ApiError::OrganizationNotFound)?;
+
+    let (org_slug, provider) = state
+        .store
+        .find_org_slug_by_email_domain(&domain)
+        .await?
+        .ok_or(ApiError::OrganizationNotFound)?;
+
+    Ok(Json(SsoDiscoverResponse { org_slug, provider }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sso_discover_response_fields() {
+        let resp = SsoDiscoverResponse {
+            org_slug: "acme".to_string(),
+            provider: "saml".to_string(),
+        };
+        assert_eq!(resp.org_slug, "acme");
+        assert_eq!(resp.provider, "saml");
+    }
 }

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -537,6 +537,7 @@ pub struct SAMLResponseForm {
 pub async fn saml_acs(
     State(state): State<AppState>,
     Path(org_slug): Path<String>,
+    headers: HeaderMap,
     Form(form): Form<SAMLResponseForm>,
 ) -> Result<Response, ApiError> {
     let pool = state.db.pool();
@@ -613,6 +614,9 @@ pub async fn saml_acs(
         .as_deref()
         .ok_or_else(|| ApiError::InvalidRequest("Email not found in SAML assertion".to_string()))?;
     let user = find_or_create_sso_user(&state, email, user_info.username.as_deref(), &org).await?;
+
+    // Audit the successful SSO login (provider: saml).
+    record_sso_login_audit(&state, &org, &user, "saml", &headers).await;
 
     // Record assertion ID to prevent replay attacks
     if let Some(assertion_id) = &user_info.assertion_id {
@@ -1178,7 +1182,7 @@ fn generate_saml_logout_response(slo_url: &str) -> String {
 ///
 /// Used by both SAML ACS and OIDC callback handlers.  `email` is required;
 /// `username` is optional — when absent the email local-part is used.
-async fn find_or_create_sso_user(
+pub(crate) async fn find_or_create_sso_user(
     state: &AppState,
     email: &str,
     username: Option<&str>,
@@ -1218,6 +1222,40 @@ async fn find_or_create_sso_user(
     };
 
     Ok(user)
+}
+
+/// Record a successful SSO login in the audit log (protocol-agnostic).
+///
+/// Shared by the SAML ACS and OIDC callback handlers. `provider` is "saml"
+/// or "oidc" and is also stored in the event `metadata`. Best-effort: a
+/// failure to write the audit row must never block the login redirect, so
+/// `record_audit_event` itself swallows DB errors (returns `()`).
+pub(crate) async fn record_sso_login_audit(
+    state: &AppState,
+    org: &Organization,
+    user: &User,
+    provider: &str,
+    headers: &HeaderMap,
+) {
+    let ip_address = headers
+        .get("X-Forwarded-For")
+        .or_else(|| headers.get("X-Real-IP"))
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.split(',').next().unwrap_or(s).trim().to_string());
+    let user_agent = headers.get("User-Agent").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+
+    state
+        .store
+        .record_audit_event(
+            org.id,
+            Some(user.id),
+            AuditEventType::SsoLogin,
+            format!("SSO login via {}", provider),
+            Some(serde_json::json!({ "provider": provider })),
+            ip_address.as_deref(),
+            user_agent.as_deref(),
+        )
+        .await;
 }
 
 /// Validate SAML assertion timestamps (NotBefore/NotOnOrAfter)

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -38,6 +38,10 @@ pub struct CreateSSOConfigRequest {
     pub require_signed_assertions: Option<bool>,
     pub require_signed_responses: Option<bool>,
     pub allow_unsolicited_responses: Option<bool>,
+    pub oidc_issuer_url: Option<String>,
+    pub oidc_client_id: Option<String>,
+    pub oidc_client_secret: Option<String>,
+    pub email_domain: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -54,6 +58,10 @@ pub struct SSOConfigResponse {
     pub require_signed_assertions: bool,
     pub require_signed_responses: bool,
     pub allow_unsolicited_responses: bool,
+    pub oidc_issuer_url: Option<String>,
+    pub oidc_client_id: Option<String>,
+    // oidc_client_secret is intentionally NOT returned — never echo secrets
+    pub email_domain: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -117,6 +125,17 @@ pub async fn create_sso_config(
         ));
     }
 
+    // Validate OIDC fields if provider is OIDC
+    if provider == SSOProvider::Oidc
+        && (request.oidc_issuer_url.is_none()
+            || request.oidc_client_id.is_none()
+            || request.oidc_client_secret.is_none())
+    {
+        return Err(ApiError::InvalidRequest(
+            "OIDC configuration requires issuer_url, client_id, and client_secret".to_string(),
+        ));
+    }
+
     // Create or update SSO configuration
     let config = state
         .store
@@ -132,6 +151,10 @@ pub async fn create_sso_config(
             request.require_signed_assertions.unwrap_or(true),
             request.require_signed_responses.unwrap_or(true),
             request.allow_unsolicited_responses.unwrap_or(false),
+            request.oidc_issuer_url.as_deref(),
+            request.oidc_client_id.as_deref(),
+            request.oidc_client_secret.as_deref(),
+            request.email_domain.as_deref(),
         )
         .await?;
 
@@ -172,6 +195,10 @@ pub async fn create_sso_config(
         require_signed_assertions: config.require_signed_assertions,
         require_signed_responses: config.require_signed_responses,
         allow_unsolicited_responses: config.allow_unsolicited_responses,
+        oidc_issuer_url: config.oidc_issuer_url,
+        oidc_client_id: config.oidc_client_id,
+        // oidc_client_secret intentionally omitted — never echo secrets
+        email_domain: config.email_domain,
         created_at: config.created_at.to_rfc3339(),
         updated_at: config.updated_at.to_rfc3339(),
     }))
@@ -220,6 +247,10 @@ pub async fn get_sso_config(
             require_signed_assertions: config.require_signed_assertions,
             require_signed_responses: config.require_signed_responses,
             allow_unsolicited_responses: config.allow_unsolicited_responses,
+            oidc_issuer_url: config.oidc_issuer_url,
+            oidc_client_id: config.oidc_client_id,
+            // oidc_client_secret intentionally omitted — never echo secrets
+            email_domain: config.email_domain,
             created_at: config.created_at.to_rfc3339(),
             updated_at: config.updated_at.to_rfc3339(),
         })))

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -607,8 +607,12 @@ pub async fn saml_acs(
         }
     }
 
-    // Find or create user
-    let user = find_or_create_user_from_saml(&state, &user_info, &org).await?;
+    // Find or create user (JIT provisioning)
+    let email = user_info
+        .email
+        .as_deref()
+        .ok_or_else(|| ApiError::InvalidRequest("Email not found in SAML assertion".to_string()))?;
+    let user = find_or_create_sso_user(&state, email, user_info.username.as_deref(), &org).await?;
 
     // Record assertion ID to prevent replay attacks
     if let Some(assertion_id) = &user_info.assertion_id {
@@ -1170,51 +1174,44 @@ fn generate_saml_logout_response(slo_url: &str) -> String {
     )
 }
 
-/// Find or create user from SAML attributes
-async fn find_or_create_user_from_saml(
+/// Find or create a user via SSO JIT provisioning (protocol-agnostic).
+///
+/// Used by both SAML ACS and OIDC callback handlers.  `email` is required;
+/// `username` is optional — when absent the email local-part is used.
+async fn find_or_create_sso_user(
     state: &AppState,
-    user_info: &SAMLUserInfo,
+    email: &str,
+    username: Option<&str>,
     org: &Organization,
 ) -> Result<User, ApiError> {
-    // Try to find user by email
-    let user = if let Some(email) = &user_info.email {
-        state.store.find_user_by_email(email).await?
-    } else {
-        None
-    };
+    use crate::models::organization::OrgRole;
 
-    let user = if let Some(user) = user {
+    // Try to find existing user by email
+    let existing = state.store.find_user_by_email(email).await?;
+
+    let user = if let Some(user) = existing {
         // User exists - ensure they're a member of the organization
-        use crate::models::organization::OrgRole;
-
         if state.store.find_org_member(org.id, user.id).await?.is_none() {
             state.store.create_org_member(org.id, user.id, OrgRole::Member).await?;
         }
-
         user
     } else {
-        // Create new user from SAML attributes
-        let email = user_info.email.as_ref().ok_or_else(|| {
-            ApiError::InvalidRequest("Email not found in SAML assertion".to_string())
-        })?;
+        // Derive username from the caller-supplied value or the email local-part
+        let derived_username = username
+            .map(|u| u.to_string())
+            .unwrap_or_else(|| email.split('@').next().unwrap_or("user").to_string());
 
-        let username = user_info.username.as_ref().cloned().unwrap_or_else(|| {
-            // Generate username from email
-            email.split('@').next().unwrap_or("user").to_string()
-        });
-
-        // Generate a random password (user won't need it for SSO login)
+        // Generate a random password (SSO users never use password login)
         let password_hash = crate::auth::hash_password(&uuid::Uuid::new_v4().to_string())
             .map_err(ApiError::Internal)?;
 
         // Create user
-        let user = state.store.create_user(&username, email, &password_hash).await?;
+        let user = state.store.create_user(&derived_username, email, &password_hash).await?;
 
         // Mark user as verified (SSO users are pre-verified)
         state.store.mark_user_verified(user.id).await?;
 
         // Add user to organization as member
-        use crate::models::organization::OrgRole;
         state.store.create_org_member(org.id, user.id, OrgRole::Member).await?;
 
         user

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -715,6 +715,16 @@ pub async fn initiate_saml_login(
         ));
     }
 
+    // SECURITY (#746): fail early (better UX) — SSO login is only safe once the
+    // org has proven ownership of its email_domain. Without a verified domain the
+    // ACS callback would reject every assertion anyway, so refuse before the IdP
+    // round-trip.
+    if config.email_domain.is_none() || !config.domain_verified {
+        return Err(ApiError::InvalidRequest(
+            "SSO domain not verified. Verify your email domain in organization settings before enabling SSO login.".to_string(),
+        ));
+    }
+
     // Get SAML SSO URL
     let sso_url = config
         .saml_sso_url
@@ -830,6 +840,14 @@ pub async fn saml_acs(
         .email
         .as_deref()
         .ok_or_else(|| ApiError::InvalidRequest("Email not found in SAML assertion".to_string()))?;
+
+    // SECURITY (#746): the IdP can assert ANY email. Refuse to provision/log in
+    // an identity whose domain isn't the org's *verified* email_domain — this is
+    // the cross-tenant takeover guard. Must run BEFORE find_or_create_sso_user.
+    assert_email_in_verified_domain(email, &config).inspect_err(|e| {
+        tracing::warn!("SAML domain-trust check failed for org_id={}: {:?}", org.id, e);
+    })?;
+
     let user = find_or_create_sso_user(&state, email, user_info.username.as_deref(), &org).await?;
 
     // Audit the successful SSO login (provider: saml).
@@ -1395,6 +1413,28 @@ fn generate_saml_logout_response(slo_url: &str) -> String {
     )
 }
 
+/// SECURITY (#746): an org's IdP may assert any email. Only trust an asserted
+/// email whose domain matches the org's *verified* email_domain. Prevents one
+/// org's IdP from asserting identities in another org's namespace.
+pub(crate) fn assert_email_in_verified_domain(
+    email: &str,
+    config: &SSOConfiguration,
+) -> Result<(), ApiError> {
+    let asserted = crate::models::normalize_email_domain(email)
+        .ok_or_else(|| ApiError::InvalidRequest("no_email".into()))?;
+    let configured = config
+        .email_domain
+        .as_deref()
+        .ok_or_else(|| ApiError::InvalidRequest("sso_domain_not_configured".into()))?;
+    if !config.domain_verified {
+        return Err(ApiError::InvalidRequest("sso_domain_not_verified".into()));
+    }
+    if !asserted.eq_ignore_ascii_case(configured) {
+        return Err(ApiError::InvalidRequest("domain_mismatch".into()));
+    }
+    Ok(())
+}
+
 /// Find or create a user via SSO JIT provisioning (protocol-agnostic).
 ///
 /// Used by both SAML ACS and OIDC callback handlers.  `email` is required;
@@ -1582,5 +1622,86 @@ mod tests {
         };
         assert_eq!(resp.org_slug, "acme");
         assert_eq!(resp.provider, "saml");
+    }
+
+    /// Build a minimal SSOConfiguration for domain-trust tests.
+    fn cfg(email_domain: Option<&str>, domain_verified: bool) -> SSOConfiguration {
+        SSOConfiguration {
+            id: uuid::Uuid::new_v4(),
+            org_id: uuid::Uuid::new_v4(),
+            provider: "oidc".to_string(),
+            enabled: true,
+            saml_entity_id: None,
+            saml_sso_url: None,
+            saml_slo_url: None,
+            saml_x509_cert: None,
+            saml_name_id_format: None,
+            oidc_issuer_url: None,
+            oidc_client_id: None,
+            oidc_client_secret: None,
+            email_domain: email_domain.map(|s| s.to_string()),
+            domain_verified,
+            domain_verification_token: None,
+            attribute_mapping: serde_json::json!({}),
+            require_signed_assertions: true,
+            require_signed_responses: true,
+            allow_unsolicited_responses: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn err_msg(r: Result<(), ApiError>) -> String {
+        match r {
+            Err(ApiError::InvalidRequest(m)) => m,
+            other => panic!("expected InvalidRequest, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn domain_trust_verified_match_ok() {
+        let config = cfg(Some("acme.com"), true);
+        assert!(assert_email_in_verified_domain("jane@acme.com", &config).is_ok());
+    }
+
+    #[test]
+    fn domain_trust_match_is_case_insensitive() {
+        let config = cfg(Some("ACME.com"), true);
+        assert!(assert_email_in_verified_domain("jane@acme.COM", &config).is_ok());
+    }
+
+    #[test]
+    fn domain_trust_unverified_domain_rejected() {
+        let config = cfg(Some("acme.com"), false);
+        assert_eq!(
+            err_msg(assert_email_in_verified_domain("jane@acme.com", &config)),
+            "sso_domain_not_verified"
+        );
+    }
+
+    #[test]
+    fn domain_trust_mismatch_rejected() {
+        // The takeover case: org's verified domain is acme.com but the IdP
+        // asserts a victim in another org's namespace.
+        let config = cfg(Some("acme.com"), true);
+        assert_eq!(
+            err_msg(assert_email_in_verified_domain("victim@evil.com", &config)),
+            "domain_mismatch"
+        );
+    }
+
+    #[test]
+    fn domain_trust_no_email_domain_rejected() {
+        let config = cfg(None, true);
+        assert_eq!(
+            err_msg(assert_email_in_verified_domain("jane@acme.com", &config)),
+            "sso_domain_not_configured"
+        );
+    }
+
+    #[test]
+    fn domain_trust_bad_email_rejected() {
+        let config = cfg(Some("acme.com"), true);
+        assert_eq!(err_msg(assert_email_in_verified_domain("not-an-email", &config)), "no_email");
     }
 }

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -62,6 +62,11 @@ pub struct SSOConfigResponse {
     pub oidc_client_id: Option<String>,
     // oidc_client_secret is intentionally NOT returned — never echo secrets
     pub email_domain: Option<String>,
+    /// Whether the email domain has been proven via a DNS TXT record.
+    pub domain_verified: bool,
+    /// The token the org admin publishes as a DNS TXT record on their domain.
+    /// Safe to return — it is what they must add to prove ownership.
+    pub domain_verification_token: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -136,6 +141,30 @@ pub async fn create_sso_config(
         ));
     }
 
+    // Determine domain-verification state. When an email domain is supplied we
+    // must (re)issue a fresh DNS-TXT verification token whenever the domain is
+    // new or changed, but preserve the existing verification status on an
+    // unrelated config edit so a verified domain isn't silently reset.
+    let existing = state.store.find_sso_config_by_org(org_ctx.org_id).await?;
+    let (domain_verified, domain_verification_token): (bool, Option<String>) =
+        match request.email_domain.as_deref() {
+            Some(requested) => {
+                let unchanged = existing
+                    .as_ref()
+                    .and_then(|c| c.email_domain.as_deref())
+                    .is_some_and(|existing_domain| existing_domain.eq_ignore_ascii_case(requested));
+                if unchanged {
+                    // Same domain — keep prior verification + token untouched.
+                    let prev = existing.as_ref().expect("unchanged implies existing");
+                    (prev.domain_verified, prev.domain_verification_token.clone())
+                } else {
+                    // New or changed domain — issue a fresh token, unverified.
+                    (false, Some(format!("mockforge-verify={}", uuid::Uuid::new_v4())))
+                }
+            }
+            None => (false, None),
+        };
+
     // Create or update SSO configuration
     let config = state
         .store
@@ -155,6 +184,8 @@ pub async fn create_sso_config(
             request.oidc_client_id.as_deref(),
             request.oidc_client_secret.as_deref(),
             request.email_domain.as_deref(),
+            domain_verified,
+            domain_verification_token.as_deref(),
         )
         .await?;
 
@@ -199,6 +230,8 @@ pub async fn create_sso_config(
         oidc_client_id: config.oidc_client_id,
         // oidc_client_secret intentionally omitted — never echo secrets
         email_domain: config.email_domain,
+        domain_verified: config.domain_verified,
+        domain_verification_token: config.domain_verification_token,
         created_at: config.created_at.to_rfc3339(),
         updated_at: config.updated_at.to_rfc3339(),
     }))
@@ -251,11 +284,164 @@ pub async fn get_sso_config(
             oidc_client_id: config.oidc_client_id,
             // oidc_client_secret intentionally omitted — never echo secrets
             email_domain: config.email_domain,
+            domain_verified: config.domain_verified,
+            domain_verification_token: config.domain_verification_token,
             created_at: config.created_at.to_rfc3339(),
             updated_at: config.updated_at.to_rfc3339(),
         })))
     } else {
         Ok(Json(None))
+    }
+}
+
+/// Resolve TXT records for `name` using the system DNS resolver (falling back
+/// to Cloudflare 1.1.1.1 if `/etc/resolv.conf` is unreadable). Each returned
+/// String is one TXT record's data, joined across the chunked-string segments
+/// DNS uses internally so the value matches what the admin published.
+async fn lookup_txt_records(name: &str) -> Result<Vec<String>, String> {
+    use hickory_resolver::config::{ResolverConfig, CLOUDFLARE};
+    use hickory_resolver::net::runtime::TokioRuntimeProvider;
+    use hickory_resolver::proto::rr::{RData, RecordType};
+    use hickory_resolver::TokioResolver;
+
+    let builder = match TokioResolver::builder_tokio() {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::debug!(error = %e, "system resolv.conf unreadable; falling back to Cloudflare");
+            TokioResolver::builder_with_config(
+                ResolverConfig::udp_and_tcp(&CLOUDFLARE),
+                TokioRuntimeProvider::default(),
+            )
+        }
+    };
+    let resolver = builder.build().map_err(|e| format!("resolver build failed: {e}"))?;
+
+    let response = resolver.lookup(name, RecordType::TXT).await.map_err(|e| format!("{e}"))?;
+    let mut out = Vec::new();
+    for record in response.answers() {
+        let RData::TXT(ref txt) = record.data else {
+            continue;
+        };
+        let mut joined = String::new();
+        for chunk in txt.txt_data.iter() {
+            match std::str::from_utf8(chunk) {
+                Ok(s) => joined.push_str(s),
+                Err(_) => continue, // non-UTF8 TXT — skip silently
+            }
+        }
+        if !joined.is_empty() {
+            out.push(joined);
+        }
+    }
+    Ok(out)
+}
+
+/// Verify domain ownership for SSO via a DNS TXT record (Team plan, org admin).
+///
+/// Looks up TXT records on the configured `email_domain` and, if any record
+/// matches the stored `domain_verification_token`, marks the domain verified.
+/// Returns 200 in all non-permission cases — a missing/mismatched record is a
+/// normal "not yet" outcome the UI re-prompts on, not an error.
+pub async fn verify_sso_domain(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+) -> ApiResult<Json<serde_json::Value>> {
+    // Resolve organization context
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization context required".to_string()))?;
+
+    // Check if user is org admin (owner or admin member)
+    use crate::models::OrgRole;
+    let is_admin = org_ctx.org.owner_id == user_id || {
+        if let Ok(Some(member)) = state.store.find_org_member(org_ctx.org_id, user_id).await {
+            let role = member.role();
+            matches!(role, OrgRole::Admin | OrgRole::Owner)
+        } else {
+            false
+        }
+    };
+
+    if !is_admin {
+        return Err(ApiError::PermissionDenied);
+    }
+
+    // Require Team plan
+    let org = state
+        .store
+        .find_organization_by_id(org_ctx.org_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
+    if org.plan() != Plan::Team {
+        return Err(ApiError::InvalidRequest("SSO is only available for Team plans".to_string()));
+    }
+
+    // Load SSO config; require an email domain + verification token
+    let config = state
+        .store
+        .find_sso_config_by_org(org_ctx.org_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Set an email domain first".to_string()))?;
+    let email_domain = config
+        .email_domain
+        .as_deref()
+        .filter(|d| !d.trim().is_empty())
+        .ok_or_else(|| ApiError::InvalidRequest("Set an email domain first".to_string()))?;
+    let token = config
+        .domain_verification_token
+        .as_deref()
+        .ok_or_else(|| ApiError::InvalidRequest("Set an email domain first".to_string()))?;
+
+    // DNS TXT lookup
+    let records = match lookup_txt_records(email_domain).await {
+        Ok(records) => records,
+        Err(err) => {
+            tracing::warn!(domain = %email_domain, error = %err, "SSO domain TXT lookup failed");
+            return Ok(Json(serde_json::json!({
+                "verified": false,
+                "error": "dns_lookup_failed",
+                "expected_token": token,
+            })));
+        }
+    };
+
+    // A TXT record may arrive wrapped in quotes; compare trimmed + de-quoted.
+    let matched = records.iter().any(|raw| {
+        let value = raw.trim().trim_matches('"').trim();
+        value == token
+    });
+
+    if matched {
+        state.store.mark_sso_domain_verified(org_ctx.org_id).await?;
+
+        let ip_address = headers
+            .get("X-Forwarded-For")
+            .or_else(|| headers.get("X-Real-IP"))
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s.split(',').next().unwrap_or(s).trim().to_string());
+        let user_agent =
+            headers.get("User-Agent").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+
+        state
+            .store
+            .record_audit_event(
+                org_ctx.org_id,
+                Some(user_id),
+                AuditEventType::SettingsUpdated,
+                "SSO email domain verified via DNS TXT".to_string(),
+                Some(serde_json::json!({ "email_domain": email_domain })),
+                ip_address.as_deref(),
+                user_agent.as_deref(),
+            )
+            .await;
+
+        Ok(Json(serde_json::json!({ "verified": true })))
+    } else {
+        Ok(Json(serde_json::json!({
+            "verified": false,
+            "expected_token": token,
+        })))
     }
 }
 

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -282,6 +282,7 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/sso/config", get(handlers::sso::get_sso_config))
         .route("/api/v1/sso/config", post(handlers::sso::create_sso_config))
         .route("/api/v1/sso/config", delete(handlers::sso::delete_sso_config))
+        .route("/api/v1/sso/domain/verify", post(handlers::sso::verify_sso_domain))
         .route("/api/v1/sso/enable", post(handlers::sso::enable_sso))
         .route("/api/v1/sso/disable", post(handlers::sso::disable_sso))
         .route("/api/v1/sso/saml/metadata/{org_slug}", get(handlers::sso::get_saml_metadata))
@@ -1203,6 +1204,7 @@ mod tests {
         // Verify SSO route paths are correctly defined
         let routes = vec![
             "/api/v1/sso/config",
+            "/api/v1/sso/domain/verify",
             "/api/v1/sso/enable",
             "/api/v1/sso/disable",
             "/api/v1/sso/saml/metadata/{org_slug}",

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -1107,6 +1107,8 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/sso/saml/login/{org_slug}", get(handlers::sso::initiate_saml_login))
         .route("/api/v1/sso/saml/acs/{org_slug}", post(handlers::sso::saml_acs))
         .route("/api/v1/sso/saml/slo/{org_slug}", post(handlers::sso::saml_slo))
+        .route("/api/v1/sso/oidc/login/{org_slug}", get(handlers::oidc::oidc_login))
+        .route("/api/v1/sso/oidc/callback/{org_slug}", get(handlers::oidc::oidc_callback))
         .route_layer(middleware::from_fn(rate_limit_middleware));
 
     // Public OAuth routes (no auth required - these handle OAuth redirects)

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -1101,8 +1101,9 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route_layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
         .route_layer(middleware::from_fn(rate_limit_middleware));
 
-    // Public SSO routes (no auth required - these handle SAML redirects)
+    // Public SSO routes (no auth required - these handle SAML redirects and discovery)
     let sso_public_routes = Router::new()
+        .route("/api/v1/sso/discover", get(handlers::sso::discover_sso))
         .route("/api/v1/sso/saml/login/{org_slug}", get(handlers::sso::initiate_saml_login))
         .route("/api/v1/sso/saml/acs/{org_slug}", post(handlers::sso::saml_acs))
         .route("/api/v1/sso/saml/slo/{org_slug}", post(handlers::sso::saml_slo))

--- a/crates/mockforge-ui/ui/src/components/auth/AuthGuard.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/AuthGuard.tsx
@@ -21,8 +21,9 @@ interface AuthGuardProps {
 const SELF_AUTHED_PREFIXES = isCloudMode() ? [] : ['/registry-login', '/registry-admin'];
 
 // Public pages that render without any auth check — legal docs, pricing, support,
-// verification landings. These render the same shell (via AuthGuard passing through)
-// but don't require an authenticated user.
+// verification landings, and the SSO callback (user is not yet authenticated when
+// the IdP redirects back here). These render the same shell (via AuthGuard passing
+// through) but don't require an authenticated user.
 const PUBLIC_PREFIXES = [
   '/terms',
   '/privacy',
@@ -32,6 +33,7 @@ const PUBLIC_PREFIXES = [
   '/support',
   '/verify-email',
   '/waitlist',
+  '/auth/sso/callback',
 ];
 
 export function AuthGuard({ children, requiredRole }: AuthGuardProps) {

--- a/crates/mockforge-ui/ui/src/components/auth/LoginForm.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/LoginForm.tsx
@@ -1,5 +1,6 @@
 import { logger } from '@/utils/logger';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Logo } from '../ui/Logo';
@@ -12,8 +13,21 @@ interface LoginFormProps {
 
 const isCloud = authApi.isCloud();
 
+// SSO discovery response shape from GET /api/v1/sso/discover?email=<email>
+interface SsoDiscoverResponse {
+  org_slug: string;
+  provider: 'saml' | 'oidc';
+}
+
 export function LoginForm({ onSuccess }: LoginFormProps) {
+  const [searchParams] = useSearchParams();
   const [mode, setMode] = useState<'login' | 'register'>('login');
+  // ssoMode: 'hidden' | 'email' (showing email input) | 'slug' (showing slug fallback input)
+  const [ssoMode, setSsoMode] = useState<'hidden' | 'email' | 'slug'>('hidden');
+  const [ssoEmail, setSsoEmail] = useState('');
+  const [ssoSlug, setSsoSlug] = useState('');
+  const [ssoError, setSsoError] = useState('');
+  const [ssoLoading, setSsoLoading] = useState(false);
   const [credentials, setCredentials] = useState({
     username: '',
     email: '',
@@ -21,6 +35,17 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+
+  // Pick up sso_error forwarded from the callback page (set on the root URL
+  // when the IdP round-trip fails). We read it once on mount and clear it so
+  // subsequent renders don't re-show a stale error.
+  useEffect(() => {
+    const ssoErrParam = searchParams.get('sso_error');
+    if (ssoErrParam) {
+      setError(decodeURIComponent(ssoErrParam));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { login, setAuthenticated } = useAuthStore();
 
@@ -58,6 +83,50 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
       viewer: { username: 'viewer', email: '', password: 'viewer123' },
     };
     setCredentials({ ...credentials, ...demoCredentials[role] });
+  };
+
+  /**
+   * Handle the SSO email discovery flow.
+   * 1. Call GET /api/v1/sso/discover?email=<email>
+   * 2. 200 → browser-navigate to the IdP login URL for the discovered provider.
+   * 3. 404 → fall back to the manual org-slug input.
+   * 4. Other errors → show inline error.
+   *
+   * Note: SAML is used as the default for the slug-only fallback because
+   * email-based discovery covers OIDC orgs (SSO now requires a verified domain,
+   * so any OIDC org will be found by the discover endpoint when its domain
+   * matches the email).
+   */
+  const handleSsoEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSsoError('');
+    setSsoLoading(true);
+    try {
+      const res = await fetch(
+        `/api/v1/sso/discover?email=${encodeURIComponent(ssoEmail)}`,
+      );
+      if (res.ok) {
+        const data = (await res.json()) as SsoDiscoverResponse;
+        window.location.href = `/api/v1/sso/${data.provider}/login/${encodeURIComponent(data.org_slug)}`;
+      } else if (res.status === 404) {
+        // No SSO domain mapping found — ask for the org slug directly.
+        setSsoMode('slug');
+      } else {
+        const body = await res.json().catch(() => ({}));
+        setSsoError((body as { error?: string; message?: string }).error ?? (body as { message?: string }).message ?? `Unexpected error (${res.status})`);
+      }
+    } catch (err) {
+      logger.error('SSO discover error', err);
+      setSsoError('Could not reach the server. Please try again.');
+    } finally {
+      setSsoLoading(false);
+    }
+  };
+
+  const handleSsoSlugSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // SAML is the default for slug-based logins (see comment on handleSsoEmailSubmit).
+    window.location.href = `/api/v1/sso/saml/login/${encodeURIComponent(ssoSlug)}`;
   };
 
   return (
@@ -188,6 +257,115 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
                     Sign in
                   </button>
                 </p>
+              )}
+            </div>
+          )}
+
+          {/* ── SSO section (cloud mode only; only shown on the login tab) ── */}
+          {isCloud && mode === 'login' && (
+            <div className="space-y-3">
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground">Or</span>
+                </div>
+              </div>
+
+              {ssoMode === 'hidden' && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => { setSsoMode('email'); setSsoError(''); }}
+                >
+                  Sign in with SSO
+                </Button>
+              )}
+
+              {ssoMode === 'email' && (
+                <form onSubmit={handleSsoEmailSubmit} className="space-y-3">
+                  <div className="space-y-2">
+                    <label htmlFor="sso-email" className="text-sm font-medium">
+                      Work email
+                    </label>
+                    <Input
+                      id="sso-email"
+                      type="email"
+                      value={ssoEmail}
+                      onChange={(e) => setSsoEmail(e.target.value)}
+                      placeholder="you@company.com"
+                      required
+                      autoComplete="email"
+                      autoFocus
+                    />
+                  </div>
+                  {ssoError && (
+                    <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded p-3">
+                      {ssoError}
+                    </div>
+                  )}
+                  <div className="flex gap-2">
+                    <Button
+                      type="submit"
+                      className="flex-1"
+                      disabled={ssoLoading || !ssoEmail.trim()}
+                    >
+                      {ssoLoading ? 'Looking up...' : 'Continue with SSO'}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => { setSsoMode('hidden'); setSsoError(''); setSsoEmail(''); }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </form>
+              )}
+
+              {ssoMode === 'slug' && (
+                <form onSubmit={handleSsoSlugSubmit} className="space-y-3">
+                  <div className="space-y-2">
+                    <label htmlFor="sso-slug" className="text-sm font-medium">
+                      Organization SSO slug
+                    </label>
+                    <Input
+                      id="sso-slug"
+                      type="text"
+                      value={ssoSlug}
+                      onChange={(e) => setSsoSlug(e.target.value)}
+                      placeholder="your-org-slug"
+                      required
+                      autoFocus
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Ask your admin for your organization&apos;s SSO slug.
+                    </p>
+                  </div>
+                  {ssoError && (
+                    <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded p-3">
+                      {ssoError}
+                    </div>
+                  )}
+                  <div className="flex gap-2">
+                    <Button
+                      type="submit"
+                      className="flex-1"
+                      disabled={!ssoSlug.trim()}
+                    >
+                      Sign in with SSO
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => { setSsoMode('email'); setSsoError(''); setSsoSlug(''); }}
+                    >
+                      Back
+                    </Button>
+                  </div>
+                </form>
               )}
             </div>
           )}

--- a/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
@@ -93,6 +93,14 @@ interface SSOConfig {
   saml_sso_url?: string;
   saml_slo_url?: string;
   saml_name_id_format?: string;
+  // OIDC fields
+  oidc_issuer_url?: string;
+  oidc_client_id?: string;
+  // oidc_client_secret is intentionally absent: the backend never returns it
+  // Email domain + verification
+  email_domain?: string;
+  domain_verified?: boolean;
+  domain_verification_token?: string;
   attribute_mapping: Record<string, unknown>;
   require_signed_assertions: boolean;
   require_signed_responses: boolean;
@@ -241,10 +249,16 @@ const saveSSOConfig = (data: {
   saml_sso_url?: string;
   saml_slo_url?: string;
   saml_x509_cert?: string;
+  oidc_issuer_url?: string;
+  oidc_client_id?: string;
+  oidc_client_secret?: string;
+  email_domain?: string;
 }) => apiFetch<SSOConfig>(`${API_BASE}/sso/config`, { method: 'POST', body: JSON.stringify(data) });
 const deleteSSOConfig = () => apiFetch<void>(`${API_BASE}/sso/config`, { method: 'DELETE' });
 const enableSSO = () => apiFetch<void>(`${API_BASE}/sso/enable`, { method: 'POST' });
 const disableSSO = () => apiFetch<void>(`${API_BASE}/sso/disable`, { method: 'POST' });
+const verifyDomain = () =>
+  apiFetch<{ verified: boolean }>(`${API_BASE}/sso/domain/verify`, { method: 'POST' });
 
 // Templates
 const fetchOrgTemplates = (orgId: string) =>
@@ -1171,10 +1185,25 @@ function TemplatesTab({ org }: { org: Organization }) {
 function SSOTab({ org }: { org: Organization }) {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
+
+  // Provider selector: 'saml' | 'oidc'
+  const [provider, setProvider] = useState<'saml' | 'oidc'>('saml');
+
+  // SAML fields
   const [entityId, setEntityId] = useState('');
   const [ssoUrl, setSsoUrl] = useState('');
   const [sloUrl, setSloUrl] = useState('');
   const [x509Cert, setX509Cert] = useState('');
+
+  // OIDC fields
+  const [oidcIssuerUrl, setOidcIssuerUrl] = useState('');
+  const [oidcClientId, setOidcClientId] = useState('');
+  // oidcClientSecret is write-only: never pre-populated from the server response
+  const [oidcClientSecret, setOidcClientSecret] = useState('');
+
+  // Email domain (shown for both providers)
+  const [emailDomain, setEmailDomain] = useState('');
+
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const { data: ssoConfig, isLoading } = useQuery({
@@ -1185,23 +1214,41 @@ function SSOTab({ org }: { org: Organization }) {
 
   useEffect(() => {
     if (ssoConfig) {
+      const p = ssoConfig.provider === 'oidc' ? 'oidc' : 'saml';
+      setProvider(p);
       setEntityId(ssoConfig.saml_entity_id || '');
       setSsoUrl(ssoConfig.saml_sso_url || '');
       setSloUrl(ssoConfig.saml_slo_url || '');
+      setOidcIssuerUrl(ssoConfig.oidc_issuer_url || '');
+      setOidcClientId(ssoConfig.oidc_client_id || '');
+      setEmailDomain(ssoConfig.email_domain || '');
     }
   }, [ssoConfig]);
 
   const saveMutation = useMutation({
-    mutationFn: () => saveSSOConfig({
-      provider: 'saml',
-      saml_entity_id: entityId,
-      saml_sso_url: ssoUrl,
-      saml_slo_url: sloUrl || undefined,
-      saml_x509_cert: x509Cert || undefined,
-    }),
+    mutationFn: () => {
+      const base = { provider, email_domain: emailDomain || undefined };
+      if (provider === 'saml') {
+        return saveSSOConfig({
+          ...base,
+          saml_entity_id: entityId,
+          saml_sso_url: ssoUrl,
+          saml_slo_url: sloUrl || undefined,
+          saml_x509_cert: x509Cert || undefined,
+        });
+      } else {
+        return saveSSOConfig({
+          ...base,
+          oidc_issuer_url: oidcIssuerUrl,
+          oidc_client_id: oidcClientId,
+          oidc_client_secret: oidcClientSecret || undefined,
+        });
+      }
+    },
     onSuccess: () => {
       showToast('success', 'SSO configuration saved');
       setX509Cert('');
+      setOidcClientSecret('');
       queryClient.invalidateQueries({ queryKey: ['sso-config', org.id] });
     },
     onError: (err: Error) => showToast('error', 'Failed to save SSO config', err.message),
@@ -1224,9 +1271,25 @@ function SSOTab({ org }: { org: Organization }) {
       setEntityId('');
       setSsoUrl('');
       setSloUrl('');
+      setOidcIssuerUrl('');
+      setOidcClientId('');
+      setEmailDomain('');
       queryClient.invalidateQueries({ queryKey: ['sso-config', org.id] });
     },
     onError: (err: Error) => showToast('error', 'Failed to delete SSO config', err.message),
+  });
+
+  const verifyDomainMutation = useMutation({
+    mutationFn: verifyDomain,
+    onSuccess: (result) => {
+      if (result.verified) {
+        showToast('success', 'Domain verified successfully');
+      } else {
+        showToast('error', 'Domain verification failed', 'DNS TXT record not found yet. DNS changes can take up to 48 hours to propagate.');
+      }
+      queryClient.invalidateQueries({ queryKey: ['sso-config', org.id] });
+    },
+    onError: (err: Error) => showToast('error', 'Domain verification error', err.message),
   });
 
   if (org.plan !== 'team') {
@@ -1235,7 +1298,7 @@ function SSOTab({ org }: { org: Organization }) {
         <Lock className="w-8 h-8 mx-auto text-muted-foreground mb-3" />
         <h4 className="font-semibold mb-1">SSO requires Team plan</h4>
         <p className="text-sm text-muted-foreground">
-          Upgrade to the Team plan to configure SAML-based Single Sign-On for your organization.
+          Upgrade to the Team plan to configure Single Sign-On for your organization.
         </p>
       </div>
     );
@@ -1245,8 +1308,15 @@ function SSOTab({ org }: { org: Organization }) {
     return <div className="text-center py-4 text-muted-foreground">Loading SSO configuration...</div>;
   }
 
+  // Save button enabled: require provider-specific required fields
+  const isSaveEnabled =
+    provider === 'saml'
+      ? Boolean(entityId.trim() && ssoUrl.trim())
+      : Boolean(oidcIssuerUrl.trim() && oidcClientId.trim());
+
   return (
     <div className="space-y-6">
+      {/* ── Status bar (only when a config already exists) ── */}
       {ssoConfig && (
         <div className="flex items-center justify-between p-3 border rounded-lg">
           <div className="flex items-center gap-3">
@@ -1254,12 +1324,19 @@ function SSOTab({ org }: { org: Organization }) {
             <Badge className={ssoConfig.enabled ? 'bg-success-100 text-success-700 dark:bg-success-900/30 dark:text-success-300' : ''}>
               {ssoConfig.enabled ? 'Enabled' : 'Disabled'}
             </Badge>
+            {!ssoConfig.domain_verified && (
+              <Badge variant="outline" className="text-warning-700 dark:text-warning-300 border-warning-400">
+                <AlertTriangle className="w-3 h-3 mr-1" />
+                Domain unverified — SSO login inactive
+              </Badge>
+            )}
           </div>
           <Button
             size="sm"
             variant="outline"
             onClick={() => toggleMutation.mutate()}
-            disabled={toggleMutation.isPending}
+            disabled={toggleMutation.isPending || !ssoConfig.domain_verified}
+            title={!ssoConfig.domain_verified ? 'Verify your email domain before enabling SSO' : undefined}
           >
             {ssoConfig.enabled ? <ToggleRight className="w-4 h-4 mr-2" /> : <ToggleLeft className="w-4 h-4 mr-2" />}
             {ssoConfig.enabled ? 'Disable' : 'Enable'}
@@ -1267,38 +1344,182 @@ function SSOTab({ org }: { org: Organization }) {
         </div>
       )}
 
-      <div className="space-y-4">
-        <h4 className="text-sm font-semibold">SAML 2.0 Configuration</h4>
-        <div>
-          <Label>Entity ID (Issuer)</Label>
-          <Input value={entityId} onChange={(e) => setEntityId(e.target.value)} placeholder="https://idp.example.com/metadata" />
-        </div>
-        <div>
-          <Label>SSO URL (Login URL)</Label>
-          <Input value={ssoUrl} onChange={(e) => setSsoUrl(e.target.value)} placeholder="https://idp.example.com/sso" />
-        </div>
-        <div>
-          <Label>SLO URL (Logout URL, optional)</Label>
-          <Input value={sloUrl} onChange={(e) => setSloUrl(e.target.value)} placeholder="https://idp.example.com/slo" />
-        </div>
-        <div>
-          <Label>X.509 Certificate (paste new cert to update)</Label>
-          <textarea
-            className="w-full border rounded px-3 py-2 text-sm bg-background font-mono min-h-[100px] mt-1"
-            value={x509Cert}
-            onChange={(e) => setX509Cert(e.target.value)}
-            placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
-          />
-        </div>
+      {/* ── Provider selector ── */}
+      <div className="space-y-2">
+        <Label>SSO Provider</Label>
         <div className="flex gap-2">
-          <Button onClick={() => saveMutation.mutate()} disabled={!entityId.trim() || !ssoUrl.trim() || saveMutation.isPending}>
-            <Save className="w-4 h-4 mr-2" />
-            {saveMutation.isPending ? 'Saving...' : 'Save Configuration'}
-          </Button>
+          {(['saml', 'oidc'] as const).map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setProvider(p)}
+              className={`px-4 py-2 text-sm rounded border transition-colors ${
+                provider === p
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background text-foreground border-border hover:bg-muted'
+              }`}
+            >
+              {p === 'saml' ? 'SAML 2.0' : 'OpenID Connect (OIDC)'}
+            </button>
+          ))}
         </div>
       </div>
 
-      {ssoConfig && (
+      {/* ── SAML fields ── */}
+      {provider === 'saml' && (
+        <div className="space-y-4">
+          <h4 className="text-sm font-semibold">SAML 2.0 Configuration</h4>
+          <div>
+            <Label>Entity ID (Issuer)</Label>
+            <Input value={entityId} onChange={(e) => setEntityId(e.target.value)} placeholder="https://idp.example.com/metadata" />
+          </div>
+          <div>
+            <Label>SSO URL (Login URL)</Label>
+            <Input value={ssoUrl} onChange={(e) => setSsoUrl(e.target.value)} placeholder="https://idp.example.com/sso" />
+          </div>
+          <div>
+            <Label>SLO URL (Logout URL, optional)</Label>
+            <Input value={sloUrl} onChange={(e) => setSloUrl(e.target.value)} placeholder="https://idp.example.com/slo" />
+          </div>
+          <div>
+            <Label>X.509 Certificate (paste new cert to update)</Label>
+            <textarea
+              className="w-full border rounded px-3 py-2 text-sm bg-background font-mono min-h-[100px] mt-1"
+              value={x509Cert}
+              onChange={(e) => setX509Cert(e.target.value)}
+              placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* ── OIDC fields ── */}
+      {provider === 'oidc' && (
+        <div className="space-y-4">
+          <h4 className="text-sm font-semibold">OpenID Connect Configuration</h4>
+          <div>
+            <Label>Issuer URL</Label>
+            <Input
+              value={oidcIssuerUrl}
+              onChange={(e) => setOidcIssuerUrl(e.target.value)}
+              placeholder="https://accounts.google.com"
+            />
+            <p className="text-xs text-muted-foreground mt-1">The OIDC provider&apos;s issuer URL (must expose a /.well-known/openid-configuration endpoint).</p>
+          </div>
+          <div>
+            <Label>Client ID</Label>
+            <Input
+              value={oidcClientId}
+              onChange={(e) => setOidcClientId(e.target.value)}
+              placeholder="your-client-id"
+            />
+          </div>
+          <div>
+            <Label>Client Secret</Label>
+            <Input
+              type="password"
+              value={oidcClientSecret}
+              onChange={(e) => setOidcClientSecret(e.target.value)}
+              placeholder="Leave blank to keep existing secret"
+              autoComplete="new-password"
+            />
+            <p className="text-xs text-muted-foreground mt-1">Write-only — the secret is never returned by the API. Leave blank to keep the stored secret unchanged.</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Email domain (always visible) ── */}
+      <div className="space-y-2">
+        <h4 className="text-sm font-semibold">Email Domain</h4>
+        <div>
+          <Label>Domain</Label>
+          <Input
+            value={emailDomain}
+            onChange={(e) => setEmailDomain(e.target.value)}
+            placeholder="company.com"
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Users signing in with an email from this domain will be redirected to SSO automatically.
+            Changing the domain resets verification and generates a new DNS token.
+          </p>
+        </div>
+      </div>
+
+      {/* ── Domain verification section ── */}
+      {ssoConfig && ssoConfig.email_domain && (
+        <div className="space-y-3 p-4 border rounded-lg bg-muted/30">
+          <div className="flex items-center gap-2">
+            <h4 className="text-sm font-semibold">Domain Verification</h4>
+            {ssoConfig.domain_verified ? (
+              <Badge className="bg-success-100 text-success-700 dark:bg-success-900/30 dark:text-success-300 flex items-center gap-1">
+                <CheckCircle2 className="w-3 h-3" />
+                Verified
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="text-warning-700 dark:text-warning-300 border-warning-400">
+                <AlertTriangle className="w-3 h-3 mr-1" />
+                Not verified
+              </Badge>
+            )}
+          </div>
+
+          {ssoConfig.domain_verified ? (
+            <p className="text-sm text-muted-foreground">
+              <strong>{ssoConfig.email_domain}</strong> is verified. SSO login is active for users on this domain.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                SSO login will not work until the domain <strong>{ssoConfig.email_domain}</strong> is verified.
+                Add the following TXT record to your DNS, then click <strong>Verify</strong>.
+              </p>
+              {ssoConfig.domain_verification_token && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <code className="flex-1 bg-background border rounded px-3 py-2 text-xs font-mono break-all">
+                      mockforge-sso-verification={ssoConfig.domain_verification_token}
+                    </code>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        navigator.clipboard.writeText(
+                          `mockforge-sso-verification=${ssoConfig.domain_verification_token}`,
+                        );
+                        showToast('success', 'Copied to clipboard');
+                      }}
+                    >
+                      <Copy className="w-4 h-4" />
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Record type: <strong>TXT</strong> &nbsp;·&nbsp; Host/Name: <strong>@</strong> (or <strong>{ssoConfig.email_domain}</strong>) &nbsp;·&nbsp; DNS changes can take up to 48 hours to propagate.
+                  </p>
+                </div>
+              )}
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => verifyDomainMutation.mutate()}
+                disabled={verifyDomainMutation.isPending}
+              >
+                {verifyDomainMutation.isPending ? 'Verifying...' : 'Verify Domain'}
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* ── Save button ── */}
+      <div className="flex gap-2">
+        <Button onClick={() => saveMutation.mutate()} disabled={!isSaveEnabled || saveMutation.isPending}>
+          <Save className="w-4 h-4 mr-2" />
+          {saveMutation.isPending ? 'Saving...' : 'Save Configuration'}
+        </Button>
+      </div>
+
+      {/* ── Service Provider details (SAML only) ── */}
+      {ssoConfig && provider === 'saml' && (
         <div className="space-y-3">
           <h4 className="text-sm font-semibold">Service Provider Details</h4>
           <div className="p-3 border rounded-lg bg-muted/50 text-sm space-y-2">
@@ -1318,6 +1539,7 @@ function SSOTab({ org }: { org: Organization }) {
         </div>
       )}
 
+      {/* ── Delete config ── */}
       {ssoConfig && (
         <div className="border-t pt-4">
           {showDeleteConfirm ? (

--- a/crates/mockforge-ui/ui/src/pages/SsoCallbackPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/SsoCallbackPage.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useRef } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { authApi } from '@/services/authApi';
+import { logger } from '@/utils/logger';
+
+// Error codes returned by the backend as sso_error= query parameter.
+const SSO_ERROR_MESSAGES: Record<string, string> = {
+  invalid_state: 'SSO state parameter was invalid. Please try again.',
+  callback_failed: 'SSO authentication failed. Please try again.',
+  user_not_found: 'Your SSO account could not be matched to a user.',
+  sso_disabled: 'SSO is not enabled for your organization.',
+  domain_not_verified: 'The email domain for your organization has not been verified.',
+  internal_error: 'An internal error occurred during SSO login.',
+};
+
+/**
+ * SsoCallbackPage — landing page after an IdP SSO round-trip.
+ *
+ * Success path: backend 302s to /auth/sso/callback?token=<jwt>&org_slug=<slug>
+ * Failure path: backend 302s to /login?sso_error=<code>
+ *
+ * On success we persist the token via the auth store's setAuthenticated action
+ * (same path used by manual registration), hydrate /users/me, then redirect
+ * into the app. This ensures auto-refresh, axios/fetch auth headers, and the
+ * localStorage sync subscriber all fire exactly as they do on a normal login.
+ *
+ * This route MUST be listed in AuthGuard's PUBLIC_PREFIXES so the user
+ * can land here before they are authenticated.
+ */
+export function SsoCallbackPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { setAuthenticated } = useAuthStore();
+  // Guard against React 18 StrictMode double-invocation in dev.
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (handled.current) return;
+    handled.current = true;
+
+    const token = searchParams.get('token');
+    // org_slug is available for analytics / logging but not needed to complete auth.
+    const orgSlug = searchParams.get('org_slug');
+    const ssoError = searchParams.get('sso_error');
+
+    if (ssoError) {
+      // Backend redirected here via /login?sso_error=<code> in some flows, but
+      // we also handle it if it appears on the callback URL directly.
+      // Navigate to root — the AuthGuard will show the LoginForm because the user
+      // is unauthenticated, and the LoginForm reads the sso_error query param.
+      const message = SSO_ERROR_MESSAGES[ssoError] ?? `SSO error: ${ssoError}`;
+      navigate(`/?sso_error=${encodeURIComponent(message)}`, { replace: true });
+      return;
+    }
+
+    if (!token) {
+      logger.warn('SsoCallbackPage: no token in URL');
+      navigate('/login?sso_error=' + encodeURIComponent('No authentication token received.'), {
+        replace: true,
+      });
+      return;
+    }
+
+    // Persist the token immediately so subsequent API calls carry the
+    // Authorization header (same pattern as register in LoginForm).
+    // We build a minimal User from the JWT payload; hydrateUserFromServer
+    // (called inside checkAuth / the store internals) will fill in the rest.
+    const minimalUser = {
+      id: '',
+      username: '',
+      email: '',
+      role: 'user' as const,
+    };
+    setAuthenticated(minimalUser, token);
+
+    // Hydrate the full profile via /users/me, then navigate into the app.
+    authApi
+      .getMe()
+      .then((profile) => {
+        // Re-call setAuthenticated with real user data so the store has the
+        // full profile (role, email, username) before we navigate.
+        setAuthenticated(
+          {
+            id: profile.user_id,
+            username: profile.username,
+            email: profile.email,
+            role: profile.is_admin ? 'admin' : 'user',
+            is_verified: profile.is_verified,
+            created_at: profile.created_at,
+          },
+          token,
+        );
+        logger.info('SSO login successful', { orgSlug, userId: profile.user_id });
+        navigate('/', { replace: true });
+      })
+      .catch((err) => {
+        logger.error('SsoCallbackPage: /users/me hydration failed', err);
+        // Token was accepted and stored; still navigate into the app — the
+        // auto-refresh flow will fill in the user profile on next checkAuth.
+        navigate('/', { replace: true });
+      });
+  }, [searchParams, navigate, setAuthenticated]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="text-center space-y-4">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto" />
+        <p className="text-muted-foreground">Signing you in&hellip;</p>
+      </div>
+    </div>
+  );
+}

--- a/crates/mockforge-ui/ui/src/routes/index.tsx
+++ b/crates/mockforge-ui/ui/src/routes/index.tsx
@@ -144,6 +144,9 @@ const PricingPage = lazy(() => import('../pages/PricingPage').then(m => ({ defau
 const EmailVerificationPage = lazy(() => import('../pages/EmailVerificationPage').then(m => ({ default: m.EmailVerificationPage })));
 const WaitlistPage = lazy(() => import('../pages/WaitlistPage').then(m => ({ default: m.WaitlistPage })));
 
+// SSO callback — must be a public route (user is not yet authenticated on arrival)
+const SsoCallbackPage = lazy(() => import('../pages/SsoCallbackPage').then(m => ({ default: m.SsoCallbackPage })));
+
 /**
  * ApiExplorerWrapper handles the special logic that was previously in the
  * switch statement: it checks for window.__mockforge_explorer_deployment
@@ -296,4 +299,8 @@ export const routes: RouteConfig[] = [
   { path: '/pricing', element: <PricingPage /> },
   { path: '/verify-email', element: <EmailVerificationPage /> },
   { path: '/waitlist', element: <WaitlistPage /> },
+
+  // SSO OAuth/SAML callback — public; user is unauthenticated on arrival.
+  // AuthGuard bypasses auth checks for /auth/sso/callback via PUBLIC_PREFIXES.
+  { path: '/auth/sso/callback', element: <SsoCallbackPage /> },
 ];

--- a/docs/superpowers/plans/2026-05-30-sso-completion.md
+++ b/docs/superpowers/plans/2026-05-30-sso-completion.md
@@ -1,0 +1,194 @@
+# SSO Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make SSO end-user-usable — close the SAML login loop in the UI and add OIDC — so the Team-tier "SSO" claim is true.
+
+**Architecture:** Reuse the existing per-org, Team-gated SSO foundation (`sso_configurations`, `handlers/sso.rs` SAML, `OrganizationPage` SSOTab). Add OIDC handlers mirroring the OAuth2 callback→JWT pattern (`handlers/oauth.rs`), generalize JIT provisioning so SAML+OIDC share it, add email-domain discovery, and wire the frontend login entry + `/auth/sso/callback`. Both protocols converge on one frontend callback.
+
+**Tech Stack:** Rust (axum, sqlx, `oauth2`, **new: `openidconnect`**, jsonwebtoken, redis), React 19 + TS (Zustand, TanStack Query, react-router v7), Postgres.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-sso-completion-design.md`
+
+**Reference patterns to mirror (read these first):**
+- SAML login init + ACS + `find_or_create_user_from_saml`: `crates/mockforge-registry-server/src/handlers/sso.rs` (login init, ACS, provisioning at :1174-1224).
+- OAuth2 authorize + callback (closest OIDC template): `crates/mockforge-registry-server/src/handlers/oauth.rs:49-256` (CSRF state in Redis, code exchange, find-or-create, token-pair issuance).
+- SSO config CRUD: `handlers/sso.rs` `create_sso_config`/`get_sso_config`; model `crates/mockforge-registry-core/src/models/sso.rs`.
+- JWT issuance: `crates/mockforge-registry-core/src/auth.rs` `create_token_pair`/`create_access_token`.
+- Routes: `crates/mockforge-registry-server/src/routes.rs` (public SAML routes + authenticated SSO config routes).
+- Frontend auth: `crates/mockforge-ui/ui/src/stores/useAuthStore.ts`, `services/authApi.ts`, `components/auth/LoginForm.tsx`; SSOTab in `pages/OrganizationPage.tsx:1171`.
+
+**Conventions:** Per-crate verification only (`cargo clippy -p mockforge-registry-server --all-targets --all-features -- -D warnings`, `cargo test -p mockforge-registry-server`). UI: `pnpm type-check` + `pnpm lint` in `crates/mockforge-ui/ui`. Run cargo with sandbox off (aws-lc) + `set -o pipefail`. Commit per task. Use the product-ui skill conventions for the React work.
+
+---
+
+### Task 1: Migration — `email_domain` on `sso_configurations`
+
+**Files:**
+- Create: `crates/mockforge-registry-server/migrations/<NEXT_PREFIX>_sso_email_domain.sql`
+
+**CRITICAL — migration prefix:** Do NOT assume a prefix. Run `ls crates/mockforge-registry-server/migrations/ | sort | tail -3` AND `gh pr list --repo SaaSy-Solutions/mockforge --state open --json headRefName,files` to confirm no concurrent migration. The pre-commit `check-migration-collisions` hook will block a collision. Pick the next free `20250101000NNN` prefix.
+
+- [ ] **Step 1:** Write the migration:
+```sql
+-- Email-domain discovery for SSO: map a work-email domain to the org's IdP.
+ALTER TABLE sso_configurations
+    ADD COLUMN IF NOT EXISTS email_domain VARCHAR(255);
+
+-- Unique so one domain maps to at most one org (discovery is deterministic).
+-- Partial: only enforced for rows that set a domain.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sso_email_domain
+    ON sso_configurations (lower(email_domain))
+    WHERE email_domain IS NOT NULL;
+```
+- [ ] **Step 2:** Verify it parses against a scratch DB if one is available (`sqlx migrate run` with `DATABASE_URL`), else rely on CI. Commit.
+```bash
+git add crates/mockforge-registry-server/migrations/
+git commit -m "feat(registry): add email_domain to sso_configurations for SSO discovery (#746)"
+```
+
+---
+
+### Task 2: Model + store — `email_domain` field & domain lookup
+
+**Files:**
+- Modify: `crates/mockforge-registry-core/src/models/sso.rs` (add `pub email_domain: Option<String>` to `SSOConfiguration`, after the oidc fields ~:56; ensure `FromRow` + any explicit `INSERT`/`SELECT`/`upsert` SQL includes the column).
+- Modify: store layer — find where `create_sso_config`/`find_by_org` SQL lives (grep `sso_configurations` in `crates/mockforge-registry-server/src` and `mockforge-registry-core`). Add a query `find_org_slug_by_email_domain(pool, domain) -> Option<(org_slug, provider)>`.
+
+- [ ] **Step 1 (test-first):** In `models/sso.rs` tests, add a unit test for a pure helper `normalize_email_domain(email: &str) -> Option<String>` (lowercases, takes substring after `@`, returns None if no `@`/empty).
+```rust
+#[test]
+fn email_domain_normalization() {
+    assert_eq!(normalize_email_domain("Jo@Acme.com"), Some("acme.com".to_string()));
+    assert_eq!(normalize_email_domain("no-at-sign"), None);
+    assert_eq!(normalize_email_domain("a@"), None);
+}
+```
+- [ ] **Step 2:** Implement `normalize_email_domain`. Run `cargo test -p mockforge-registry-core sso`. Expected PASS.
+- [ ] **Step 3:** Add the `email_domain` column to the struct + all SQL touching `sso_configurations` (INSERT columns/values, SELECT lists). Add the `find_org_slug_by_email_domain` query (join `sso_configurations` → `organizations` on `org_id`, `WHERE lower(email_domain)=lower($1) AND enabled=true`, return slug + provider).
+- [ ] **Step 4:** `cargo build -p mockforge-registry-core -p mockforge-registry-server` (sandbox off). Fix SQL/struct mismatches. Commit.
+
+---
+
+### Task 3: Shared JIT provisioning (`find_or_create_sso_user`)
+
+**Files:**
+- Modify: `crates/mockforge-registry-server/src/handlers/sso.rs:1174-1224` — rename/generalize `find_or_create_user_from_saml` to `find_or_create_sso_user(state, email: &str, username: Option<&str>, org: &Organization) -> Result<User, ApiError>` (take email/username directly instead of `SAMLUserInfo`); update the SAML ACS caller to pass `user_info.email`/`user_info.username`.
+
+- [ ] **Step 1:** Refactor the function signature to accept `email: &str` + `username: Option<&str>`. Body unchanged otherwise (link-by-email → ensure Member; else create+verify+add Member). Keep behavior identical.
+- [ ] **Step 2:** Update the SAML ACS call site to pass the extracted email/username.
+- [ ] **Step 3:** `cargo build -p mockforge-registry-server` (sandbox off). `cargo test -p mockforge-registry-server --lib sso`. Commit: "refactor(registry): generalize SSO JIT provisioning for SAML+OIDC (#746)".
+
+---
+
+### Task 4: Discovery endpoint `GET /api/v1/sso/discover`
+
+**Files:**
+- Modify: `crates/mockforge-registry-server/src/handlers/sso.rs` (add `discover_sso` handler + `SsoDiscoverResponse { org_slug: String, provider: String }`).
+- Modify: `crates/mockforge-registry-server/src/routes.rs` (register `GET /api/v1/sso/discover` in the **public** router group, alongside the SAML public routes).
+
+- [ ] **Step 1:** Handler: read `?email=` query, `normalize_email_domain`, call `find_org_slug_by_email_domain`. On match return 200 `{org_slug, provider}`; on no match return **404 with a generic body** (no domain confirmation). Rate-limit note: rely on the existing global rate-limit layer; do not echo the input.
+- [ ] **Step 2:** Register the route (public). Verify it compiles. `cargo clippy -p mockforge-registry-server ...`. Commit: "feat(registry): SSO email-domain discovery endpoint (#746)".
+
+---
+
+### Task 5: Add `openidconnect` + OIDC login initiation
+
+**Files:**
+- Modify: root `Cargo.toml` (workspace deps) + `crates/mockforge-registry-server/Cargo.toml` — add `openidconnect = "3"` (verify latest 3.x; features for reqwest blocking off / async on). Mirror how `oauth2` is declared.
+- Create: `crates/mockforge-registry-server/src/handlers/oidc.rs` (or add to `sso.rs` — prefer a new `oidc.rs` submodule for focus; wire `mod oidc;` in `handlers/mod.rs`).
+- Modify: `routes.rs` — public `GET /api/v1/sso/oidc/login/{org_slug}` and `GET /api/v1/sso/oidc/callback/{org_slug}`.
+
+- [ ] **Step 1:** `oidc_login` handler: load org by slug → load enabled OIDC `sso_configurations` (provider="oidc") → **Team-plan gate** (mirror SAML's check) → use `openidconnect` `CoreClient` from discovery (`IssuerUrl` = `oidc_issuer_url`, `ClientId`, `ClientSecret`) → generate `state` + `nonce` (PKCE optional) → store `{state, nonce, org_slug}` in Redis with 15-min TTL (mirror `oauth.rs` CSRF storage) → 302 to the authorization URL (scopes `openid email profile`).
+- [ ] **Step 2:** Build. Register routes. `cargo clippy`. Commit: "feat(registry): OIDC login initiation (#746)". (Callback in Task 6 — login alone won't compile if it references the callback; if so, stub the callback to `todo!()`-free `ApiError::InvalidRequest("not yet")` placeholder and replace in Task 6, OR implement 5+6 together in one commit.)
+
+---
+
+### Task 6: OIDC callback — ID-token validation + provisioning
+
+**Files:**
+- Modify: `crates/mockforge-registry-server/src/handlers/oidc.rs`.
+
+- [ ] **Step 1 (test-first, pure validation):** Add a unit test module for a pure helper `extract_identity_from_claims(claims) -> Result<(email, Option<username>), ApiError>` (pulls `email` from standard claims; `name`/`preferred_username` for username). Test: claims with email → Ok; without email → Err.
+- [ ] **Step 2:** Implement `extract_identity_from_claims`. Test PASS.
+- [ ] **Step 3:** `oidc_callback` handler: read `?code`+`?state` → verify `state` against Redis (consume it) → exchange code via `openidconnect` (`exchange_code`) → **verify ID token** with the discovered JWKS + stored `nonce` (`id_token.claims(&verifier, &nonce)`) — this enforces signature, `iss`, `aud`, `exp`. → `extract_identity_from_claims` → load org by slug → `find_or_create_sso_user` → `create_access_token` (1h, mirror SAML ACS redirect token) → 302 `"{app_base_url}/auth/sso/callback?token={token}&org_slug={slug}"`. On any error → 302 `"{app_base_url}/login?sso_error={code}"` (never leak crypto detail).
+- [ ] **Step 4:** `cargo clippy -p mockforge-registry-server --all-targets --all-features -- -D warnings`; `cargo test -p mockforge-registry-server --lib oidc`. Commit: "feat(registry): OIDC callback with ID-token validation + JIT provisioning (#746)".
+
+---
+
+### Task 7: Extend config CRUD for OIDC + `email_domain`
+
+**Files:**
+- Modify: `handlers/sso.rs` `create_sso_config` request struct + handler.
+
+- [ ] **Step 1:** Add `email_domain: Option<String>` and the OIDC fields (`oidc_issuer_url`, `oidc_client_id`, `oidc_client_secret`) to the create/update request and persist them. Validate per provider: SAML requires entity_id+sso_url+x509_cert; OIDC requires issuer_url+client_id+client_secret. Return `InvalidRequest` listing missing fields.
+- [ ] **Step 2:** `cargo test -p mockforge-registry-server --lib sso`. Commit: "feat(registry): SSO config accepts OIDC fields + email_domain (#746)".
+
+---
+
+### Task 8: SSO-login audit event
+
+**Files:**
+- Modify: `handlers/sso.rs` (SAML ACS success path) + `handlers/oidc.rs` (callback success path).
+
+- [ ] **Step 1:** After successful provisioning + before redirect, call `state.store.record_audit_event(org.id, Some(user.id), AuditEventType::<SsoLogin or existing Login variant>, "SSO login via {provider}", metadata{provider}, ip, ua)`. If no suitable `AuditEventType` variant exists, add one (grep the enum in `mockforge-registry-core/src/models`).
+- [ ] **Step 2:** Build + test. Commit: "feat(registry): audit successful SSO logins (#746)".
+
+---
+
+### Task 9: Frontend — `/auth/sso/callback` route
+
+**Files:**
+- Create: `crates/mockforge-ui/ui/src/pages/SsoCallbackPage.tsx`.
+- Modify: the app router (grep `createBrowserRouter`/`<Routes>` in `crates/mockforge-ui/ui/src` — likely `App.tsx` or `main.tsx`) to add `/auth/sso/callback`.
+- Modify: `stores/useAuthStore.ts` if needed to expose a "set token from external redirect" path (mirror how OAuth/login stores the token).
+
+- [ ] **Step 1:** `SsoCallbackPage`: on mount, read `token`/`org_slug`/`sso_error` from `useSearchParams`. If `sso_error` → redirect to `/login` + toast. Else persist `token` via the auth store (same as login success), call `/users/me` to hydrate, then `navigate` into the app. Show a minimal "Signing you in…" state (product-ui loading).
+- [ ] **Step 2:** Register the route. `pnpm type-check` + `pnpm lint`. Commit.
+
+---
+
+### Task 10: Frontend — login-page SSO entry (email→discover→slug fallback)
+
+**Files:**
+- Modify: `crates/mockforge-ui/ui/src/components/auth/LoginForm.tsx` (+ `services/authApi.ts` for the discover call).
+
+- [ ] **Step 1:** Add a "Sign in with SSO" affordance. Click → email input → `GET /api/v1/sso/discover?email=` → 200: `window.location = "/api/v1/sso/{provider}/login/{org_slug}"`; 404: reveal an org-slug input → on submit `window.location = "/api/v1/sso/saml/login/{slug}"` (default SAML; or call discover by slug if a slug→provider endpoint is added — for now default the slug path to a `/sso/login/{slug}` resolver if one exists, else SAML). Keep it minimal and product-ui consistent (label-above, inline errors).
+- [ ] **Step 2:** `pnpm type-check` + `pnpm lint`. Commit.
+
+---
+
+### Task 11: Frontend — SSOTab OIDC + `email_domain` fields
+
+**Files:**
+- Modify: `crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx` (`SSOTab`, ~:1171; `SSOConfig` interface + `saveSSOConfig` body ~:236-247).
+
+- [ ] **Step 1:** Add a provider toggle (SAML | OIDC). When OIDC: show issuer URL / client ID / client secret. Always show `email_domain`. Extend `SSOConfig` type + `saveSSOConfig` payload. Reuse existing form/input patterns; secrets use password inputs.
+- [ ] **Step 2:** `pnpm type-check` + `pnpm lint`. Commit.
+
+---
+
+### Task 12: Tests — unit + mock-IdP e2e
+
+**Files:**
+- Backend unit tests live inline (already added in Tasks 2/4/6). Ensure coverage: domain normalization, discovery lookup (needs DB → put under existing DB-backed test pattern or keep pure-helper level), ID-token identity extraction.
+- Create: `crates/mockforge-registry-server/tests/sso_e2e.rs` (gated/`#[ignore]` per the repo's e2e convention — see existing `*_e2e.rs`).
+
+- [ ] **Step 1:** SAML e2e: POST a canned signed assertion to `/sso/saml/acs/{slug}` against a test config; assert a session row + 302 to `/auth/sso/callback`. (Reuse any existing SAML test fixtures; if none, document the manual checklist instead and mark the e2e `#[ignore]` with a comment — no silent gap.)
+- [ ] **Step 2:** OIDC e2e: stand up a stub issuer (axum test server serving `.well-known/openid-configuration`, JWKS, and a signed ID token) OR, if that proves heavy, cover ID-token validation at unit level with a hand-built JWKS + token and document the manual Okta/Azure checklist. State explicitly which path was taken.
+- [ ] **Step 3:** Run the full crate suite. Commit.
+
+---
+
+### Task 13: Verify, docs, close
+
+- [ ] **Step 1:** Full verification: `cargo fmt --all --check`; `cargo clippy -p mockforge-registry-server --all-targets --all-features -- -D warnings`; `cargo test -p mockforge-registry-server`; UI `pnpm type-check` + `pnpm lint`. If `mockforge-collab` SQL changed, `make sqlx-prepare` (N/A here — different crate).
+- [ ] **Step 2:** Browser-verify the SSOTab + login SSO entry render (dev server) if feasible; otherwise note pending preview-env verification with a real IdP.
+- [ ] **Step 3:** Update `docs/ENVIRONMENT_VARIABLES.md` if any new env vars (none expected — OIDC config is per-org in DB, not env). Open PR; auto-merge. Comment on #746 that the login loop + OIDC are implemented; the "SSO" pricing claim is now true.
+
+---
+
+## Self-Review notes
+- **Spec coverage:** schema (T1), discovery (T2,T4), shared provisioning (T3), OIDC login+callback+validation (T5,T6), config OIDC+domain (T7), audit (T8), frontend callback (T9), login entry (T10), SSOTab (T11), tests (T12), verify+correct-issue (T13). All spec sections mapped.
+- **Risk/uncertainty (flagged, not hidden):** (a) exact `openidconnect` API surface — confirm against docs.rs for the pinned version during T5/T6. (b) mock-OIDC e2e may be heavy → documented fallback to unit + manual checklist. (c) login-page slug-fallback assumes SAML default; if mixed SAML/OIDC by slug is needed, add a `GET /sso/resolve/{slug}→provider` endpoint (small) in T10.
+- **No new env vars.** **No `unsafe`.** **Team-plan gating** reused at every login-init + config-save path.


### PR DESCRIPTION
Closes #746.

> ⚠️ **Security-sensitive auth PR — please review before merging.** It introduces a cross-tenant trust boundary. I left auto-merge OFF deliberately.

## Background (the issue premise was wrong)
#746 claimed "no SSO is implemented." In fact a full **SAML 2.0 backend + admin config UI already shipped** — but the login loop was never wired in the UI, OIDC was unimplemented, and (critically) the provisioning trusted any IdP-asserted email. This PR makes SSO genuinely usable **and safe**.

## What's here (8 commits)

**Backend — protocols**
- **OIDC** (`handlers/oidc.rs`, `openidconnect 3.5`): discovery, authorization-code flow, full **ID-token validation** (JWKS signature, iss/aud/exp, **nonce**), CSRF `state` (one-time, Redis). Mirrors the SAML pipeline; both converge on one frontend callback.
- **Discovery**: `GET /sso/discover?email=` maps a work-email domain → `{org_slug, provider}` (enumeration-resistant 404).
- Shared JIT provisioning for SAML+OIDC; **audit** on every successful SSO login.

**Backend — security (the important part)**
- **Cross-tenant takeover fix (was critical, also latent in the pre-existing SAML path):** an org's IdP can assert any email, so we now only trust an asserted email whose domain matches the org's **verified** `email_domain`. Enforced in BOTH `oidc_callback` and `saml_acs` before provisioning, and fail-early at login-init.
- **Domain-ownership verification** via DNS TXT challenge (`mockforge-verify=<token>`) — `POST /sso/domain/verify`; SSO login is blocked until the domain is verified, which stops domain squatting.
- **SSRF guard** on the tenant-controlled OIDC issuer URL: https-only + reject loopback/private/link-local/metadata/CGNAT/ULA IPs (resolved), plus a 10s-timeout HTTP client for discovery/exchange.

**Frontend**
- `/auth/sso/callback` page (outside the auth guard) — captures the token, hydrates, enters the app.
- Login page "Sign in with SSO" (work-email → discover → org-slug fallback).
- `SSOTab`: SAML/OIDC provider selector, OIDC fields (secret write-only, never returned), email-domain field + DNS-TXT **verify** flow; Enable is gated on `domain_verified`.

## Verification
- `cargo clippy -p mockforge-registry-server --all-targets --all-features -- -D warnings` + `-p mockforge-registry-core` — clean
- Default-feature build clean (OIDC/SAML behind the `saml` feature in the `saas` rollup)
- `cargo test -p mockforge-registry-server --lib` — **496 passed, 0 failed** (incl. domain-trust, SSRF-classifier, ID-token-identity, provisioning tests)
- `cargo fmt --all --check` clean; UI `tsc --noEmit` + eslint clean on changed files
- Migrations 079–081, no collision with main (latest 078)

## Known gaps / follow-ups (no silent gaps)
- **No automated mock-IdP e2e.** Validation/SSRF/domain logic is unit-tested; a full stub-OIDC-issuer + signed-SAML-assertion e2e is a follow-up. **Recommend a manual run against an Okta/Azure dev tenant before enabling for customers.**
- An independent security review (in-session) confirmed OIDC crypto/CSRF/secret-handling/SQL are solid and the cross-tenant fix closes the takeover; a second human pass on the trust model is wise given the stakes.

Design spec: #770. Implementation plan: `docs/superpowers/plans/2026-05-30-sso-completion.md` (in this PR).