### PR TITLE
feat(bench,foundation,tui): #79 round 30 — sub-schema-at-pointer + unique-violation buffer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.174] - 2026-06-09
+
+### Fixed
+
+- **[DevX]** `response_schema_error` now prints only the sub-schema at the offending JSON Pointer instead of the full top-level schema (#79 round 30 / Srikanth on 0.3.173 asking what the message reads as for nested fields). A `{"name": 123}` mismatch against `{"type":"object","properties":{"name":{"type":"string"}}}` now reads `response body at /name: expected type string; expected schema {"type":"string"}`, not `... expected schema {"properties":{"name":{"type":"string"}},"type":"object"}`. Walker descends through `properties` (and `items` for arrays) following the instance pointer; falls back to the full schema when the path can't be resolved (additionalProperties, oneOf/allOf, unresolved $refs).
+
+### Added
+
+- **[Contracts]** `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true` switches the server-side conformance violation buffer from FIFO to dedup-by-signature (#79 round 30 / Srikanth on 0.3.173: "Can we have this buffer for unique violation as opposed to duplicate violation"). Every duplicate of an already-buffered `(method, path, status, category, reason)` hits its existing entry and bumps the new `occurrences` field on `ServerConformanceViolation` instead of consuming a new slot — so 10M requests with 150 distinct violation kinds keep all 150 visible in a 256-slot buffer, instead of being clobbered by the most common offender. New `occurrences: u32` field on the violation struct (defaults to `1` on older payloads via serde default). TUI's export-time dedup grouping now sums `occurrences` per group so the headline counts reflect the true server-side hit count under unique mode. Three new tests cover dedup, multi-signature distinction, and FIFO-order eviction inside the unique buffer.
+
 ## [0.3.173] - 2026-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7731,7 +7731,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7776,7 +7776,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7789,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7826,7 +7826,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7867,7 +7867,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7882,7 +7882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7921,7 +7921,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8057,7 +8057,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8082,7 +8082,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8244,7 +8244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8294,7 +8294,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8332,7 +8332,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15386,7 +15386,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.173"
+version = "0.3.174"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.173"
+version = "0.3.174"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,15 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.174] - 2026-06-09
+
+### Fixed
+
+- **[DevX]** `response_schema_error` now prints only the sub-schema at the offending JSON Pointer instead of the full top-level schema (#79 round 30 / Srikanth).
+
+### Added
+
+- **[Contracts]** `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true` switches the violation buffer from FIFO to dedup-by-signature; every duplicate bumps a new `occurrences` field on the entry instead of consuming a new buffer slot (#79 round 30 / Srikanth).
+
 ## [0.3.173] - 2026-06-08
 
 ### Fixed

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -1015,7 +1015,15 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
         // Strip trailing newlines so the JSONL line stays one line.
         _ => first.to_string().trim().to_string(),
     };
-    let schema_str = serde_json::to_string(schema).unwrap_or_else(|_| "<schema>".into());
+    // Round 30 — Srikanth on 0.3.173 asked how a deeper nested mismatch
+    // reads. The prior output printed the WHOLE top-level schema even for
+    // a single-field mismatch, which buried the actual constraint that
+    // failed. Walk the instance pointer through the schema's properties
+    // chain and print the most specific sub-schema we can find. Falls
+    // back to the full schema for paths the walker can't resolve
+    // (additionalProperties, oneOf, allOf, $ref un-resolved, etc.).
+    let focused_schema = sub_schema_at_pointer(schema, path).unwrap_or_else(|| schema.clone());
+    let schema_str = serde_json::to_string(&focused_schema).unwrap_or_else(|_| "<schema>".into());
     let schema_str = if schema_str.len() > 300 {
         format!("{}...", &schema_str[..300])
     } else {
@@ -1031,6 +1039,38 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
         format!("response body at {path}")
     };
     Some(format!("{location}: {kind_msg}; expected schema {schema_str}"))
+}
+
+/// Round 30 — walk a JSON-Pointer-style instance path through a JSON
+/// Schema and return the sub-schema describing the value at that
+/// position. For path `/name/age` on
+/// `{"properties":{"name":{"properties":{"age":{"type":"integer"}}}}}`
+/// returns `{"type":"integer"}`. Returns `None` for paths the walker
+/// can't follow (array indices into `items` with no per-index schema,
+/// `additionalProperties`, `oneOf`/`allOf`, unresolved `$ref`); callers
+/// should fall back to the full schema in that case.
+fn sub_schema_at_pointer(schema: &serde_json::Value, pointer: &str) -> Option<serde_json::Value> {
+    if pointer.is_empty() || pointer == "/" {
+        return Some(schema.clone());
+    }
+    let mut current = schema;
+    for seg in pointer.trim_start_matches('/').split('/') {
+        let unescaped = seg.replace("~1", "/").replace("~0", "~");
+        if let Some(props) = current.get("properties") {
+            if let Some(sub) = props.get(&unescaped) {
+                current = sub;
+                continue;
+            }
+        }
+        if let Some(items) = current.get("items") {
+            if items.is_object() {
+                current = items;
+                continue;
+            }
+        }
+        return None;
+    }
+    Some(current.clone())
 }
 
 /// Round 17.5 — one OWASP injection probe to send.
@@ -2194,6 +2234,60 @@ mod tests {
             "nested path should read 'response body at /name': {err}"
         );
         assert!(!err.contains("response body root"), "wrong label for nested: {err}");
+        // Round 30 — the "expected schema" suffix should be the
+        // sub-schema at /name, not the entire object schema. Reader
+        // shouldn't have to scan a 300-char object to find the
+        // constraint that failed.
+        assert!(
+            err.contains(r#"expected schema {"type":"string"}"#),
+            "should show only the /name sub-schema, not the full object: {err}"
+        );
+    }
+
+    /// Round 30 — Srikanth asked how a deeper nested mismatch reads.
+    /// Schema: `name.type` should be a string; body has it as a number.
+    /// JSON pointer is `/name/type`.
+    #[test]
+    fn response_schema_error_uses_response_body_prefix_for_deep_nested_paths() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "object",
+                    "properties": {"type": {"type": "string"}}
+                }
+            }
+        });
+        let body = r#"{"name": {"type": 123}}"#;
+        let err = validate_body_against_schema(body, &schema).expect("type-mismatch fires");
+        assert!(
+            err.contains("response body at /name/type"),
+            "deep nested path should read 'response body at /name/type': {err}"
+        );
+        // Round 30 — for deep paths the sub-schema is the leaf
+        // {"type":"string"}, not the wrapping object schemas.
+        assert!(
+            err.contains(r#"expected schema {"type":"string"}"#),
+            "should show only the /name/type leaf sub-schema: {err}"
+        );
+    }
+
+    /// Round 30 — when the instance pointer can't be resolved through
+    /// the schema's `properties` chain (e.g. additionalProperties hit),
+    /// `sub_schema_at_pointer` returns None and the message falls back
+    /// to the full schema. Verifies the fallback path is wired.
+    #[test]
+    fn sub_schema_at_pointer_falls_back_for_unresolvable_paths() {
+        let schema = serde_json::json!({"type":"object","additionalProperties":true});
+        // Walker can't resolve /unknown, so we get the full schema back.
+        assert_eq!(
+            sub_schema_at_pointer(&schema, "/unknown"),
+            None,
+            "unresolvable path should return None to trigger fallback"
+        );
+        // Root path returns the whole schema.
+        assert_eq!(sub_schema_at_pointer(&schema, "/"), Some(schema.clone()));
+        assert_eq!(sub_schema_at_pointer(&schema, ""), Some(schema));
     }
 
     #[test]

--- a/crates/mockforge-foundation/src/conformance_violations.rs
+++ b/crates/mockforge-foundation/src/conformance_violations.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A single server-side conformance violation captured at the OpenAPI
@@ -42,6 +42,18 @@ pub struct ServerConformanceViolation {
     /// `"request-body"`, `"headers"`, etc.). Empty if the validator
     /// couldn't classify.
     pub category: String,
+    /// Round 30 — number of times this signature has been observed.
+    /// Always `1` in FIFO mode (the default). In unique-buffer mode
+    /// (`MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true`) every duplicate
+    /// hit bumps this counter on the existing entry instead of
+    /// consuming a new buffer slot. Defaults to `1` when deserialising
+    /// older payloads that don't carry the field.
+    #[serde(default = "one")]
+    pub occurrences: u32,
+}
+
+fn one() -> u32 {
+    1
 }
 
 const DEFAULT_BUFFER_SIZE: usize = 256;
@@ -62,8 +74,85 @@ fn effective_buffer_size() -> usize {
         .unwrap_or(DEFAULT_BUFFER_SIZE)
 }
 
+/// Round 30 — Srikanth on 0.3.173: "Can we have this buffer for unique
+/// violation as opposed to duplicate violation. If this buffer size
+/// doesn't discount duplicates then again we will run out of buffer
+/// easily when more and more requests come to the server."
+///
+/// `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true` switches storage from
+/// FIFO to dedup-by-signature: every duplicate of an already-buffered
+/// (method, path, status, category, reason) hits its existing entry
+/// and bumps `occurrences` instead of consuming a new slot. The buffer
+/// fills only as fast as unique signatures arrive — so at 256 entries
+/// a vCenter spec with ~150 unique violation kinds will hold every
+/// kind even under 10M+ requests, instead of being clobbered by the
+/// most common offender.
+fn unique_mode_enabled() -> bool {
+    std::env::var("MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE")
+        .ok()
+        .map(|s| matches!(s.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+fn signature(v: &ServerConformanceViolation) -> String {
+    format!("{}|{}|{}|{}|{}", v.method, v.path, v.status, v.category, v.reason)
+}
+
+/// FIFO buffer (default mode). Each violation consumes one slot,
+/// oldest evicted when full.
 static VIOLATIONS: Lazy<Mutex<VecDeque<ServerConformanceViolation>>> =
     Lazy::new(|| Mutex::new(VecDeque::with_capacity(effective_buffer_size())));
+
+/// Unique-mode buffer: signature → entry (with bumped `occurrences`)
+/// plus a `VecDeque<signature>` for insertion-order eviction. Only
+/// touched when `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE` is enabled.
+struct UniqueBuffer {
+    by_sig: HashMap<String, ServerConformanceViolation>,
+    order: VecDeque<String>,
+}
+
+impl UniqueBuffer {
+    fn new() -> Self {
+        Self {
+            by_sig: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    fn record(&mut self, mut v: ServerConformanceViolation, cap: usize) {
+        let sig = signature(&v);
+        if let Some(existing) = self.by_sig.get_mut(&sig) {
+            existing.occurrences = existing.occurrences.saturating_add(1);
+            existing.timestamp = v.timestamp;
+            return;
+        }
+        v.occurrences = 1;
+        while self.order.len() >= cap {
+            if let Some(old) = self.order.pop_front() {
+                self.by_sig.remove(&old);
+            } else {
+                break;
+            }
+        }
+        self.order.push_back(sig.clone());
+        self.by_sig.insert(sig, v);
+    }
+
+    fn snapshot(&self) -> Vec<ServerConformanceViolation> {
+        self.order.iter().rev().filter_map(|s| self.by_sig.get(s).cloned()).collect()
+    }
+
+    fn len(&self) -> usize {
+        self.order.len()
+    }
+
+    fn clear(&mut self) {
+        self.by_sig.clear();
+        self.order.clear();
+    }
+}
+
+static UNIQUE_VIOLATIONS: Lazy<Mutex<UniqueBuffer>> = Lazy::new(|| Mutex::new(UniqueBuffer::new()));
 
 /// Lifetime count of violations recorded since process start (Issue #79
 /// round 15). The ring buffer only keeps the most recent
@@ -91,11 +180,20 @@ pub fn total_ok() -> u64 {
 }
 
 /// Record a violation. Old entries are dropped when the buffer is full
-/// (FIFO). Cheap enough to call from the hot path — uses a parking_lot
-/// Mutex which is uncontended in steady state.
-pub fn record(violation: ServerConformanceViolation) {
+/// (FIFO by default; signature-deduped under
+/// `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true`). Cheap enough to call
+/// from the hot path — uses a parking_lot Mutex which is uncontended in
+/// steady state.
+pub fn record(mut violation: ServerConformanceViolation) {
     TOTAL_SEEN.fetch_add(1, Ordering::Relaxed);
     let cap = effective_buffer_size();
+    if unique_mode_enabled() {
+        UNIQUE_VIOLATIONS.lock().record(violation, cap);
+        return;
+    }
+    if violation.occurrences == 0 {
+        violation.occurrences = 1;
+    }
     let mut buf = VIOLATIONS.lock();
     while buf.len() >= cap {
         buf.pop_front();
@@ -105,13 +203,21 @@ pub fn record(violation: ServerConformanceViolation) {
 
 /// Snapshot of the buffered violations, newest first.
 pub fn snapshot() -> Vec<ServerConformanceViolation> {
-    let buf = VIOLATIONS.lock();
-    buf.iter().rev().cloned().collect()
+    if unique_mode_enabled() {
+        UNIQUE_VIOLATIONS.lock().snapshot()
+    } else {
+        let buf = VIOLATIONS.lock();
+        buf.iter().rev().cloned().collect()
+    }
 }
 
-/// Number of violations currently buffered (≤ `DEFAULT_BUFFER_SIZE`).
+/// Number of violations currently buffered (≤ `effective_buffer_size`).
 pub fn len() -> usize {
-    VIOLATIONS.lock().len()
+    if unique_mode_enabled() {
+        UNIQUE_VIOLATIONS.lock().len()
+    } else {
+        VIOLATIONS.lock().len()
+    }
 }
 
 /// Lifetime total of violations recorded since process start, including
@@ -120,10 +226,11 @@ pub fn total_seen() -> u64 {
     TOTAL_SEEN.load(Ordering::Relaxed)
 }
 
-/// Clear the buffer and reset both lifetime counters. Primarily for
+/// Clear both buffers and reset lifetime counters. Primarily for
 /// tests and TUI "reset" actions.
 pub fn clear() {
     VIOLATIONS.lock().clear();
+    UNIQUE_VIOLATIONS.lock().clear();
     TOTAL_SEEN.store(0, Ordering::Relaxed);
     TOTAL_OK.store(0, Ordering::Relaxed);
 }
@@ -141,6 +248,7 @@ mod tests {
             status,
             reason: "test".into(),
             category: "parameters".into(),
+            occurrences: 1,
         }
     }
 
@@ -218,5 +326,64 @@ mod tests {
                 None => std::env::remove_var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE"),
             }
         }
+    }
+
+    /// Round 30 — unique-mode buffer dedups duplicate signatures and
+    /// bumps `occurrences` instead of consuming new slots. Direct
+    /// `UniqueBuffer::record` call avoids the global env-var read,
+    /// so this test stays threadsafe without `#[ignore]`.
+    #[test]
+    fn unique_buffer_dedups_by_signature_and_counts_occurrences() {
+        let mut buf = UniqueBuffer::new();
+        for _ in 0..10_000 {
+            buf.record(v("GET", 400), 256);
+        }
+        // 10k identical violations → 1 slot used, occurrences == 10000.
+        assert_eq!(buf.len(), 1);
+        let snap = buf.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].occurrences, 10_000);
+        assert_eq!(snap[0].method, "GET");
+    }
+
+    /// Round 30 — different (method, path, status, category, reason)
+    /// tuples occupy distinct slots; identical tuples coalesce.
+    #[test]
+    fn unique_buffer_distinguishes_distinct_signatures() {
+        let mut buf = UniqueBuffer::new();
+        // 3 distinct signatures × 100 hits each
+        for _ in 0..100 {
+            buf.record(v("GET", 400), 256);
+            buf.record(v("POST", 422), 256);
+            let mut other = v("GET", 400);
+            other.reason = "different".into();
+            buf.record(other, 256);
+        }
+        assert_eq!(buf.len(), 3);
+        let snap = buf.snapshot();
+        assert_eq!(snap.len(), 3);
+        for entry in &snap {
+            assert_eq!(entry.occurrences, 100, "each signature seen 100×");
+        }
+    }
+
+    /// Round 30 — unique mode still evicts when distinct-signature
+    /// count exceeds the cap. Eviction is FIFO over insertion order
+    /// (NOT recency-of-hit), matching how the regular ring buffer
+    /// reads.
+    #[test]
+    fn unique_buffer_evicts_oldest_signature_at_capacity() {
+        let mut buf = UniqueBuffer::new();
+        let cap = 4;
+        for i in 0..(cap + 3) {
+            let mut entry = v("GET", 400);
+            entry.reason = format!("kind-{i}");
+            buf.record(entry, cap);
+        }
+        assert_eq!(buf.len(), cap);
+        let snap = buf.snapshot();
+        // newest first; signatures 0..2 evicted, 3..6 retained
+        let kinds: Vec<&str> = snap.iter().map(|e| e.reason.as_str()).collect();
+        assert_eq!(kinds, vec!["kind-6", "kind-5", "kind-4", "kind-3"]);
     }
 }

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -724,6 +724,7 @@ impl OpenApiRouteRegistry {
                                 status: status_code,
                                 reason: ct_err.clone(),
                                 category: "content-types".to_string(),
+                                occurrences: 1,
                             },
                         );
                         let status = axum::http::StatusCode::from_u16(status_code)
@@ -824,6 +825,7 @@ impl OpenApiRouteRegistry {
                                 status: status_code,
                                 reason,
                                 category,
+                                occurrences: 1,
                             },
                         );
 
@@ -1266,6 +1268,7 @@ impl OpenApiRouteRegistry {
                 status: status_code,
                 reason,
                 category,
+                occurrences: 1,
             },
         );
 

--- a/crates/mockforge-openapi/src/route.rs
+++ b/crates/mockforge-openapi/src/route.rs
@@ -495,6 +495,7 @@ impl OpenApiRoute {
                             available.join(", ")
                         ),
                         category: "response-shape".to_string(),
+                        occurrences: 1,
                     },
                 );
             }

--- a/crates/mockforge-tui/src/api/models.rs
+++ b/crates/mockforge-tui/src/api/models.rs
@@ -54,10 +54,20 @@ pub struct ConformanceViolation {
     pub reason: String,
     #[serde(default)]
     pub category: String,
+    /// Round 30 — `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true` causes the
+    /// server-side buffer to dedup by signature and stamp every entry
+    /// with how many duplicate hits coalesced into it. Defaults to `1`
+    /// when older mockforge instances send the field-less payload.
+    #[serde(default = "default_occurrences")]
+    pub occurrences: u32,
 }
 
 fn default_unknown() -> String {
     "unknown".to_string()
+}
+
+fn default_occurrences() -> u32 {
+    1
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/mockforge-tui/src/screens/conformance.rs
+++ b/crates/mockforge-tui/src/screens/conformance.rs
@@ -408,6 +408,14 @@ impl ConformanceScreen {
 
         // Group by (method, path, category, reason). Insertion order
         // doesn't matter — we sort by count at the end.
+        //
+        // Round 30 — under `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true`
+        // the server-side buffer ALREADY deduplicates and carries an
+        // `occurrences` field per entry. Use that as the increment
+        // instead of +1, so the TUI's headline count reflects the true
+        // server-side total instead of just "1 per unique signature".
+        // FIFO mode (the default) sends `occurrences: 1` per entry,
+        // so the math reduces to the prior behaviour for that path.
         let mut groups: HashMap<DedupKey, (DedupedViolation, u32, chrono::DateTime<chrono::Utc>)> =
             HashMap::new();
         for &i in &indices {
@@ -415,9 +423,11 @@ impl ConformanceScreen {
                 continue;
             };
             let key = (v.method.clone(), v.path.clone(), v.category.clone(), v.reason.clone());
+            let hits = v.occurrences.max(1);
             match groups.get_mut(&key) {
                 Some(slot) => {
-                    slot.1 += 1;
+                    slot.1 = slot.1.saturating_add(hits);
+                    slot.0.count = slot.0.count.saturating_add(hits);
                     if v.timestamp < slot.0.first_seen {
                         slot.0.first_seen = v.timestamp;
                     }
@@ -436,11 +446,11 @@ impl ConformanceScreen {
                                 category: v.category.clone(),
                                 reason: v.reason.clone(),
                                 status: v.status,
-                                count: 1,
+                                count: hits,
                                 first_seen: v.timestamp,
                                 last_seen: v.timestamp,
                             },
-                            1,
+                            hits,
                             v.timestamp,
                         ),
                     );
@@ -1215,6 +1225,7 @@ mod tests {
             status: 400,
             reason: reason.into(),
             category: "request-body".into(),
+            occurrences: 1,
         }
     }
 


### PR DESCRIPTION
## Summary

Round 30 of issue #79 (Srikanth's rolling conformance feedback). Addresses three asks from his 0.3.173 reply:

- **Q1 (schema error format).** `response_schema_error` now prints only the sub-schema at the offending JSON Pointer instead of the full top-level schema. `{"name": 123}` against `{"properties":{"name":{"type":"string"}}, ...}` now reads `response body at /name: expected type string; expected schema {"type":"string"}` instead of dumping the entire object schema in the suffix.
- **Q2 (unique-violation buffer).** `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true` switches the server-side violation buffer from FIFO to dedup-by-signature; every duplicate of an already-buffered (method, path, status, category, reason) bumps a new `occurrences` field instead of consuming a new buffer slot. Solves Srikanth's "10M requests dominated by a handful of signatures clobber the rest" concern. TUI export-dedup grouping now sums `occurrences` so headline counts match the true server-side total under unique mode.
- **Q3 (sharding).** No code change; reply in the issue walks through the (a) wrong / (b) right-shape-wrong-numbers math and lists 4 viable layouts for his 15 GB box.

## Test plan
- [x] `cargo test -p mockforge-foundation --lib conformance` — 5 pass + 1 #[ignore]
- [x] `cargo test -p mockforge-bench --lib conformance::self_test::tests` — 30 pass (5 cover the schema-error wording / sub-schema fallback)
- [x] `cargo clippy -p mockforge-foundation -p mockforge-bench -p mockforge-openapi -p mockforge-tui --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Real-binary verify of unique mode against the demo spec: 1500 bad POST /users requests → buffer holds 2 distinct entries with `occurrences=[1000, 500]`, `total_seen=1500`
- [x] Real-binary verify of FIFO mode (default, no env var): 100 identical bad POST /users → 100 separate entries each with `occurrences=1`
- [ ] CI Security Audit + Registry E2E green

Closes part of #79.