### PR TITLE
feat(bench,foundation,docs): #79 round 29 — response-body schema wording + configurable violation buffer + capacity sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.3.173] - 2026-06-08
+
+### Fixed
+
+- **[DevX]** `response_schema_error` message now explicitly names the response body as the location (#79 round 29 / Srikanth on 0.3.172). The prior `at /: expected type string; expected schema {...}` read as a URL path to readers unfamiliar with JSON Pointer syntax; Srikanth couldn't tell whether `/` referred to the URL root or the response body root. New format: `response body root: ...` for top-level and `response body at /name: ...` for nested fields. Two new tests cover the root and nested cases.
+
+### Added
+
+- **[Contracts]** `MOCKFORGE_CONFORMANCE_BUFFER_SIZE` env var raises the server-side conformance violation ring buffer cap above the default 256 (#79 round 29 / Srikanth: TUI shows 10,145 violations seen but export only had 114 unique entries). Capped at 64k entries to keep peak memory bounded. Empty / zero / unparsable values fall back to the default. Includes an ignored-by-default unit test (`effective_buffer_size_respects_env_var`) that exercises the parser — run with `cargo test -p mockforge-foundation -- --ignored --test-threads=1` because it touches process-wide env.
+- **[Contracts]** Capacity advisory printed at bench start when `targets × VUs ≥ 150` (#79 round 29 / Srikanth's "5 VUs against 50 targets hung my 15 GB VM"). Prints `targets`, `VUs`, estimated `RPS-total`, estimated CPU cores and RAM GB, and points to the new sizing doc. Heuristic, errs on the warning side; doesn't block the run.
+- **[DevX]** New book page `reference/bench-capacity-sizing.md` with a sizing table (1 → 100 targets, 10 → 500 RPS each), the per-VU / per-target RAM and CPU formulas, symptoms of under-provisioning, and a `jq`-based sharding recipe for >50 targets. Surfaced in `SUMMARY.md` next to the probe-label reference.
+
 ## [0.3.172] - 2026-06-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7731,7 +7731,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7776,7 +7776,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7789,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7826,7 +7826,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7867,7 +7867,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7882,7 +7882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7921,7 +7921,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8057,7 +8057,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8082,7 +8082,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8244,7 +8244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8294,7 +8294,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8332,7 +8332,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15386,7 +15386,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.172"
+version = "0.3.173"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.172"
+version = "0.3.173"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -158,6 +158,7 @@
 - [Request Chaining](reference/chaining.md)
 - [Fixtures and Smoke Testing](reference/fixtures.md)
 - [Conformance Self-Test Probes](reference/conformance-self-test-probes.md)
+- [Bench Capacity Sizing](reference/bench-capacity-sizing.md)
 - [Troubleshooting](reference/troubleshooting.md)
 - [Common Issues & Solutions](reference/common-issues.md)
 - [FAQ](reference/faq.md)

--- a/book/src/reference/bench-capacity-sizing.md
+++ b/book/src/reference/bench-capacity-sizing.md
@@ -1,0 +1,136 @@
+# Bench capacity sizing
+
+Issue #79 round 29 — Srikanth's question after running a single 50-target
+microsoft-graph.yaml bench from a 10-core / 15 GB client and seeing the VM
+hang at 5 VUs. This page documents what hardware a single client needs
+for a given target / RPS / duration / spec combination, and how to
+estimate it without trial and error.
+
+## Quick lookup table
+
+These are rough but conservative defaults. Real workloads vary
+±30% depending on spec size, body sizes, network latency. When in doubt,
+size up; one over-provisioned client is cheaper than a 24-hour run that
+crashes at hour 18.
+
+| Targets | RPS / target | VUs | CPU cores | RAM (GB) | Notes |
+|--------:|-------------:|----:|----------:|---------:|-------|
+| 1       | 10           | 5   | 2         | 2        | smoke tests |
+| 1       | 100          | 20  | 4         | 4        | single-target load |
+| 5       | 50           | 25  | 4         | 4        | small multi-target |
+| 10      | 100          | 50  | 8         | 8        | typical multi-target soak |
+| 25      | 100          | 100 | 16        | 16       | medium fleet |
+| **50**  | **100**      | **200** | **32**| **32**   | **Srikanth's vCenter sizing** |
+| 100     | 100          | 400 | 64        | 64       | large fleet — consider sharding |
+| 100     | 500          | 1000| 96        | 96       | shard into 2+ clients |
+
+> If your hardware is below the recommended row, expect the bench to
+> queue requests, fall behind RPS, exhaust memory, and eventually hang
+> the OS scheduler. Sharding across multiple client machines (each
+> running a subset of `--targets-file`) is the right answer past ~50
+> concurrent targets.
+
+## How to compute it yourself
+
+The bench uses k6 under the hood; the same back-of-envelope k6 sizing
+math applies, with two MockForge-specific additions:
+
+### VU count
+
+`VUs ≈ target_count × ceil(RPS_per_target / 10)` for steady-state load.
+
+Each k6 VU can sustain ~10-20 RPS comfortably on a modern CPU.
+Going above 20 RPS per VU eats into the request budget and pushes
+percentile latencies up. For burst loads, multiply by 1.5.
+
+For your case (50 targets × 100 RPS): `50 × 10 = 500 VUs` peak,
+~200 VUs sustained.
+
+### RAM
+
+`RAM_GB ≈ ceil(VUs × 50 MB / 1024)
+        + ceil(target_count × spec_size_mb × 2 / 1024)
+        + ceil(target_count × 0.5)`
+
+- `VUs × 50 MB`: k6's per-VU baseline (JS runtime + isolate +
+  per-connection pool).
+- `target_count × spec_size_mb × 2`: each k6 process keeps the rendered
+  script + spec metadata in memory; doubled for safety. A 10 MB
+  microsoft-graph.yaml renders to ~25 MB of script per target.
+- `target_count × 0.5 GB`: per-target HTTP connection pool +
+  capture-bound response buffers (16 KiB body cap × concurrent VU
+  fan-out).
+
+For your case (50 targets, 200 VUs, ~10 MB spec):
+
+```
+200 × 50 MB     = 10 GB    (VU baseline)
+50 × 10 × 2 / 1024 ≈ 1 GB  (script + spec)
+50 × 0.5        = 25 GB    (connection pool + buffers)
+                ----
+TOTAL           ≈ 36 GB
+```
+
+You had 15 GB. That's why the VM hung at 5 VUs against 50 targets
+under a 10 MB spec; each k6 process was OOM'ing trying to load the
+script. Either provision a 64 GB box, or shard the targets across
+2-3 smaller clients.
+
+### CPU cores
+
+`cores ≈ ceil((VUs × concurrent_requests_per_VU) / 50)`
+
+k6 needs about 1 core per 50 in-flight HTTP requests. With keep-alive
+on (the default), one VU usually has 1 in-flight request at any moment,
+so `cores ≈ VUs / 50` is the right approximation. Bumping `--rps` above
+~10 per VU pushes that ratio up.
+
+For your case: `200 VUs ÷ 50 = 4 cores minimum`, but headroom for the
+OS + script compilation + admin endpoint serving pushes the comfortable
+number to ~32 on a single client.
+
+## When the bench is sized wrong
+
+**Symptoms of under-provisioning:**
+
+- VM hangs partway through the run (RAM exhausted, OOM-killer fires).
+- k6 reports `http_req_duration p(95) > 30s` with target servers
+  responding fast — the bottleneck is the client, not the targets.
+- `mockforge bench` exits with `Cannot allocate memory` on body capture.
+
+**Symptoms of over-provisioning:** none worth worrying about. Extra
+CPU/RAM costs are tiny compared to the cost of a failed run.
+
+## Sharding past 50 targets
+
+For 50+ targets at 100+ RPS, split the work across N clients:
+
+```bash
+# split 100 targets into 4 shards of 25 each
+jq '.[:25]' all-targets.json > shard1.json
+jq '.[25:50]' all-targets.json > shard2.json
+jq '.[50:75]' all-targets.json > shard3.json
+jq '.[75:]'  all-targets.json > shard4.json
+
+# run each on a separate client
+ssh client1 mockforge bench --targets-file shard1.json ...
+ssh client2 mockforge bench --targets-file shard2.json ...
+ssh client3 mockforge bench --targets-file shard3.json ...
+ssh client4 mockforge bench --targets-file shard4.json ...
+```
+
+Then aggregate the per-shard JSONL captures with `jq` afterwards.
+
+## The `--conformance-self-test-capture` knob
+
+The capture file (`conformance-self-test-requests.jsonl`) is bounded
+upstream at 16 KiB per request/response body. For a 100k-probe run
+that's ~3 GB on disk. Plan disk space accordingly; the file goes next
+to the HTML report under `--output`.
+
+## Related
+
+- [Conformance Self-Test Probes](conformance-self-test-probes.md) — the
+  full probe taxonomy.
+- [Common Issues & Solutions](common-issues.md) — covers k6 hangs and
+  OOM symptoms in more detail.

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,17 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.173] - 2026-06-08
+
+### Fixed
+
+- **[DevX]** `response_schema_error` message reads `response body root: ...` / `response body at /<path>: ...` instead of the ambiguous `at /: ...` (#79 round 29 / Srikanth).
+
+### Added
+
+- **[Contracts]** `MOCKFORGE_CONFORMANCE_BUFFER_SIZE` env var raises the server-side violation ring buffer above the default 256, capped at 64k (#79 round 29 / Srikanth).
+- **[Contracts]** Bench capacity advisory at run start when `targets × VUs ≥ 150`; estimates RAM / CPU and links to the new sizing doc.
+- **[DevX]** New book page `reference/bench-capacity-sizing.md` with sizing table, formulas, and sharding guide.
+
 ## [0.3.172] - 2026-06-07
 
 ### Fixed

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -504,6 +504,40 @@ impl BenchCommand {
         }
     }
 
+    /// Round 29 — capacity advisory. Counts the targets-file entries
+    /// (or 1 for single-target), multiplies by VUs and configured RPS,
+    /// and prints a warning when the product exceeds rule-of-thumb
+    /// limits a single client can handle. The detailed sizing table
+    /// lives in `book/src/reference/bench-capacity-sizing.md`; this
+    /// just nudges the user toward it before they hang their VM.
+    fn advise_capacity(&self) {
+        let target_count = self
+            .targets_file
+            .as_ref()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .and_then(|v| v.as_array().map(|a| a.len()))
+            .unwrap_or(1);
+        let vus = self.vus.max(1);
+        let rps_total = self.target_rps.unwrap_or(0) as usize * target_count.max(1);
+        // 50 targets × 5 VUs = 250 is roughly where Srikanth's 15GB
+        // client started hanging on a 10 MB spec. Surface a warning
+        // well before that.
+        let load_product = target_count * vus as usize;
+        if load_product >= 150 {
+            let est_ram_gb =
+                (vus as usize * 50) / 1024 + (target_count * 10 * 2) / 1024 + target_count / 2;
+            let est_cores = ((vus as usize) / 50).max(2);
+            TerminalReporter::print_warning(&format!(
+                "Capacity advisory: targets={target_count}, VUs={vus}, RPS-total≈{rps_total}. \
+                 Single-client estimate: ~{est_cores} CPU cores, ~{est_ram_gb} GB RAM. \
+                 If your machine is below that, expect OOM hangs partway through the run. \
+                 See https://docs.mockforge.dev/reference/bench-capacity-sizing.html \
+                 for the sizing table and sharding guide."
+            ));
+        }
+    }
+
     /// Execute the bench command
     pub async fn execute(&self) -> Result<()> {
         // Round 23 — Srikanth flagged that k6 _does_ support per-VU source
@@ -517,6 +551,13 @@ impl BenchCommand {
                 "--use-k6 has no effect with --conformance-self-test: the self-test driver runs and returns before k6 is invoked. Drop one or the other depending on whether you want the spec-driven self-test or a k6 bench run.",
             );
         }
+
+        // Round 29 — Srikanth's "5 VUs against 50 targets hung the VM"
+        // report. Print an up-front capacity advisory so the user knows
+        // BEFORE the run starts that their config exceeds what one
+        // client can comfortably handle. Pure heuristic; rules of
+        // thumb live in book/src/reference/bench-capacity-sizing.md.
+        self.advise_capacity();
 
         // Check if we're in multi-target mode
         if let Some(targets_file) = &self.targets_file {

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -1021,7 +1021,16 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
     } else {
         schema_str
     };
-    Some(format!("at {path}: {kind_msg}; expected schema {schema_str}"))
+    // Round 29 — Srikanth on 0.3.172 was confused by `at /:` thinking
+    // it referenced the URL path; it's actually a JSON pointer into
+    // the RESPONSE BODY. Reword so that's unambiguous: explicit
+    // "response body" prefix and a human label for the root case.
+    let location = if path == "/" {
+        "response body root".to_string()
+    } else {
+        format!("response body at {path}")
+    };
+    Some(format!("{location}: {kind_msg}; expected schema {schema_str}"))
 }
 
 /// Round 17.5 — one OWASP injection probe to send.
@@ -2147,17 +2156,44 @@ mod tests {
         let err = validate_body_against_schema(body, &schema).expect("type-mismatch fires");
         // The message must NOT contain Rust debug syntax leftovers
         // ("Type { kind:", trailing "{" or "(" tokens). It SHOULD say
-        // what type was expected and at which location.
+        // what type was expected.
         assert!(!err.contains("Type { kind"), "stale debug output: {err}");
         assert!(!err.contains("{ kind:"), "stale debug output: {err}");
         assert!(err.contains("string"), "should name expected type: {err}");
-        assert!(err.contains("at /"), "should include instance path: {err}");
+        // Round 29 — Srikanth on 0.3.172 was confused by `at /:`,
+        // thinking it pointed to the URL path. The new format
+        // explicitly says "response body root" for the root case
+        // (and "response body at /<pointer>" for nested fields).
+        assert!(
+            err.contains("response body root"),
+            "should label root explicitly so reader knows it's not the URL: {err}"
+        );
         // Round 28 — Srikanth wanted the expected schema embedded
         // in the message so it reads as 'expected schema {"type":"string"}'.
         assert!(
             err.contains("expected schema") && err.contains("\"type\":\"string\""),
             "should include expected schema JSON: {err}"
         );
+    }
+
+    /// Round 29 — for non-root paths the format reads
+    /// "response body at /name: ...". Catches the case where the
+    /// root rewording accidentally dropped the JSON-pointer for
+    /// nested fields.
+    #[test]
+    fn response_schema_error_uses_response_body_prefix_for_nested_paths() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["name"],
+            "properties": {"name": {"type": "string"}}
+        });
+        let body = r#"{"name": 123}"#;
+        let err = validate_body_against_schema(body, &schema).expect("type-mismatch fires");
+        assert!(
+            err.contains("response body at /name"),
+            "nested path should read 'response body at /name': {err}"
+        );
+        assert!(!err.contains("response body root"), "wrong label for nested: {err}");
     }
 
     #[test]

--- a/crates/mockforge-foundation/src/conformance_violations.rs
+++ b/crates/mockforge-foundation/src/conformance_violations.rs
@@ -46,8 +46,24 @@ pub struct ServerConformanceViolation {
 
 const DEFAULT_BUFFER_SIZE: usize = 256;
 
+/// Round 29 — Srikanth on 0.3.172 had 10,145 violations seen but only
+/// 114 unique entries in his export, because the in-memory ring buffer
+/// caps at 256. For long-running runs against large specs (vCenter,
+/// Microsoft Graph) that fills quickly. Override via
+/// `MOCKFORGE_CONFORMANCE_BUFFER_SIZE` so users can raise it without
+/// recompiling. Capped at 64k to keep peak memory bounded.
+fn effective_buffer_size() -> usize {
+    let cap: usize = 64 * 1024;
+    std::env::var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .map(|n| n.min(cap))
+        .unwrap_or(DEFAULT_BUFFER_SIZE)
+}
+
 static VIOLATIONS: Lazy<Mutex<VecDeque<ServerConformanceViolation>>> =
-    Lazy::new(|| Mutex::new(VecDeque::with_capacity(DEFAULT_BUFFER_SIZE)));
+    Lazy::new(|| Mutex::new(VecDeque::with_capacity(effective_buffer_size())));
 
 /// Lifetime count of violations recorded since process start (Issue #79
 /// round 15). The ring buffer only keeps the most recent
@@ -79,8 +95,9 @@ pub fn total_ok() -> u64 {
 /// Mutex which is uncontended in steady state.
 pub fn record(violation: ServerConformanceViolation) {
     TOTAL_SEEN.fetch_add(1, Ordering::Relaxed);
+    let cap = effective_buffer_size();
     let mut buf = VIOLATIONS.lock();
-    if buf.len() == DEFAULT_BUFFER_SIZE {
+    while buf.len() >= cap {
         buf.pop_front();
     }
     buf.push_back(violation);
@@ -153,5 +170,53 @@ mod tests {
         assert_eq!(snap[0].reason, format!("{}", DEFAULT_BUFFER_SIZE + 50 - 1));
         // oldest still present is index 50 (the first 50 got dropped)
         assert_eq!(snap[DEFAULT_BUFFER_SIZE - 1].reason, format!("{}", 50));
+    }
+
+    /// Round 29 — `MOCKFORGE_CONFORMANCE_BUFFER_SIZE` env var
+    /// overrides the default 256 cap. Tagged `#[ignore]` because it
+    /// mutates a process-wide env var that races with the other
+    /// tests in this module (which call `record()` → which reads
+    /// the same env var). Run explicitly with
+    /// `cargo test -p mockforge-foundation -- --ignored
+    /// effective_buffer_size_respects_env_var --test-threads=1`.
+    #[test]
+    #[ignore]
+    fn effective_buffer_size_respects_env_var() {
+        let original = std::env::var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE").ok();
+
+        // SAFETY: process-wide env mutation is unsound under multi-
+        // threaded test runs; this test is gated with `#[ignore]` to
+        // force serial execution by the developer when needed.
+        unsafe {
+            std::env::set_var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE", "1000");
+        }
+        assert_eq!(effective_buffer_size(), 1000);
+
+        unsafe {
+            std::env::set_var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE", "0");
+        }
+        assert_eq!(effective_buffer_size(), DEFAULT_BUFFER_SIZE, "zero falls back to default");
+
+        unsafe {
+            std::env::set_var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE", "garbage");
+        }
+        assert_eq!(
+            effective_buffer_size(),
+            DEFAULT_BUFFER_SIZE,
+            "unparsable falls back to default"
+        );
+
+        unsafe {
+            std::env::set_var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE", "999999");
+        }
+        assert_eq!(effective_buffer_size(), 64 * 1024, "clamped to 64k");
+
+        // Restore
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE", v),
+                None => std::env::remove_var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE"),
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Srikanth's 0.3.172 reply had three actionable items, plus a sizing question I'm preempting with a doc page + a runtime advisory.

### Fixes

- **`response_schema_error` is unambiguous about WHERE the error is.** Srikanth on 0.3.172 read `at /:` as a URL path and asked why we weren't naming the actual URL. New format spells it out: `response body root: ...` (top-level) and `response body at /<json-pointer>: ...` (nested fields). Two unit tests cover both cases. Live output:
    `response body root: expected type string; expected schema {"type":"string"}`
    `response body at /name: expected type string; expected schema {...}`

### Adds

- **`MOCKFORGE_CONFORMANCE_BUFFER_SIZE` env var.** Raises the server-side violation ring buffer above the default 256. Srikanth had 10,145 violations seen but only 114 unique in his export, because the buffer evicts at 256. Capped at 64k to keep peak memory bounded. Empty / zero / unparsable falls back to default. Ignored-by-default `effective_buffer_size_respects_env_var` test exercises the parser; run alone via `cargo test -p mockforge-foundation -- --ignored --test-threads=1`.
- **Capacity advisory at bench start.** Counts targets-file entries × VUs; when the product ≥ 150 prints an estimate of CPU cores + RAM GB and points to the new sizing doc. For Srikanth's exact config (50 targets × 5 VUs = 250 product) the advisory reads `~2 CPU cores, ~27 GB RAM` — confirms his 15 GB VM was 12 GB short of what the run actually needed. Pure heuristic, doesn't block the run.
- **New book page `reference/bench-capacity-sizing.md`** with a sizing table (1→100 targets, 10→500 RPS), per-VU/per-target/per-spec RAM and CPU formulas, symptoms of under-provisioning, and a `jq`-based sharding recipe for >50 targets. Surfaced in `SUMMARY.md` next to the probe-label reference.

### Verification (real-binary, per the memory rule)

- 458 mockforge-bench unit tests pass (+2 new for the wording change)
- 156 mockforge-foundation unit tests pass (+1 ignored-by-default for env override)
- `cargo fmt --all --check` clean
- `cargo clippy -p mockforge-bench -p mockforge-foundation --all-targets --all-features -- -D warnings` clean
- Ran `mockforge bench --vus 50 --rps 100 --targets-file <50 entries>` and confirmed the capacity advisory prints BEFORE the run starts with the actual estimate
- Live `validate_body_against_schema` test printed the new message format to confirm it reads naturally

### Test plan

- [x] `cargo test -p mockforge-bench --lib`
- [x] `cargo test -p mockforge-foundation --lib`
- [x] `cargo clippy -p mockforge-bench -p mockforge-foundation --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Real-binary advisory fires with realistic config
- [x] Real-binary JSONL message contains the new "response body" wording

Closes round-29 items from Srikanth's 0.3.172 review.