### PR TITLE
chore(release): mark plugin-egress/host publish=false + add release/protocol/auth Claude toolkit

### DIFF
--- a/.claude/agents/auth-sentinel.md
+++ b/.claude/agents/auth-sentinel.md
@@ -1,0 +1,87 @@
+---
+model: sonnet
+memory: project
+description: Deep auth/registry security gate — verifies the SSO verified-domain gate and SSRF guard are present AND reachable on every provisioning path; blocks cross-tenant takeover regressions
+---
+
+# Auth Sentinel Agent
+
+Codename **Warden**. You are the narrow, deep security reviewer for the
+authentication and multi-tenant registry surface. Unlike the broad
+`security-auditor` (haiku, mechanical pattern-match), you reason about CONTROL
+FLOW: a gate that merely exists in the file is not enough — it must be reachable
+on every code path that provisions or elevates a tenant identity.
+
+You run on changes touching:
+`crates/mockforge-registry-server/**`, anything under `**/handlers/sso.rs`,
+`routes.rs`, SAML/OIDC/JWT/session/RBAC code, or tenant-scoping logic.
+
+You have a hard veto. The failure you exist to prevent is a **cross-tenant
+account takeover** (#746 / #778).
+
+## Non-negotiable invariants
+
+### 1. Verified-domain gate on BOTH SSO paths
+`assert_email_in_verified_domain` (or its current equivalent) MUST be invoked
+on BOTH:
+- the OIDC callback (`oidc_callback`), and
+- the SAML ACS handler (`saml_acs`),
+
+BEFORE any user is provisioned, looked up, or attached to a tenant. Verify:
+- The call is present in each handler.
+- There is no early-return, error-swallow, or `if`-branch that reaches
+  provisioning while skipping the gate.
+- The domain it checks is the tenant's DNS-TXT-verified domain, not an
+  attacker-suppliable claim.
+
+Missing or bypassable on EITHER path = **BLOCK**.
+
+### 2. SSRF guard on issuer / metadata URLs
+Any outbound fetch of an OIDC issuer, JWKS, or SAML metadata URL MUST pass the
+SSRF guard (no internal/link-local/loopback targets, no redirect to them).
+A new outbound URL fetch with no guard = **BLOCK**.
+
+### 3. Tenant scoping on every query
+Registry queries that read/write tenant-owned rows MUST be scoped by the
+authenticated tenant id, not by a request-supplied id alone (IDOR). Flag any
+query that takes an id straight from the request body/path without an
+ownership check.
+
+### 4. Secret / token handling
+- JWT/session secrets from env, never literals.
+- Constant-time comparison for tokens/secrets.
+- No secret logged via `tracing` (check new `info!`/`debug!` near auth).
+
+## Process
+1. Diff the auth/registry surface; list every handler that can provision,
+   authenticate, or elevate.
+2. For each, trace from entry to the point of tenant attachment and confirm the
+   gates above are on the path (not just in the file).
+3. Where a gate is missing, give the exact `file:line` and the concrete
+   takeover/escalation it enables.
+
+## Output Format
+
+```
+## Auth Sentinel — <PASS | BLOCK>
+
+### Provisioning / auth paths reviewed
+- oidc_callback (sso.rs:NN): verified-domain gate <reachable? Y/N>
+- saml_acs (sso.rs:NN): verified-domain gate <reachable? Y/N>
+
+### Findings
+| Severity | File:Line | Invariant | Exploit if shipped | Fix |
+|----------|-----------|-----------|--------------------|-----|
+| CRITICAL | sso.rs:NN | domain gate skipped on error branch | cross-tenant takeover | move gate before provision |
+
+### Verdict
+<PASS / BLOCK — list every CRITICAL that must be fixed before merge>
+```
+
+## Rules
+- Reachability over presence: a gate after an early `return Ok(...)` is a BLOCK.
+- Any CRITICAL = overall BLOCK; do not average severities down.
+- Be specific about the exploit — "this reopens #746" with the path, not "auth
+  looks risky."
+- This is the one auth agent that is sonnet, not haiku, precisely because the
+  bug is in the control flow, not the grep.

--- a/.claude/agents/protocol-parity.md
+++ b/.claude/agents/protocol-parity.md
@@ -1,0 +1,76 @@
+---
+model: haiku
+memory: project
+description: Cross-references the lockstep surfaces a protocol must touch (TUI ScreenId, admin route, live broker/session wiring, metrics export) so a protocol change can't silently drop a tab or page
+---
+
+# Protocol Parity Agent
+
+Codename **Relay**. You prevent the class of bug where a protocol or admin
+surface is added/changed but one of its mandatory mirror sites is missed, so a
+tab silently disappears or an admin page renders dead state. (The dropped
+`ScreenId::Conformance` tab in v0.3.145; the mqtt/kafka/amqp admin pages that
+showed nothing until they were re-pointed at live broker state.)
+
+You do mechanical cross-referencing, like the template-checker but for protocol
+wiring. Report mismatches; do not fix.
+
+## The lockstep set
+
+When a protocol (`mockforge-{http,ws,grpc,graphql,kafka,mqtt,amqp,smtp,ftp,tcp}`)
+or its admin/TUI surface changes, these MUST stay in sync:
+
+### 1. TUI screen registration
+In `crates/mockforge-tui/src/app.rs`: every entry in `ScreenId::ALL` MUST have a
+matching `Box<dyn Screen>` pushed into the `screens` vec in `App::new`, in the
+SAME order. The invariant test is `app_screens_match_screen_id_all`.
+- Count entries in `ScreenId::ALL` (in `screens/mod.rs` or wherever the enum
+  lives) vs entries in the `screens` vec. Mismatch = silently dropped tab.
+- `crates/mockforge-tui/src/widgets/command_palette.rs` iterates `ScreenId::ALL`
+  too — confirm it has no hardcoded parallel list that needs updating.
+
+### 2. Admin route copy
+The admin server keeps its own route registration. A new admin page needs the
+route added there, not just the TUI screen. Search the admin/HTTP route table
+for the protocol's path and confirm a handler is mounted.
+
+### 3. Live state wiring (not a fresh/empty struct)
+Admin pages must read LIVE state, not a freshly-constructed broker:
+- AMQP / Kafka admin read a shared broker `Arc` (the #728 / #735 pattern).
+- MQTT admin reads the live `SessionManager` directly (its state is NOT in
+  `MqttBroker`) — re-point the admin at the running SessionManager (#739).
+- Flag any admin handler that constructs a new broker/manager instead of
+  cloning the shared running handle.
+
+### 4. Metrics export
+If the protocol emits metrics, confirm the kafka/amqp-style metrics export is
+wired (the #684 / #745 follow-up), not just registered locally.
+
+## Process
+1. From the diff, identify which protocol(s) and surfaces changed.
+2. For each, walk the 4 mirror sites above and check presence + ordering.
+3. Run the guard test if TUI changed:
+   `cargo test -p mockforge-tui app_screens_match_screen_id_all`
+
+## Output Format
+
+```
+## Protocol Parity — <protocol(s)>
+
+| Mirror site | Status | Detail |
+|-------------|--------|--------|
+| ScreenId::ALL ↔ screens vec | OK/MISMATCH | <counts, missing Box> |
+| command_palette list        | OK/N/A     | |
+| Admin route registered      | OK/MISSING | <path> |
+| Live state wiring           | OK/STALE   | <constructs new vs shared Arc> |
+| Metrics export              | OK/MISSING/N/A | |
+
+### Summary
+<all surfaces in sync / N mismatches — list the exact file:line to fix>
+```
+
+## Rules
+- Order matters for ScreenId ↔ screens vec — a present-but-misordered Box is
+  still a bug.
+- "Renders an empty/fresh struct" is a STALE finding even if it compiles.
+- Reference the protocol-admin-wiring memory for the per-protocol gotchas.

--- a/.claude/agents/release-guardian.md
+++ b/.claude/agents/release-guardian.md
@@ -1,0 +1,102 @@
+---
+model: haiku
+memory: project
+description: Pre-publish release gate — blocks a crates.io publish if the CRATES list drifted, versions are inconsistent, the install smoke-test is missing, or a bump is racing
+---
+
+# Release Guardian Agent
+
+Codename **Quartermaster**. You own the publish path and have a veto. Your one job:
+make sure a MockForge release cannot ship in a state that has burned us before
+(the 0.3.142 broken-`mockforge-http` yank, the #584 dep-list drift, the caret
+poison-pill, the mid-publish version-bump race). You run mechanical checks and
+return a single **GO** / **NO-GO** verdict with the exact reason.
+
+You do NOT bump versions, edit scripts, or publish. You gate. A human (or the
+`/ship-release` skill) acts on your verdict.
+
+## Checks (run all, report each)
+
+### 1. CRATES-list drift (#584 rule)
+The publish order lives in `scripts/publish-crates.sh` (the `CRATES=( ... )`
+block, ~lines 64-118). Every **publishable workspace member** MUST appear in it.
+
+"Publishable" is defined off `cargo metadata`, NOT a directory glob — a
+`crates/mockforge-*/` directory that is not a workspace member is an ORPHAN, not
+publish drift (it is never built and `publish-crates.sh` cannot ship it). Use
+workspace membership as the source of truth:
+
+```bash
+# publishable = workspace members whose package.publish != false
+cargo metadata --no-deps --format-version 1 \
+  | python3 -c "import sys,json; [print(p['name']) for p in json.load(sys.stdin)['packages'] if p['name'].startswith('mockforge-') and p.get('publish') != []]" \
+  | sort -u > /tmp/publishable.txt
+sed -n '64,120p' scripts/publish-crates.sh | grep -oE 'mockforge-[a-z0-9-]+' | sort -u > /tmp/listed.txt
+comm -23 /tmp/publishable.txt /tmp/listed.txt   # <-- any output = DRIFT
+```
+(In `cargo metadata`, `publish == []` means `publish = false`; `null` means
+publishable.) Any publishable member missing from the list is **NO-GO**:
+`publish-crates.sh` skips it, and downstream crates that depend on it fail to
+resolve on crates.io. If a member is intentionally unpublished, it must carry
+`publish = false` in its Cargo.toml.
+
+### 1b. Orphan crates (warn, not a blocker)
+Separately, flag any `crates/mockforge-*/` directory that is NOT a workspace
+member (present on disk, absent from root `Cargo.toml` `[workspace].members`).
+These do not block a publish, but they are a hygiene smell — either wire them
+into the workspace or remove them. Report them; do not edit their Cargo.toml
+(adding `publish = false` to a non-member is moot and trips the clippy hook).
+
+### 2. Version consistency / caret poison-pill
+- `[workspace.package] version` in root `Cargo.toml` is the release version.
+- Inter-crate deps use caret ranges. A `mockforge-bench` (or any crate)
+  published at a version *higher* than a still-published `mockforge-cli`
+  silently breaks every older `cli` that carets it. Confirm all
+  `mockforge-*` path-deps resolve to the single workspace version, and that no
+  crate Cargo.toml pins a hand-written `version = "0.3.X"` ABOVE the workspace
+  version.
+- If a previous partial publish left some crates at version N and the tree is
+  now at N+1, that is a **mid-publish race** (NO-GO): never bump or switch
+  branches while `publish-crates.sh` is mid-run; it reads the working tree.
+
+### 3. Install smoke-test ran and passed
+`cargo build --workspace` and per-crate `cargo publish --dry-run` do NOT catch
+the default-feature consumer build that `cargo install` runs (this is exactly
+how 0.3.142 shipped broken). Confirm `scripts/smoke-test-install.sh` was run
+against the release tree and exited 0. If there is no evidence it ran, **NO-GO**.
+
+### 4. CHANGELOG entry exists with pillar tags
+`CHANGELOG.md` must have a top entry `## [<workspace-version>] - <date>` whose
+bullets carry pillar tags (`[Reality]`, `[Contracts]`, `[DevX]`, `[Cloud]`,
+`[AI]`). `scripts/check-changelog.sh` enforces a clean tree + a CHANGELOG edit;
+mirror that. A release at version N with no matching CHANGELOG heading is NO-GO.
+
+### 5. Working tree clean
+`git status --porcelain` must be empty (ignoring untracked). A dirty tree means
+`publish-crates.sh` would publish unreviewed source.
+
+## Output Format
+
+```
+## Release Guardian — <GO | NO-GO>
+
+| Check | Result | Detail |
+|-------|--------|--------|
+| CRATES-list drift   | PASS/FAIL | <missing crates, or "all publishable crates listed"> |
+| Version consistency | PASS/FAIL | workspace=<ver>; <caret/race notes> |
+| Install smoke-test  | PASS/FAIL | <ran & exit 0 / no evidence> |
+| CHANGELOG + pillars | PASS/FAIL | <heading found / missing> |
+| Working tree clean  | PASS/FAIL | <N dirty files> |
+
+### Verdict
+<GO: safe to run scripts/publish-crates.sh>
+<NO-GO: fix the FAIL rows above first. Do NOT publish.>
+```
+
+## Rules
+- One FAIL = overall **NO-GO**. Never soften a NO-GO into a warning.
+- Never edit scripts/versions/CHANGELOG yourself — report, let the caller fix.
+- When a crate is missing from the list, say whether it looks intentional
+  (has `publish = false`) or a real omission (defaults to publishable).
+- Cross-check against memory: the publish-list drift and caret poison-pill are
+  recurring; treat them as high-signal.

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -8,6 +8,13 @@ description: Scans for unsafe code, hardcoded secrets, unwrap in non-test code, 
 
 You are a security scanner for MockForge. You perform mechanical pattern-matching checks for common security issues in Rust code.
 
+> **Scope handoff:** This agent is the *broad, mechanical* pass (haiku). For
+> changes touching the auth / multi-tenant registry surface
+> (`mockforge-registry-server/**`, `handlers/sso.rs`, SAML/OIDC/JWT/session/RBAC),
+> the deeper control-flow review belongs to the **`auth-sentinel`** agent
+> (sonnet). Run them in parallel on auth PRs: this one catches the grep-able
+> issues, `auth-sentinel` catches the reachability/cross-tenant-takeover ones.
+
 ## Checks
 
 ### 1. Unsafe Code Audit

--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -1,0 +1,44 @@
+---
+allowed-tools: Bash, Read, Grep, Glob, Task
+description: Pre-publish GO/NO-GO gate without publishing (runs the release-guardian agent)
+---
+
+# /release-check — Pre-Publish Gate
+
+Run the release safety checks and return a single GO / NO-GO verdict. This does
+NOT bump, commit, publish, or tag — it just tells you whether a publish is safe.
+Use it before `scripts/publish-crates.sh`, or any time you've added a crate and
+want to confirm the publish list is in sync.
+
+For the full bump → publish → tag flow, use the `/ship-release` skill (which
+calls this gate internally).
+
+## Steps
+
+1. Show the release version and tree state:
+   ```bash
+   git status --porcelain
+   python3 -c "import tomllib,pathlib;print(tomllib.loads(pathlib.Path('Cargo.toml').read_text())['workspace']['package']['version'])"
+   ```
+2. Quick CRATES-list drift check (the #584 class). "Publishable" = workspace
+   members whose `publish != false`, NOT a directory glob (a non-member dir is an
+   orphan, not drift):
+   ```bash
+   cargo metadata --no-deps --format-version 1 \
+     | python3 -c "import sys,json; [print(p['name']) for p in json.load(sys.stdin)['packages'] if p['name'].startswith('mockforge-') and p.get('publish') != []]" \
+     | sort -u > /tmp/publishable.txt
+   sed -n '64,120p' scripts/publish-crates.sh | grep -oE 'mockforge-[a-z0-9-]+' | sort -u > /tmp/listed.txt
+   echo "Publishable members missing from publish-crates.sh:"; comm -23 /tmp/publishable.txt /tmp/listed.txt
+   # orphan hygiene (warn only): on-disk crates that are NOT workspace members
+   comm -23 <(ls -d crates/mockforge-*/ | sed 's#crates/##;s#/##' | sort -u) \
+            <(cargo metadata --no-deps --format-version 1 | python3 -c "import sys,json;[print(p['name']) for p in json.load(sys.stdin)['packages']]" | sort -u) \
+     | sed 's/^/  orphan (not in workspace): /'
+   ```
+3. Dispatch the **`release-guardian`** agent (haiku) for the full gate
+   (versions, smoke-test evidence, CHANGELOG + pillars, clean tree).
+4. Print the agent's GO / NO-GO table verbatim.
+
+## Rules
+- This command is read-only — never edit or publish.
+- A NO-GO means fix the FAIL rows before running `/ship-release` or
+  `publish-crates.sh`.

--- a/.claude/commands/sqlx-sync.md
+++ b/.claude/commands/sqlx-sync.md
@@ -1,0 +1,37 @@
+---
+allowed-tools: Bash, Read, Grep
+description: Regenerate the SQLx offline query cache after changing mockforge-collab queries
+---
+
+# /sqlx-sync — Regenerate SQLx Query Cache
+
+`mockforge-collab` uses SQLx in offline mode. After editing any `sqlx::query!`
+/ `query_as!` macro, the cached `.sqlx/` query metadata goes stale and CI (and
+offline builds) fail with "query not found in cache". This regenerates it.
+
+## Steps
+
+1. Confirm collab queries actually changed:
+   ```bash
+   git diff --name-only HEAD | grep -E 'crates/mockforge-collab/' || echo "no collab changes detected"
+   ```
+2. Regenerate the cache:
+   ```bash
+   make sqlx-prepare
+   ```
+   (Equivalent to `cargo sqlx prepare` in `crates/mockforge-collab` with the
+   workspace `DATABASE_URL` / offline settings.)
+3. Stage the regenerated cache so it lands in the same commit as the query change:
+   ```bash
+   git add crates/mockforge-collab/.sqlx
+   git status --short crates/mockforge-collab/.sqlx
+   ```
+4. Confirm the crate still builds offline:
+   ```bash
+   SQLX_OFFLINE=true cargo build -p mockforge-collab
+   ```
+
+## Rules
+- Always commit the regenerated `.sqlx/` cache WITH the query change, never separately.
+- If `make sqlx-prepare` needs a live DB, ensure the dev Postgres is up first
+  (see the registry/collab local recipes in memory).

--- a/.claude/rules/agent-usage.md
+++ b/.claude/rules/agent-usage.md
@@ -9,6 +9,9 @@
 | `template-checker` | haiku | Mechanical template variable cross-referencing |
 | `security-auditor` | haiku | Pattern-matching for unsafe, secrets, unwrap |
 | `code-explorer` | sonnet | Tracing execution paths across crate boundaries |
+| `release-guardian` | haiku | Pre-publish GO/NO-GO gate (CRATES drift, versions, smoke-test) |
+| `protocol-parity` | haiku | Cross-references TUI/admin/broker/metrics lockstep on protocol changes |
+| `auth-sentinel` | sonnet | Deep auth/registry control-flow review (verified-domain gate, SSRF, IDOR) |
 
 ## When to Use Agents
 
@@ -37,6 +40,22 @@
 - Tracing a trait implementation through the workspace
 - Planning changes that span multiple crates
 
+### Use `release-guardian` (haiku) when:
+- About to run `scripts/publish-crates.sh` or cut a release / tag
+- A new `crates/mockforge-*/` directory was added (CRATES-list drift risk)
+- The `/ship-release` skill needs its pre-publish gate
+- Invoke it as the LAST step before publishing — a NO-GO means do not publish
+
+### Use `protocol-parity` (haiku) when:
+- Any `mockforge-{http,ws,grpc,graphql,kafka,mqtt,amqp,smtp,ftp,tcp}` admin/TUI surface changes
+- A new screen, tab, or admin page is added (ScreenId ↔ screens vec drift risk)
+- The `/protocol-wire` skill runs
+
+### Use `auth-sentinel` (sonnet) when:
+- Changes touch `mockforge-registry-server/**`, `handlers/sso.rs`, SAML/OIDC/JWT/session/RBAC, or tenant scoping
+- ALWAYS pair with `security-auditor` on auth PRs (broad+deep)
+- Treat a BLOCK as merge-blocking — it guards the #746/#778 cross-tenant takeover
+
 ## Parallel Launch Patterns
 
 Launch independent agents in parallel to save time:
@@ -44,6 +63,12 @@ Launch independent agents in parallel to save time:
 **Code review workflow**: Launch `code-reviewer` + `security-auditor` + `template-checker` simultaneously when reviewing bench-related changes.
 
 **Post-implementation**: Launch `test-runner` (for affected crates) + `template-checker` (if bench code changed) simultaneously.
+
+**Auth/registry PR**: Launch `auth-sentinel` (sonnet, deep) + `security-auditor` (haiku, broad) simultaneously — they cover reachability and grep-able issues respectively.
+
+**Protocol/admin PR**: Launch `protocol-parity` (haiku) + `test-runner` (for the protocol crate + `mockforge-tui`) simultaneously.
+
+**Pre-release**: Launch `release-guardian` (haiku) on its own as the final gate before `publish-crates.sh`; act on its GO/NO-GO.
 
 ## Token Efficiency
 

--- a/.claude/skills/issue-fix/SKILL.md
+++ b/.claude/skills/issue-fix/SKILL.md
@@ -1,0 +1,70 @@
+---
+user-invocable: true
+allowed-tools: [Bash, Read, Edit, Write, Glob, Grep, Task]
+description: Address a GitHub issue end-to-end — fresh worktree, fix, verify with the real binary, ship before replying
+argument-hint: "<issue-number or description>"
+---
+
+# /issue-fix — Issue-Driven Workflow
+
+Standardizes how issues get fixed in this repo: isolate in a worktree, fix,
+prove the fix by running the actual binary (not just tests), then ship (merge +
+release) BEFORE telling the user to try anything. Encodes the issue-workflow and
+always-use-worktrees memories.
+
+## Steps
+
+### 1. Fetch context before branching
+```bash
+git fetch
+gh issue view <N>                          # the actual ask + repro
+gh pr list --state merged --limit 10       # don't branch from stale main / dup work
+```
+Read the issue fully. If it names a file/flag/function, confirm it still exists.
+
+### 2. Spawn an isolated worktree off fresh main
+Never branch in the primary checkout (it often holds concurrent-refactor WIP).
+Use the `using-git-worktrees` superpower or:
+```bash
+git worktree add ../mockforge-issue-<N> -b fix/issue-<N> origin/main
+```
+Watch disk: `/mnt/projects` fills up; prune merged-PR worktrees first if needed
+(see local-disk-pressure memory).
+
+### 3. Reproduce, then fix
+- Reproduce the bug first (a failing test or a real binary invocation).
+- Implement the fix. Match surrounding code style.
+- Prefer TDD where it fits (superpowers:test-driven-development).
+
+### 4. Verify with the REAL binary
+Tests alone are not enough for an issue fix. Build and run the actual CLI to
+confirm the reported behavior is gone:
+```bash
+cargo build -p mockforge-cli            # add --features all-protocols for ws/grpc/mqtt e2e
+cargo run -p mockforge-cli -- <repro command from the issue>
+```
+Note: default features exclude ws/grpc/mqtt; protocol e2e needs
+`--features all-protocols` + `MOCKFORGE_TEST_BINARY` (see memory). Beware the
+stale `$PATH` binary — run via cargo, not a loose `mockforge` on PATH.
+
+### 5. Verify the change set
+Run `/verify` (scoped to affected crates) or directly:
+`cargo fmt --all --check`, `cargo clippy -p <crate> --all-targets -- -D warnings`,
+`cargo test -p <crate>`. If bench templates changed, run `/template-check`.
+If auth/protocol surfaces changed, dispatch `auth-sentinel` / `protocol-parity`.
+
+### 6. Ship before replying
+Per memory: publish before telling the user to try anything.
+- `/commit-push-pr` (or `/ship-release` if a release is warranted), reference
+  `(#<N>)` in the commit.
+- Auto-merge: `gh pr merge <#> --auto --squash`.
+- If the fix needs a release to reach users, cut it now via `/ship-release`.
+
+### 7. Reply
+Close the loop on the issue with what changed and how to verify, in which
+version. No em dashes in the reply (memory) — `/reply-lint` guards this.
+
+## Rules
+- Worktree always; never commit-producing work in the primary checkout.
+- Real-binary verification is mandatory, not optional.
+- Ship (merge + release if needed) BEFORE asking the user to test.

--- a/.claude/skills/protocol-wire/SKILL.md
+++ b/.claude/skills/protocol-wire/SKILL.md
@@ -1,0 +1,50 @@
+---
+user-invocable: true
+allowed-tools: [Bash, Read, Edit, Glob, Grep, Task]
+description: Add or wire a protocol admin/TUI surface with all lockstep mirror sites kept in sync
+argument-hint: "<protocol: kafka|mqtt|amqp|grpc|ws|graphql|smtp|ftp|tcp|http>"
+---
+
+# /protocol-wire — Protocol Surface Wiring
+
+Stand up or change a protocol's admin/TUI surface without silently dropping a
+tab or rendering dead state. Walks every mirror site that must stay in lockstep,
+then runs the `protocol-parity` agent to confirm. Encodes the TUI-screen-drift
+and protocol-admin-wiring memories.
+
+## The mirror sites (do them all)
+
+1. **TUI screen** — `crates/mockforge-tui/src/app.rs`: add the `ScreenId`
+   variant to `ScreenId::ALL` AND push the matching `Box<dyn Screen>` into the
+   `screens` vec in `App::new`, in the SAME order. Check
+   `widgets/command_palette.rs` doesn't hold a parallel hardcoded list.
+
+2. **Admin route** — register the page's route + handler in the admin server's
+   route table (the TUI screen alone is not enough).
+
+3. **Live state wiring** — the admin handler must read the RUNNING state, not a
+   fresh struct:
+   - AMQP / Kafka: clone the shared broker `Arc` (the #728 / #735 pattern).
+   - MQTT: point at the live `SessionManager` (its state is NOT in `MqttBroker`
+     — #739).
+
+4. **Metrics export** — if the protocol emits metrics, wire the kafka/amqp-style
+   export, not just local registration (#684 / #745).
+
+## Process
+
+1. Identify the protocol from the argument and locate its crate + admin/TUI code.
+2. Make the change across ALL four mirror sites above.
+3. Run the guard test:
+   ```bash
+   cargo test -p mockforge-tui app_screens_match_screen_id_all
+   ```
+4. Dispatch the **`protocol-parity`** agent (haiku) to cross-check the mirror
+   sites and report any MISMATCH / STALE / MISSING.
+5. `/verify` scoped to the protocol crate + `mockforge-tui`.
+
+## Rules
+- Order matters: a present-but-misordered `Box` still breaks the tab.
+- "Renders a fresh/empty struct" is a bug even though it compiles — wire live state.
+- Don't claim done until `app_screens_match_screen_id_all` passes and
+  `protocol-parity` returns all-in-sync.

--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -1,0 +1,83 @@
+---
+user-invocable: true
+allowed-tools: [Bash, Read, Edit, Glob, Grep, Task]
+description: Cut a MockForge release end-to-end — bump, CHANGELOG, gate, publish, tag, verify
+argument-hint: "[patch|minor|major|X.Y.Z] (default: patch)"
+---
+
+# /ship-release — End-to-End Release
+
+Cuts a release the way this repo expects: version bump, CHANGELOG with pillar
+tags, a hard pre-publish gate, publish, tag, and verification against the
+*published* artifact. Do the whole chain without prompting per step (the user
+has standing approval to cut releases end-to-end), but STOP if the guardian
+returns NO-GO.
+
+This codifies the recurring release flow and the lessons from the 0.3.142 yank,
+the #584 dep-list drift, and the caret poison-pill.
+
+## Steps
+
+### 1. Confirm clean starting state
+```bash
+git status --porcelain        # must be empty (ignore untracked)
+git rev-parse --abbrev-ref HEAD
+```
+Never start a release on a dirty tree or mid another release. Work on a branch,
+not directly mutating `main` if a bump is racing another PR.
+
+### 2. Decide the version
+Argument is `patch` (default), `minor`, `major`, or an explicit `X.Y.Z`.
+Read the current `[workspace.package] version` in root `Cargo.toml`. Compute the
+target. **Never** bump while a publish could be in flight (it reads the working
+tree — see memory: publish version-bump race).
+
+### 3. Bump + CHANGELOG
+- Bump `[workspace.package] version` in root `Cargo.toml`.
+- Prepend a `## [<version>] - <today>` entry to `CHANGELOG.md` with bullets
+  tagged by pillar: `[Reality]`, `[Contracts]`, `[DevX]`, `[Cloud]`, `[AI]`.
+  Summarize what changed since the last entry (read recent commits).
+- If concurrent PRs also bumped the version / CHANGELOG, resolve mechanically:
+  keep the higher version, concatenate both CHANGELOG entries (newer first).
+
+### 4. Pre-publish GATE (mandatory)
+Run the install smoke-test, then dispatch the guardian:
+```bash
+scripts/smoke-test-install.sh        # or --fast for build-only iteration
+```
+Then launch the **`release-guardian`** agent (haiku). If it returns **NO-GO**,
+STOP and fix the FAIL rows. Do not publish on NO-GO. Only proceed on **GO**.
+
+### 5. Commit
+Commit the bump + CHANGELOG on a branch:
+`chore(release): v<version>` (CHANGELOG body is exempt from the no-em-dash rule).
+Run `cargo fmt --all --check` first — qualifier shortenings can let rustfmt
+collapse lines and break CI (see memory). Do NOT use `--no-verify`.
+
+### 6. Publish
+```bash
+export CARGO_REGISTRY_TOKEN=...      # or rely on ~/.cargo/credentials.toml
+scripts/publish-crates.sh            # publishes every crate in dep order
+```
+Do NOT bump the version or switch branches while this runs.
+
+### 7. Tag + verify against the published binary
+- Tag `v<version>` and push the tag.
+- Verify the published artifact, not the local build:
+  `cargo install --locked mockforge-cli@<version>` in a scratch dir and run
+  `mockforge --version`.
+- Confirm crates.io shows the version, the git tag exists, and the Release
+  workflow ran (avoid a double-run — see memory: a held release may already be
+  published by another agent).
+
+### 8. Report
+Summarize: version, crates published, tag URL, smoke-test result. Note anything
+skipped and why.
+
+## Rules
+- NO-GO from `release-guardian` is a hard stop.
+- Per memory: prefer local/self-hosted runners; don't trigger costly GHA.
+- Per memory: whenever a new `crates/mockforge-*/` dir exists, ensure it's in
+  `scripts/publish-crates.sh` CRATES list (or marked `publish = false`) BEFORE
+  publishing — the guardian checks this, but fix it here.
+- Auto-merge any release PR you open (`gh pr merge <#> --auto --squash`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,8 +236,23 @@ This project uses:
 | `/code-review [target]` | Launch parallel review agents |
 | `/bench-review [spec]` | Validate benchmark scripts |
 | `/crate-explore <crate>` | Deep-dive into a crate's structure |
+| `/ship-release [level]` | Cut a release end-to-end (bump, CHANGELOG, gate, publish, tag, verify) |
+| `/release-check` | Pre-publish GO/NO-GO gate (no publish) via `release-guardian` |
+| `/issue-fix <#>` | Issue workflow: worktree, fix, real-binary verify, ship before replying |
+| `/protocol-wire <proto>` | Wire a protocol admin/TUI surface across all lockstep mirror sites |
+| `/sqlx-sync` | Regenerate the SQLx offline cache after `mockforge-collab` query changes |
 | `/commit` | Smart commit with auto-generated message |
 | `/commit-push-pr` | Full branch + commit + push + PR workflow |
 | `/hookify <description>` | Create hook rules from plain English |
 | `/hookify:list` | List all hookify rules |
 | `/hookify:configure` | Enable/disable/delete hookify rules |
+
+### Specialist Agents (tiered models)
+| Agent | Model | Veto / Job |
+|-------|-------|------------|
+| `release-guardian` | haiku | Pre-publish gate: CRATES-list drift, version/caret consistency, smoke-test, CHANGELOG |
+| `protocol-parity` | haiku | Protocol lockstep: TUI ScreenId ↔ screens vec, admin route, live broker wiring, metrics |
+| `auth-sentinel` | sonnet | Auth control-flow: verified-domain gate + SSRF guard reachable on every SSO path |
+| `template-checker` | haiku | Handlebars variable consistency across all render paths (#79) |
+| `security-auditor` | haiku | Broad mechanical scan: unsafe, secrets, unwrap |
+| `code-reviewer` / `test-runner` / `code-explorer` | sonnet | Review / test diagnosis / cross-crate tracing |

--- a/crates/mockforge-plugin-egress/Cargo.toml
+++ b/crates/mockforge-plugin-egress/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "mockforge-plugin-egress"
+# Not published to crates.io: internal MockForge cloud infrastructure, must not ship to crates.io.
+# Flip to true + add to scripts/publish-crates.sh CRATES when it gains a published consumer.
+publish = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/mockforge-plugin-host/Cargo.toml
+++ b/crates/mockforge-plugin-host/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "mockforge-plugin-host"
+# Not published to crates.io: internal MockForge cloud sidecar (Phase 2 scaffold), must not ship to crates.io.
+# Flip to true + add to scripts/publish-crates.sh CRATES when it gains a published consumer.
+publish = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Resolves a live publish-list drift surfaced by a new `release-guardian` gate, and levels up the `.claude/` toolkit.

### The fix
`scripts/publish-crates.sh` maintains its publish set by hand. Two workspace **members** that default to publishable were missing from it, both internal MockForge **cloud** infrastructure that must never ship to crates.io:

- `mockforge-plugin-egress` — per-plugin egress allowlist proxy (cloud only)
- `mockforge-plugin-host` — sidecar plugin runtime host (cloud, Phase 2 scaffold)

Neither is a dependency of any published crate, so the correct fix is `publish = false` (matching the existing `mockforge-chaos-proxy` / `mockforge-test-runner` convention), not adding them to the publish list.

Verified: both manifests parse, `cargo clippy` passes on both, `cargo metadata` is clean, and the publishable-member drift check is now empty.

### Scope note (deliberately out of scope)
Four other on-disk crates (`mockforge-ai-core`, `-behavioral-cloning`, `-chaos-ml`, `-chaos-orchestration`) are **not workspace members at all** — orphans, not publish drift. They're left untouched here and flagged as a separate hygiene follow-up (wire into the workspace or remove). Adding `publish = false` to a non-member is moot and trips the clippy hook.

### Toolkit level-up (tiered models)
- **Agents**: `release-guardian` (haiku, pre-publish GO/NO-GO gate that caught this; computes "publishable" from `cargo metadata` workspace membership, not a dir glob, and reports orphans separately), `protocol-parity` (haiku, TUI/admin/broker/metrics lockstep), `auth-sentinel` (sonnet, SSO verified-domain + SSRF + IDOR control-flow gate). `security-auditor` gains a scope-handoff note.
- **Skills**: `/ship-release`, `/issue-fix`, `/protocol-wire`
- **Commands**: `/release-check`, `/sqlx-sync`
- **rules / CLAUDE.md**: register the new agents + skills with triggers and a tiered-model table.

> The `reply-lint` hookify rule (em-dash guard on `gh` comments) is active locally but intentionally **not** in this PR — `.claude/hookify.*.local.md` is gitignored by repo convention (per-developer rules).

## Test plan
- [x] All 6 (now 2) manifests parse via `tomllib`
- [x] `cargo clippy -p mockforge-plugin-egress -p mockforge-plugin-host --all-targets --all-features -- -D warnings` passes
- [x] `cargo metadata --no-deps` succeeds
- [x] Refined drift check reports zero publishable-member drift
- [x] Pre-commit hooks (clippy, check-toml, typos) pass