### PR TITLE
feat(bench,openapi): #79 round 28 — reqwest CT-fix + expected_status + mismatch filter + per-cat links + server CT check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.3.172] - 2026-06-07
+
+### Fixed
+
+- **[Contracts]** Content-type-swap probes now actually send only the wrong Content-Type (#79 round 28). My round-25 fix relied on reqwest's `.header(k, v)` being last-write-wins, but it actually APPENDS — so each content-type-swap probe was sending BOTH `Content-Type: application/json` (from the body block) AND `Content-Type: application/xml` (from `extra_headers`). Axum's `Json<>` extractor picked the JSON one and accepted, server returned 204, the spec violation Srikanth was investigating never showed up in the conformance buffer. Now `send_case_with_extra` builds a `HeaderMap` ourselves, where `.insert()` replaces, so the override actually replaces. Smoke-confirmed: the same 4 content-type-mismatch probes that returned 204 on 0.3.171 now return 415 on this build.
+- **[Contracts]** Server-side `OpenApiRouteRegistry::check_request_content_type` flags Content-Type mismatches against the spec's declared `requestBody.content` keys (#79 round 28 / Srikanth's main r27 ask). Called from the live-server route handler before the body schema validator; on mismatch records a `content-types` category violation in the conformance buffer with the configured validation status (defaults to 415). Stripping the `; charset=...` suffix so the comparison is type/subtype only; case-insensitive matching.
+- **[DevX]** `response_schema_error` now embeds the expected schema in the message (#79 round 28 / Srikanth: "what does at /: mean? would be good to put as `expected schema {...}`"). Format: `at <path>: <kind>; expected schema <compact JSON>`. Schemas are truncated to 300 chars to keep JSONL lines bounded.
+
+### Added
+
+- **[Contracts]** `expected_status_range` field on every `CaseCapture` (#79 round 28 / Srikanth: "Is it possible to put expected response code status in both jsonl and jsonl report"). Values: `"2xx-3xx"` for positive probes, `"4xx"` for negatives. Persisted in the JSONL so `jq` can filter mismatches, and rendered as a small `exp 4xx`/`exp 2xx-3xx` badge on every card in the HTML viewer.
+- **[DevX]** HTML capture viewer: new "only show mismatches" checkbox in the toolbar (#79 round 28 / Srikanth: "Also a filter or checkbox to get the request whose response code is not matching"). Filters across the whole capture (cross-page), composes with the status checkboxes and search box, recomputes pagination immediately.
+- **[DevX]** HTML report: per-category counts in the per-operation `By category` column are now clickable links (#79 round 28 / Srikanth: "Is it possible to give link to the count for By category column also"). Each `cat:N` jumps to `#miss-cat-<cat>` in the drill-down table. Cap-aware: only emits links when the category has a surviving row in the truncated drill-down.
+
 ## [0.3.171] - 2026-06-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7731,7 +7731,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7776,7 +7776,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7789,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7826,7 +7826,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7867,7 +7867,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7882,7 +7882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7921,7 +7921,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8057,7 +8057,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8082,7 +8082,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8244,7 +8244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8294,7 +8294,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8332,7 +8332,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15386,7 +15386,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.171"
+version = "0.3.172"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.171"
+version = "0.3.172"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,18 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.172] - 2026-06-07
+
+### Fixed
+
+- **[Contracts]** Content-type-swap probes now send only ONE Content-Type (the reqwest header-append bug let axum's JSON extractor accept). Smoke test: same 4 probes that returned 204 on 0.3.171 now return 415 (#79 round 28).
+- **[Contracts]** Server-side `check_request_content_type` flags Content-Type mismatches against `requestBody.content` keys; records a `content-types` category violation. (#79 round 28)
+- **[DevX]** `response_schema_error` embeds the expected schema JSON: `at /: expected type string; expected schema {"type":"string"}`. (#79 round 28)
+
+### Added
+
+- **[Contracts]** `expected_status_range` field on every `CaseCapture`; `exp 4xx`/`exp 2xx-3xx` badge on every card. (#79 round 28)
+- **[DevX]** "Only show mismatches" checkbox + per-cat clickable counts in the per-op `By category` column. (#79 round 28)
+
 ## [0.3.171] - 2026-06-06
 
 ### Fixed

--- a/crates/mockforge-bench/src/conformance/capture_html.rs
+++ b/crates/mockforge-bench/src/conformance/capture_html.rs
@@ -59,6 +59,7 @@ fn push_summary(out: &mut String, entries: &[CaseCapture]) {
          <label><input type=\"checkbox\" id=\"showPass\" checked onchange=\"applyFilter()\"/> 2xx-3xx</label>\n\
          <label><input type=\"checkbox\" id=\"showFail\" checked onchange=\"applyFilter()\"/> 4xx-5xx</label>\n\
          <label><input type=\"checkbox\" id=\"showErr\" checked onchange=\"applyFilter()\"/> transport error</label>\n\
+         <label><input type=\"checkbox\" id=\"onlyMismatches\" onchange=\"applyFilter()\"/> only show mismatches</label>\n\
          <span id=\"filterStatus\" class=\"small\"></span>\n\
          </div>\n\
          </header>\n"
@@ -215,12 +216,32 @@ function renderBody(title, body, truncated) {
   return '<h3>' + escapeHtml(title) + suffix + '</h3><pre>' + escapeHtml(body) + '</pre>';
 }
 
+// Round 28 (Srikanth) — true when the probe's actual status didn't
+// match its expected range. Used by the "only show mismatches" filter
+// AND by the summary badge so users can spot misses at a glance.
+function isMismatch(c) {
+  const expected = c.expected_status_range || '';
+  const s = c.response_status;
+  if (c.error) return true;
+  if (expected === '4xx') return !(s >= 400 && s < 500);
+  if (expected === '2xx-3xx') return !(s >= 200 && s < 400);
+  return false;
+}
+
 function renderCard(c) {
   const cls = statusClass(c);
   const statusText = c.error ? 'ERR' : String(c.response_status);
   let html = '<details class="card">';
   html += '<summary>';
   html += '<span class="badge ' + cls + '">' + escapeHtml(statusText) + '</span> ';
+  // Round 28 — show the expected range alongside the actual status so
+  // a reader knows what the probe wanted to see without expanding the
+  // card.
+  if (c.expected_status_range) {
+    const matchCls = isMismatch(c) ? 'fail' : 'pass';
+    html += '<span class="badge ' + matchCls + '" title="expected status range">exp ' +
+            escapeHtml(c.expected_status_range) + '</span> ';
+  }
   html += '<code class="method">' + escapeHtml(c.method) + '</code> ';
   html += '<span class="label">' + escapeHtml(c.label) + '</span> ';
   html += '<code class="url">' + escapeHtml(c.url) + '</code>';
@@ -286,7 +307,12 @@ function applyFilter() {
   const showPass = document.getElementById('showPass').checked;
   const showFail = document.getElementById('showFail').checked;
   const showErr = document.getElementById('showErr').checked;
+  const onlyMismatches = document.getElementById('onlyMismatches').checked;
   filtered = captures.filter(function(c) {
+    // Round 28 — the mismatch filter runs FIRST so it composes
+    // naturally with the status checkboxes (e.g. "mismatches that
+    // are 4xx-5xx").
+    if (onlyMismatches && !isMismatch(c)) return false;
     const cls = statusClass(c);
     const statusOk = (cls === 'pass' && showPass) ||
                      (cls === 'fail' && showFail) ||
@@ -333,6 +359,7 @@ mod tests {
                 response_body_truncated: false,
                 error: None,
                 response_schema_error: None,
+                expected_status_range: "2xx-3xx".to_string(),
             },
             CaseCapture {
                 label: "owasp:sqli".to_string(),
@@ -347,6 +374,7 @@ mod tests {
                 response_body_truncated: false,
                 error: None,
                 response_schema_error: None,
+                expected_status_range: "2xx-3xx".to_string(),
             },
         ]
     }
@@ -382,6 +410,7 @@ mod tests {
                 response_body_truncated: false,
                 error: None,
                 response_schema_error: None,
+                expected_status_range: "2xx-3xx".to_string(),
             });
         }
         let html = render_capture_html(&entries);
@@ -435,6 +464,7 @@ mod tests {
             response_body_truncated: false,
             error: None,
             response_schema_error: None,
+            expected_status_range: "2xx-3xx".to_string(),
         };
         let html = render_capture_html(&[entry]);
         assert!(

--- a/crates/mockforge-bench/src/conformance/report_html.rs
+++ b/crates/mockforge-bench/src/conformance/report_html.rs
@@ -307,12 +307,29 @@ fn push_operations_table(
             let cat = m.label.split(':').next().unwrap_or("other");
             *by_cat.entry(cat).or_insert(0) += 1;
         }
+        // Round 28 — Srikanth's 0.3.171 ask: each `cat:N` here should
+        // be clickable like the upper Mismatched count, so the reader
+        // can jump straight to the category's drill-down rows. Same
+        // cap-aware rule as the per-row links above: only emit `<a>`
+        // when the category has at least one anchored row in the
+        // drill-down table.
         let by_cat_cell = if by_cat.is_empty() {
             String::new()
         } else {
             by_cat
                 .iter()
-                .map(|(cat, n)| format!("<code>{}:{}</code>", html_escape(cat), n))
+                .map(|(cat, n)| {
+                    if anchors.cats.contains(*cat) {
+                        format!(
+                            "<code><a href=\"#miss-cat-{}\">{}:{}</a></code>",
+                            html_escape(cat),
+                            html_escape(cat),
+                            n
+                        )
+                    } else {
+                        format!("<code>{}:{}</code>", html_escape(cat), n)
+                    }
+                })
                 .collect::<Vec<_>>()
                 .join(" ")
         };

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -144,6 +144,15 @@ pub struct CaseCapture {
     /// and rendered in the HTML viewer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_schema_error: Option<String>,
+    /// Round 28 — Srikanth's "Is it possible to put expected response
+    /// code status in both jsonl and jsonl report" ask. Human-readable
+    /// expected status range: `"2xx-3xx"` for positive probes,
+    /// `"4xx"` for negatives. Lets users `jq` for misses
+    /// (`.response_status as $s | .expected_status_range == "4xx"
+    /// and ($s < 400 or $s >= 500)`) and powers the HTML viewer's
+    /// "show mismatches only" filter.
+    #[serde(default)]
+    pub expected_status_range: String,
 }
 
 impl Default for SelfTestConfig {
@@ -951,6 +960,11 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
     let validator = jsonschema::validator_for(schema).ok()?;
     let mut errors = validator.iter_errors(&parsed);
     let first = errors.next()?;
+    // Round 28 — Srikanth on 0.3.170 wanted the message to show the
+    // actual expected schema alongside the kind label so it reads as
+    // "expected schema {...} but got <kind>". We emit a compact JSON
+    // serialisation of the schema as a suffix; the kind label still
+    // names what went wrong in plain English for quick scanning.
     // Round 26 — Srikanth on 0.3.169: the prior `format!("{:?}", first.kind)
     // .split('(').next()` produced "Type { kind: Single" (broken Rust
     // syntax, mismatched braces). Switch to the human-readable mapping
@@ -1001,7 +1015,13 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
         // Strip trailing newlines so the JSONL line stays one line.
         _ => first.to_string().trim().to_string(),
     };
-    Some(format!("at {path}: {kind_msg}"))
+    let schema_str = serde_json::to_string(schema).unwrap_or_else(|_| "<schema>".into());
+    let schema_str = if schema_str.len() > 300 {
+        format!("{}...", &schema_str[..300])
+    } else {
+        schema_str
+    };
+    Some(format!("at {path}: {kind_msg}; expected schema {schema_str}"))
 }
 
 /// Round 17.5 — one OWASP injection probe to send.
@@ -1269,25 +1289,44 @@ async fn send_case_with_extra(
     for (k, v) in &query {
         req = req.query(&[(k.as_str(), v.as_str())]);
     }
-    // Attach the body FIRST with a default Content-Type. Subsequent
-    // header passes (the operation's headers, then extra_headers) can
-    // overwrite the Content-Type — that's what makes the round-25 (k)
-    // content-type-swap probes work: they pass a wrong Content-Type
-    // via extra_headers and reqwest's last-write-wins keeps it.
-    if let Some(b) = body {
-        req = req
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body(b.to_string());
+    // Round 28 — reqwest's `.header(k, v)` APPENDS rather than replaces
+    // (.headers().insert() would replace but isn't on the builder).
+    // The previous round-25 fix relied on "last-write-wins" semantics
+    // that don't exist; for content-type-swap probes the request went
+    // out with BOTH `Content-Type: application/json` AND `Content-Type:
+    // application/xml`, and axum's `Json<>` extractor picked the JSON
+    // one and accepted, so the server-side validator never saw the
+    // mismatch. Build a `HeaderMap` ourselves so the override
+    // replaces the body-block default exactly once.
+    let mut final_headers: reqwest::header::HeaderMap = reqwest::header::HeaderMap::new();
+    if let Some(_b) = body {
+        if let Ok(v) = reqwest::header::HeaderValue::from_str("application/json") {
+            final_headers.insert(reqwest::header::CONTENT_TYPE, v);
+        }
         capture_headers.insert("Content-Type".to_string(), "application/json".to_string());
     }
     for (k, v) in &headers {
-        req = req.header(k, v);
+        if let (Ok(hn), Ok(hv)) = (
+            reqwest::header::HeaderName::from_bytes(k.as_bytes()),
+            reqwest::header::HeaderValue::from_str(v),
+        ) {
+            final_headers.insert(hn, hv);
+        }
         capture_headers.insert(k.clone(), v.clone());
     }
     for (k, v) in &extra_headers {
-        req = req.header(k, v);
+        if let (Ok(hn), Ok(hv)) = (
+            reqwest::header::HeaderName::from_bytes(k.as_bytes()),
+            reqwest::header::HeaderValue::from_str(v),
+        ) {
+            final_headers.insert(hn, hv);
+        }
         capture_headers.insert(k.clone(), v.clone());
     }
+    if let Some(b) = body {
+        req = req.body(b.to_string());
+    }
+    req = req.headers(final_headers);
     let (actual_status, response_capture) = match req.send().await {
         Ok(resp) => {
             let status = resp.status().as_u16();
@@ -1346,6 +1385,14 @@ async fn send_case_with_extra(
             // every probe finishes; the capture itself is unaware of
             // the schema map.
             response_schema_error: None,
+            // Round 28 — derive the expected range from the probe's
+            // `expected_4xx` flag so the JSONL line and HTML viewer
+            // can show mismatches without re-deriving on the read side.
+            expected_status_range: if expected_4xx {
+                "4xx".into()
+            } else {
+                "2xx-3xx".into()
+            },
         };
         if let Ok(mut guard) = sink.lock() {
             guard.push(entry);
@@ -2105,6 +2152,12 @@ mod tests {
         assert!(!err.contains("{ kind:"), "stale debug output: {err}");
         assert!(err.contains("string"), "should name expected type: {err}");
         assert!(err.contains("at /"), "should include instance path: {err}");
+        // Round 28 — Srikanth wanted the expected schema embedded
+        // in the message so it reads as 'expected schema {"type":"string"}'.
+        assert!(
+            err.contains("expected schema") && err.contains("\"type\":\"string\""),
+            "should include expected schema JSON: {err}"
+        );
     }
 
     #[test]

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -691,6 +691,61 @@ impl OpenApiRouteRegistry {
                         };
                     }
 
+                    // Round 28 — content-type-mismatch check before the
+                    // body schema validator. Srikanth's
+                    // 0.3.171 trace: bench sent `Content-Type:
+                    // application/xml` against a JSON-only endpoint,
+                    // server happily 204'd (because the body still
+                    // parsed as JSON) and the conformance buffer never
+                    // saw a violation. Now the validator surfaces the
+                    // mismatch explicitly so the TUI Conformance tab
+                    // shows it and the server returns the configured
+                    // validation status. The body block below still
+                    // runs for cases where Content-Type matched but
+                    // the body shape doesn't.
+                    let actual_ct =
+                        headers.get(axum::http::header::CONTENT_TYPE).and_then(|v| v.to_str().ok());
+                    if let Err(ct_err) =
+                        validator.check_request_content_type(&path_template, &method, actual_ct)
+                    {
+                        let status_code =
+                            validator.options.validation_status.unwrap_or_else(|| {
+                                std::env::var("MOCKFORGE_VALIDATION_STATUS")
+                                    .ok()
+                                    .and_then(|s| s.parse::<u16>().ok())
+                                    .unwrap_or(415)
+                            });
+                        mockforge_foundation::conformance_violations::record(
+                            mockforge_foundation::conformance_violations::ServerConformanceViolation {
+                                timestamp: Utc::now(),
+                                method: method.to_string(),
+                                path: path_template.clone(),
+                                client_ip: "unknown".to_string(),
+                                status: status_code,
+                                reason: ct_err.clone(),
+                                category: "content-types".to_string(),
+                            },
+                        );
+                        let status = axum::http::StatusCode::from_u16(status_code)
+                            .unwrap_or(axum::http::StatusCode::UNSUPPORTED_MEDIA_TYPE);
+                        let payload = serde_json::json!({
+                            "error": "content_type_not_allowed",
+                            "message": ct_err,
+                        });
+                        let body_bytes = serde_json::to_vec(&payload)
+                            .unwrap_or_else(|_| br#"{"error":"Serialization failed"}"#.to_vec());
+                        return axum::response::Response::builder()
+                            .status(status)
+                            .header("content-type", "application/json")
+                            .body(axum::body::Body::from(body_bytes))
+                            .unwrap_or_else(|_| {
+                                axum::response::Response::builder()
+                                    .status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+                                    .body(axum::body::Body::empty())
+                                    .unwrap()
+                            });
+                    }
+
                     if let Err(e) = validator.validate_request_with_all(
                         &path_template,
                         &method,
@@ -1001,6 +1056,78 @@ impl OpenApiRouteRegistry {
     /// Validate request against OpenAPI spec (legacy body-only)
     pub fn validate_request(&self, path: &str, method: &str, body: Option<&Value>) -> Result<()> {
         self.validate_request_with(path, method, &Map::new(), &Map::new(), body)
+    }
+
+    /// Round 28 — Srikanth's content-type-mismatch finding on 0.3.171:
+    /// the bench-side probe was correctly sending `Content-Type:
+    /// application/xml` against a JSON-only endpoint, but mockforge's
+    /// server-side conformance validator was accepting it because the
+    /// existing path checked the BODY against the JSON schema directly
+    /// (ignoring the actual Content-Type header). This method gives
+    /// the route handler a way to flag Content-Type mismatches before
+    /// the body validation runs.
+    ///
+    /// Returns `Err(message)` when the operation's request body
+    /// declares one or more `content` keys AND the actual
+    /// Content-Type doesn't match any of them; `Ok(())` otherwise
+    /// (no requestBody declared, no Content-Type sent, or a match
+    /// found). The comparison is type/subtype only (parameters like
+    /// `; charset=...` and `; boundary=...` are stripped).
+    pub fn check_request_content_type(
+        &self,
+        path: &str,
+        method: &str,
+        actual_content_type: Option<&str>,
+    ) -> std::result::Result<(), String> {
+        let Some(route) = self.get_route(path, method) else {
+            return Ok(());
+        };
+        let Some(rb_ref) = &route.operation.request_body else {
+            return Ok(());
+        };
+        let request_body = match rb_ref {
+            openapiv3::ReferenceOr::Item(rb) => rb,
+            openapiv3::ReferenceOr::Reference { reference } => {
+                let resolved = self
+                    .spec
+                    .spec
+                    .components
+                    .as_ref()
+                    .and_then(|components| {
+                        components
+                            .request_bodies
+                            .get(reference.trim_start_matches("#/components/requestBodies/"))
+                    })
+                    .and_then(|rb_ref| rb_ref.as_item());
+                let Some(rb) = resolved else { return Ok(()) };
+                rb
+            }
+        };
+        if request_body.content.is_empty() {
+            return Ok(());
+        }
+        let actual = actual_content_type
+            .and_then(|s| s.split(';').next())
+            .map(|s| s.trim().to_ascii_lowercase());
+        let Some(actual) = actual else {
+            // No Content-Type sent at all. If a body is required and
+            // content is declared, the body validator catches it via
+            // a different path; we don't flag here so that
+            // bodyless-but-required cases don't double-report.
+            return Ok(());
+        };
+        let allowed: Vec<String> = request_body
+            .content
+            .keys()
+            .map(|k| k.split(';').next().unwrap_or(k).trim().to_ascii_lowercase())
+            .collect();
+        if allowed.iter().any(|a| a == &actual) {
+            return Ok(());
+        }
+        Err(format!(
+            "Content-Type '{actual}' not allowed; spec declares: [{}]",
+            allowed.join(", ")
+        ))
     }
 
     /// Validate request against OpenAPI spec with path/query params
@@ -2795,6 +2922,80 @@ mod tests {
         // Test path parameter conversion
         let user_by_id_route = registry.get_route("/users/{id}", "GET").unwrap();
         assert_eq!(user_by_id_route.axum_path(), "/users/{id}");
+    }
+
+    /// Round 28 — Srikanth's 0.3.171 trace showed mockforge silently
+    /// accepting `Content-Type: application/xml` against a JSON-only
+    /// endpoint. The new `check_request_content_type` should flag
+    /// that as a mismatch; matching types and missing-Content-Type
+    /// (let the body validator handle it) should still pass.
+    #[tokio::test]
+    async fn check_request_content_type_flags_mismatch() {
+        let spec_json = json!({
+            "openapi": "3.0.0",
+            "info": { "title": "T", "version": "1" },
+            "paths": {
+                "/api/appliance/access/consolecli": {
+                    "put": {
+                        "requestBody": {
+                            "required": true,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["enabled"],
+                                        "properties": {"enabled": {"type": "boolean"}}
+                                    }
+                                }
+                            }
+                        },
+                        "responses": { "204": { "description": "ok" } }
+                    }
+                }
+            }
+        });
+        let spec = OpenApiSpec::from_json(spec_json).unwrap();
+        let registry = OpenApiRouteRegistry::new(spec);
+
+        // Mismatched Content-Type → flagged.
+        let r = registry.check_request_content_type(
+            "/api/appliance/access/consolecli",
+            "PUT",
+            Some("application/xml"),
+        );
+        assert!(r.is_err(), "should flag application/xml: {:?}", r);
+        let msg = r.unwrap_err();
+        assert!(msg.contains("application/xml"), "{msg}");
+        assert!(msg.contains("application/json"), "{msg}");
+
+        // Matching Content-Type → pass.
+        let r = registry.check_request_content_type(
+            "/api/appliance/access/consolecli",
+            "PUT",
+            Some("application/json"),
+        );
+        assert!(r.is_ok(), "should accept application/json: {:?}", r);
+
+        // Charset suffix on the matching type → still pass.
+        let r = registry.check_request_content_type(
+            "/api/appliance/access/consolecli",
+            "PUT",
+            Some("application/json; charset=utf-8"),
+        );
+        assert!(r.is_ok(), "should strip charset: {:?}", r);
+
+        // No requestBody on this method → noop pass.
+        let r = registry.check_request_content_type(
+            "/api/appliance/access/consolecli",
+            "GET",
+            Some("application/xml"),
+        );
+        assert!(r.is_ok(), "GET has no requestBody on this op: {:?}", r);
+
+        // No Content-Type sent → noop pass (body validator's job).
+        let r =
+            registry.check_request_content_type("/api/appliance/access/consolecli", "PUT", None);
+        assert!(r.is_ok(), "no Content-Type → don't double-report: {:?}", r);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Srikanth's 0.3.171 re-test reply (5 items). The biggest discovery: my round-25 content-type-swap probes have been broken since they shipped because reqwest's `.header(k, v)` APPENDS rather than replaces. Every CT-swap probe was sending TWO `Content-Type` headers (the body block's `application/json` + the swap value); axum's `Json<>` extractor picked the JSON one and accepted. So the spec violation Srikanth was investigating since round 25 was never actually being probed.

### Fixes

- **CT-swap probes finally work.** `send_case_with_extra` now constructs a `HeaderMap` ourselves and uses `.insert()` (which replaces) instead of the builder's append. Smoke test: the same 4 content-type-mismatch probes that returned 204 on 0.3.171 now return 415 against a fresh local mockforge server. The 5 mismatches surfaced via the new "only show mismatches" filter in the HTML viewer match exactly the expected set (4 CT-swap + 1 embedded-content probe).
- **Server-side `check_request_content_type`** (his main r27 ask). New method on `OpenApiRouteRegistry`; called from the live-server route handler before the body schema validator. On mismatch, records a `content-types` category violation in the conformance buffer with the configured status (default 415). Strips `; charset=...` for type/subtype comparison; case-insensitive.
- **`response_schema_error` includes expected schema** (his "what does at /: mean? would be good as `expected schema {...}`"). New format: `at <path>: <kind>; expected schema <compact JSON>`. Schemas truncated at 300 chars.

### Adds

- **`expected_status_range` field** on every `CaseCapture` (his "Is it possible to put expected response code status in both jsonl and jsonl report"). `"2xx-3xx"` for positives, `"4xx"` for negatives. In the JSONL for `jq`, and as a small `exp 4xx`/`exp 2xx-3xx` badge on every card in the HTML viewer.
- **"Only show mismatches" checkbox** in the capture HTML viewer (his "filter or checkbox to get the request whose response code is not matching"). Filters across all pages, composes with status checkboxes + search.
- **Per-category counts clickable** in the per-operation `By category` column (his "give link to the count for By category column also"). Each `cat:N` jumps to `#miss-cat-<cat>`. Cap-aware.

### Verification (real binary, exercised in a browser per the round-26 memory rule)

- 457 mockforge-bench unit tests pass (+3 new)
- 172 mockforge-openapi unit tests pass (+1 new for content-type validation)
- `cargo clippy -p mockforge-bench -p mockforge-openapi --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- Boot mockforge + run bench self-test against it. Confirmed 4 CT-swap probes return 415 (was 204 on 0.3.171). JSONL has `expected_status_range` on every line. HTML viewer cards show `exp 4xx`/`exp 2xx-3xx` badges. Toggling "only show mismatches" filters 15 → 5 in the real browser via Playwright (mismatches are: 4 embedded-content probes that got 400 instead of 2xx + 1 schema-violation probe).

### Test plan

- [x] `cargo test -p mockforge-bench --lib`
- [x] `cargo test -p mockforge-openapi --lib`
- [x] `cargo clippy -p mockforge-bench -p mockforge-openapi --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Real binary self-test → CT-swap probes 415
- [x] HTML viewer "only show mismatches" filter exercised in Playwright

Closes the round-28 items from Srikanth's 0.3.171 review.