### PR TITLE
fix(intelligence): #79 round 31 follow-up — MockAI mutation responses honor spec schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.176] - 2026-06-10
+
+### Fixed
+
+- **[Contracts]** `mockforge serve` POST / PUT / PATCH / DELETE responses now match the spec's response schema instead of MockAI's hardcoded `{id, status, data}` envelope (#79 round 31 follow-up / Srikanth's vCenter `Archive.Info` `comment` finding). Root cause: MockAI is wired on by default through the reality engine's `ModerateRealism` level (`reality.enabled = true` → `mockai.enabled = true`), and its `generate_response_body` for the Create / Update / PartialUpdate / Delete mutation kinds returned a hardcoded envelope that ignored the OpenAPI 2xx response schema. Result: every write operation came back as `{"id":"generated_id","status":"created","data":<echoed body>}`, missing whichever required fields the spec actually defined (e.g. the six fields on vCenter's `Appliance.Recovery.Backup.SystemName.Archive.Info`). The function now returns `{}` for every mutation kind, which the calling site already handles as "fall through to the OpenAPI ResponseGenerator", so the response body becomes spec-shape automatically and required fields are populated. New regression test enumerates every `MutationType` and asserts each returns `{}`. Real-binary verified against the exact vCenter route from Srikanth's r31 report: the response now contains `comment`, `location`, `parts`, `system_name`, `timestamp`, `version`.
+
 ## [0.3.175] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7787,7 +7787,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7824,7 +7824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7865,7 +7865,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7880,7 +7880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7919,7 +7919,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8000,7 +8000,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8045,7 +8045,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8055,7 +8055,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8080,7 +8080,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8373,7 +8373,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8454,7 +8454,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8501,7 +8501,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8536,7 +8536,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8558,7 +8558,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8585,7 +8585,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8610,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8633,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8659,7 +8659,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8675,7 +8675,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8705,7 +8705,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8724,7 +8724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8783,7 +8783,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8798,7 +8798,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8822,7 +8822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8862,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8899,7 +8899,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8924,7 +8924,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8942,7 +8942,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8976,7 +8976,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9014,7 +9014,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9091,7 +9091,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9111,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9124,7 +9124,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9146,7 +9146,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9183,7 +9183,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9211,7 +9211,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9241,7 +9241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9268,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9291,14 +9291,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9325,7 +9325,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9336,7 +9336,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9358,7 +9358,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9376,7 +9376,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9400,7 +9400,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9483,7 +9483,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9518,7 +9518,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9529,7 +9529,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9546,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15390,7 +15390,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.175"
+version = "0.3.176"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.175"
+version = "0.3.176"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.176] - 2026-06-10
+
+### Fixed
+
+- **[Contracts]** Write requests (POST / PUT / PATCH / DELETE) now return spec-shape response bodies instead of MockAI's hardcoded `{id, status, data}` envelope (#79 round 31 follow-up / Srikanth).
+
 ## [0.3.175] - 2026-06-10
 
 ### Fixed

--- a/crates/mockforge-intelligence/src/intelligent_behavior/mockai.rs
+++ b/crates/mockforge-intelligence/src/intelligent_behavior/mockai.rs
@@ -293,21 +293,22 @@ impl MockAI {
             });
         }
 
-        // Generate normal response based on mutation type
-        // For GET/HEAD/OPTIONS (Read operations), this should return an empty object
-        // to signal that OpenAPI response generation should be used instead
+        // Round 31 (#79) — `generate_response_body` now ALWAYS returns
+        // an empty object so the calling site (mockforge-openapi's
+        // router) falls back to spec-driven OpenAPI response
+        // generation. We still call it for mutation methods so any
+        // future mutation-side-effects (state tracking, drift
+        // detection) keep firing; we just don't let it shape the
+        // response body any more.
         let response_body = if is_mutation_method {
-            // Only use mutation-based response generation for actual mutations
             self.generate_response_body(&mutation_analysis, request, session_context)
                 .await?
         } else {
-            // For GET/HEAD/OPTIONS, return empty object to signal OpenAPI generation should be used
-            // This prevents GET requests from returning POST-style {id: "generated_id", status: "created"} responses
             tracing::debug!(
                 "Skipping mutation-based response generation for {} request - using OpenAPI response generation",
                 method_upper
             );
-            serde_json::json!({}) // Empty object signals to use OpenAPI response generation
+            serde_json::json!({})
         };
 
         Ok(Response {
@@ -482,55 +483,41 @@ impl MockAI {
         }))
     }
 
-    /// Generate response body based on mutation analysis
+    /// Generate response body based on mutation analysis.
+    ///
+    /// Issue #79 round 31 — Srikanth on 0.3.174 hit the vCenter
+    /// `Appliance.Recovery.Backup.SystemName.Archive_get` route (a
+    /// POST that vCenter's spec models as a Create-style mutation) and
+    /// saw the response come back as the hardcoded envelope
+    /// `{id: "generated_id", status: "created", data: <echoed body>}`,
+    /// even though the spec's 200 response promised
+    /// `Archive.Info` with six required fields. The hardcoded envelope
+    /// here was a holdover from before the OpenAPI ResponseGenerator
+    /// could shape Create/Update/Delete responses on its own — but
+    /// keeping it means MockAI silently overrides the spec for every
+    /// write request and the body Srikanth got back was missing
+    /// required fields like `comment` / `parts` / `timestamp` /
+    /// `version`.
+    ///
+    /// The fix: for any mutation kind, return an empty object. The
+    /// calling site in `mockforge-openapi`'s router (the
+    /// `if is_empty { fall through to OpenAPI response generation }`
+    /// branch) already treats `{}` as "use the spec-driven response".
+    /// So the body becomes spec-shape automatically and required
+    /// fields are populated by the same path that already handles
+    /// `NoChange` (GET/HEAD/OPTIONS). MockAI's mutation analysis still
+    /// runs (state tracking, drift detection, etc.); only the
+    /// response-body shape changes.
     async fn generate_response_body(
         &self,
-        mutation: &super::mutation_analyzer::MutationAnalysis,
-        request: &Request,
+        _mutation: &super::mutation_analyzer::MutationAnalysis,
+        _request: &Request,
         _session_context: &StatefulAiContext,
     ) -> Result<Value> {
-        // Generate response based on mutation type
-        // CRITICAL: NoChange (used for GET/HEAD/OPTIONS) should return empty object
-        // to signal that OpenAPI response generation should be used instead
-        match mutation.mutation_type {
-            super::mutation_analyzer::MutationType::NoChange => {
-                // For read operations (GET, HEAD, OPTIONS), return empty object
-                // This signals to use OpenAPI response generation, not mutation responses
-                tracing::debug!("MutationType::NoChange - returning empty object to use OpenAPI response generation");
-                Ok(serde_json::json!({}))
-            }
-            super::mutation_analyzer::MutationType::Create => {
-                // Generate created resource response
-                Ok(serde_json::json!({
-                    "id": "generated_id",
-                    "status": "created",
-                    "data": request.body.clone().unwrap_or(serde_json::json!({}))
-                }))
-            }
-            super::mutation_analyzer::MutationType::Update
-            | super::mutation_analyzer::MutationType::PartialUpdate => {
-                // Generate updated resource response
-                Ok(serde_json::json!({
-                    "id": "resource_id",
-                    "status": "updated",
-                    "data": request.body.clone().unwrap_or(serde_json::json!({}))
-                }))
-            }
-            super::mutation_analyzer::MutationType::Delete => {
-                // Generate deletion response
-                Ok(serde_json::json!({
-                    "status": "deleted",
-                    "message": "Resource deleted successfully"
-                }))
-            }
-            _ => {
-                // Default success response
-                Ok(serde_json::json!({
-                    "status": "success",
-                    "data": request.body.clone().unwrap_or(serde_json::json!({}))
-                }))
-            }
-        }
+        tracing::debug!(
+            "MockAI mutation response: returning empty object so spec-driven OpenAPI response generation populates the body (#79 r31)"
+        );
+        Ok(serde_json::json!({}))
     }
 
     /// Merge new rules with existing rules
@@ -1024,6 +1011,63 @@ mod tests {
                 headers: HashMap::new(),
             };
             assert_eq!(response.status_code, status_code);
+        }
+    }
+
+    /// Round 31 (#79) — Srikanth on 0.3.174: MockAI was returning
+    /// `{id: "generated_id", status: "created", data: ...}` for POST
+    /// (and similar envelopes for PUT / PATCH / DELETE), overriding
+    /// the response body the OpenAPI spec described. The vCenter
+    /// `Archive.Info` schema requires six fields; MockAI's three-field
+    /// envelope was missing five of them, leading to
+    /// `response body root: required field missing: "comment"` reports
+    /// from the bench. Fixed by making `generate_response_body` return
+    /// `{}` for every mutation kind so the calling site's
+    /// `is_empty → use OpenAPI ResponseGenerator` fall-through kicks
+    /// in. Regression guard: every variant must return an empty
+    /// object.
+    #[tokio::test]
+    async fn generate_response_body_returns_empty_for_all_mutation_kinds() {
+        use crate::intelligent_behavior::mutation_analyzer::{MutationAnalysis, MutationType};
+        let mockai = MockAI::new(IntelligentBehaviorConfig::default());
+        let req = Request {
+            method: "POST".to_string(),
+            path: "/api/anything".to_string(),
+            body: Some(json!({"name": "X"})),
+            query_params: HashMap::new(),
+            headers: HashMap::new(),
+        };
+        let ctx = StatefulAiContext::new("test-session", IntelligentBehaviorConfig::default());
+
+        for kind in [
+            MutationType::NoChange,
+            MutationType::Create,
+            MutationType::Update,
+            MutationType::PartialUpdate,
+            MutationType::Delete,
+        ] {
+            let kind_label = format!("{:?}", kind);
+            let mutation = MutationAnalysis {
+                mutation_type: kind,
+                changed_fields: Vec::new(),
+                added_fields: Vec::new(),
+                removed_fields: Vec::new(),
+                validation_issues: Vec::new(),
+                confidence: 1.0,
+            };
+            let body = mockai
+                .generate_response_body(&mutation, &req, &ctx)
+                .await
+                .expect("generate_response_body should not error");
+            assert_eq!(
+                body,
+                json!({}),
+                "MockAI must return empty object for mutation kind {} so the calling \
+                 site falls back to spec-driven response generation (regression #79 r31). \
+                 Got: {:?}",
+                kind_label,
+                body
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Real mockforge bug uncovered while re-reading Srikanth's r31 setup. He's benching `mockforge serve --spec vcenter.yaml`, not the real vCenter, so the `comment` missing-required-field finding is on mockforge's own response synthesis.

Root cause: `mockai.enabled` is true by default through the reality engine's `ModerateRealism` level. MockAI then hijacks every POST/PUT/PATCH/DELETE and `generate_response_body` returns a hardcoded envelope `{id: "generated_id", status: "created", data: <echoed body>}` for Create (and similar envelopes for Update/Delete), ignoring the OpenAPI 2xx response schema entirely.

For vCenter's `Archive.Info` schema with 6 required fields, that envelope is missing 5 of them, so the bench reports `response body root: required field missing: "comment"`.

Fix: `generate_response_body` returns `{}` for every mutation kind. The caller already handles `{}` as "fall through to OpenAPI ResponseGenerator", so the body becomes spec-shape automatically. MockAI's mutation analysis (state tracking, drift detection) still runs; only the body shape changes.

## Test plan
- [x] New unit test `generate_response_body_returns_empty_for_all_mutation_kinds` enumerates every `MutationType` and asserts each returns `{}` (regression guard)
- [x] `cargo test -p mockforge-intelligence --lib` — 344 pass (343 prior + 1 new)
- [x] `cargo test -p mockforge-openapi --lib` — 172 pass
- [x] `cargo clippy -p mockforge-intelligence -p mockforge-openapi --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Real-binary verify against Srikanth's exact route `POST /api/appliance/recovery/backup/system-name/X/archives/Y?action=get`: response now returns `{comment, location, parts, system_name, timestamp, version}` (all 6 spec-required fields), not `{id, status, data}`
- [ ] CI Security Audit + Registry E2E green

Closes part of #79.