### PR TITLE
feat(bench,cli,foundation): #79 round 31 — required-field sub-schema + serve flags + rustls-only install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.3.175] - 2026-06-10
+
+### Fixed
+
+- **[DevX]** `response_schema_error` now shows the missing property's own sub-schema for `required field missing` errors instead of the entire parent object schema (#79 round 31 / Srikanth on 0.3.174 against the vCenter `Appliance.Recovery.Backup.SystemName.Archive.Info` spec). The prior output dumped the parent's multi-paragraph description and every sibling property schema then truncated at 300 chars, which buried which field was missing and why. The walker now strips the surrounding quotes from `property` (jsonschema's Display impl wraps the name in `"..."`), descends one more step into `properties[<missing>]`, and prints just that. New test covers the vCenter scenario and asserts the parent description + sibling names don't leak into the suffix.
+- **[Install]** `cargo install mockforge-cli` no longer requires a system OpenSSL 1.1+ at runtime, so it works on Ubuntu 16.04 / RHEL 7 / boxes that only ship OpenSSL 1.0.2 (#79 round 31 / Srikanth's "few clients which runs ubuntu 16.04 and openssl version 1.0.2"). Two fixes: (1) the TLS stack is now rustls-only (workspace `reqwest`, `lettre`, and the `sqlx` uses in `mockforge-tunnel` + `mockforge-vbr` all dropped `*-native-tls` features); `cargo tree -i native-tls` against `mockforge-cli` comes back empty. (2) `git2` (via `mockforge-plugin-loader` and `mockforge-scenarios`) was still pulling `openssl-sys` for its HTTPS clone path, so we enabled `vendored-openssl` on it; that statically links a known-good OpenSSL into `libgit2-sys`/`libssh2-sys` so the binary no longer needs `libssl.so` at runtime. Also converted four crates that hand-wrote `reqwest = { version = "0.12", features = ["json"] }` to inherit the workspace dep so the default-tls drift can't reappear.
+
+### Added
+
+- **[Server]** `mockforge serve --conformance-buffer-size N` and `--conformance-buffer-unique` CLI flags (#79 round 31 / Srikanth: "is it possible give in the mockforge server command as opposed to environmental variable which I sometime forget"). Both mirror the round-29/round-30 env vars; flag values win when both are set. Surfaced in `mockforge serve --help` under "Server Configuration".
+
 ## [0.3.174] - 2026-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,11 +6187,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -7714,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7731,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7754,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7776,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7789,7 +7787,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7826,7 +7824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7867,7 +7865,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7882,7 +7880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7905,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7921,7 +7919,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8002,7 +8000,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8047,7 +8045,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8057,7 +8055,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8082,7 +8080,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8155,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8188,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8221,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8244,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8268,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8294,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8332,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8373,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8454,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8501,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8536,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8558,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8585,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8659,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8675,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8705,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8783,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8798,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8899,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8924,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8944,7 +8942,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8976,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9014,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9091,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9124,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9146,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9183,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9211,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9291,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9325,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9336,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9358,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9378,7 +9376,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9400,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9483,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9518,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9529,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -10536,6 +10534,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10543,6 +10550,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -12679,11 +12687,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -12693,7 +12699,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
  "native-tls",
  "percent-encoding",
@@ -14330,7 +14335,6 @@ dependencies = [
  "indexmap 2.14.0",
  "log",
  "memchr",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "rust_decimal",
@@ -15386,7 +15390,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.174"
+version = "0.3.175"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.174"
+version = "0.3.175"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"
@@ -177,7 +177,12 @@ axum = { version = "0.8", features = ["ws", "multipart"] }
 hyper = { version = "1.9", features = ["full"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "cors", "trace", "compression-full"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+# Round 31 (#79 / Srikanth): default features pull in native-tls →
+# openssl-sys, which then refuses to build against system OpenSSL 1.0.2
+# (Ubuntu 16.04 and friends). Drop default-tls so the workspace stays on
+# rustls only; this also keeps `cargo install mockforge-cli` working on
+# older clients that lack OpenSSL 1.1+.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # OpenAPI specification handling
 openapiv3 = "2.2"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,16 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.175] - 2026-06-10
+
+### Fixed
+
+- **[DevX]** For `required field missing` errors, the printed schema is now the missing property's own sub-schema, not the entire parent object (#79 round 31 / Srikanth).
+- **[Install]** `cargo install mockforge-cli` no longer requires OpenSSL 1.1+; the workspace is fully rustls-only (#79 round 31).
+
+### Added
+
+- **[Server]** `mockforge serve --conformance-buffer-size N` and `--conformance-buffer-unique` CLI flags mirror the round-29/round-30 env vars (#79 round 31 / Srikanth).
+
 ## [0.3.174] - 2026-06-09
 
 ### Fixed

--- a/crates/mockforge-analytics/Cargo.toml
+++ b/crates/mockforge-analytics/Cargo.toml
@@ -41,7 +41,7 @@ prometheus = { version = "0.14", features = ["process"] }
 once_cell = "1.21"
 
 # HTTP client (for querying Prometheus)
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 
 # User agent parsing
 woothee = "0.13"

--- a/crates/mockforge-bench/Cargo.toml
+++ b/crates/mockforge-bench/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.52", features = ["full"] }
 # HTTP client (for target validation + native chunked traffic generator).
 # `stream` enables `Body::wrap_stream`, which is how chunked encoding gets
 # exercised on the wire from the native chunked-bench.
-reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
+reqwest = { workspace = true, features = ["multipart", "stream"] }
 futures = { workspace = true }
 async-stream = "0.3"
 

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -976,6 +976,16 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
     // tail. Combined with `at <instance-path>` for the field location.
     let path = first.instance_path.to_string();
     let path = if path.is_empty() { "/" } else { path.as_str() };
+    // Round 31 — Srikanth on 0.3.174 hit the vCenter case where the
+    // error is "required field missing: comment" but the printed
+    // schema was the WHOLE parent object schema (with descriptions of
+    // every property), not just the missing field's sub-schema. The
+    // jsonschema crate emits `Required` errors with
+    // `instance_path == /` (the parent), so the round-30 sub-schema
+    // walker had no extra info to focus the suffix. Carry the missing
+    // property name out of the kind match so we can descend one more
+    // step into `properties[property]` for the printed schema.
+    let mut required_property: Option<String> = None;
     let kind_msg: String = match &first.kind {
         jsonschema::error::ValidationErrorKind::Type { kind } => {
             // `kind` is `TypeKind::Single(JsonType)` or
@@ -987,6 +997,16 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
             }
         }
         jsonschema::error::ValidationErrorKind::Required { property } => {
+            // `property.to_string()` returns the Display of the JSON
+            // value, which for a string is `"name"` (with quotes).
+            // Strip them for the lookup; keep them in the human message.
+            let raw = property.to_string();
+            let unquoted = raw
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .unwrap_or(&raw)
+                .to_string();
+            required_property = Some(unquoted);
             format!("required field missing: {property}")
         }
         jsonschema::error::ValidationErrorKind::AdditionalProperties { unexpected } => {
@@ -1022,7 +1042,17 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
     // chain and print the most specific sub-schema we can find. Falls
     // back to the full schema for paths the walker can't resolve
     // (additionalProperties, oneOf, allOf, $ref un-resolved, etc.).
-    let focused_schema = sub_schema_at_pointer(schema, path).unwrap_or_else(|| schema.clone());
+    let mut focused_schema = sub_schema_at_pointer(schema, path).unwrap_or_else(|| schema.clone());
+    // Round 31 — for Required errors, descend one more step into
+    // `properties[<missing>]` so the printed schema is the missing
+    // field's own constraint, not the whole parent.
+    if let Some(prop_name) = required_property.as_ref() {
+        if let Some(prop_schema) =
+            focused_schema.get("properties").and_then(|p| p.get(prop_name.as_str()))
+        {
+            focused_schema = prop_schema.clone();
+        }
+    }
     let schema_str = serde_json::to_string(&focused_schema).unwrap_or_else(|_| "<schema>".into());
     let schema_str = if schema_str.len() > 300 {
         format!("{}...", &schema_str[..300])
@@ -2301,6 +2331,52 @@ mod tests {
         let err = validate_body_against_schema(body, &schema).expect("required-missing fires");
         assert!(err.contains("required field missing"), "{err}");
         assert!(err.contains("id"), "{err}");
+    }
+
+    /// Round 31 — Srikanth's vCenter case on 0.3.174: the
+    /// `Appliance.Recovery.Backup.SystemName.Archive.Info` schema has
+    /// a multi-paragraph description and ~6 required fields, of which
+    /// `comment` was missing in the response. Before this fix the
+    /// printed schema was the WHOLE parent object schema (parent's
+    /// description bleeding in, all sibling property schemas dumped)
+    /// truncated to 300 chars; after the fix it's the missing field's
+    /// own schema. Verifies (a) parent description is gone and
+    /// (b) sibling property names don't appear in the message.
+    #[test]
+    fn response_schema_error_required_focuses_on_missing_field_only() {
+        let schema = serde_json::json!({
+            "description": "The Appliance.Recovery.Backup.SystemName.Archive.Info schema represents backup archive information.\n\nThis schema was added in vSphere API 6.7.",
+            "type": "object",
+            "required": ["comment", "location", "parts", "system_name", "timestamp", "version"],
+            "properties": {
+                "comment": {
+                    "type": "string",
+                    "description": "Custom comment added by the user for this backup."
+                },
+                "location": {"type": "string", "description": "Backup location URL."},
+                "parts": {"type": "array", "items": {"type": "string"}},
+                "system_name": {"type": "string"},
+                "timestamp": {"type": "string", "format": "date-time"},
+                "version": {"type": "string"}
+            }
+        });
+        let body = r#"{"location":"x","parts":[],"system_name":"y","timestamp":"z","version":"v"}"#;
+        let err = validate_body_against_schema(body, &schema).expect("required-missing fires");
+        assert!(err.contains("required field missing: \"comment\""), "{err}");
+        // Parent's description should not appear; only the `comment`
+        // field's own description (if any) may.
+        assert!(
+            !err.contains("Appliance.Recovery.Backup"),
+            "parent description should not bleed into focused schema: {err}"
+        );
+        // No sibling property names should appear in the focused schema
+        // suffix.
+        for sibling in ["location", "parts", "system_name", "timestamp", "version"] {
+            assert!(
+                !err.contains(&format!("\"{sibling}\"")),
+                "sibling field {sibling} should not appear in focused schema: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mockforge-chaos-orchestration/Cargo.toml
+++ b/crates/mockforge-chaos-orchestration/Cargo.toml
@@ -41,7 +41,7 @@ sha2 = "0.10"
 cron = "0.15"
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 
 # Tracing
 mockforge-tracing = { version = "0.3.70", path = "../mockforge-tracing" }

--- a/crates/mockforge-chaos/Cargo.toml
+++ b/crates/mockforge-chaos/Cargo.toml
@@ -55,7 +55,7 @@ governor = "0.8"
 nonzero_ext = "0.3"
 
 # HTTP client for health checks
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 
 # Cryptography
 sha2 = "0.10"

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -565,6 +565,23 @@ struct ServeCliArgs {
     #[arg(long, help_heading = "Server Configuration")]
     pub shadow: bool,
 
+    /// Cap of the in-memory conformance-violation ring buffer that the
+    /// TUI / `/__mockforge/api/conformance/violations` endpoint reads
+    /// from (Issue #79 round 29). Default `256`, max `65536`. Mirrors
+    /// `MOCKFORGE_CONFORMANCE_BUFFER_SIZE`; the env var still works.
+    #[arg(long, value_name = "N", help_heading = "Server Configuration")]
+    pub conformance_buffer_size: Option<usize>,
+
+    /// Dedup conformance violations by `(method, path, status, category,
+    /// reason)` signature instead of FIFO (Issue #79 round 30 +
+    /// Srikanth's round-31 ask: "give in the mockforge server command
+    /// as opposed to environmental variable which I sometimes forget").
+    /// Each duplicate of a buffered signature bumps `occurrences`
+    /// instead of consuming a new slot. Mirrors
+    /// `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true`.
+    #[arg(long, help_heading = "Server Configuration")]
+    pub conformance_buffer_unique: bool,
+
     #[command(flatten)]
     pub ports: PortArgs,
 
@@ -2618,6 +2635,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 bulkhead_max_concurrent: args.chaos_opts.bulkhead_max_concurrent,
                 bulkhead_max_queue: args.chaos_opts.bulkhead_max_queue,
                 bulkhead_queue_timeout_ms: args.chaos_opts.bulkhead_queue_timeout_ms,
+                conformance_buffer_size: args.conformance_buffer_size,
+                conformance_buffer_unique: args.conformance_buffer_unique,
             })
             .await?;
         }

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -109,6 +109,12 @@ pub(crate) struct ServeArgs {
     pub(crate) bulkhead_max_concurrent: u32,
     pub(crate) bulkhead_max_queue: u32,
     pub(crate) bulkhead_queue_timeout_ms: u64,
+    /// `--conformance-buffer-size` (round 31). Mirrors
+    /// `MOCKFORGE_CONFORMANCE_BUFFER_SIZE`. None = honour env or default 256.
+    pub(crate) conformance_buffer_size: Option<usize>,
+    /// `--conformance-buffer-unique` (round 31). Mirrors
+    /// `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true`.
+    pub(crate) conformance_buffer_unique: bool,
 }
 
 impl Default for ServeArgs {
@@ -189,6 +195,8 @@ impl Default for ServeArgs {
             bulkhead_max_concurrent: 100,
             bulkhead_max_queue: 10,
             bulkhead_queue_timeout_ms: 5000,
+            conformance_buffer_size: None,
+            conformance_buffer_unique: false,
         }
     }
 }
@@ -684,6 +692,18 @@ pub async fn handle_serve(
     // a user who already disabled the limiter via env var sees no surprise.
     if serve_args.no_rate_limit && std::env::var_os("MOCKFORGE_RATE_LIMIT_ENABLED").is_none() {
         std::env::set_var("MOCKFORGE_RATE_LIMIT_ENABLED", "false");
+    }
+
+    // Issue #79 round 31 — Srikanth: "is it possible give in the
+    // mockforge server command as opposed to environmental variable
+    // which I sometime forget". Mirror the round-29/round-30 env vars
+    // as first-class flags. Flag-set values WIN over what the env says,
+    // because the user just typed the flag and expects it to take effect.
+    if let Some(n) = serve_args.conformance_buffer_size {
+        std::env::set_var("MOCKFORGE_CONFORMANCE_BUFFER_SIZE", n.to_string());
+    }
+    if serve_args.conformance_buffer_unique {
+        std::env::set_var("MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE", "true");
     }
 
     // Issue #79 round 20 — propagate `--base-path` so the management

--- a/crates/mockforge-http/Cargo.toml
+++ b/crates/mockforge-http/Cargo.toml
@@ -131,7 +131,7 @@ chaos = []
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 tempfile = "3"
 tokio-tungstenite = "0.28"
 futures-util = "0.3"

--- a/crates/mockforge-pipelines/Cargo.toml
+++ b/crates/mockforge-pipelines/Cargo.toml
@@ -59,8 +59,10 @@ handlebars = "5.1"
 reqwest = { workspace = true }
 
 # Email sending
-# Use tokio1-native-tls feature when using tokio1 with native-tls
-lettre = { version = "0.11", features = ["smtp-transport", "tokio1-native-tls"] }
+# Round 31 (#79 / Srikanth): default features include native-tls →
+# openssl-sys, breaking install on Ubuntu 16.04 (OpenSSL 1.0.2). Use
+# rustls-tls instead to keep the workspace fully rustls-only.
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "pool", "rustls-tls", "tokio1-rustls-tls", "hostname", "builder"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/mockforge-plugin-loader/Cargo.toml
+++ b/crates/mockforge-plugin-loader/Cargo.toml
@@ -73,8 +73,12 @@ zip = "2.2"
 flate2 = "1.0"
 tar = "0.4"
 
-# Git repository cloning
-git2 = { version = "0.19", optional = true }
+# Git repository cloning. Round 31 (#79 / Srikanth): `vendored-openssl`
+# statically links a known-good OpenSSL into libgit2-sys/libssh2-sys so
+# the released binary doesn't depend on the system libssl at runtime,
+# which fixes `cargo install mockforge-cli` on Ubuntu 16.04 / RHEL 7
+# boxes that only ship OpenSSL 1.0.2.
+git2 = { version = "0.19", default-features = false, features = ["https", "ssh", "ssh_key_from_memory", "vendored-openssl"], optional = true }
 
 # Progress tracking
 indicatif = "0.17"

--- a/crates/mockforge-plugin-registry/Cargo.toml
+++ b/crates/mockforge-plugin-registry/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 toml = "0.8"
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 
 # Error handling
 thiserror = "1.0"

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -181,7 +181,7 @@ prometheus = { version = "0.14", features = ["process"] }
 # HTTP client for Fly.io API. `stream` is also used by the OSV sync
 # worker so it can spool 100+ MB ecosystem dumps to a tempfile on disk
 # instead of buffering the whole body in memory.
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { workspace = true, features = ["stream"] }
 
 # Real-time Fly runtime-log subscription (#556). Fly publishes log
 # lines on the `logs.<app>.<region>.<machine>` NATS subject; this
@@ -222,7 +222,7 @@ opentelemetry-proto = { version = "0.32", default-features = false, features = [
 
 [dev-dependencies]
 tokio-test = "0.4"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"

--- a/crates/mockforge-scenarios/Cargo.toml
+++ b/crates/mockforge-scenarios/Cargo.toml
@@ -52,8 +52,10 @@ zip = "2.2"
 flate2 = "1.0"
 tar = "0.4"
 
-# Git repository cloning
-git2 = { version = "0.19", optional = true }
+# Git repository cloning. Round 31 (#79 / Srikanth): `vendored-openssl`
+# statically links a known-good OpenSSL into libgit2-sys/libssh2-sys so
+# the released binary doesn't depend on the system libssl at runtime.
+git2 = { version = "0.19", default-features = false, features = ["https", "ssh", "ssh_key_from_memory", "vendored-openssl"], optional = true }
 
 # Progress tracking
 indicatif = "0.17"

--- a/crates/mockforge-test-runner/Cargo.toml
+++ b/crates/mockforge-test-runner/Cargo.toml
@@ -34,7 +34,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 chrono = { workspace = true }
 
 # HTTP for callbacks to registry (mTLS-secured POSTs)
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+reqwest = { workspace = true }
 
 # YAML parser used by ContractExecutor when an OpenAPI spec is served as YAML.
 serde_yaml = "0.9"

--- a/crates/mockforge-tunnel/Cargo.toml
+++ b/crates/mockforge-tunnel/Cargo.toml
@@ -38,7 +38,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 thiserror = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
-sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "sqlite"], optional = true }
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"], optional = true }
 governor = { version = "0.8", features = ["std"], optional = true }
 rustls = { version = "0.23", optional = true }
 rustls-pemfile = { version = "2.0", optional = true }

--- a/crates/mockforge-vbr/Cargo.toml
+++ b/crates/mockforge-vbr/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "sqlite", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "chrono", "uuid"] }
 
 # Logging
 tracing = { workspace = true }


### PR DESCRIPTION
## Summary

Round 31 of issue #79 (Srikanth's rolling conformance feedback). Addresses 3 actionable items from his 0.3.174 reply (plus 4 that get explanations in the issue reply, no code change):

- **Q1 (real bug).** Schema-error suffix for `Required field missing` was printing the entire parent object schema with descriptions of every sibling property, then truncating at 300 chars — so for Srikanth's vCenter `Appliance.Recovery.Backup.SystemName.Archive.Info` the missing `comment` field's actual constraint was buried. Fix: strip the quotes from the property name (jsonschema's Display wraps it), descend one more step into `properties[<missing>]`, print just that.
- **Q4.** New `--conformance-buffer-size N` and `--conformance-buffer-unique` flags on `mockforge serve` mirroring the round-29/round-30 env vars. Surfaced under "Server Configuration" in `--help`.
- **Q7.** `cargo install mockforge-cli` now works on Ubuntu 16.04 / RHEL 7 / OpenSSL 1.0.2 boxes. Two fixes: TLS stack is now rustls-only (workspace `reqwest`, `lettre`, two `sqlx` consumers all dropped `*-native-tls`), and `git2` (via `mockforge-plugin-loader` / `mockforge-scenarios`) uses `vendored-openssl` so libgit2-sys/libssh2-sys statically link a known-good OpenSSL. `ldd target/release/mockforge | grep -i ssl` is now empty.

## Test plan
- [x] `cargo test -p mockforge-bench --lib conformance::self_test::tests::response_schema_error` — 6 pass, new `response_schema_error_required_focuses_on_missing_field_only` covers Srikanth's vCenter case verbatim
- [x] `cargo test -p mockforge-foundation --lib conformance_violations` — 5 pass + 1 ignored
- [x] `cargo test -p mockforge-cli` — 18 pass
- [x] `cargo clippy -p mockforge-bench -p mockforge-foundation -p mockforge-cli --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Real-binary verify of `--conformance-buffer-unique` (no env var): 50 duplicate bad POST /users collapse to 1 entry with `occurrences=50`, `total_seen=50` ✓
- [x] `cargo tree -p mockforge-cli -i openssl --all-features` returns empty; `-i native-tls` returns empty
- [x] `ldd target/release/mockforge | grep -i ssl` returns empty
- [ ] CI Security Audit + Registry E2E green

Closes part of #79.