### PR TITLE
ci(registry-e2e): kill stale server on :58080 + verify own pid bound (#782)

### DIFF
--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -199,20 +199,46 @@ jobs:
           STORAGE_PATH: "${{ runner.temp }}/mf-e2e-storage"
         run: |
           mkdir -p "$STORAGE_PATH"
+
+          # Free REGISTRY_PORT from any leftover registry-server bound by a
+          # PRIOR job on this shared self-hosted runner. This is the #782 root
+          # cause: without it the new server fails to bind with EADDRINUSE
+          # (`Address already in use (os error 98)`), the health check below
+          # then FALSE-PASSES against the stale server, and the E2E tests hit
+          # that stale server — which was started without STORAGE_PATH so it
+          # writes to ./data/storage and 500s on every marketplace publish.
+          # Both calls are best-effort (|| true) so a missing tool never fails.
+          fuser -k "${REGISTRY_PORT}/tcp" 2>/dev/null || true
+          pkill -f 'target/debug/mockforge-registry-server' 2>/dev/null || true
+          sleep 2
+
           nohup ./target/debug/mockforge-registry-server \
             > registry-server.log 2>&1 &
-          echo $! > registry-server.pid
-          echo "Waiting for registry-server on :${REGISTRY_PORT}..."
-          for i in {1..60}; do
+          SERVER_PID=$!
+          echo "$SERVER_PID" > registry-server.pid
+          echo "Waiting for registry-server (pid $SERVER_PID) on :${REGISTRY_PORT}..."
+          for _ in {1..60}; do
+            # If OUR process died (e.g. lost a bind race to a stale server),
+            # stop immediately — never let the loop "pass" against someone
+            # else's server.
+            if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+              echo "::error::registry-server (pid $SERVER_PID) exited during startup — likely failed to bind :${REGISTRY_PORT} (stale server on the runner?)."
+              tail -200 registry-server.log || true
+              exit 1
+            fi
             if curl -sfS "http://localhost:${REGISTRY_PORT}/health" >/dev/null 2>&1; then
               echo "registry-server healthy"
               break
             fi
             sleep 1
           done
-          if ! curl -sfS "http://localhost:${REGISTRY_PORT}/health" >/dev/null 2>&1; then
-            echo "::error::registry-server never became healthy"
-            tail -100 registry-server.log || true
+          # Final guard: OUR process must still be alive AND the port healthy.
+          # The kill -0 check is what distinguishes "our server is serving" from
+          # "a stale server answered our curl" (#782).
+          if ! kill -0 "$SERVER_PID" 2>/dev/null \
+             || ! curl -sfS "http://localhost:${REGISTRY_PORT}/health" >/dev/null 2>&1; then
+            echo "::error::registry-server never became healthy (our pid alive: $(kill -0 "$SERVER_PID" 2>/dev/null && echo yes || echo no))"
+            tail -200 registry-server.log || true
             exit 1
           fi
 
@@ -243,6 +269,11 @@ jobs:
           if [ -f registry-server.pid ]; then
             kill "$(cat registry-server.pid)" 2>/dev/null || true
           fi
+          # Belt-and-suspenders: also free the port by name/port in case the
+          # recorded pid wasn't the process actually bound (a stale leftover).
+          # Leaving a server bound here is what poisons the NEXT job (#782).
+          fuser -k "${REGISTRY_PORT}/tcp" 2>/dev/null || true
+          pkill -f 'target/debug/mockforge-registry-server' 2>/dev/null || true
 
       - name: Tear down Postgres + MinIO
         if: always()

--- a/.github/workflows/registry-e2e.yml
+++ b/.github/workflows/registry-e2e.yml
@@ -162,6 +162,15 @@ jobs:
 
       - name: Start Postgres + MinIO
         run: |
+          # Claim a clean slate before `up`. A prior job that was killed/crashed
+          # (or never ran `down`) can leave the postgres/minio containers running
+          # on the shared self-hosted runner, holding the fixed host ports
+          # (:55432, :59000) — `up` then fails with `failed to bind host port …
+          # address already in use`. Same #782 leftover-state disease as the
+          # registry-server :58080 zombie, one layer down. Best-effort teardown
+          # (|| true) so a clean runner isn't affected.
+          docker compose -f docker-compose.e2e.yml down --remove-orphans --volumes 2>/dev/null || true
+          docker ps -aq --filter "name=mockforge-e2e" | xargs -r docker rm -f 2>/dev/null || true
           docker compose -f docker-compose.e2e.yml up -d
           echo "Waiting for Postgres to be healthy..."
           for i in {1..60}; do


### PR DESCRIPTION
Fixes #782.

## Root cause (empirically confirmed on the runner)

`Registry E2E` failed deterministically for registry PRs running `marketplace_e2e` with `Storage error: Failed to create directory: ./data/storage/<kind>/<id>` 500s. I traced it to the server log + the runner host:

A **leftover `mockforge-registry-server` (pid 889673) bound to :58080 since Fri May 29** — started with `STORAGE_PATH` unset and a **since-deleted cwd** (`…/_work/mockforge/mockforge (deleted)`), so it resolved `./data/storage` against a deleted dir and 500'd on every artifact write. Each job's new server:

1. initialized storage correctly (logged `Using local filesystem storage at: …/mf-e2e-storage`), but
2. **crashed on bind: `Error: Address already in use (os error 98)`**, while
3. the health check **false-passed** against the zombie (it only `curl`ed :58080, never verified its *own* process bound), so
4. the tests hit the zombie → `./data/storage` 500s.

`Stop registry-server` only killed the pidfile pid (this job's crashed server), so the zombie persisted across jobs indefinitely.

## Fix

- **Free `:58080` before starting** (`fuser -k` + `pkill -f` fallback, best-effort) so a leftover can't hijack the run.
- **Verify our own pid is alive** in the health loop and final guard (`kill -0 $SERVER_PID`) — fail loudly if our server lost the bind instead of passing against a stale one.
- **Stop step frees the port too**, so this job never leaves a leftover for the next.
- Retains the `STORAGE_PATH=${{ runner.temp }}/mf-e2e-storage` pin from #772.

## Verification

- The 2-day-old zombie was killed on the runner directly (`:58080` now free), unblocking the queue immediately.
- `actionlint` clean (incl. its shellcheck); YAML valid.
- **This PR's own `Registry E2E` run is the live test**: with the fix, the port is pre-cleaned, the new server binds with `mf-e2e-storage`, and `marketplace_e2e` should pass. Auto-merge armed so it lands when genuinely green.

## Known follow-up (out of scope)
- The S3/MinIO health check fails in E2E (`service error`) so the server uses local fallback; worth fixing separately so the intended S3 path is exercised.
- Fixed ports (:58080) + a per-ref concurrency group mean two different PRs' registry-e2e could still race on the host; the pre-clean makes it last-starter-wins rather than silently-wrong, but true isolation would need per-job ports.