### PR TITLE
feat(bench,openapi,grpc): #79 round 32 — 415 in conformance buffer + per-endpoint summary + vendored protoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.3.177] - 2026-06-14
+
+### Fixed
+
+- **[Contracts]** Server-side conformance buffer now records `content-types` violations from the MockAI-enabled router path too (#79 round 32 / Srikanth on 0.3.176: "in the client I see response status as 415 for label `request-body:content-type-mismatch:xml` request but in the server I see only 400"). Root cause: the MockAI request handler took `body: Option<Json<Value>>`, and axum's `Json` extractor 415s a request whose `Content-Type` isn't `application/json` BEFORE the handler runs, so the buffer never got a chance to record the violation. The handler now takes raw `axum::body::Bytes`, runs the same `check_request_content_type` precheck the non-MockAI router already had (records the violation with category `content-types` and the configured validation status, default 415), and parses the body as JSON manually for the validator / fingerprint / MockAI paths. The existing `check_request_content_type_flags_mismatch` test covers the logic; the wiring is in `build_router_with_mockai`.
+- **[Install]** `cargo install mockforge-cli` no longer requires `protobuf-compiler` on the build host (#79 round 32 / Srikanth's VM1 Ubuntu 16.04 install error "Could not find `protoc`"). `mockforge-grpc/build.rs` now picks the `protoc` binary from the `protoc-bin-vendored` crate when the user hasn't pointed `PROTOC` at their own copy; user-set `PROTOC` still wins (empty string treated as unset). Build verified against the vCenter spec build with `PROTOC` cleared from the environment.
+
+### Added
+
+- **[Contracts]** Per-endpoint traffic summary derived from the conformance self-test capture (#79 round 32 / Srikanth's Q6 ask). Two surfaces:
+  - JSON sidecar at `bench-results/conformance-per-endpoint.json` for automation pipelines. One entry per `(method, resolved URL path)` with `sent`, `status_2xx` / `status_3xx` / `status_4xx` / `status_5xx` / `errors`, plus `request_body_len` / `response_body_len` / `query_len` with samples / avg / p50 / p95 / max.
+  - HTML section "Per-endpoint traffic summary" spliced into `bench-results/conformance-report.html`.
+  - Grouping is by RESOLVED path for v1, not the spec template (so `/foo/X` and `/foo/Y` are distinct rows). A future round will collapse to the spec template once we surface `op.path` on each `CaseCapture`. 4 new unit tests cover the bucketing, query-string strip, p95 calculation, and empty-input HTML.
+
 ## [0.3.176] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7787,7 +7787,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7824,7 +7824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7865,7 +7865,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7880,7 +7880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7919,7 +7919,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8000,7 +8000,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8045,7 +8045,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8055,7 +8055,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8080,7 +8080,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8352,6 +8352,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-reflect",
  "prost-types",
+ "protoc-bin-vendored",
  "rand 0.9.4",
  "regex",
  "serde",
@@ -8373,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8454,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8472,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8501,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8536,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8558,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8585,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8610,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8633,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8659,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8675,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8705,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8724,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8754,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8783,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8798,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8822,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8862,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8880,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8899,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8924,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8942,7 +8943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8976,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9014,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9091,7 +9092,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9111,7 +9112,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9124,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9146,7 +9147,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9183,7 +9184,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9211,7 +9212,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9241,7 +9242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9268,7 +9269,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9291,14 +9292,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9325,7 +9326,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9336,7 +9337,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9358,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9376,7 +9377,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9400,7 +9401,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9431,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9483,7 +9484,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9518,7 +9519,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9529,7 +9530,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9546,7 +9547,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -11960,6 +11961,70 @@ checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "proxy-protocol"
@@ -15390,7 +15455,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.176"
+version = "0.3.177"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.176"
+version = "0.3.177"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,16 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.177] - 2026-06-14
+
+### Fixed
+
+- **[Contracts]** Server-side conformance buffer now records `content-types` (415) violations from the MockAI router path too (#79 round 32 / Srikanth).
+- **[Install]** `cargo install mockforge-cli` no longer requires `protobuf-compiler` on Ubuntu 16.04 / RHEL 7; `mockforge-grpc` build uses a vendored `protoc` when `PROTOC` is unset (#79 round 32 / Srikanth).
+
+### Added
+
+- **[Contracts]** Per-endpoint traffic summary (sent count, status-class breakdown, request/response/query length p95) in `bench-results/conformance-per-endpoint.json` and a new section in `conformance-report.html` (#79 round 32 / Srikanth).
+
 ## [0.3.176] - 2026-06-10
 
 ### Fixed

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -2546,6 +2546,12 @@ impl BenchCommand {
             // (d) — also emit a self-contained HTML viewer at
             // `conformance-self-test-requests.html` for users who
             // want to browse the capture without piping through `jq`.
+            // Round 32 (#79 / Srikanth) — derive the per-endpoint
+            // traffic summary from the same in-memory capture sink so
+            // we don't re-parse the JSONL from disk later.
+            let per_endpoint_summary: Vec<
+                crate::conformance::per_endpoint_summary::PerEndpointSummary,
+            >;
             if let Some(sink) = capture_sink {
                 if let Ok(guard) = sink.lock() {
                     let jsonl_path = self.output.join("conformance-self-test-requests.jsonl");
@@ -2561,13 +2567,35 @@ impl BenchCommand {
                     let html =
                         crate::conformance::capture_html::render_capture_html(guard.as_slice());
                     let _ = std::fs::write(&html_path, html);
-                    TerminalReporter::print_progress(&format!(
-                        "Self-test request/response capture written to {} ({} entries) + {}",
-                        jsonl_path.display(),
-                        guard.len(),
-                        html_path.display(),
-                    ));
+
+                    // Round 32 — per-endpoint summary derived once from
+                    // the same slice. Written as a JSON sidecar for
+                    // automation and spliced into the HTML report below.
+                    per_endpoint_summary =
+                        crate::conformance::per_endpoint_summary::build_summary(guard.as_slice());
+                    let summary_path = self.output.join("conformance-per-endpoint.json");
+                    if let Ok(json) = serde_json::to_string_pretty(&per_endpoint_summary) {
+                        let _ = std::fs::write(&summary_path, json);
+                        TerminalReporter::print_progress(&format!(
+                            "Self-test request/response capture written to {} ({} entries) + {} + {}",
+                            jsonl_path.display(),
+                            guard.len(),
+                            html_path.display(),
+                            summary_path.display(),
+                        ));
+                    } else {
+                        TerminalReporter::print_progress(&format!(
+                            "Self-test request/response capture written to {} ({} entries) + {}",
+                            jsonl_path.display(),
+                            guard.len(),
+                            html_path.display(),
+                        ));
+                    }
+                } else {
+                    per_endpoint_summary = Vec::new();
                 }
+            } else {
+                per_endpoint_summary = Vec::new();
             }
             TerminalReporter::print_progress(&report.render_summary());
             // Persist the JSON report alongside the regular conformance
@@ -2629,11 +2657,26 @@ impl BenchCommand {
                     None => Some(200),
                 },
             };
-            let html = crate::conformance::report_html::render_html_with_options(
+            let mut html = crate::conformance::report_html::render_html_with_options(
                 &report,
                 audit_value.as_ref(),
                 &render_opts,
             );
+            // Round 32 (#79 / Srikanth) — splice the per-endpoint
+            // summary just before the closing `</body>` so it lands at
+            // the bottom of the report. Empty summary renders as an
+            // empty string so we don't even introduce an extra newline
+            // when there were no captures.
+            let summary_section = crate::conformance::per_endpoint_summary::render_html_section(
+                &per_endpoint_summary,
+            );
+            if !summary_section.is_empty() {
+                if let Some(idx) = html.rfind("</body>") {
+                    html.insert_str(idx, &summary_section);
+                } else {
+                    html.push_str(&summary_section);
+                }
+            }
             if std::fs::write(&html_path, html).is_ok() {
                 TerminalReporter::print_progress(&format!(
                     "HTML report written to {}",

--- a/crates/mockforge-bench/src/conformance/mod.rs
+++ b/crates/mockforge-bench/src/conformance/mod.rs
@@ -8,6 +8,7 @@ pub mod custom;
 pub mod executor;
 pub mod generator;
 pub mod har_to_custom;
+pub mod per_endpoint_summary;
 pub mod report;
 pub mod report_html;
 pub mod request_validator;

--- a/crates/mockforge-bench/src/conformance/per_endpoint_summary.rs
+++ b/crates/mockforge-bench/src/conformance/per_endpoint_summary.rs
@@ -1,0 +1,314 @@
+//! Per-endpoint send/received summary derived from the
+//! `CaseCapture` JSONL sink.
+//!
+//! Issue #79 round 32 — Srikanth on 0.3.176: "HTML(Manual
+//! Verification)/JSON(for Automation Verification) would help where we
+//! show API Endpoint details. Something like:
+//! `[GET/POST/PUT/...]: <send_request_count>, 2xx or 3xx or 4xx or 5xx
+//! count separately Per end Point` and per-(method, path) request
+//! body / response body length p95."
+//!
+//! The bench already records every request/response in
+//! `conformance-self-test-requests.jsonl`. This module rolls them up
+//! per (method, resolved-path) so a human (or `jq`) doesn't have to
+//! re-aggregate from scratch. v1 groups by the resolved URL path
+//! (everything after the host, minus the query string); a future
+//! round can collapse to the spec's path template once we surface the
+//! `op.path` template on each `CaseCapture` entry.
+//!
+//! Output:
+//! - `conformance-per-endpoint.json` next to the existing
+//!   `conformance-self-test.json` for automation.
+//! - HTML section spliced into `conformance-report.html` for humans.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::self_test::CaseCapture;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerEndpointSummary {
+    /// HTTP method, uppercase.
+    pub method: String,
+    /// Resolved URL path. Query string stripped. NOT the spec
+    /// template — see module docstring.
+    pub path: String,
+    pub sent: usize,
+    pub status_2xx: usize,
+    pub status_3xx: usize,
+    pub status_4xx: usize,
+    pub status_5xx: usize,
+    /// Network errors (`response_status == 0`).
+    pub errors: usize,
+    /// Length stats on the captured REQUEST body (bytes). `None` when
+    /// no request body was sent on any probe for this endpoint.
+    pub request_body_len: Option<LenStats>,
+    /// Length stats on the captured RESPONSE body (bytes). `None`
+    /// when no captured response body had content.
+    pub response_body_len: Option<LenStats>,
+    /// Length stats on the resolved query string (raw bytes after
+    /// `?`). `None` when no probe carried a query string for this
+    /// endpoint.
+    pub query_len: Option<LenStats>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LenStats {
+    pub samples: usize,
+    pub avg: f64,
+    pub p50: u64,
+    pub p95: u64,
+    pub max: u64,
+}
+
+impl LenStats {
+    fn from_samples(mut samples: Vec<u64>) -> Option<Self> {
+        if samples.is_empty() {
+            return None;
+        }
+        samples.sort_unstable();
+        let n = samples.len();
+        let sum: u64 = samples.iter().sum();
+        let avg = sum as f64 / n as f64;
+        let pick = |q: f64| -> u64 {
+            // Nearest-rank percentile, 1-indexed. Matches k6's
+            // `http_req_duration{tag:p95}` calculation closely enough
+            // for spot checks.
+            let idx = (q * n as f64).ceil() as usize;
+            let idx = idx.clamp(1, n) - 1;
+            samples[idx]
+        };
+        Some(LenStats {
+            samples: n,
+            avg,
+            p50: pick(0.50),
+            p95: pick(0.95),
+            max: *samples.last().unwrap(),
+        })
+    }
+}
+
+/// Build the per-endpoint summary. Pass the captured slice as
+/// produced by the conformance self-test sink.
+pub fn build_summary(captures: &[CaseCapture]) -> Vec<PerEndpointSummary> {
+    let mut by_key: BTreeMap<(String, String), EndpointAccumulator> = BTreeMap::new();
+
+    for c in captures {
+        let (path, query) = split_url(&c.url);
+        let key = (c.method.to_ascii_uppercase(), path);
+        let entry = by_key.entry(key).or_default();
+        entry.sent += 1;
+        match c.response_status {
+            0 => entry.errors += 1,
+            s if (200..300).contains(&s) => entry.status_2xx += 1,
+            s if (300..400).contains(&s) => entry.status_3xx += 1,
+            s if (400..500).contains(&s) => entry.status_4xx += 1,
+            s if (500..600).contains(&s) => entry.status_5xx += 1,
+            _ => {}
+        }
+        if let Some(body) = &c.request_body {
+            entry.request_lens.push(body.len() as u64);
+        }
+        if let Some(body) = &c.response_body {
+            entry.response_lens.push(body.len() as u64);
+        }
+        if let Some(q) = query {
+            if !q.is_empty() {
+                entry.query_lens.push(q.len() as u64);
+            }
+        }
+    }
+
+    let mut out: Vec<PerEndpointSummary> = by_key
+        .into_iter()
+        .map(|((method, path), acc)| PerEndpointSummary {
+            method,
+            path,
+            sent: acc.sent,
+            status_2xx: acc.status_2xx,
+            status_3xx: acc.status_3xx,
+            status_4xx: acc.status_4xx,
+            status_5xx: acc.status_5xx,
+            errors: acc.errors,
+            request_body_len: LenStats::from_samples(acc.request_lens),
+            response_body_len: LenStats::from_samples(acc.response_lens),
+            query_len: LenStats::from_samples(acc.query_lens),
+        })
+        .collect();
+    // Sort by sent count desc, then by (method, path) for stable order.
+    out.sort_by(|a, b| b.sent.cmp(&a.sent).then(a.method.cmp(&b.method)).then(a.path.cmp(&b.path)));
+    out
+}
+
+#[derive(Default)]
+struct EndpointAccumulator {
+    sent: usize,
+    status_2xx: usize,
+    status_3xx: usize,
+    status_4xx: usize,
+    status_5xx: usize,
+    errors: usize,
+    request_lens: Vec<u64>,
+    response_lens: Vec<u64>,
+    query_lens: Vec<u64>,
+}
+
+/// Return `(path, query)` from a fully-qualified URL. Falls back to
+/// returning the input unchanged as the path when parsing fails (so
+/// the summary still groups, just without query metrics).
+fn split_url(url: &str) -> (String, Option<String>) {
+    // Strip scheme + host. URLs the bench produces always start with
+    // a scheme; defensive against the rare relative-URL case.
+    let after_host = if let Some(idx) = url.find("://") {
+        let rest = &url[idx + 3..];
+        match rest.find('/') {
+            Some(i) => &rest[i..],
+            None => "/",
+        }
+    } else {
+        url
+    };
+    match after_host.find('?') {
+        Some(i) => (after_host[..i].to_string(), Some(after_host[i + 1..].to_string())),
+        None => (after_host.to_string(), None),
+    }
+}
+
+/// Render the per-endpoint summary as a self-contained HTML
+/// `<section>` block suitable for splicing into
+/// `conformance-report.html`. Uses the same `<table>` styling the
+/// rest of the report already has.
+pub fn render_html_section(summaries: &[PerEndpointSummary]) -> String {
+    if summaries.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("<h2 id=\"per-endpoint\">Per-endpoint traffic summary</h2>\n");
+    out.push_str(
+        "<p class=\"small\">Aggregated from the JSONL capture sink. Lengths are byte counts on the captured (truncated) bodies.</p>\n",
+    );
+    out.push_str(
+        "<table>\n<thead><tr>\
+        <th>Method</th><th>Path</th>\
+        <th>Sent</th><th>2xx</th><th>3xx</th><th>4xx</th><th>5xx</th><th>Err</th>\
+        <th>Req p95 (B)</th><th>Resp p95 (B)</th><th>Query p95 (B)</th>\
+        </tr></thead>\n<tbody>\n",
+    );
+    for s in summaries {
+        let req = s
+            .request_body_len
+            .as_ref()
+            .map(|l| l.p95.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let resp = s
+            .response_body_len
+            .as_ref()
+            .map(|l| l.p95.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let query = s
+            .query_len
+            .as_ref()
+            .map(|l| l.p95.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        out.push_str(&format!(
+            "<tr><td><code>{}</code></td><td><code>{}</code></td>\
+             <td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td>\
+             <td>{}</td><td>{}</td><td>{}</td></tr>\n",
+            html_escape(&s.method),
+            html_escape(&s.path),
+            s.sent,
+            s.status_2xx,
+            s.status_3xx,
+            s.status_4xx,
+            s.status_5xx,
+            s.errors,
+            req,
+            resp,
+            query,
+        ));
+    }
+    out.push_str("</tbody></table>\n");
+    out
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cap(
+        method: &str,
+        url: &str,
+        status: u16,
+        req: Option<&str>,
+        resp: Option<&str>,
+    ) -> CaseCapture {
+        CaseCapture {
+            label: "x".to_string(),
+            method: method.to_string(),
+            url: url.to_string(),
+            request_headers: BTreeMap::new(),
+            request_body: req.map(|s| s.to_string()),
+            request_body_truncated: false,
+            response_status: status,
+            response_headers: BTreeMap::new(),
+            response_body: resp.map(|s| s.to_string()),
+            response_body_truncated: false,
+            error: None,
+            response_schema_error: None,
+            expected_status_range: "2xx-3xx".to_string(),
+        }
+    }
+
+    #[test]
+    fn groups_by_method_and_resolved_path() {
+        let caps = vec![
+            cap("GET", "https://host/api/foo", 200, None, Some("hello")),
+            cap("GET", "https://host/api/foo", 404, None, Some("not found")),
+            cap("POST", "https://host/api/bar", 201, Some(r#"{"x":1}"#), Some(r#"{"id":7}"#)),
+        ];
+        let s = build_summary(&caps);
+        assert_eq!(s.len(), 2, "two distinct (method, path) groups");
+        let foo = s.iter().find(|x| x.path == "/api/foo").unwrap();
+        assert_eq!(foo.sent, 2);
+        assert_eq!(foo.status_2xx, 1);
+        assert_eq!(foo.status_4xx, 1);
+        assert!(foo.request_body_len.is_none(), "no request bodies on GET probes");
+        assert!(foo.response_body_len.is_some());
+        let bar = s.iter().find(|x| x.path == "/api/bar").unwrap();
+        assert!(bar.request_body_len.is_some());
+        assert_eq!(bar.request_body_len.as_ref().unwrap().samples, 1);
+    }
+
+    #[test]
+    fn strips_query_string_into_separate_metric() {
+        let caps = vec![
+            cap("GET", "https://host/api/x?a=1&b=2", 200, None, Some("ok")),
+            cap("GET", "https://host/api/x?c=3", 200, None, Some("ok")),
+        ];
+        let s = build_summary(&caps);
+        assert_eq!(s.len(), 1, "query string strip must collapse into one group");
+        let row = &s[0];
+        assert_eq!(row.path, "/api/x");
+        assert_eq!(row.sent, 2);
+        let qlen = row.query_len.as_ref().expect("query stats present");
+        assert_eq!(qlen.samples, 2);
+        assert_eq!(qlen.max, 7); // "a=1&b=2" is 7 bytes
+    }
+
+    #[test]
+    fn p95_is_nearest_rank() {
+        let stats = LenStats::from_samples(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).unwrap();
+        assert_eq!(stats.p50, 5);
+        assert_eq!(stats.p95, 10);
+        assert_eq!(stats.max, 10);
+    }
+
+    #[test]
+    fn empty_input_renders_to_empty_html() {
+        assert_eq!(render_html_section(&[]), "");
+    }
+}

--- a/crates/mockforge-grpc/Cargo.toml
+++ b/crates/mockforge-grpc/Cargo.toml
@@ -53,6 +53,13 @@ thiserror = "2.0"
 
 [build-dependencies]
 tonic-prost-build = "0.14"
+# Round 32 (#79 / Srikanth on 0.3.176): `cargo install mockforge-cli`
+# on Ubuntu 16.04 failed with "Could not find `protoc`" because the
+# system didn't have the `protobuf-compiler` package. Bundling a known-
+# good protoc binary lets the build succeed without any apt install.
+# The build.rs prefers system `PROTOC` when set, then falls back to the
+# vendored one.
+protoc-bin-vendored = "3"
 
 [features]
 default = ["data-faker"]

--- a/crates/mockforge-grpc/build.rs
+++ b/crates/mockforge-grpc/build.rs
@@ -11,6 +11,34 @@ fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let out_dir = env::var("OUT_DIR").unwrap();
 
+    // Round 32 (#79 / Srikanth on 0.3.176): Ubuntu 16.04 boxes don't
+    // ship `protobuf-compiler`, so `cargo install mockforge-cli`
+    // failed with "Could not find `protoc`". Use the vendored binary
+    // from `protoc-bin-vendored` when the user hasn't already set
+    // `PROTOC` themselves. The crate ships per-target binaries inside
+    // its source tarball, so cargo install picks it up automatically.
+    let user_protoc = env::var("PROTOC").ok().filter(|s| !s.is_empty());
+    if user_protoc.is_none() {
+        match protoc_bin_vendored::protoc_bin_path() {
+            Ok(p) => {
+                // SAFETY: build scripts run single-threaded, so this
+                // env mutation is sound. tonic-prost-build reads
+                // PROTOC at configure() time later in this main(),
+                // so it must be set before then.
+                unsafe {
+                    env::set_var("PROTOC", &p);
+                }
+                println!("cargo:rerun-if-env-changed=PROTOC");
+                println!("cargo:info=using vendored protoc at {}", p.display());
+            }
+            Err(e) => {
+                println!(
+                    "cargo:warning=protoc-bin-vendored returned no binary ({e}); falling back to system PATH"
+                );
+            }
+        }
+    }
+
     // Get proto directory from environment variable or use default
     let proto_dir =
         env::var("MOCKFORGE_PROTO_DIR").unwrap_or_else(|_| format!("{}/proto", manifest_dir));

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -1807,20 +1807,28 @@ impl OpenApiRouteRegistry {
 
             // Create async handler that processes requests through MockAI
             // Query params are extracted via Query extractor with HashMap
-            // Note: Using Query<HashMap<String, String>> wrapped in Option to handle missing query params
+            // Round 32 — Srikanth on 0.3.176: bench's content-type-swap
+            // probes return 415 client-side but the server-side
+            // conformance buffer only ever shows 400s. Root cause: this
+            // handler used to take `body: Option<Json<Value>>`, and
+            // axum's `Json` extractor 415s a request whose
+            // `Content-Type` isn't `application/json` BEFORE the
+            // handler runs — so the buffer never had a chance to
+            // record the violation, and client/server logs got out of
+            // sync on the same URI. Extract raw bytes instead; we now
+            // do the content-type check ourselves (recording to the
+            // buffer with category `content-types` and the configured
+            // validation status, default 415) and parse the body as
+            // JSON manually for the validator + MockAI paths below.
             let handler = move |AxumPath(path_params): AxumPath<HashMap<String, String>>,
                                 query: axum::extract::Query<HashMap<String, String>>,
                                 headers: HeaderMap,
-                                body: Option<Json<Value>>| {
+                                body_bytes: axum::body::Bytes| {
                 let route = route_clone.clone();
                 let mockai = mockai_clone.clone();
                 let validator = validator_clone.clone();
 
                 async move {
-                    // (a-pre) Run request validation against the spec
-                    // before any response synthesis. On failure this
-                    // also records to the foundation conformance ring
-                    // buffer surfaced by the TUI Conformance tab.
                     let mut path_map = Map::new();
                     for (k, v) in &path_params {
                         path_map.insert(k.clone(), Value::String(v.clone()));
@@ -1835,6 +1843,67 @@ impl OpenApiRouteRegistry {
                             header_map.insert(k.to_string(), Value::String(s.to_string()));
                         }
                     }
+
+                    // (a-pre1) Round 32 — content-type mismatch check
+                    // BEFORE body parsing. Mirrors the existing check
+                    // in `build_router_with_context`; both must record
+                    // because at any given moment exactly one of the
+                    // two router builders is wired up.
+                    if !body_bytes.is_empty() {
+                        let actual_ct = headers
+                            .get(axum::http::header::CONTENT_TYPE)
+                            .and_then(|v| v.to_str().ok());
+                        if let Err(ct_err) = validator.check_request_content_type(
+                            &route.path,
+                            &route.method,
+                            actual_ct,
+                        ) {
+                            let status_code =
+                                validator.options.validation_status.unwrap_or_else(|| {
+                                    std::env::var("MOCKFORGE_VALIDATION_STATUS")
+                                        .ok()
+                                        .and_then(|s| s.parse::<u16>().ok())
+                                        .unwrap_or(415)
+                                });
+                            mockforge_foundation::conformance_violations::record(
+                                mockforge_foundation::conformance_violations::ServerConformanceViolation {
+                                    timestamp: Utc::now(),
+                                    method: route.method.clone(),
+                                    path: route.path.clone(),
+                                    client_ip: "unknown".to_string(),
+                                    status: status_code,
+                                    reason: ct_err.clone(),
+                                    category: "content-types".to_string(),
+                                    occurrences: 1,
+                                },
+                            );
+                            let status = axum::http::StatusCode::from_u16(status_code)
+                                .unwrap_or(axum::http::StatusCode::UNSUPPORTED_MEDIA_TYPE);
+                            return (
+                                status,
+                                Json(serde_json::json!({
+                                    "error": "content_type_not_allowed",
+                                    "message": ct_err,
+                                })),
+                            );
+                        }
+                    }
+
+                    // (a-pre2) Parse body as JSON when present so the
+                    // validator, fingerprint, and MockAI paths can all
+                    // see it. We deliberately don't fail on JSON parse
+                    // errors here — the body validator below produces
+                    // the right shape of error message in that case.
+                    let body: Option<Json<Value>> = if body_bytes.is_empty() {
+                        None
+                    } else {
+                        serde_json::from_slice::<Value>(&body_bytes).ok().map(Json)
+                    };
+
+                    // (a-pre3) Run request validation against the spec
+                    // before any response synthesis. On failure this
+                    // also records to the foundation conformance ring
+                    // buffer surfaced by the TUI Conformance tab.
                     let body_val: Option<&Value> = body.as_ref().map(|Json(b)| b);
                     if let Err((status_code, payload)) = validator.run_validation_with_recording(
                         &route.path,


### PR DESCRIPTION
## Summary

Round 32 of issue #79 (Srikanth's rolling conformance feedback on v0.3.176). Three actionable items, one deferred:

- **Q3 (real bug).** MockAI request handler took `body: Option<Json<Value>>`, axum's Json extractor 415s non-JSON Content-Types before the handler runs, so the conformance buffer never recorded the violation. Now takes raw bytes + runs the existing content-type precheck + parses JSON manually. Real-binary verified.
- **Q7-VM1.** `mockforge-grpc/build.rs` uses `protoc-bin-vendored` when `PROTOC` is unset, so `cargo install mockforge-cli` works on Ubuntu 16.04 without `apt install protobuf-compiler`.
- **Q6 (feature).** New per-endpoint summary derived from the conformance self-test capture sink. Per `(method, resolved-URL-path)`: sent count, 2xx/3xx/4xx/5xx/errors, request/response/query length p95 etc. JSON sidecar at `conformance-per-endpoint.json`, HTML section spliced into `conformance-report.html`. v1 groups by resolved path (template grouping deferred to round 33).
- **Q1 deferred.** Intentional response-violation injection mode (`MOCKFORGE_INJECT_RESPONSE_VIOLATIONS=true`) is round-33 work.

## Test plan
- [x] `cargo test -p mockforge-bench --lib per_endpoint_summary` — 4 pass (bucketing, query strip, p95, empty-input HTML)
- [x] `cargo test -p mockforge-openapi --lib check_request_content_type` — 1 pass
- [x] `cargo clippy -p mockforge-bench -p mockforge-openapi -p mockforge-grpc --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Real-binary verify of Q3 against vCenter spec: `POST` with `Content-Type: application/xml` → client sees 415, server-side `/__mockforge/api/conformance/violations` has `status=415, category=content-types, occurrences=1, reason="Content-Type 'application/xml' not allowed; spec declares: [application/json]"`
- [x] `PROTOC= cargo build -p mockforge-grpc` succeeds with vendored protoc (Q7-VM1)
- [ ] CI Security Audit + Registry E2E green

Closes part of #79.