### PR TITLE
feat(tooling): /new-crate scaffolder + /prune-worktrees disk reclaimer

### DIFF
--- a/.claude/commands/prune-worktrees.md
+++ b/.claude/commands/prune-worktrees.md
@@ -1,0 +1,39 @@
+---
+allowed-tools: Bash, Read
+description: Remove git worktrees whose PR has merged, to recover disk (dry-run first)
+---
+
+# /prune-worktrees — Reclaim Disk from Merged Worktrees
+
+`/mnt/projects` fills up because each worktree carries ~15-26G of build
+artifacts. This removes worktrees whose branch's PR has already merged.
+
+Squash-merge aware: because PRs land as squash commits, `git branch --merged`
+can't see them, so merged-ness is matched against `gh pr list --state merged`
+head branches (the correct signal for this repo — see the disk-pressure memory).
+
+## Steps
+
+1. **Dry-run first** (always):
+   ```bash
+   scripts/prune-worktrees.sh
+   ```
+   Shows each worktree it would remove (with size), which it would skip for
+   uncommitted changes, and which it keeps (main, current, unmerged, detached).
+
+2. **Review the plan with the user.** Confirm nothing in the "would remove" list
+   is still wanted. The script never touches the main checkout, the current
+   worktree, `main`, or any worktree with uncommitted changes.
+
+3. **Execute** once confirmed:
+   ```bash
+   scripts/prune-worktrees.sh --execute
+   ```
+   Removes only merged + clean worktrees (never `--force`), then
+   `git worktree prune`. Reports how many were removed / skipped / kept.
+
+## Rules
+- Dry-run before `--execute`, every time. Show the plan; don't surprise-delete.
+- The script refuses to remove dirty worktrees (no `--force`) — if one is dirty
+  but you know it's disposable, the human handles it manually.
+- Safe to run often; it's idempotent.

--- a/.claude/skills/new-crate/SKILL.md
+++ b/.claude/skills/new-crate/SKILL.md
@@ -1,0 +1,59 @@
+---
+user-invocable: true
+allowed-tools: [Bash, Read, Edit, Glob, Grep]
+description: Scaffold a new mockforge-* crate already wired into every required registration point
+argument-hint: "<name> [--desc \"...\"] [--bin] [--publish]"
+---
+
+# /new-crate — Scaffold a Fully-Wired Crate
+
+Create a new `mockforge-*` crate that is registered everywhere a crate has to be,
+so it cannot become an orphan (#796) or a publish-list drift (#795). Every
+problem fixed in those issues traced to a crate being created but missing one of
+its registration points; this closes that gap at creation time.
+
+## Process
+
+### 1. Run the scaffolder
+```bash
+scripts/new-crate.sh <name> [--desc "one-line description"] [--bin] [--publish]
+```
+It creates `crates/mockforge-<name>/` (Cargo.toml with workspace inheritance +
+`[lints] workspace = true`, `src/lib.rs` or `src/main.rs`, `README.md`), adds the
+crate to root `Cargo.toml` `[workspace].members`, and — with `--publish` — inserts
+it into `scripts/publish-crates.sh` before `mockforge-cli`. It then verifies the
+crate is a workspace member and compiles.
+
+Defaults: **library** crate, **`publish = false`** (most new crates have no
+published consumer yet). Pass `--bin` for a binary, `--publish` to ship it now.
+
+### 2. Decide publish posture (the one judgment call)
+- **`publish = false`** (default) is correct when nothing published depends on
+  the crate yet. The pre-push drift guard / `release-guardian` stay green.
+- **`--publish`** only when a published crate will depend on it (or it ships
+  standalone). If you use `--publish`, double-check its slot in the
+  `scripts/publish-crates.sh` CRATES list: it must come AFTER every
+  `mockforge-*` crate it depends on. The script inserts before `mockforge-cli`,
+  which is safe for a leaf crate but not if an earlier crate depends on it.
+
+### 3. Wire dependencies + code
+- Add workspace deps to `[dependencies]` (`dep.workspace = true`).
+- Replace the placeholder in `src/`.
+- If the crate exposes public items, keep doc comments (workspace
+  `missing_docs` lint).
+
+### 4. Verify
+```bash
+cargo clippy -p mockforge-<name> --all-targets -- -D warnings
+cargo test -p mockforge-<name>
+```
+If this crate will ship, run `/release-check` before the next release so the
+guardian confirms it's listed (or correctly `publish = false`).
+
+## Rules
+- Never hand-create a crate dir without registering it in `[workspace].members`
+  — that is exactly the orphan bug from #796.
+- Use `[lints] workspace = true` (the scaffolder does), not a hand-rolled
+  `[lints.rust]` block, so the crate inherits the curated workspace lint set.
+- A `publish = false` crate must still be a workspace member (so it's built and
+  linted); it just doesn't ship.

--- a/scripts/new-crate.sh
+++ b/scripts/new-crate.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Scaffold a new mockforge-* crate already wired into every place a crate has to
+# be registered, so it can't become an orphan (#796) or a publish-list drift
+# (#795). Without this, a hand-rolled crate routinely misses one of:
+#   - root Cargo.toml [workspace].members  -> never built/tested/linted (orphan)
+#   - [lints] workspace = true             -> escapes the workspace lint set
+#   - scripts/publish-crates.sh CRATES     -> publish drift if it ships
+#
+# Usage:
+#   scripts/new-crate.sh <name> [--desc "one-line description"] [--bin] [--publish]
+#
+#   <name>      crate name, with or without the mockforge- prefix (e.g. "widget"
+#               or "mockforge-widget")
+#   --desc      crate description (default: a placeholder you should edit)
+#   --bin       scaffold a binary (src/main.rs) instead of a library (src/lib.rs)
+#   --publish   make it publishable now and insert it into the publish list.
+#               DEFAULT is publish=false (most new crates have no published
+#               consumer yet; flip later — release-guardian will flag it).
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+NAME=""
+DESC=""
+KIND="lib"
+PUBLISH=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --desc) DESC="$2"; shift 2 ;;
+    --bin) KIND="bin"; shift ;;
+    --publish) PUBLISH=true; shift ;;
+    -h|--help) sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) NAME="$1"; shift ;;
+  esac
+done
+
+[ -n "$NAME" ] || { echo "error: crate name required" >&2; exit 2; }
+NAME="${NAME#mockforge-}"          # strip prefix if supplied
+CRATE="mockforge-$NAME"
+DIR="crates/$CRATE"
+[ -d "$DIR" ] && { echo "error: $DIR already exists" >&2; exit 1; }
+[ -n "$DESC" ] || DESC="TODO: describe $CRATE"
+
+echo "Scaffolding $CRATE (kind=$KIND, publish=$([ "$PUBLISH" = true ] && echo true || echo false))"
+
+mkdir -p "$DIR/src"
+
+# --- Cargo.toml -------------------------------------------------------------
+PUBLISH_LINE=""
+[ "$PUBLISH" = false ] && PUBLISH_LINE=$'# Not yet consumed by any published crate, so it does not ship to crates.io.\n# Flip to true + add to scripts/publish-crates.sh CRATES when it gains a\n# published consumer (release-guardian / the pre-push drift guard will flag it).\npublish = false\n'
+
+cat > "$DIR/Cargo.toml" <<EOF
+[package]
+name = "$CRATE"
+${PUBLISH_LINE}version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "$DESC"
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true
+EOF
+
+# --- source -----------------------------------------------------------------
+if [ "$KIND" = bin ]; then
+  cat > "$DIR/src/main.rs" <<EOF
+//! $CRATE — $DESC
+
+fn main() {
+    println!("$CRATE");
+}
+EOF
+else
+  cat > "$DIR/src/lib.rs" <<EOF
+//! $CRATE — $DESC
+//!
+//! TODO: replace this with the crate's public API. The crate-level doc comment
+//! above satisfies the workspace \`missing_docs\` lint for an otherwise empty lib.
+EOF
+fi
+# Minimal README so \`cargo publish\`/\`cargo doc\` are happy if this crate later ships.
+cat > "$DIR/README.md" <<EOF
+# $CRATE
+
+$DESC
+EOF
+
+# --- register in root Cargo.toml [workspace].members ------------------------
+python3 - "$CRATE" <<'PY'
+import sys, pathlib, re
+crate = sys.argv[1]
+p = pathlib.Path("Cargo.toml")
+lines = p.read_text().splitlines(keepends=True)
+entry = f'    "crates/{crate}",\n'
+if any(entry.strip() == l.strip() for l in lines):
+    print("  members: already present"); sys.exit(0)
+# insert right after the last existing "crates/mockforge-*" member line
+last = None
+for i, l in enumerate(lines):
+    if re.match(r'\s*"crates/mockforge-[^"]+",', l):
+        last = i
+assert last is not None, "could not find an existing crates/mockforge-* member to anchor to"
+lines.insert(last + 1, entry)
+p.write_text("".join(lines))
+print(f"  members: added {crate}")
+PY
+
+# --- optionally register in the publish list --------------------------------
+if [ "$PUBLISH" = true ]; then
+  python3 - "$CRATE" <<'PY'
+import sys, pathlib, re
+crate = sys.argv[1]
+p = pathlib.Path("scripts/publish-crates.sh")
+lines = p.read_text().splitlines(keepends=True)
+if any(re.match(rf'\s*{re.escape(crate)}\s*$', l) for l in lines):
+    print("  publish list: already present"); sys.exit(0)
+# Insert before mockforge-cli (a final consumer that depends on ~everything),
+# which is a safe topological slot for a new leaf crate. Reorder if the new
+# crate is itself a dependency of something earlier.
+for i, l in enumerate(lines):
+    if re.match(r'\s*mockforge-cli\s*$', l):
+        indent = re.match(r'(\s*)', l).group(1)
+        lines.insert(i, f"{indent}{crate}\n")
+        p.write_text("".join(lines))
+        print(f"  publish list: inserted {crate} before mockforge-cli")
+        break
+else:
+    print("  publish list: WARN could not find mockforge-cli anchor; add manually")
+PY
+fi
+
+# --- verify -----------------------------------------------------------------
+echo "Verifying..."
+if cargo metadata --no-deps --format-version 1 2>/dev/null | python3 -c "import sys,json;exit(0 if '$CRATE' in {p['name'] for p in json.load(sys.stdin)['packages']} else 1)"; then
+  echo "  ✓ $CRATE is a workspace member"
+else
+  echo "  ✗ $CRATE is NOT a member — check root Cargo.toml" >&2; exit 1
+fi
+cargo check -p "$CRATE" 2>&1 | tail -3
+
+cat <<EOF
+
+Done. Next steps:
+  - edit $DIR/Cargo.toml description + add dependencies
+  - write code in $DIR/src/
+  - if it should ship, re-run with --publish or add it to scripts/publish-crates.sh
+  - run: cargo clippy -p $CRATE --all-targets -- -D warnings
+EOF

--- a/scripts/prune-worktrees.sh
+++ b/scripts/prune-worktrees.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Prune git worktrees whose branch's PR has already been merged, to recover disk
+# (/mnt/projects fills up; each worktree is ~15-26G of build artifacts).
+#
+# Squash-merge aware: because PRs land as squash commits, `git branch --merged`
+# does NOT detect a merged branch (its commits never become ancestors of main).
+# So merged-ness is determined by matching each worktree's branch against
+# `gh pr list --state merged` head branches — the correct signal for this repo.
+#
+# Safety:
+#   - never touches the main checkout or the current worktree
+#   - never removes a worktree with uncommitted changes (no --force)
+#   - DEFAULTS TO DRY-RUN: prints the plan; pass --execute to actually remove
+#
+# Usage:
+#   scripts/prune-worktrees.sh            # dry-run: show what would be removed
+#   scripts/prune-worktrees.sh --execute  # actually remove merged, clean worktrees
+set -uo pipefail
+
+EXECUTE=false
+[ "${1:-}" = "--execute" ] && EXECUTE=true
+
+command -v gh >/dev/null 2>&1 || { echo "error: gh CLI required (merged-PR detection)" >&2; exit 2; }
+
+# Merged head branches (squash-merge aware signal).
+mapfile -t MERGED < <(gh pr list --state merged --limit 300 --json headRefName -q '.[].headRefName' 2>/dev/null | sort -u)
+is_merged() { local b="$1"; for m in "${MERGED[@]}"; do [ "$m" = "$b" ] && return 0; done; return 1; }
+
+MAIN_WT="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+CUR_WT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+removed=0 skipped_dirty=0 kept=0 freed_note=""
+path="" branch=""
+flush() {
+  [ -z "$path" ] && return
+  if [ "$path" = "$MAIN_WT" ] || [ "$path" = "$CUR_WT" ]; then kept=$((kept+1)); path=""; branch=""; return; fi
+  if [ -z "$branch" ]; then kept=$((kept+1)); path=""; branch=""; return; fi   # detached HEAD
+  if [ "$branch" = "main" ]; then kept=$((kept+1)); path=""; branch=""; return; fi
+  if is_merged "$branch"; then
+    if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then
+      echo "  SKIP (uncommitted changes): $path [$branch]"; skipped_dirty=$((skipped_dirty+1))
+    else
+      local sz; sz="$(du -sh "$path" 2>/dev/null | cut -f1)"
+      if [ "$EXECUTE" = true ]; then
+        if git worktree remove "$path" 2>/dev/null; then echo "  REMOVED ($sz): $path [$branch]"; removed=$((removed+1));
+        else echo "  FAILED to remove (left intact): $path [$branch]"; fi
+      else
+        echo "  would remove ($sz): $path [$branch]"; removed=$((removed+1))
+      fi
+    fi
+  else
+    kept=$((kept+1))
+  fi
+  path=""; branch=""
+}
+
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) flush; path="${line#worktree }" ;;
+    "branch "*)   branch="${line#branch refs/heads/}" ;;
+    "detached")   branch="" ;;
+    "")           flush ;;
+  esac
+done < <(git worktree list --porcelain; echo "")
+flush
+
+echo ""
+if [ "$EXECUTE" = true ]; then
+  git worktree prune
+  echo "Pruned $removed worktree(s); skipped $skipped_dirty dirty; kept $kept."
+else
+  echo "DRY-RUN: would prune $removed; would skip $skipped_dirty dirty; keep $kept."
+  echo "Re-run with --execute to remove."
+fi


### PR DESCRIPTION
## Summary

Two preventive tools, both motivated directly by this session's fixes.

### `/new-crate` (`scripts/new-crate.sh` + skill)
Scaffolds a `mockforge-*` crate already wired into **every** place a crate has to be registered: root `Cargo.toml` `[workspace].members`, `[lints] workspace = true`, and (with `--publish`) the `scripts/publish-crates.sh` CRATES list. Every problem fixed in #795/#796 traced to a crate created but missing one of these, so this makes the orphan / publish-drift class impossible at creation time.

```
scripts/new-crate.sh <name> [--desc "..."] [--bin] [--publish]
```
Defaults to a library, `publish = false`. Verified: scaffolds a member that compiles and is **clippy-clean under the strict workspace lints**; `--publish` also inserts into the publish list before `mockforge-cli`; both throwaway test crates were cleaned up.

### `/prune-worktrees` (`scripts/prune-worktrees.sh` + command)
Removes worktrees whose PR has merged, to recover disk (`/mnt/projects` fills up; ~15-26G per worktree). **Squash-merge aware**: matches `gh pr list --state merged` head branches, because `git branch --merged` can't detect squash merges. Never touches `main`, the current worktree, or any worktree with uncommitted changes. **Dry-run by default**, `--execute` to remove.

Dry-run on the current box: would reclaim **400G+ across 38 merged worktrees**, while correctly **skipping 5 dirty** and keeping 11 active.

## Test plan
- [x] `/new-crate` scaffolds a compiling, clippy-clean (`-D warnings`) workspace member
- [x] `--publish` inserts into `publish-crates.sh`; default leaves `publish = false`
- [x] throwaway test crates removed; no Cargo.toml/lock drift left behind
- [x] `/prune-worktrees` dry-run correctly classifies remove / skip-dirty / keep
- [x] pre-commit hooks pass (shebang-executable, eof, typos)

## Notes
- CLAUDE.md Key Skills rows intentionally omitted to avoid a merge conflict with the `/round-table` row in-flight on #797. Both tools are auto-discovered regardless.
- This PR does not run `/prune-worktrees --execute`; that's a separate, user-confirmed action.