### PR TITLE
fix(openapi,bench): live-server schema-$ref resolution + CIDR ranges for GEODB source-IP (#79 round 19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.163] - 2026-06-01
+
+### Fixed
+
+- **[Contracts]** Live-server request-body validator now resolves nested `$ref` pointers against the spec's components map (#79 round 19) — Srikanth's vCenter 0.3.162 run still produced 120 `"Failed to create schema validator: Pointer '/components/schemas/Esx.Settings.Inventory.EntitySpec' does not exist"` violations against schemas that DO exist in the spec. Round 18.3 fixed the bench-side + the `validation::validate_request_body` helper, but missed a third call site in `openapi_routes.rs::validate_request_with_all` (line 1250 + 1267) that used `OpenApiSchema::new(...).validate()` with a naked validator. Switched both branches to `schema_ref_resolver::build_validator(&schema, &spec)` which inlines the components. Dotted-name schemas (`Esx.Settings.Inventory.EntitySpec`, `Vapi.Std.DynamicID`, etc.) now resolve correctly.
+
+### Added
+
+- **[Contracts][DevX]** `--source-ip` and `--geo-source-ip` now accept CIDR ranges (#79 round 19 — Srikanth's follow-up on round 18.5 (j)). Pass `--source-ip 10.0.0.0/28` to bind 16 hosts, `--geo-source-ip 2001:db8::/126` for 4 IPv6 hosts, or mix all three forms in one CLI value: `--geo-source-ip 10.0.0.0/30,2001:db8::1,203.0.113.42`. CIDR expansion is capped at 256 hosts per range to guard against `/8` typos blowing up the bench client; the cap is logged when triggered. IPv4 and IPv6 supported.
+
 ## [0.3.162] - 2026-05-31
 
 Issue #79 rounds 17.1 through 18.5 — TUI clipboard + non-violating counter, schema-driven negatives, security probes, spec-level audits, OWASP/WAF unification, HTML report, base-path bug, schema-`$ref` resolution, OWASP coverage hints, GEODB multi-source-IP testing. Squash-merged from PRs #729 / #731 / #732 / #736 / #737 / #738 / #740 / #741 / #742 / #744. Version chain compressed from incremental 0.3.153–0.3.161 into a single 0.3.162 release; the intermediate version numbers were never published to crates.io.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.162"
+version = "0.3.163"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,13 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.163] - 2026-06-01
+
+### Fixed
+- Live-server route handler now resolves nested `$ref` pointers against the spec's components (#79 round 19) — third schema-validator call site, missed by round 18.3. Dotted-name vCenter schemas resolve.
+
+### Added
+- `--source-ip` and `--geo-source-ip` accept CIDR ranges (`10.0.0.0/28`, `2001:db8::/126`) capped at 256 hosts per range. IPv4 + IPv6 supported (#79 round 19).
+
 ## [0.3.162] - 2026-05-31
 
 Issue #79 rounds 17.1–18.5 consolidated into a single release. Intermediate version numbers (0.3.153–0.3.161) were never published.

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -243,13 +243,22 @@ pub struct BenchCommand {
     pub owasp_iterations: u32,
 }
 
-/// Round 18.5 — parse a list of CLI IP strings (each entry may be a
-/// single IP or a comma-separated list — the CLI flag is repeatable
-/// AND comma-friendly so `--source-ip 10.0.0.1,10.0.0.2` and
-/// `--source-ip 10.0.0.1 --source-ip 10.0.0.2` are equivalent).
+/// Round 18.5 / 19 — parse a list of CLI IP strings. Each entry may be:
+/// - a single IPv4/IPv6 (`10.0.0.5` / `2001:db8::1`)
+/// - a comma-separated list (`10.0.0.5,10.0.0.6,2001:db8::1`)
+/// - a CIDR range (`10.0.0.0/29` expands to 8 hosts;
+///   `2001:db8::/126` expands to 4 IPv6 hosts)
+///
+/// CIDR ranges are capped at `MAX_CIDR_EXPANSION` (256) host
+/// addresses to avoid OOM'ing on `/8` typos. The cap is generous
+/// for GEODB testing (you want 20–100 IPs, not 10M) and the warning
+/// names the cap so it's debuggable.
+///
 /// Malformed entries log a warning and are dropped; the bench
 /// continues with whatever resolved cleanly.
 fn parse_ip_list(raw: &[String], flag_name: &str) -> Vec<std::net::IpAddr> {
+    use std::net::IpAddr;
+    const MAX_CIDR_EXPANSION: usize = 256;
     let mut out = Vec::new();
     for entry in raw {
         for piece in entry.split(',') {
@@ -257,7 +266,27 @@ fn parse_ip_list(raw: &[String], flag_name: &str) -> Vec<std::net::IpAddr> {
             if s.is_empty() {
                 continue;
             }
-            match s.parse::<std::net::IpAddr>() {
+            // CIDR form: `ip/prefix`
+            if let Some((addr_part, prefix_part)) = s.split_once('/') {
+                let prefix: u32 = match prefix_part.parse() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::warn!(target: "mockforge::bench", "ignoring --{flag_name} '{s}': bad CIDR prefix: {e}");
+                        continue;
+                    }
+                };
+                let net_addr: IpAddr = match addr_part.parse() {
+                    Ok(a) => a,
+                    Err(e) => {
+                        tracing::warn!(target: "mockforge::bench", "ignoring --{flag_name} '{s}': bad CIDR address: {e}");
+                        continue;
+                    }
+                };
+                expand_cidr(net_addr, prefix, MAX_CIDR_EXPANSION, flag_name, s, &mut out);
+                continue;
+            }
+            // Plain IP form
+            match s.parse::<IpAddr>() {
                 Ok(ip) => out.push(ip),
                 Err(e) => {
                     tracing::warn!(target: "mockforge::bench", "ignoring malformed --{flag_name} value '{s}': {e}");
@@ -266,6 +295,71 @@ fn parse_ip_list(raw: &[String], flag_name: &str) -> Vec<std::net::IpAddr> {
         }
     }
     out
+}
+
+/// Expand a CIDR (IPv4 or IPv6) into individual host IPs, appending
+/// to `out`. Capped at `cap` to prevent runaway expansion on a `/8`
+/// typo. When the cap kicks in we log a warning and skip the rest.
+fn expand_cidr(
+    net: std::net::IpAddr,
+    prefix: u32,
+    cap: usize,
+    flag_name: &str,
+    raw: &str,
+    out: &mut Vec<std::net::IpAddr>,
+) {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    match net {
+        IpAddr::V4(ipv4) => {
+            if prefix > 32 {
+                tracing::warn!(target: "mockforge::bench", "ignoring --{flag_name} '{raw}': IPv4 prefix must be <= 32");
+                return;
+            }
+            let total: u64 = 1u64 << (32 - prefix);
+            let take = total.min(cap as u64) as u32;
+            if total > cap as u64 {
+                tracing::warn!(target: "mockforge::bench", "--{flag_name} '{raw}': CIDR has {total} addresses, capping at {cap}");
+            }
+            let mask: u32 = if prefix == 0 {
+                0
+            } else {
+                !0u32 << (32 - prefix)
+            };
+            let net_u32 = u32::from(ipv4) & mask;
+            for i in 0..take {
+                out.push(IpAddr::V4(Ipv4Addr::from(net_u32.wrapping_add(i))));
+            }
+        }
+        IpAddr::V6(ipv6) => {
+            if prefix > 128 {
+                tracing::warn!(target: "mockforge::bench", "ignoring --{flag_name} '{raw}': IPv6 prefix must be <= 128");
+                return;
+            }
+            // Total addresses = 2^(128-prefix). Cap at u128::MAX
+            // conceptually but since `cap` is small (256) we just
+            // iterate up to cap.
+            let mask: u128 = if prefix == 0 {
+                0
+            } else {
+                !0u128 << (128 - prefix)
+            };
+            let net_u128 = u128::from(ipv6) & mask;
+            let remaining_bits = 128 - prefix;
+            // Compute total carefully — for prefix=0 this is 2^128
+            // which overflows; we just clamp via take.
+            let total_capped = if remaining_bits >= 64 {
+                cap as u128
+            } else {
+                (1u128 << remaining_bits).min(cap as u128)
+            };
+            if remaining_bits < 128 && (1u128 << remaining_bits) > cap as u128 {
+                tracing::warn!(target: "mockforge::bench", "--{flag_name} '{raw}': IPv6 CIDR exceeds {cap} addresses, capping");
+            }
+            for i in 0..total_capped {
+                out.push(IpAddr::V6(Ipv6Addr::from(net_u128.wrapping_add(i))));
+            }
+        }
+    }
 }
 
 impl BenchCommand {
@@ -3037,6 +3131,74 @@ mod tests {
         assert_eq!(BenchCommand::parse_duration("5m").unwrap(), 300);
         assert_eq!(BenchCommand::parse_duration("1h").unwrap(), 3600);
         assert_eq!(BenchCommand::parse_duration("60").unwrap(), 60);
+    }
+
+    /// Round 19 — single IPs and comma-separated lists already
+    /// worked in 18.5; this regression-locks the parse paths.
+    #[test]
+    fn parse_ip_list_plain_and_comma() {
+        let v = parse_ip_list(&["10.0.0.5".into(), "10.0.0.6,10.0.0.7".into()], "source-ip");
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[0].to_string(), "10.0.0.5");
+        assert_eq!(v[2].to_string(), "10.0.0.7");
+    }
+
+    /// Round 19 — IPv4 CIDR expands to host count up to the cap.
+    /// `/29` = 8 hosts (well under cap), all 8 enumerated.
+    #[test]
+    fn parse_ip_list_ipv4_cidr_29_expands_to_8() {
+        let v = parse_ip_list(&["10.0.0.0/29".into()], "source-ip");
+        assert_eq!(v.len(), 8);
+        assert_eq!(v[0].to_string(), "10.0.0.0");
+        assert_eq!(v[7].to_string(), "10.0.0.7");
+    }
+
+    /// Round 19 — IPv4 CIDR larger than the cap is truncated, not
+    /// rejected. Cap is 256; `/8` would be 16M without the guard.
+    #[test]
+    fn parse_ip_list_ipv4_cidr_8_capped_at_256() {
+        let v = parse_ip_list(&["10.0.0.0/8".into()], "source-ip");
+        assert_eq!(v.len(), 256);
+        assert_eq!(v[0].to_string(), "10.0.0.0");
+        assert_eq!(v[255].to_string(), "10.0.0.255");
+    }
+
+    /// Round 19 — IPv6 CIDR also expands. `/126` = 4 hosts.
+    #[test]
+    fn parse_ip_list_ipv6_cidr_126_expands_to_4() {
+        let v = parse_ip_list(&["2001:db8::/126".into()], "geo-source-ip");
+        assert_eq!(v.len(), 4);
+        assert!(v[0].is_ipv6());
+        assert_eq!(v[0].to_string(), "2001:db8::");
+        assert_eq!(v[3].to_string(), "2001:db8::3");
+    }
+
+    /// Round 19 — mixed IPv4 + IPv6 + CIDR in one call works.
+    #[test]
+    fn parse_ip_list_mixed_v4_v6_cidr() {
+        let v = parse_ip_list(&["10.0.0.0/30,2001:db8::1,203.0.113.42".into()], "geo-source-ip");
+        assert_eq!(v.len(), 6); // 4 from /30 + 1 + 1
+        assert!(v.iter().any(|ip| ip.to_string() == "2001:db8::1"));
+        assert!(v.iter().any(|ip| ip.to_string() == "203.0.113.42"));
+    }
+
+    /// Round 19 — malformed entries log and skip; the run continues
+    /// with whatever resolved.
+    #[test]
+    fn parse_ip_list_skips_malformed() {
+        let v = parse_ip_list(
+            &[
+                "10.0.0.5".into(),
+                "not-an-ip".into(),
+                "10.0.0.6".into(),
+                "/24".into(),
+                "1.2.3.4/200".into(),
+            ],
+            "source-ip",
+        );
+        assert_eq!(v.len(), 2);
+        assert_eq!(v[0].to_string(), "10.0.0.5");
+        assert_eq!(v[1].to_string(), "10.0.0.6");
     }
 
     #[test]

--- a/crates/mockforge-bench/src/conformance/schema_mutator.rs
+++ b/crates/mockforge-bench/src/conformance/schema_mutator.rs
@@ -292,7 +292,7 @@ mod tests {
     }
 
     fn string_field(min: Option<usize>, max: Option<usize>, pattern: Option<&str>) -> Schema {
-        let s = openapiv3::StringType {
+        let s = StringType {
             min_length: min,
             max_length: max,
             pattern: pattern.map(|p| p.to_string()),

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -1242,49 +1242,54 @@ impl OpenApiRouteRegistry {
                     if let Some(rb) = request_body {
                         if let Some(content) = rb.content.get("application/json") {
                             if let Some(schema_ref) = &content.schema {
-                                // Resolve schema reference and validate
-                                match schema_ref {
-                                    openapiv3::ReferenceOr::Item(schema) => {
-                                        // Direct schema - validate immediately
-                                        if let Err(validation_error) =
-                                            OpenApiSchema::new(schema.clone()).validate(value)
-                                        {
-                                            let error_msg = validation_error.to_string();
-                                            errors.push(format!(
-                                                "body validation failed: {}",
-                                                error_msg
-                                            ));
-                                            if aggregate {
-                                                details.push(serde_json::json!({"path":"body","code":"schema_validation","message":error_msg}));
-                                            }
+                                // Issue #79 round 19 — every body validator on
+                                // this path used `OpenApiSchema::new(...).validate()`
+                                // which builds a naked jsonschema validator with
+                                // no `components` context. Nested `$ref` strings
+                                // to `#/components/schemas/X` (especially
+                                // dotted vCenter names) then fail with
+                                // "Pointer does not exist". Round 18.3 fixed
+                                // the bench-side + the `validate_request_body`
+                                // sibling; this is the live-server route
+                                // handler, the third path. Switch to
+                                // `schema_ref_resolver::build_validator` which
+                                // inlines the spec's components.
+                                let root_schema = match schema_ref {
+                                    openapiv3::ReferenceOr::Item(s) => Some((*s).clone()),
+                                    openapiv3::ReferenceOr::Reference { reference } => {
+                                        self.spec.get_schema(reference).map(|s| s.schema.clone())
+                                    }
+                                };
+                                if let Some(root_schema) = root_schema {
+                                    let result = crate::schema_ref_resolver::build_validator(
+                                        &root_schema,
+                                        &self.spec.spec,
+                                    )
+                                    .and_then(|validator| {
+                                        let errs: Vec<String> = validator
+                                            .iter_errors(value)
+                                            .map(|e| e.to_string())
+                                            .collect();
+                                        if errs.is_empty() {
+                                            Ok(())
+                                        } else {
+                                            Err(errs.join("; "))
+                                        }
+                                    });
+                                    if let Err(error_msg) = result {
+                                        errors
+                                            .push(format!("body validation failed: {}", error_msg));
+                                        if aggregate {
+                                            details.push(serde_json::json!({"path":"body","code":"schema_validation","message":error_msg}));
                                         }
                                     }
-                                    openapiv3::ReferenceOr::Reference { reference } => {
-                                        // Referenced schema - resolve and validate
-                                        if let Some(resolved_schema_ref) =
-                                            self.spec.get_schema(reference)
-                                        {
-                                            if let Err(validation_error) = OpenApiSchema::new(
-                                                resolved_schema_ref.schema.clone(),
-                                            )
-                                            .validate(value)
-                                            {
-                                                let error_msg = validation_error.to_string();
-                                                errors.push(format!(
-                                                    "body validation failed: {}",
-                                                    error_msg
-                                                ));
-                                                if aggregate {
-                                                    details.push(serde_json::json!({"path":"body","code":"schema_validation","message":error_msg}));
-                                                }
-                                            }
-                                        } else {
-                                            // Schema reference couldn't be resolved
-                                            errors.push(format!("body validation failed: could not resolve schema reference {}", reference));
-                                            if aggregate {
-                                                details.push(serde_json::json!({"path":"body","code":"reference_error","message":"Could not resolve schema reference"}));
-                                            }
-                                        }
+                                } else if let openapiv3::ReferenceOr::Reference { reference } =
+                                    schema_ref
+                                {
+                                    // Schema reference couldn't be resolved
+                                    errors.push(format!("body validation failed: could not resolve schema reference {}", reference));
+                                    if aggregate {
+                                        details.push(serde_json::json!({"path":"body","code":"reference_error","message":"Could not resolve schema reference"}));
                                     }
                                 }
                             }
@@ -3079,6 +3084,65 @@ mod tests {
         assert!(registry
             .validate_request_with("/composite", "POST", &Map::new(), &Map::new(), Some(&bad_allof))
             .is_err());
+    }
+
+    /// Round 19 — regression for Srikanth's vCenter spec which has
+    /// component schemas with dotted names like
+    /// `Esx.Settings.Inventory.EntitySpec`. The route-handler's body
+    /// validator used to build a naked `jsonschema` validator with no
+    /// `components` context, so nested `$ref` strings to
+    /// `#/components/schemas/X` failed with "Pointer does not exist".
+    /// Round 18.3 fixed the bench + `validate_request_body` paths;
+    /// round 19 fixes this third path in `openapi_routes`.
+    #[tokio::test]
+    async fn dotted_schema_ref_resolves_in_route_validator() {
+        let spec_json = json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Dotted", "version": "1.0.0" },
+            "paths": {
+                "/x": {
+                    "post": {
+                        "requestBody": {
+                            "required": true,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/Esx.Settings.Inventory.EntitySpec"
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"200": {"description": "ok"}}
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "Esx.Settings.Inventory.EntitySpec": {
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {"type": {"type": "string"}}
+                    }
+                }
+            }
+        });
+        let registry = create_registry_from_json(spec_json).unwrap();
+        // Pre-fix: this errored with `Pointer '/components/schemas/Esx.Settings.Inventory.EntitySpec' does not exist`.
+        // Post-fix: the dotted ref resolves and the body validates.
+        let good = json!({"type": "HOST"});
+        let res =
+            registry.validate_request_with("/x", "POST", &Map::new(), &Map::new(), Some(&good));
+        assert!(res.is_ok(), "valid body should pass; got {res:?}");
+        // And a bad body should still error from inside the resolved schema, not from a build failure.
+        let bad = json!({"unrelated": 1});
+        let err = registry
+            .validate_request_with("/x", "POST", &Map::new(), &Map::new(), Some(&bad))
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            !msg.contains("Pointer") || !msg.contains("does not exist"),
+            "should not be a pointer-resolution failure; got: {msg}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Srikanth's 0.3.162 re-test surfaced two follow-ups:

1. **Schema-\$ref still failing in 120 cases** on his vCenter spec. Round 18.3 fixed two call sites, but missed a third in the live-server route handler.
2. **GEODB usability ask**: can \`--source-ip\` / \`--geo-source-ip\` take CIDR ranges instead of individual IPs?

## Schema-\$ref live-server fix

The third schema-validator call site lives in
\`openapi_routes.rs::validate_request_with_all\` at lines 1250 (\`ReferenceOr::Item\`) and 1267 (\`ReferenceOr::Reference\`). Both branches built naked \`jsonschema\` validators via \`OpenApiSchema::new(...).validate()\` with no \`components\` resolution context, so nested \$refs to \`#/components/schemas/X\` failed with the dreaded "Pointer does not exist" error every time. Dotted names (\`Esx.Settings.Inventory.EntitySpec\`, \`Vapi.Std.DynamicID\`, \`Vcenter.Vcha.CredentialsSpec\`) were the easiest visible failure class on Srikanth's spec.

Fix: switch to \`schema_ref_resolver::build_validator(&schema, &spec)\` (the helper introduced in round 18.3). Locks in via a regression test that constructs a spec with a dotted-name component schema, runs a body request through \`validate_request_with\`, and asserts both the happy path passes and the failing path doesn't return a "Pointer does not exist" error.

## CIDR for source-IP flags

\`--source-ip\` and \`--geo-source-ip\` now accept CIDR alongside individual IPs and comma-separated lists:

\`\`\`bash
mockforge bench ... --source-ip 10.0.0.0/28           # 16 hosts
mockforge bench ... --geo-source-ip 2001:db8::/126    # 4 IPv6 hosts
mockforge bench ... --geo-source-ip 10.0.0.0/30,2001:db8::1,203.0.113.42  # mixed
\`\`\`

Bounded at 256 hosts per CIDR to guard against \`/8\` typos blowing up the bench client; the cap is logged when triggered. IPv4 + IPv6 both supported.

## Tests

- **1 new regression test** in \`openapi_routes::tests::dotted_schema_ref_resolves_in_route_validator\`. Pre-fix: errored with "Pointer does not exist". Post-fix: schema resolves and validates.
- **6 new tests** for CIDR parsing: plain + comma, IPv4 /29 = 8 hosts, IPv4 /8 capped at 256, IPv6 /126 = 4 hosts, mixed v4+v6+CIDR, malformed-skip.

171/171 openapi tests pass. 435/435 bench tests pass.

## Test plan

- [x] \`cargo test -p mockforge-openapi --lib\` — 171/171 pass.
- [x] \`cargo test -p mockforge-bench --lib\` — 435/435 pass.
- [x] \`cargo clippy -p mockforge-openapi -p mockforge-bench --all-targets -- -D clippy::correctness -D unused_qualifications\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [ ] Smoke-test against Srikanth's vCenter spec — the 120 "Pointer does not exist" violations should vanish.

v0.3.162 → v0.3.163.