### PR TITLE
fix(http,cli): shadow mode gates 200 on --base-path prefix (#79 round 20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.164] - 2026-06-01
+
+### Fixed
+
+- **[Reality][Contracts]** Shadow mode now gates its `200` response on the configured `--base-path` (#79 round 20). Pre-round-20, `mockforge serve --shadow --base-path /api` returned `200 {"shadow":true,"matched":false}` for *any* unmatched path, including ones outside the configured prefix (Srikanth's report: client used `/api123/...` against a server configured for `/api` and saw `200` instead of `404`). Now `dynamic_mock_fallback` calls `path_in_base()` which checks at the segment boundary (`/api123` is NOT under `/api`), and only returns the shadow `200` when the path is actually under the configured surface. Outside the surface still 404s in shadow mode, matching pre-shadow semantics. The CLI's `--base-path` flag propagates to the management layer via a new `MOCKFORGE_API_BASE_PATH` env var; `ManagementState::new()` reads it and `ManagementState::with_base_path()` is exposed for callers that want to set it programmatically. Empty or `/` paths normalise to "no prefix gate" (the pre-round-20 behaviour, useful when neither client nor server has a base path).
+
 ## [0.3.163] - 2026-06-01
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.163"
+version = "0.3.164"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,10 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.164] - 2026-06-01
+
+### Fixed
+- Shadow mode now gates `200` on the configured `--base-path` (#79 round 20). Paths outside the configured prefix (e.g. `/api123/...` when server is `/api`) return `404` even with `--shadow` enabled, matching pre-shadow semantics. `path_in_base` checks at the segment boundary, so `/api123` is not under `/api`.
+
 ## [0.3.163] - 2026-06-01
 
 ### Fixed

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -686,6 +686,21 @@ pub async fn handle_serve(
         std::env::set_var("MOCKFORGE_RATE_LIMIT_ENABLED", "false");
     }
 
+    // Issue #79 round 20 — propagate `--base-path` so the management
+    // layer can gate shadow-mode 200 responses on path prefix. Pre-
+    // round-20, shadow returned 200 for every unmatched path, even
+    // ones outside the configured `--base-path` (Srikanth: client used
+    // /api123 against a server configured for /api and saw 200 instead
+    // of 404). Setting the env var here keeps `mockforge-http` (which
+    // doesn't take a base_path argument on its public router entry
+    // points) library-clean while letting the lib read the value at
+    // ManagementState construction time.
+    if let Some(bp) = serve_args.base_path.as_deref() {
+        if !bp.is_empty() {
+            std::env::set_var("MOCKFORGE_API_BASE_PATH", bp);
+        }
+    }
+
     // Opt-in federation scenario poller. If the four env vars
     // (MOCKFORGE_FEDERATION_POLL_URL / WORKSPACE_ID / POLL_TOKEN /
     // POLL_INTERVAL_SECS) aren't set this is a no-op; otherwise a tokio
@@ -1315,7 +1330,7 @@ pub async fn handle_serve(
         None
     };
     #[cfg(not(feature = "smtp"))]
-    let smtp_registry = None::<Arc<dyn std::any::Any + Send + Sync>>;
+    let smtp_registry = None::<Arc<dyn Any + Send + Sync>>;
 
     #[cfg(feature = "mqtt")]
     // Loaded for its fixture-validation side effects + user-facing logs. The

--- a/crates/mockforge-http/src/management/mod.rs
+++ b/crates/mockforge-http/src/management/mod.rs
@@ -762,6 +762,14 @@ pub struct ManagementState {
     pub chaos_api_state: Option<Arc<mockforge_chaos::api::ChaosApiState>>,
     /// Optional server configuration for profile application
     pub server_config: Option<Arc<RwLock<mockforge_core::config::ServerConfig>>>,
+    /// Issue #79 round 20 — the API base path the server was started with
+    /// (e.g. `/api`). When `MOCKFORGE_SHADOW_MODE=true`, the dynamic-mock
+    /// fallback returns 200 only for requests whose path is under this
+    /// prefix, and 404 otherwise. Pre-round-20, shadow returned 200 for
+    /// every unmatched path, including paths outside the configured
+    /// surface (e.g. `/api123/...` when the server is `/api`). Empty or
+    /// `None` means no prefix gate.
+    pub base_path: Option<String>,
     /// Conformance testing state
     #[cfg(feature = "conformance")]
     pub conformance_state: crate::handlers::conformance::ConformanceState,
@@ -806,9 +814,35 @@ impl ManagementState {
             #[cfg(feature = "chaos")]
             chaos_api_state: None,
             server_config: None,
+            // Round 20 — read the API base path from the env var the
+            // CLI sets for `--base-path`. Empty / `/` normalises to
+            // None (no prefix gate, pre-round-20 behaviour).
+            base_path: std::env::var("MOCKFORGE_API_BASE_PATH").ok().and_then(|p| {
+                let trimmed = p.trim_end_matches('/').to_string();
+                if trimmed.is_empty() || trimmed == "/" {
+                    None
+                } else {
+                    Some(trimmed)
+                }
+            }),
             #[cfg(feature = "conformance")]
             conformance_state: crate::handlers::conformance::ConformanceState::new(),
         }
+    }
+
+    /// Set the API base path (e.g. `/api`). Required for shadow-mode's
+    /// base-path gate (#79 round 20). Normalises by trimming trailing
+    /// `/`, and treats empty / `/` as None.
+    pub fn with_base_path(mut self, base_path: Option<String>) -> Self {
+        self.base_path = base_path.and_then(|p| {
+            let trimmed = p.trim_end_matches('/').to_string();
+            if trimmed.is_empty() || trimmed == "/" {
+                None
+            } else {
+                Some(trimmed)
+            }
+        });
+        self
     }
 
     /// Add lifecycle hook registry to management state
@@ -1191,9 +1225,22 @@ pub async fn dynamic_mock_fallback(
         None => {
             // Issue #79 round 14 — shadow mode returns 200 for unknown
             // paths (instead of 404) while still recording them, so a
-            // proxy replay flows through non-blocking. The recorded
-            // `status` reflects what the client actually saw.
-            let shadow = mockforge_foundation::unknown_paths::shadow_mode_enabled();
+            // proxy replay flows through non-blocking.
+            //
+            // Issue #79 round 20 — but only when the path is INSIDE
+            // the configured `--base-path` prefix. Pre-round-20, shadow
+            // returned 200 for every unmatched path, including paths
+            // outside the configured surface (e.g. `/api123/...` when
+            // the server is started with `--base-path /api`). Srikanth
+            // hit this when his client config drifted from the server's
+            // base path: every request looked "shadow" instead of "404
+            // because that prefix isn't ours".
+            let shadow_enabled = mockforge_foundation::unknown_paths::shadow_mode_enabled();
+            let in_base_path = match state.base_path.as_deref() {
+                Some(bp) => path_in_base(&path, bp),
+                None => true, // no base path configured — shadow applies to everything
+            };
+            let shadow = shadow_enabled && in_base_path;
             let status = if shadow {
                 StatusCode::OK
             } else {
@@ -1226,9 +1273,66 @@ pub async fn dynamic_mock_fallback(
     }
 }
 
+/// Round 20 — is `path` under `base_path` for shadow-mode purposes?
+///
+/// Matches at the **segment** boundary, so `/api123/foo` does not match
+/// `--base-path /api`. The check is `path == bp || path.starts_with(bp+'/')`,
+/// which also accepts the exact base path itself (a request to `/api`
+/// when configured for `/api` is in-prefix).
+pub(crate) fn path_in_base(path: &str, base_path: &str) -> bool {
+    let bp = base_path.trim_end_matches('/');
+    if bp.is_empty() {
+        return true;
+    }
+    if path == bp {
+        return true;
+    }
+    // Must end at a segment boundary: bp followed by `/` or end-of-string.
+    path.starts_with(bp) && path.as_bytes().get(bp.len()).copied() == Some(b'/')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Round 20 — `path_in_base` accepts the base path itself plus
+    /// anything under a `/`-delimited segment boundary, and rejects
+    /// paths that merely share a string prefix (e.g. `/api123` is not
+    /// under `/api`).
+    #[test]
+    fn path_in_base_segment_boundary() {
+        // Exact match.
+        assert!(path_in_base("/api", "/api"));
+        // Under prefix.
+        assert!(path_in_base("/api/users", "/api"));
+        assert!(path_in_base("/api/v1/items/42", "/api"));
+        // The Srikanth bug: same string prefix but different segment.
+        assert!(!path_in_base("/api123", "/api"));
+        assert!(!path_in_base("/api123/foo", "/api"));
+        // Sibling prefix is not in-base.
+        assert!(!path_in_base("/", "/api"));
+        assert!(!path_in_base("/admin", "/api"));
+        // Trailing slash on base normalises.
+        assert!(path_in_base("/api/users", "/api/"));
+        // Empty base = no gate.
+        assert!(path_in_base("/anything", ""));
+    }
+
+    /// Round 20 — `ManagementState::with_base_path` normalises
+    /// trailing slash and treats empty / `/` as no-prefix.
+    #[test]
+    fn with_base_path_normalises() {
+        let s = ManagementState::new(None, None, 3000).with_base_path(Some("/api".to_string()));
+        assert_eq!(s.base_path.as_deref(), Some("/api"));
+        let s = ManagementState::new(None, None, 3000).with_base_path(Some("/api/".to_string()));
+        assert_eq!(s.base_path.as_deref(), Some("/api"));
+        let s = ManagementState::new(None, None, 3000).with_base_path(Some("".to_string()));
+        assert_eq!(s.base_path.as_deref(), None);
+        let s = ManagementState::new(None, None, 3000).with_base_path(Some("/".to_string()));
+        assert_eq!(s.base_path.as_deref(), None);
+        let s = ManagementState::new(None, None, 3000).with_base_path(None);
+        assert_eq!(s.base_path.as_deref(), None);
+    }
 
     #[tokio::test]
     async fn test_create_and_get_mock() {


### PR DESCRIPTION
## Summary

Srikanth's report (#79): with `mockforge serve --shadow --base-path /api` and a client misconfigured to hit `/api123/...`, the server returned `200 {"shadow":true,"matched":false}` for every request. The right answer is `404` because the path is outside the configured surface entirely.

Pre-round-20, `dynamic_mock_fallback` returned `200` for ANY unmatched path when shadow mode was on, with no awareness of the configured `--base-path`. The shadow "report-only" contract is meant to swallow violations on KNOWN routes, not silently absorb traffic outside the configured prefix.

## What lands

- `ManagementState` gains a `base_path: Option<String>` field, plus a `with_base_path()` builder that normalises trailing `/` and treats empty / `/` as None.
- `ManagementState::new()` reads `MOCKFORGE_API_BASE_PATH` from the environment for the default-constructor path.
- `mockforge-cli`'s `serve` handler sets `MOCKFORGE_API_BASE_PATH` from `--base-path` before constructing the router.
- `dynamic_mock_fallback` calls a new `path_in_base()` helper, then only returns the shadow `200` if `shadow_mode_enabled() && in_base_path`. Outside the base path still 404s.

## Segment-aware matching

The non-obvious case: `/api123` is NOT under `/api`, even though it shares the string prefix. `path_in_base()` checks at the `/`-delimited segment boundary:

```rust
path == bp || (path.starts_with(bp) && next_char == '/')
```

So `/api`, `/api/users`, `/api/v1/items/42` all match `/api`; `/api123`, `/api123/foo`, `/admin` do not.

## Behaviour matrix

| Request path | `--base-path` | `--shadow` | Status |
|---|---|---|---|
| `/api/unknown` | `/api` | on | `200` (was `200` — unchanged) |
| `/api123/foo` | `/api` | on | `404` (was `200` — fixed) |
| `/unrelated` | `/api` | on | `404` (was `200` — fixed) |
| `/api/unknown` | `/api` | off | `404` (unchanged) |
| `/anywhere` | none | on | `200` (no prefix gate, pre-round-20 behaviour) |

## Tests

- `path_in_base_segment_boundary` — exact match, under prefix, the Srikanth bug case, siblings, root, trailing slash on base, empty base.
- `with_base_path_normalises` — trailing `/`, empty, `/`, None.

573 mockforge-http tests pass.

## Test plan

- [x] `cargo test -p mockforge-http --lib` — 573/573 pass.
- [x] `cargo clippy -p mockforge-http -p mockforge-cli --all-targets -- -D clippy::correctness -D unused_qualifications` — clean.
- [x] `cargo fmt --all --check` — clean.
- [ ] Smoke-test against Srikanth's `--base-path /api123` vs `--base-path /api` config and confirm 404 fires.

v0.3.163 → v0.3.164.