### PR TITLE
chore(workspace): wire 4 orphaned AI/chaos crates into the workspace (closes #796)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7713,6 +7713,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockforge-ai-core"
+version = "0.3.168"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "mockforge-amqp"
 version = "0.3.168"
 dependencies = [
@@ -7755,6 +7772,19 @@ dependencies = [
  "tracing",
  "urlencoding",
  "woothee",
+]
+
+[[package]]
+name = "mockforge-behavioral-cloning"
+version = "0.3.168"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -7831,6 +7861,44 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "mockforge-chaos-ml"
+version = "0.3.168"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "mockforge-chaos-orchestration",
+ "parking_lot",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "mockforge-chaos-orchestration"
+version = "0.3.168"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "cron",
+ "mockforge-recorder",
+ "mockforge-tracing",
+ "parking_lot",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ members = [
     # Advanced features
     "crates/mockforge-chaos",
     "crates/mockforge-chaos-proxy",
+    "crates/mockforge-chaos-ml",
+    "crates/mockforge-chaos-orchestration",
+    "crates/mockforge-ai-core",
+    "crates/mockforge-behavioral-cloning",
     "crates/mockforge-federation",
     "crates/mockforge-performance",
     "crates/mockforge-pipelines",

--- a/crates/mockforge-ai-core/Cargo.toml
+++ b/crates/mockforge-ai-core/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "mockforge-ai-core"
+# Wired into the workspace (#796) but not yet consumed by any published
+# crate, so it does not ship to crates.io. Flip to true + add to
+# scripts/publish-crates.sh CRATES when it gains a published consumer.
+publish = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/mockforge-ai-core/src/error.rs
+++ b/crates/mockforge-ai-core/src/error.rs
@@ -23,8 +23,13 @@ pub enum Error {
 }
 
 impl Error {
-    /// Create a generic error
-    pub fn generic<S: Into<String>>(message: S) -> Self {
+    /// Create an internal error.
+    ///
+    /// Constructs the [`Error::Generic`] variant. Named `internal` to match the
+    /// 2026-04-01 `Error::generic` -> `Error::internal` rename that swept the
+    /// call sites across the workspace; this constructor was missed because the
+    /// crate was not yet a workspace member (see #796).
+    pub fn internal<S: Into<String>>(message: S) -> Self {
         Self::Generic {
             message: message.into(),
         }

--- a/crates/mockforge-behavioral-cloning/Cargo.toml
+++ b/crates/mockforge-behavioral-cloning/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "mockforge-behavioral-cloning"
+# Wired into the workspace (#796) but not yet consumed by any published
+# crate, so it does not ship to crates.io. Flip to true + add to
+# scripts/publish-crates.sh CRATES when it gains a published consumer.
+publish = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/mockforge-chaos-ml/Cargo.toml
+++ b/crates/mockforge-chaos-ml/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "mockforge-chaos-ml"
+# Wired into the workspace (#796) but not yet consumed by any published
+# crate, so it does not ship to crates.io. Flip to true + add to
+# scripts/publish-crates.sh CRATES when it gains a published consumer.
+publish = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/mockforge-chaos-orchestration/Cargo.toml
+++ b/crates/mockforge-chaos-orchestration/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "mockforge-chaos-orchestration"
+# Wired into the workspace (#796) but not yet consumed by any published
+# crate, so it does not ship to crates.io. Flip to true + add to
+# scripts/publish-crates.sh CRATES when it gains a published consumer.
+publish = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Resolves #796. Four crates (~27k LOC from the 2026-03-20 architectural overhaul) lived under `crates/` but were never in `[workspace].members`, so they were never built, tested, linted, or covered by CI. They are substantial product code (AI + chaos pillars), not scaffolds, so the fix is to **wire them in**, not delete:

| Crate | LOC | State |
|-------|-----|-------|
| `mockforge-ai-core` | 7.7k | compiled after a 1-line fix (below) |
| `mockforge-behavioral-cloning` | 1.3k | compiled clean |
| `mockforge-chaos-ml` | 5.5k | compiled clean |
| `mockforge-chaos-orchestration` | 12.7k | compiled clean |

### The `ai-core` bit-rot
`ai-core` had drifted: the 2026-04-01 `Error::generic` → `Error::internal` rename swept its call sites but not its constructor, because the crate wasn't a workspace member and so never compiled during that sweep. Renamed the constructor to match; the cascading `str`-sizing errors were the same root cause and cleared with it.

### Publish posture
All four are marked `publish = false` (matching the `plugin-egress` / `plugin-host` precedent from #795): nothing published consumes them yet, so they don't ship to crates.io and don't trip the publish-list drift guard. Flip to publishable + add to `scripts/publish-crates.sh` when they gain a consumer.

## Test plan
- [x] All 4 compile clean (`cargo check -p`)
- [x] All 4 clippy-clean at `--all-targets` (zero warnings)
- [x] Unit tests pass: **316 passed, 0 failed** (111 + 33 + 172 + 0)
- [x] Workspace `cargo fmt --check --all` passes (pre-commit)
- [x] Drift guard reports zero orphans and zero publishable-member drift

## Follow-up (out of scope)
Bring these crates under the strict `[lints] workspace = true` set (`missing_docs`, `unwrap_used`, `needless_pass_by_value`, ...) like the rest of the workspace. They currently build clean under **default** clippy only; the strict set will surface doc/unwrap warnings to clean up separately.