### PR TITLE
chore(release): consolidate #79 17.1-18.5 chain into v0.3.162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,35 @@
-## [0.3.159] - 2026-05-29
+## [0.3.162] - 2026-05-31
+
+Issue #79 rounds 17.1 through 18.5 — TUI clipboard + non-violating counter, schema-driven negatives, security probes, spec-level audits, OWASP/WAF unification, HTML report, base-path bug, schema-`$ref` resolution, OWASP coverage hints, GEODB multi-source-IP testing. Squash-merged from PRs #729 / #731 / #732 / #736 / #737 / #738 / #740 / #741 / #742 / #744. Version chain compressed from incremental 0.3.153–0.3.161 into a single 0.3.162 release; the intermediate version numbers were never published to crates.io.
+
+### Added — TUI / Admin
+
+- **[Contracts][DevX]** TUI Conformance detail view gains a **`c`** keystroke to copy the selected violation to the system clipboard as pretty-printed JSON (round 17.1) — Srikanth's (c-i) ask. Uses `arboard` with default features so it works on X11, Wayland, macOS NSPasteboard, and Win32 without per-platform setup. On a clipboard-less TTY the failure surfaces in the flash strip instead of silently no-op'ing.
+- **[Contracts]** New `total_ok` lifetime counter on the conformance violations API (round 17.1) — Srikanth's (f) follow-up. Each request that *passes* the validator bumps the counter; the admin API returns `total_ok` alongside `total_seen`, and the TUI title now reads e.g. `Conformance Violations (256 buffered, 256 shown, 517498/522830 validated failed)`. Gives the real pass/fail ratio under sustained traffic instead of just the violation count.
+
+### Added — Self-test
+
+- **[Contracts][DevX]** Schema-driven request-body mutator for `--conformance-self-test` (round 17.2) — when both a positive sample AND a resolved request-body schema are available, the self-test now emits per-field negatives (type mismatch, required-field removal, min/max bound breaks, pattern miss, enum out-of-range, additional-property), plus a URI-too-long parameter probe. Labels carry the field path (e.g. `request-body:type-mismatch:user.email`). Bounded by `SCHEMA_MUTATION_CAP = 12` per operation (top 20 properties, top 5 required) so a 100-property body on a 22 000-operation spec doesn't produce a runaway test matrix.
+- **[Contracts][DevX][Security]** Security probes (round 17.3) — operations declaring a security requirement now get bad-credential negatives (`security:bad-bearer`, `security:bad-basic`, `security:bad-apikey:<name>`, `security:no-auth`) plus auth-stripping so the probe's credential is the only thing the server sees. Surfaces validators that don't enforce auth even when the spec says they should.
+- **[Contracts][DevX]** Spec-level audit alongside `--conformance-self-test` (round 17.4) — pure audit of the OpenAPI document (no network I/O) covering `servers` (missing/localhost-only/relative-only), `callbacks` (unsecured webhook ops), `polymorphism` (`oneOf` / `anyOf` without `discriminator`), and a datatype coverage map. Writes `conformance-spec-audit.json` next to the self-test JSON.
+- **[Contracts][DevX][Security]** OWASP / WAF unification into `--conformance-self-test` (round 17.5) — folds one canonical payload per OWASP category (`owasp:sqli`, `owasp:xss`, `owasp:command-injection`, `owasp:path-traversal`, `owasp:ssti`, `owasp:ldap-injection`, `owasp:xxe`) into the existing self-test driver. Injects into the first query param or first string body field; skips operations with no injectable surface. 7 probes max per operation; server should return 4xx (5xx = crashed on payload).
+- **[Contracts][DevX]** Self-contained HTML conformance report (round 17.6) — `--conformance-self-test` writes `conformance-report.html` next to the JSON. Inline CSS, no external assets. Sections: headline cards, negatives by category, per-operation results, missed-negative drill-down (capped at 200 rows), and an optional spec-audit section when a round-17.4 audit JSON is present.
+
+### Added — GEODB multi-source-IP
+
+- **[Contracts][DevX]** GEODB / multi-source-IP testing in `--conformance-self-test` (round 18.5). `--source-ip <IP>` (repeatable) builds a pool of reqwest clients bound via `local_address()`; `--geo-source-ip <IP>` rotates fake source IPs across `X-Forwarded-For` / `True-Client-IP` / `CF-Connecting-IP` (configurable via `--geo-source-header`). Self-test only for v0; bench / k6 path lands in a follow-up.
+
+### Changed
+
+- **[Contracts][DevX]** OWASP coverage table now appends an "Untested OWASP categories" footer that tells you exactly which `--conformance-categories` value to add for each uncovered OWASP category (round 18.4). Removes the "Not Working" confusion when a user-selected subset of categories doesn't cover the full OWASP Top 10.
 
 ### Fixed
 
-- **[Contracts][DevX]** `--conformance-self-test` now honours `--base-path` (#79 round 18.1) — Srikanth's 0.3.152 vCenter run on a deployment served behind `/api` saw every one of 1275 positives return 404, because the self-test built URLs straight from the spec's `path` ignoring the resolved base path. Now passes `base_path` through `SelfTestConfig` into `build_url_with_base`, so a spec declaring `/users` against `--base-path /api` correctly hits `<target>/api/users`. The path-param probe (`parameters:bad-path-param`) also applies the prefix so its 404 doesn't get misattributed to "bad path param".
-- **[Contracts][DevX]** Self-test now surfaces "target misconfiguration" loudly (#79 round 18.1) — when every positive case fails with the same status code (e.g. all 404), the report previously showed all-green negative buckets because 404 falls in the 4xx range that negatives expect. `SelfTestReport::detect_target_misconfiguration()` catches this pattern and the CLI prints a hard warning before the negative rollup: `Self-test misconfiguration: every positive case returned 404. Likely cause: spec paths don't match deployed routes — check --base-path and the spec's `servers` block.`
-- **[DevX]** Bench header no longer prints "Operations: 0 endpoints" before the spec is parsed (#79 round 18.2) — Srikanth's run displayed `Operations: 0 endpoints` in the banner immediately followed by `Analyzed 1275 operations` from the parse log. The header now shows `Operations: (analyzing spec…)` until the parse completes; the analysis line below carries the real count.
+- **[Contracts][DevX]** `--conformance-self-test` now honours `--base-path` (round 18.1) — pre-fix every positive 404'd on deployments served behind a path prefix.
+- **[Contracts][DevX]** Self-test now emits a hard warning when every positive case fails with the same status code, instead of silently treating 404s as "negatives caught" (round 18.1).
+- **[DevX]** Bench header no longer prints `Operations: 0 endpoints` before the spec is parsed (round 18.2). Shows `(analyzing spec…)` until the count is known.
+- **[Contracts]** Request-body validator now resolves nested `$ref` pointers against the spec's components map (round 18.3) — pre-fix specs whose component schemas had dotted names (`Vcenter.VM.DiskCloneSpec`) or were referenced from nested schemas failed with `Pointer '/components/schemas/X' does not exist`. New `schema_ref_resolver::build_validator(&schema, &spec)` inlines the components into the validator's document context.
 
-||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
-## [0.3.153] - 2026-05-29
-
-### Added
-
-- **[Contracts][DevX]** TUI Conformance detail view gains a **`c`** keystroke to copy the selected violation to the system clipboard as pretty-printed JSON (#79 round 17.1) — Srikanth's (c-i) ask. Uses `arboard` with default features so it works on X11, Wayland, macOS NSPasteboard, and Win32 without per-platform setup. On a clipboard-less TTY the failure surfaces in the flash strip instead of silently no-op'ing.
-- **[Contracts]** New `total_ok` lifetime counter on the conformance violations API (#79 round 17.1) — Srikanth's (f) follow-up. Each request that *passes* the validator bumps the counter; the admin API returns `total_ok` alongside `total_seen`, and the TUI title now reads e.g. `Conformance Violations (256 buffered, 256 shown, 517498/522830 validated failed)`. Gives the real pass/fail ratio under sustained traffic instead of just the violation count.
-
-||||||| parent of f41e0530 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
 ## [0.3.152] - 2026-05-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.159"
+version = "0.3.162"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,22 +1,21 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
-## [0.3.159] - 2026-05-29
+## [0.3.162] - 2026-05-31
 
-### Fixed
-
-- **[Contracts][DevX]** `--conformance-self-test` now honours `--base-path` (#79 round 18.1) — pre-fix every positive 404'd on deployments served behind a path prefix.
-- **[Contracts][DevX]** Self-test now emits a hard warning when every positive case fails with the same status code, instead of silently treating 404s as "negatives caught".
-- **[DevX]** Bench header no longer prints `Operations: 0 endpoints` before the spec is parsed (#79 round 18.2). Shows `(analyzing spec…)` until the count is known.
-
-||||||| parent of 483a9524 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
-## [0.3.153] - 2026-05-29
+Issue #79 rounds 17.1–18.5 consolidated into a single release. Intermediate version numbers (0.3.153–0.3.161) were never published.
 
 ### Added
+- TUI Conformance: **`c`** copies the selected violation to clipboard (round 17.1); `total_ok` counter alongside `total_seen` for accurate pass/fail ratio (round 17.1).
+- `--conformance-self-test` schema-driven body mutator (round 17.2), security probes (round 17.3), spec-level audit (round 17.4), OWASP/WAF unification (round 17.5), self-contained HTML report (round 17.6).
+- GEODB multi-source-IP testing (round 18.5): `--source-ip` (real bind) + `--geo-source-ip` (forwarded-IP headers).
 
-- **[Contracts][DevX]** TUI Conformance detail view: **`c`** copies the selected violation to the system clipboard as JSON (#79 round 17.1, Srikanth's (c-i)).
-- **[Contracts]** `total_ok` lifetime counter alongside `total_seen` — admin API and TUI title now show the real pass/fail ratio (#79 round 17.1, Srikanth's (f) follow-up).
+### Changed
+- OWASP coverage table now explains the "-" rows with actionable category hints (round 18.4).
 
-||||||| parent of f41e0530 (feat(bench): OWASP/WAF unification in self-test (#79 round 17.5))
+### Fixed
+- `--conformance-self-test` honours `--base-path` (round 18.1); hard warning when every positive returns the same status (round 18.1); accurate bench header before spec parse (round 18.2).
+- Request-body validator resolves nested `$ref` pointers against the spec's components map (round 18.3) — fixes the `Vcenter.VM.DiskCloneSpec` "Pointer does not exist" class of failures.
+
 ## [0.3.152] - 2026-05-28
 
 ### Changed

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -2244,6 +2244,16 @@ impl BenchCommand {
                 // own first server prefix) so a deployment served
                 // under a path-prefix doesn't 404 every positive.
                 base_path: resolved_base_path.clone(),
+                // Round 18.5 — GEODB multi-source-IP. Parse CLI IP
+                // lists (malformed entries log a warning and are
+                // dropped). Empty lists keep pre-18.5 behaviour.
+                source_ips: parse_ip_list(&self.source_ips, "source-ip"),
+                geo_source_ips: parse_ip_list(&self.geo_source_ips, "geo-source-ip"),
+                geo_source_headers: if self.geo_source_headers.is_empty() {
+                    crate::conformance::self_test::default_geo_source_headers()
+                } else {
+                    self.geo_source_headers.clone()
+                },
             };
             TerminalReporter::print_progress(&format!(
                 "Self-test mode: driving {} operations with positive + per-category negative cases",

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -50,6 +50,18 @@ pub struct SelfTestConfig {
     /// Pre-fix this was ignored entirely and every operation 404'd
     /// (Srikanth's vCenter run on 0.3.152: 1275 positives, 1275 4xx).
     pub base_path: Option<String>,
+    /// Round 18.5 — local source IPs to bind outgoing requests to.
+    /// Each IP must already be assigned to an interface on the host.
+    /// Operations round-robin through the resulting client pool.
+    pub source_ips: Vec<IpAddr>,
+    /// Round 18.5 — fake source IPs to advertise via forwarded-IP
+    /// headers (used to exercise GEODB lookup at the destination).
+    /// Rotated per operation.
+    pub geo_source_ips: Vec<IpAddr>,
+    /// Which forwarded-IP header(s) to populate when `geo_source_ips`
+    /// is non-empty. Empty → no-op; default below sets the standard
+    /// three-header set.
+    pub geo_source_headers: Vec<String>,
 }
 
 impl Default for SelfTestConfig {
@@ -61,6 +73,9 @@ impl Default for SelfTestConfig {
             extra_headers: Vec::new(),
             delay_between_requests: Duration::from_millis(0),
             base_path: None,
+            source_ips: Vec::new(),
+            geo_source_ips: Vec::new(),
+            geo_source_headers: default_geo_source_headers(),
         }
     }
 }
@@ -701,6 +716,204 @@ fn inject_into_body_field(body: Option<&str>, field: &str, payload: &str) -> Opt
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Round 17.3 — one synthesised bad credential to send.
+#[derive(Debug, Clone)]
+struct SecurityProbe {
+    /// Self-test label, e.g. `security:bad-bearer`.
+    label: String,
+    /// Headers to attach to the probe request.
+    headers: Vec<(String, String)>,
+    /// Query parameters to attach (API key in query case).
+    query: Vec<(String, String)>,
+}
+
+/// For each declared security scheme, produce one bad-credential
+/// probe plus a single "no auth at all" probe that exercises the
+/// missing-credential code path. Deduplicates by scheme kind so an
+/// operation declaring `[bearer, bearer]` only yields one Bearer
+/// probe.
+fn build_security_probes(schemes: &[SecuritySchemeInfo]) -> Vec<SecurityProbe> {
+    if schemes.is_empty() {
+        return Vec::new();
+    }
+    let mut probes: Vec<SecurityProbe> = Vec::new();
+    let mut seen_bearer = false;
+    let mut seen_basic = false;
+    // `(loc_tag, name)` — ApiKeyLocation doesn't implement Ord, so
+    // we tag it with a short discriminant string for dedup.
+    let mut seen_apikey: std::collections::BTreeSet<(&'static str, String)> = Default::default();
+    for s in schemes {
+        match s {
+            SecuritySchemeInfo::Bearer if !seen_bearer => {
+                seen_bearer = true;
+                probes.push(SecurityProbe {
+                    label: "security:bad-bearer".into(),
+                    headers: vec![(
+                        "Authorization".into(),
+                        "Bearer self-test-invalid-token".into(),
+                    )],
+                    query: Vec::new(),
+                });
+            }
+            SecuritySchemeInfo::Basic if !seen_basic => {
+                seen_basic = true;
+                // base64("self-test:invalid") — valid base64, wrong creds.
+                probes.push(SecurityProbe {
+                    label: "security:bad-basic".into(),
+                    headers: vec![(
+                        "Authorization".into(),
+                        "Basic c2VsZi10ZXN0OmludmFsaWQ=".into(),
+                    )],
+                    query: Vec::new(),
+                });
+            }
+            SecuritySchemeInfo::ApiKey { location, name } => {
+                let loc_tag = match location {
+                    ApiKeyLocation::Header => "header",
+                    ApiKeyLocation::Query => "query",
+                    ApiKeyLocation::Cookie => "cookie",
+                };
+                if seen_apikey.contains(&(loc_tag, name.clone())) {
+                    continue;
+                }
+                seen_apikey.insert((loc_tag, name.clone()));
+                let label = format!("security:bad-apikey:{}", name);
+                let bad = "self-test-invalid-key".to_string();
+                match location {
+                    ApiKeyLocation::Header => probes.push(SecurityProbe {
+                        label,
+                        headers: vec![(name.clone(), bad)],
+                        query: Vec::new(),
+                    }),
+                    ApiKeyLocation::Query => probes.push(SecurityProbe {
+                        label,
+                        headers: Vec::new(),
+                        query: vec![(name.clone(), bad)],
+                    }),
+                    ApiKeyLocation::Cookie => probes.push(SecurityProbe {
+                        label,
+                        headers: vec![("Cookie".into(), format!("{}={}", name, bad))],
+                        query: Vec::new(),
+                    }),
+                }
+            }
+            _ => {}
+        }
+    }
+    // Always add a "no auth at all" probe when *any* security scheme
+    // is declared — useful even if all schemes failed to resolve to a
+    // testable kind, because it surfaces validators that aren't
+    // checking auth presence at all.
+    probes.push(SecurityProbe {
+        label: "security:no-auth".into(),
+        headers: Vec::new(),
+        query: Vec::new(),
+    });
+    probes
+}
+
+/// Remove Authorization and any API-key headers declared by the
+/// operation's security schemes from `headers`, so a security probe
+/// can supply its own credential (or none) cleanly.
+fn strip_auth(
+    headers: &[(String, String)],
+    schemes: &[SecuritySchemeInfo],
+) -> Vec<(String, String)> {
+    let mut apikey_headers: std::collections::BTreeSet<String> = Default::default();
+    for s in schemes {
+        if let SecuritySchemeInfo::ApiKey {
+            location: ApiKeyLocation::Header,
+            name,
+        } = s
+        {
+            apikey_headers.insert(name.to_lowercase());
+        }
+        if let SecuritySchemeInfo::ApiKey {
+            location: ApiKeyLocation::Cookie,
+            ..
+        } = s
+        {
+            apikey_headers.insert("cookie".into());
+        }
+    }
+    headers
+        .iter()
+        .filter(|(k, _)| {
+            let lk = k.to_lowercase();
+            lk != "authorization" && !apikey_headers.contains(&lk)
+        })
+        .cloned()
+        .collect()
+}
+
+/// Remove API-key query parameters declared by the operation's
+/// security schemes from `query`, so a probe can supply its own.
+fn strip_auth_query(
+    query: &[(String, String)],
+    schemes: &[SecuritySchemeInfo],
+) -> Vec<(String, String)> {
+    let mut apikey_query: std::collections::BTreeSet<String> = Default::default();
+    for s in schemes {
+        if let SecuritySchemeInfo::ApiKey {
+            location: ApiKeyLocation::Query,
+            name,
+        } = s
+        {
+            apikey_query.insert(name.clone());
+        }
+    }
+    query.iter().filter(|(k, _)| !apikey_query.contains(k)).cloned().collect()
+}
+
+/// Variant of `send_case` that takes an explicit `extra_headers`
+/// (rather than reading them from `config`). Used by security probes
+/// to substitute or strip the configured Authorization header.
+#[allow(clippy::too_many_arguments)]
+async fn send_case_with_extra(
+    client: &Client,
+    config: &SelfTestConfig,
+    method: Method,
+    url: &str,
+    label: &str,
+    expected_4xx: bool,
+    body: Option<&str>,
+    query: Vec<(String, String)>,
+    headers: Vec<(String, String)>,
+    extra_headers: Vec<(String, String)>,
+) -> CaseOutcome {
+    let _ = config; // signature parity; timeout already on `client`.
+    let mut req = client.request(method, url);
+    for (k, v) in &query {
+        req = req.query(&[(k.as_str(), v.as_str())]);
+    }
+    for (k, v) in &headers {
+        req = req.header(k, v);
+    }
+    for (k, v) in &extra_headers {
+        req = req.header(k, v);
+    }
+    if let Some(b) = body {
+        req = req
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(b.to_string());
+    }
+    let actual_status = match req.send().await {
+        Ok(resp) => resp.status().as_u16(),
+        Err(_) => 0,
+    };
+    let passed = if expected_4xx {
+        (400..500).contains(&actual_status)
+    } else {
+        (200..400).contains(&actual_status)
+    };
+    CaseOutcome {
+        label: label.to_string(),
+        expected_4xx,
+        actual_status,
+        passed,
+    }
+}
+
 async fn send_case(
     client: &Client,
     config: &SelfTestConfig,


### PR DESCRIPTION
## Why

The 10 squash-merges of PRs #729 / #731 / #732 / #736 / #737 / #738 / #740 / #741 / #742 / #744 produced cascading conflicts in \`CHANGELOG.md\`, \`book/src/reference/changelog.md\`, and \`Cargo.toml\` via the rebase chain (each PR rebased N times against an increasingly cumulative main). The final state on \`main\` is broken in three concrete ways:

1. **\`CHANGELOG.md\` has stray \`|||||||\` merge-conflict markers** and only surfaces the 18.1 + 17.1 entries — every other version entry got dropped during the cascade.
2. **\`Cargo.toml\` landed at 0.3.159**, but the actual code shipped covers rounds through 18.5 (target version 0.3.162).
3. **\`crates/mockforge-bench/src/conformance/self_test.rs\` is missing ~200 LOC** of 17.3 function definitions (\`build_security_probes\`, \`strip_auth\`, \`strip_auth_query\`, \`send_case_with_extra\`) plus the \`SelfTestConfig\` struct fields for 18.5 (\`source_ips\`, \`geo_source_ips\`, \`geo_source_headers\`). Call sites for these functions/fields are still present, so \`cargo build -p mockforge-bench\` fails with 11 E0425/E0609 errors. Root cause: \`git rebase -X theirs\` on the later branches preferred each branch's older view of the file when conflicting against main's newer cumulative state.

\`crates.io\` confirms only 0.3.152 is published — none of the in-flight intermediate versions ever went out. Consolidating into a single 0.3.162 release is the cleanest representation.

## What

- **Bumped** \`workspace.package.version\` to **0.3.162**.
- **Recovered** the lost 17.3 function block from the original 17.3 branch commit (\`6e7e285c\`) and re-inserted it before \`send_case\` in \`self_test.rs\`.
- **Added** the missing \`source_ips\` / \`geo_source_ips\` / \`geo_source_headers\` fields to \`SelfTestConfig\` + its \`Default\` impl.
- **Repaired** the CLI's \`SelfTestConfig\` literal in \`command.rs\` to populate the three new fields via the existing \`parse_ip_list\` helper.
- **Consolidated** \`CHANGELOG.md\` + book changelog into a single 0.3.162 entry covering all 10 rounds.

## Verification

- \`cargo build --workspace --exclude mockforge-desktop\` — ✅ clean
- \`cargo test -p mockforge-bench --lib self_test\` — ✅ **18/18 pass** (covers all new probes: schema-driven negatives, security probes, OWASP, GEODB source IPs, target-misconfig detection, base-path)
- \`cargo install --path crates/mockforge-cli --locked --offline --force\` — ✅ installs as \`mockforge-cli v0.3.162\`
- Installed binary surfaces all the new flags via \`mockforge bench --help\`:
  - \`--conformance-self-test\`
  - \`--source-ip <IP>\`
  - \`--geo-source-ip <IP>\`
  - \`--geo-source-header <HEADER>\`

## Test plan

- [x] Workspace builds clean.
- [x] Bench self-test suite passes (18/18).
- [x] \`cargo install --locked --offline\` succeeds — this is the smoke test that has historically caught default-feature consumer breakage that per-crate \`cargo publish\` missed (see v0.3.142 post-mortem).
- [x] Installed binary surfaces the new flags from rounds 17.2-18.5.

## What's next once this lands

1. \`scripts/publish-crates.sh\` to push 53 crates to crates.io at 0.3.162.
2. \`git tag v0.3.162 && git push origin v0.3.162\`.
3. Verify a fresh install of the *published* binary works.
4. Reply on issue #79 with the release notification and Srikanth's three sample commands.