### PR TITLE
fix(changelog): remove stray merge-conflict marker (unblocks 0.3.155 publish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 
   Labels carry the field path (e.g. `request-body:type-mismatch:user.email`) so the self-test report tells you exactly which field caught (or didn't). Bounded by `SCHEMA_MUTATION_CAP = 12` per operation (top 20 properties, top 5 required) so a 100-property body on a 22 000-operation spec doesn't produce a runaway test matrix. No-op when the body annotator couldn't resolve a schema — falls back to the existing schema-agnostic empty/wrong-type negatives unchanged.
 
-||||||| parent of f59ea5f4 (feat(bench): security probes in conformance self-test (#79 round 17.3))
 ## [0.3.153] - 2026-05-29
 
 ### Added


### PR DESCRIPTION
## What

`main`'s `CHANGELOG.md` had a stray `diff3` merge-conflict marker committed at line 27:
```
||||||| parent of f59ea5f4 (feat(bench): security probes ... round 17.3)
```
Residue from a concurrent-PR CHANGELOG collision (the 0.3.154 and 0.3.155 entries landing near-simultaneously). Both version entries were preserved correctly — only the orphan marker line remained. Removed it; **no content change** to any version entry.

## Why it matters

This is almost certainly why the release stalled: **`main` is at `0.3.155` but crates.io is still `0.3.152`** — the 0.3.153/154/155 work (Srikanth's conformance rounds 17.1–17.3) is merged but unpublished, and a CHANGELOG with a conflict marker taints the release / changelog validation.

Verified: `grep -cE '^(<<<<<<<|\|\|\|\|\|\|\||>>>>>>>|=======)' CHANGELOG.md` → `0` after the fix; the three top headings (0.3.155/154/153) render clean.