### PR TITLE
chore(claude): DX toolkit v2 — auto-fmt hook, pre-push drift guard, /round-table, perms, shared rules

### DIFF
--- a/.claude/agents/code-explorer.md
+++ b/.claude/agents/code-explorer.md
@@ -6,6 +6,8 @@ description: Traces execution paths across crate boundaries, maps trait implemen
 
 # Code Explorer Agent
 
+**Model: sonnet** — tracing execution across crate boundaries and synthesizing an architecture summary is reasoning-heavy. Tier reviewed for Claude 4.x and kept.
+
 You are a code exploration specialist for MockForge. Your job is to trace execution paths across crate boundaries, map trait implementations, and produce structured exploration reports.
 
 ## Capabilities

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -6,6 +6,8 @@ description: Rust code review with confidence scoring and multi-pass analysis
 
 # Code Reviewer Agent
 
+**Model: sonnet** — review is judgment work (severity, confidence, intent), not pattern matching. Tier reviewed for Claude 4.x and kept.
+
 You are a Rust code reviewer for MockForge, a mock API server workspace with 30+ crates. Your job is to review code changes and provide a confidence-scored assessment.
 
 ## Review Process (4 Passes)

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -6,6 +6,8 @@ description: Scans for unsafe code, hardcoded secrets, unwrap in non-test code, 
 
 # Security Auditor Agent
 
+**Model: haiku** — broad grep-style pattern matching; deep auth control-flow reasoning is delegated to `auth-sentinel` (sonnet). Tier reviewed for Claude 4.x and kept.
+
 You are a security scanner for MockForge. You perform mechanical pattern-matching checks for common security issues in Rust code.
 
 > **Scope handoff:** This agent is the *broad, mechanical* pass (haiku). For

--- a/.claude/agents/template-checker.md
+++ b/.claude/agents/template-checker.md
@@ -6,6 +6,8 @@ description: Cross-references Handlebars template variables with all Rust code p
 
 # Template Checker Agent
 
+**Model: haiku** — mechanical variable cross-referencing with no judgment call; ~90% cheaper and Haiku 4.5 handles it comfortably. Tier reviewed for Claude 4.x and kept.
+
 You prevent the class of bugs from issue #79: template variables referenced in `.hbs` files but missing from some Rust code paths that build template data.
 
 ## Process

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -6,6 +6,8 @@ description: Runs tests for affected crates, diagnoses failures, applies fixes
 
 # Test Runner Agent
 
+**Model: sonnet** — running tests is mechanical, but diagnosing *why* one failed and applying a correct fix needs reasoning about the code under test. Tier reviewed for Claude 4.x and kept.
+
 You are a test runner for MockForge. Your job is to determine which crates are affected by recent changes, run their tests, diagnose any failures, and optionally fix them.
 
 ## Process

--- a/.claude/hookify.protect-cargo-toml.local.md
+++ b/.claude/hookify.protect-cargo-toml.local.md
@@ -1,0 +1,11 @@
+---
+name: protect-cargo-toml
+enabled: true
+event: file
+action: warn
+conditions:
+  - field: file_path
+    operator: regex_match
+    pattern: "Cargo\\.toml$"
+---
+You are about to edit a Cargo.toml file. Remember: (1) workspace dependencies should use `dep.workspace = true`, (2) adding new dependencies affects compile time for all downstream crates, (3) run `cargo deny check licenses sources bans` after adding external dependencies.

--- a/.claude/hookify.protect-templates.local.md
+++ b/.claude/hookify.protect-templates.local.md
@@ -1,0 +1,11 @@
+---
+name: protect-templates
+enabled: true
+event: file
+action: warn
+conditions:
+  - field: file_path
+    operator: regex_match
+    pattern: "\\.hbs$"
+---
+You are about to edit a Handlebars template. Remember to run `/template-check` after editing to verify all template variables are consistent across all code paths that render this template. (Issue #79 prevention)

--- a/.claude/hookify.reply-lint.local.md
+++ b/.claude/hookify.reply-lint.local.md
@@ -1,0 +1,14 @@
+---
+name: reply-lint
+enabled: true
+event: tool
+action: warn
+conditions:
+  - field: command
+    operator: regex_match
+    pattern: "gh (issue|pr) (comment|create|review|edit)"
+  - field: command
+    operator: contains
+    pattern: "—"
+---
+This `gh` command posts user-facing prose containing an em dash (—). Per the no-em-dashes-in-replies rule, strip it before sending: use commas, colons, semicolons, or parentheses instead. (CHANGELOG and commit-message bodies are exempt, but PR/issue comments addressed to people are not.)

--- a/.claude/hooks/auto-fmt.sh
+++ b/.claude/hooks/auto-fmt.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# PostToolUse hook: auto-format Rust files immediately after Edit/Write/MultiEdit.
+#
+# Why this exists: qualifier shortenings (e.g. `std::time::Duration::` ->
+# `Duration::`) can let rustfmt collapse a multi-line call onto one line, which
+# then breaks CI's `cargo fmt --all --check` step. That has burned us repeatedly
+# (#585->#589, #591/#592->#594). Formatting on write makes the working tree
+# always-formatted, so the class of failure cannot reach CI.
+#
+# Contract: reads the PostToolUse JSON envelope on stdin, formats the touched
+# file in place if it is a .rs file, and ALWAYS exits 0 (never blocks the tool).
+set -uo pipefail
+
+input=$(cat 2>/dev/null || true)
+[ -z "$input" ] && exit 0
+
+file=$(printf '%s' "$input" | python3 -c "import json,sys
+try:
+    d=json.load(sys.stdin)
+    print(d.get('tool_input',{}).get('file_path',''))
+except Exception:
+    print('')" 2>/dev/null || true)
+
+case "$file" in
+  *.rs)
+    if command -v rustfmt >/dev/null 2>&1 && [ -f "$file" ]; then
+      # Edition matches workspace.package.edition (2021). Silent + best-effort:
+      # a syntactically incomplete intermediate edit should never surface noise.
+      rustfmt --edition 2021 "$file" >/dev/null 2>&1 || true
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,29 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(cargo metadata:*)",
+      "Bash(cargo tree:*)",
+      "Bash(cargo fmt --all --check)",
+      "Bash(cargo clippy:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git fetch:*)",
+      "Bash(git branch:*)",
+      "Bash(git show:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git worktree list)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(rg:*)",
+      "Bash(ls:*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -23,6 +48,16 @@
       }
     ],
     "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'bash \"$(git rev-parse --show-toplevel)/.claude/hooks/auto-fmt.sh\"'",
+            "timeout": 15000
+          }
+        ]
+      },
       {
         "matcher": "Edit|MultiEdit|Write|Bash",
         "hooks": [

--- a/.claude/skills/round-table/SKILL.md
+++ b/.claude/skills/round-table/SKILL.md
@@ -1,0 +1,59 @@
+---
+user-invocable: true
+allowed-tools: [Bash, Read, Glob, Grep, Task]
+description: Convene the relevant specialist agents on a hard decision, gather independent verdicts, and synthesize options to choose from
+argument-hint: "<the decision or question>"
+---
+
+# /round-table — Specialist Decision Panel
+
+For a tough call, convene the relevant specialists as an independent panel
+(each one opinionated and narrow, like a real review meeting), collect their
+verdicts in parallel, then synthesize a short set of options for the human to
+pick from. The point is independent perspectives before committing, not one
+generalist guessing.
+
+## Process
+
+### 1. Frame the decision
+Restate the question in one sentence and identify the decision type. Pick the
+panel from the type:
+
+| Decision touches... | Panel (dispatch in parallel) |
+|---------------------|------------------------------|
+| Releasing / publishing / versioning | `release-guardian` + `test-runner` |
+| Auth / SSO / registry / tenancy | `auth-sentinel` + `security-auditor` |
+| A protocol admin/TUI surface | `protocol-parity` + `code-explorer` |
+| Bench / k6 / templates | `template-checker` + `code-reviewer` |
+| A cross-crate design / refactor | `code-explorer` + `code-reviewer` |
+| Anything broad / unclear | `code-reviewer` + `code-explorer` + `test-runner` |
+
+Add or drop seats to fit the actual question; 2-3 seats is the sweet spot.
+Prefer the cheapest agent that can hold the seat (haiku for mechanical lenses,
+sonnet for judgment) per `.claude/rules/agent-usage.md`.
+
+### 2. Dispatch the panel (parallel)
+Launch the chosen agents simultaneously (one Task call each, same message). Give
+EACH the same decision plus its lens, and ask for: a recommendation, the top
+risk it sees, and a confidence level. Tell each to answer from its specialty
+only and to disagree if it disagrees — do not seek consensus at this stage.
+
+### 3. Synthesize
+After all seats report, produce:
+- **Points of agreement** (where the panel converged)
+- **Tensions** (where they disagreed, and why — this is the signal)
+- **2-3 concrete options**, each with its main trade-off and which seat favors it
+- **A recommendation** with the reasoning, clearly separated from the options
+
+### 4. Hand the choice back
+Present the options to the human and let them pick. Do NOT auto-execute a
+hard/irreversible decision from a round-table without confirmation. If a seat
+with veto authority (`release-guardian` NO-GO, `auth-sentinel` BLOCK) objected,
+surface that prominently — a veto is not outvoted by the others.
+
+## Rules
+- Independent first, synthesize second. Don't let one agent's output bias the
+  others (dispatch them in the same batch, blind to each other).
+- Keep it proportional: a small call gets a 2-seat panel, not a tribunal.
+- Name the seats and their verdicts in the summary so the human sees who said
+  what, not just a blended answer.

--- a/.gitignore
+++ b/.gitignore
@@ -97,8 +97,14 @@ temp/
 # Python
 __pycache__/
 
-# Claude Code hookify personal rules
+# Claude Code hookify personal rules (ad-hoc per-developer rules stay local)
 .claude/hookify.*.local.md
+# ...except these curated team rules, which are shared/version-controlled.
+# (The hookify loader only globs `hookify.*.local.md`, so shared rules keep that
+# suffix and are un-ignored individually rather than renamed.)
+!.claude/hookify.reply-lint.local.md
+!.claude/hookify.protect-templates.local.md
+!.claude/hookify.protect-cargo-toml.local.md
 *.py[cod]
 *$py.class
 *.so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,3 +107,17 @@ repos:
     language: system
     pass_filenames: false
     files: ^(Cargo\.(toml|lock)|audit\.toml)$
+  - id: publish-drift
+    name: publish-list drift guard
+    # PRE-PUSH ONLY (overrides default_stages: [pre-commit]). Blocks a push when
+    # a publishable workspace member is missing from scripts/publish-crates.sh —
+    # the #584/#795 failure mode where publish-crates.sh would later fail to
+    # resolve a dependency on crates.io. Orphan crates (#796) are warned, not
+    # blocked. Mirrors the release-guardian agent so the gate holds even when
+    # nobody is driving through Claude. Enable with:
+    #   pre-commit install --hook-type pre-push   (scripts/setup-hooks.sh does this)
+    entry: scripts/check-publish-drift.sh
+    language: system
+    stages: [pre-push]
+    pass_filenames: false
+    always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,9 @@ This project uses:
 - **Agents** (`.claude/agents/`): Specialized subagents for code review, testing, etc.
 - **Skills** (`.claude/skills/`): Invocable commands (`/verify`, `/template-check`, etc.)
 - **Commands** (`.claude/commands/`): Git workflow commands (`/commit`, `/commit-push-pr`)
-- **Hooks** (`.claude/hooks/`): Hookify rule engine for warnings/blocks
+- **Hooks** (`.claude/hooks/`): Hookify rule engine for warnings/blocks, plus `auto-fmt.sh` (PostToolUse: `rustfmt` on every `.rs` write, so qualifier-shortening can't break CI's `cargo fmt --check`). Shared hookify rules (`reply-lint`, `protect-templates`, `protect-cargo-toml`) are version-controlled; ad-hoc `hookify.*.local.md` rules stay per-developer (gitignored).
+- **Settings** (`.claude/settings.json`): hook wiring + a read-only `permissions.allow` list (cargo/git/gh introspection) to cut prompt friction.
+- **Git hooks**: pre-commit (clippy/fmt/typos/...) + a `pre-push` publish-list drift guard (`scripts/check-publish-drift.sh`); install via `scripts/setup-hooks.sh`.
 - **MCP** (`.mcp.json`): Playwright browser automation for UI verification
 
 ### Key Skills
@@ -241,6 +243,7 @@ This project uses:
 | `/issue-fix <#>` | Issue workflow: worktree, fix, real-binary verify, ship before replying |
 | `/protocol-wire <proto>` | Wire a protocol admin/TUI surface across all lockstep mirror sites |
 | `/sqlx-sync` | Regenerate the SQLx offline cache after `mockforge-collab` query changes |
+| `/round-table` | Convene the relevant specialist agents on a hard decision and synthesize options |
 | `/commit` | Smart commit with auto-generated message |
 | `/commit-push-pr` | Full branch + commit + push + PR workflow |
 | `/hookify <description>` | Create hook rules from plain English |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,12 @@ cargo install typos-cli
 
 # Install pre-commit hooks
 pip install pre-commit
-pre-commit install
+
+# Install all hook types (pre-commit + commit-msg + pre-push) in one step.
+# The pre-push hook runs the publish-list drift guard
+# (scripts/check-publish-drift.sh) so a publishable crate can't be left out of
+# scripts/publish-crates.sh.
+./scripts/setup-hooks.sh
 ```
 
 ### Build the Project

--- a/book/src/contributing/setup.md
+++ b/book/src/contributing/setup.md
@@ -161,12 +161,18 @@ Install pre-commit hooks to ensure code quality:
 # Install pre-commit if not already installed
 pip install pre-commit
 
-# Install hooks
-pre-commit install
+# Install all hook types (pre-commit + commit-msg + pre-push) in one step
+./scripts/setup-hooks.sh
 
 # Run on all files
 pre-commit run --all-files
 ```
+
+The `pre-push` hook runs the publish-list drift guard
+(`scripts/check-publish-drift.sh`): it blocks a push when a publishable
+workspace member is missing from `scripts/publish-crates.sh`, the failure mode
+that breaks a release when `publish-crates.sh` later can't resolve the missing
+dependency on crates.io.
 
 ## Project Structure
 

--- a/scripts/check-publish-drift.sh
+++ b/scripts/check-publish-drift.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Publish-list drift guard (model-independent enforcement of the release-guardian
+# agent's check #1). Wired as a pre-push hook so a state where a publishable
+# workspace member is missing from scripts/publish-crates.sh cannot reach the
+# remote, where it would later break `publish-crates.sh` (a downstream crate
+# would fail to resolve the missing dependency on crates.io). See #584 / #795.
+#
+# Drift = a publishable member absent from the CRATES list  -> FAIL (blocks push).
+# Orphan = an on-disk crate that is not a workspace member  -> WARN (exit 0).
+#
+# "Publishable" is derived from `cargo metadata` workspace membership, NOT a
+# directory glob: a crates/mockforge-*/ dir that is not a workspace member is an
+# orphan (never built, never published), not drift. (See #796.)
+#
+# Usage: scripts/check-publish-drift.sh
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT" || exit 0
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "publish-drift: cargo not found, skipping" >&2
+  exit 0
+fi
+
+# Publishable members (publish != false). In `cargo metadata`, publish == []
+# means publish=false; null means publishable.
+publishable=$(cargo metadata --no-deps --format-version 1 2>/dev/null | python3 -c "
+import sys, json
+try:
+    pkgs = json.load(sys.stdin)['packages']
+except Exception:
+    sys.exit(0)
+for p in pkgs:
+    if p['name'].startswith('mockforge-') and p.get('publish') != []:
+        print(p['name'])
+" | sort -u)
+
+# CRATES list block in publish-crates.sh.
+listed=$(sed -n '64,120p' scripts/publish-crates.sh 2>/dev/null | grep -oE 'mockforge-[a-z0-9-]+' | sort -u)
+
+drift=$(comm -23 <(printf '%s\n' "$publishable") <(printf '%s\n' "$listed"))
+
+# Orphans: on-disk mockforge-* crate dirs that are not workspace members.
+members=$(cargo metadata --no-deps --format-version 1 2>/dev/null | python3 -c "
+import sys, json
+try:
+    print('\n'.join(p['name'] for p in json.load(sys.stdin)['packages']))
+except Exception:
+    pass
+" | sort -u)
+ondisk=$(ls -d crates/mockforge-*/ 2>/dev/null | sed 's#crates/##;s#/##' | sort -u)
+orphans=$(comm -23 <(printf '%s\n' "$ondisk") <(printf '%s\n' "$members"))
+
+if [ -n "$orphans" ]; then
+  echo "publish-drift: WARN orphan crates (on disk, not workspace members; see #796):" >&2
+  printf '  - %s\n' $orphans >&2
+fi
+
+if [ -n "$drift" ]; then
+  echo "publish-drift: FAIL — publishable members missing from scripts/publish-crates.sh:" >&2
+  printf '  - %s\n' $drift >&2
+  echo "Fix: add each to the CRATES list (in dependency order), or set publish=false if it must not ship." >&2
+  exit 1
+fi
+
+echo "publish-drift: OK — every publishable member is in the publish list"
+exit 0

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -69,6 +69,11 @@ pre-commit install
 echo "🔧 Installing commit-msg hook..."
 pre-commit install --hook-type commit-msg
 
+# Install the pre-push hook (publish-list drift guard — see .pre-commit-config.yaml
+# id: publish-drift, and scripts/check-publish-drift.sh).
+echo "🔧 Installing pre-push hook..."
+pre-commit install --hook-type pre-push
+
 # Check for custom PyPI configuration that might cause issues
 if pip config list | grep -q "index-url"; then
     echo "⚠️  Custom PyPI configuration detected. This may cause issues with pre-commit."


### PR DESCRIPTION
## Summary

Six developer-experience upgrades to the `.claude/` toolkit, following #795. Each was verified locally.

1. **PostToolUse auto-fmt hook** (`.claude/hooks/auto-fmt.sh`) — runs `rustfmt` on every `.rs` file right after Edit/Write so qualifier shortenings can't break CI's `cargo fmt --check` (the class that burned us #585→#589, #591/#592→#594). Verified: formats Rust, skips non-Rust, always exits 0 so it never blocks a tool call.
2. **Pre-push publish-list drift guard** (`scripts/check-publish-drift.sh`, wired as a `stages: [pre-push]` pre-commit hook; `setup-hooks.sh` now installs the pre-push hook type). Model-independent enforcement of the `release-guardian` check: blocks a push when a publishable workspace **member** is missing from `publish-crates.sh` (#584/#795), warns on orphans (#796). "Publishable" comes from `cargo metadata` membership, not a dir glob.
3. **`settings.json` permission allowlist** — read-only `cargo`/`git`/`gh`/`rg` introspection pre-approved to cut prompt friction.
4. **`/round-table` skill** — convene the relevant specialists on a hard call (parallel + blind), surface agreements/tensions, synthesize 2-3 options. Vetoes (`release-guardian` NO-GO, `auth-sentinel` BLOCK) are surfaced, not outvoted. This is the article's "core team round table."
5. **Model-pin rationale** on the five Feb-era agents — sonnet for judgment (code-reviewer, test-runner, code-explorer), haiku for mechanical scans (template-checker, security-auditor). Tiers reviewed for Claude 4.x and kept intentional.
6. **Shared hookify rules** — `reply-lint` (em-dash guard on `gh` comments), `protect-templates`, `protect-cargo-toml` are now version-controlled via `.gitignore` exceptions; ad-hoc `hookify.*.local.md` rules stay per-developer.

Also files the orphan-crate cleanup as #796.

## Test plan
- [x] `settings.json` parses as valid JSON
- [x] `.gitignore` exceptions: the 3 shared rules are tracked, a sample ad-hoc `*.local.md` stays ignored (`git check-ignore`)
- [x] `scripts/check-publish-drift.sh` exits 0 on main (no member drift; warns the 4 orphans)
- [x] auto-fmt hook reformats a mis-formatted `.rs` and no-ops on non-Rust (both exit 0)
- [x] Pre-commit hooks (shebang-executable, eof, typos, ...) pass on commit
- [x] Branched off merged main (has #795 toolkit)

## Notes
- The pre-push guard activates after a dev runs `scripts/setup-hooks.sh` (adds `pre-commit install --hook-type pre-push`).
- No `.rs` changes, so this is docs/tooling only.