### PR TITLE
fix(sdk-java): wire Maven Central publish via Central Portal (#674)

### DIFF
--- a/.github/workflows/maven-publish-sdk.yml
+++ b/.github/workflows/maven-publish-sdk.yml
@@ -1,21 +1,22 @@
 name: Publish mockforge-sdk to Maven Central
 
-# Publishes `sdk/java/` as `com.mockforge:mockforge-sdk` on Maven Central.
-# Mirrors `npm-publish-sdk.yml` for the Java SDK so #674 closes uniformly
-# across registries.
+# Publishes `sdk/java/` as `io.github.saasy-solutions:mockforge-sdk` on Maven
+# Central via the Sonatype Central Portal. Mirrors `npm-publish-sdk.yml` for the
+# Java SDK so #674 closes uniformly across registries.
 #
 # Triggers:
 #   1. `workflow_dispatch` — manual publish (RC, dry-runs).
 #   2. `push` on a tag matching `java-sdk-v*` (e.g. `java-sdk-v0.1.0`).
 #
-# Prereqs (one-time setup on the repo):
-#   - `OSSRH_USERNAME` + `OSSRH_TOKEN` repo secrets (Sonatype Central
-#     portal user-token credentials).
+# Prereqs (one-time setup on the repo — NOT yet done as of this commit):
+#   - Register the `io.github.saasy-solutions` namespace at
+#     central.sonatype.com (auto-verified via the SaaSy-Solutions GitHub org).
+#   - `CENTRAL_USERNAME` + `CENTRAL_PASSWORD` repo secrets — a Central Portal
+#     *user token* (generated under your Central account), NOT legacy OSSRH.
 #   - `MAVEN_GPG_PRIVATE_KEY` + `MAVEN_GPG_PASSPHRASE` repo secrets
 #     (ascii-armored signing key for Central's GPG requirement).
-#   - `pom.xml` must include the standard Central metadata
-#     (developers, scm, distributionManagement); the SDK pom.xml ships
-#     the essentials.
+# The pom's `release` profile (added alongside this change) supplies the
+# sources/javadoc jars, GPG signing, and central-publishing-maven-plugin upload.
 
 on:
   push:
@@ -52,7 +53,11 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-          server-id: ossrh
+          # `central` matches <publishingServerId>central</publishingServerId>
+          # in the pom's release profile. setup-java writes a settings.xml
+          # <server id="central"> whose credentials come from the env vars named
+          # below, populated in the Publish step.
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
@@ -73,10 +78,11 @@ jobs:
       - name: Publish to Maven Central
         if: ${{ env.DRY_RUN != 'true' }}
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        # -P release activates the gpg + nexus-staging plugins. If the
-        # SDK's pom doesn't have a `release` profile yet, this step
-        # fails loudly — the fix is a pom change, not a workflow bug.
+        # -P release activates source/javadoc jars, GPG signing, and the
+        # central-publishing-maven-plugin (autoPublish) defined in the pom's
+        # release profile. The plugin uploads to the Central Portal using the
+        # `central` server credentials wired by setup-java above.
         run: mvn -B -P release deploy

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -4,7 +4,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.mockforge</groupId>
+    <!-- groupId io.github.saasy-solutions: Sonatype Central auto-verifies the
+         io.github.<org> namespace via ownership of the GitHub org SaaSy-Solutions,
+         so no DNS/domain verification is required. -->
+    <groupId>io.github.saasy-solutions</groupId>
     <artifactId>mockforge-sdk</artifactId>
     <version>0.1.0</version>
     <packaging>jar</packaging>
@@ -23,8 +26,18 @@
     <developers>
         <developer>
             <name>MockForge Contributors</name>
+            <organization>SaaSy Solutions</organization>
+            <organizationUrl>https://github.com/SaaSy-Solutions</organizationUrl>
         </developer>
     </developers>
+
+    <!-- SCM block is required by Maven Central. -->
+    <scm>
+        <connection>scm:git:https://github.com/SaaSy-Solutions/mockforge.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/SaaSy-Solutions/mockforge.git</developerConnection>
+        <url>https://github.com/SaaSy-Solutions/mockforge</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -81,4 +94,86 @@
             </plugin>
         </plugins>
     </build>
+
+    <!--
+        The `release` profile carries everything Maven Central requires that a
+        normal build does not: a sources jar, a javadoc jar, GPG signatures on
+        every artifact, and upload via the Sonatype Central Portal.
+
+        It is profile-gated so day-to-day `mvn verify` stays fast and needs no
+        GPG key. The publish workflow activates it with `-P release deploy`.
+
+        Central Portal (central.sonatype.com) is the current publishing path —
+        the legacy OSSRH / s01.oss.sonatype.org / nexus-staging flow no longer
+        accepts new namespaces, so this uses central-publishing-maven-plugin.
+
+        Prereqks the workflow supplies (see maven-publish-sdk.yml):
+          - Central Portal user token -> server id `central`
+          - ascii-armored GPG key + passphrase for signing
+    -->
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <!-- Matches the `server-id: central` set up by
+                                 setup-java in the publish workflow. -->
+                            <publishingServerId>central</publishingServerId>
+                            <!-- Auto-release once Central's validation passes,
+                                 so a tag push fully publishes with no manual
+                                 "release" click in the portal UI. -->
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Why

Part of #674. The 5-way SDK audit found the Java SDK has **real, complete source** (~10 classes, full MockServer/verification API) but has **never published** — because the publish path was structurally broken in two ways:

1. The workflow ran `mvn -P release deploy` against a `release` profile **that didn't exist** in the pom. Its own comment admitted: *"If the SDK's pom doesn't have a `release` profile yet, this step fails loudly — the fix is a pom change."*
2. groupId `com.mockforge` requires owning `mockforge.com` to verify the namespace with Sonatype.

## Changes

**`pom.xml`**
- **groupId** `com.mockforge` → **`io.github.saasy-solutions`** (per your choice) — Sonatype Central auto-verifies the `io.github.<org>` namespace via GitHub org ownership; no DNS/domain needed.
- Added the **`<scm>`** block Central requires.
- Added a profile-gated **`release` profile** (so plain `mvn verify` stays fast and GPG-free) with everything Central mandates: **source jar**, **javadoc jar**, **GPG signing**, and the **`central-publishing-maven-plugin`** (autoPublish). This uses the current **Central Portal** path — legacy OSSRH/`nexus-staging`/`s01.oss.sonatype.org` no longer accepts new namespaces.

**`maven-publish-sdk.yml`**
- `setup-java` `server-id: ossrh` → **`central`** (matches `<publishingServerId>central</publishingServerId>`).
- Publish creds `OSSRH_USERNAME/OSSRH_TOKEN` → **`CENTRAL_USERNAME/CENTRAL_PASSWORD`** (a Central Portal user token).
- Header rewritten to document the exact remaining setup.

## ⚠️ Not end-to-end verified — needs your one-time setup

I can't complete or fully verify this lane without registry access. Maven isn't installed in this environment either, so the `release` profile is **XML-valid + actionlint-clean but not locally build-tested**. To finish:

1. Register the **`io.github.saasy-solutions`** namespace at central.sonatype.com (auto-verifies via the GitHub org).
2. Add repo secrets: **`CENTRAL_USERNAME`** + **`CENTRAL_PASSWORD`** (Central Portal user token), and **`MAVEN_GPG_PRIVATE_KEY`** + **`MAVEN_GPG_PASSPHRASE`** (an ascii-armored signing key).
3. First validation: run the workflow via **`workflow_dispatch` with `dry_run=true`** (does `mvn verify` only) to confirm the profile resolves, then push **`java-sdk-v0.1.0`** to publish.

## Runner cost
Touches only `sdk/java/**` + a tag-triggered workflow → **zero per-PR self-hosted runner load.**