### PR TITLE
fix(bench): #79 round 34 — strip schema noise, prefix base_path, skip embedded-content (#827, #828, #829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.3.179] - 2026-06-15
+
+### Fixed
+
+- **[DevX]** `response_schema_error` strips `description` / `example` / `examples` / `summary` / `title` / `externalDocs` / `xml` from the focused schema before serializing, so the actually-useful constraint keywords (`type`, `required`, `properties`, `format`, `min*`/`max*`, `pattern`, `oneOf`/`anyOf`/`allOf`/`not`) survive the 300-char truncation cap (#79 round 34 / #827 / Srikanth on 0.3.178: vCenter's `enabled: boolean` property had a multi-paragraph description that ate the budget before `"type":"boolean"` could appear). Two new unit tests assert (1) the vCenter-shaped case keeps `"type":"boolean"` in the printed schema and (2) `strip_schema_noise` keeps every constraint keyword while dropping every prose key.
+- **[Contracts]** Per-endpoint summary `path` column now matches the URL the user actually sent (#79 round 34 / #828 / Srikanth on 0.3.178: searched for `/api/appliance/access/consolecli` in `conformance-per-endpoint.json` and didn't find it because round 33 stored just the spec template `/appliance/access/consolecli`). The bench now constructs `path_template` as `base_path + op.path` and stamps that on every `CaseCapture`, matching the same prefix logic `build_url_with_base` already uses. New unit test asserts the prefixed value flows through to `PerEndpointSummary.path`.
+- **[Contracts]** Embedded-content variant-b probes are skipped when the positive sample body has no string field (#79 round 34 / #829 / Srikanth on 0.3.178: PUT `/api/appliance/access/consolecli` expects `{enabled: boolean}` but the round-27 fallback envelope `{"data": <snippet>}` was structurally different, so the server correctly 400'd and the bench misreported the `2xx-3xx` expectation as a miss). `embed_payload_in_first_string_field` now returns `Option<String>`; the variant-b loop `continue`s when the helper returns `None`. Three test cases cover Srikanth's exact `{"enabled":true}` shape, the no-string scalar-only case, and invalid-JSON samples.
+
 ## [0.3.178] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7787,7 +7787,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7824,7 +7824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7865,7 +7865,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7880,7 +7880,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7919,7 +7919,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8000,7 +8000,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8045,7 +8045,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8055,7 +8055,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8080,7 +8080,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8502,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -8943,7 +8943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9092,7 +9092,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9112,7 +9112,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9125,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9147,7 +9147,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9184,7 +9184,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9212,7 +9212,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9242,7 +9242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9269,7 +9269,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9292,14 +9292,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9326,7 +9326,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9337,7 +9337,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9359,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.0",
@@ -9377,7 +9377,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9401,7 +9401,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9432,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9484,7 +9484,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9519,7 +9519,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9530,7 +9530,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9547,7 +9547,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15455,7 +15455,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.178"
+version = "0.3.179"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.178"
+version = "0.3.179"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,13 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.179] - 2026-06-15
+
+### Fixed
+
+- **[DevX]** `response_schema_error` strips description/example fields from the focused schema before truncation so `type` survives (#79 round 34 / #827 / Srikanth).
+- **[Contracts]** Per-endpoint summary `path` column matches the URL user sent: `base_path` prefixed (#79 round 34 / #828 / Srikanth).
+- **[Contracts]** Embedded-content variant-b probes skip when positive sample has no string field, instead of synthesizing a non-conforming envelope (#79 round 34 / #829 / Srikanth).
+
 ## [0.3.178] - 2026-06-14
 
 ### Added

--- a/crates/mockforge-bench/src/conformance/per_endpoint_summary.rs
+++ b/crates/mockforge-bench/src/conformance/per_endpoint_summary.rs
@@ -467,4 +467,44 @@ mod tests {
         assert_eq!(s[0].path, "/api/foo");
         assert_eq!(s[0].sent, 2);
     }
+
+    /// Round 34 (#828) — Srikanth on 0.3.178 searched for
+    /// `/api/appliance/access/consolecli` in the per-endpoint JSON
+    /// and didn't find it; r33 stored just the spec path
+    /// `/appliance/access/consolecli` because the bench bench
+    /// threaded `&op.path` (no base_path prefix). r34 prefixes
+    /// `--base-path` so the stored `path_template` matches the URL
+    /// the user actually sent. Captures stamped with the prefixed
+    /// template here simulate the new behavior and the summary
+    /// surfaces the user-facing URL path.
+    #[test]
+    fn base_path_prefixed_template_appears_in_path_column() {
+        let caps = vec![
+            cap_with_template(
+                "PUT",
+                "https://host/api/appliance/access/consolecli",
+                204,
+                Some(r#"{"enabled":true}"#),
+                None,
+                "/api/appliance/access/consolecli",
+            ),
+            cap_with_template(
+                "PUT",
+                "https://host/api/appliance/access/consolecli",
+                400,
+                Some(r#"{"data":"x"}"#),
+                Some("bad"),
+                "/api/appliance/access/consolecli",
+            ),
+        ];
+        let s = build_summary(&caps);
+        assert_eq!(s.len(), 1, "both probes collapse into one row");
+        assert_eq!(
+            s[0].path, "/api/appliance/access/consolecli",
+            "stored path includes the --base-path prefix so it matches the URL the user sent"
+        );
+        assert_eq!(s[0].sent, 2);
+        assert_eq!(s[0].status_2xx, 1);
+        assert_eq!(s[0].status_4xx, 1);
+    }
 }

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -441,6 +441,34 @@ async fn test_operation(
     );
     let method = Method::from_bytes(op.method.to_uppercase().as_bytes()).unwrap_or(Method::GET);
 
+    // Round 34 (#828) — stamp every `CaseCapture` with the spec
+    // template PREFIXED by `--base-path`, so the per-endpoint
+    // summary's `path` column matches what the user sees in URLs
+    // and logs. Srikanth searched for `/api/appliance/access/...`
+    // and didn't find it because round 33 stored just `/appliance/
+    // access/...`. Same normalization as `build_url_with_base`:
+    // leading `/` auto-added, trailing `/` stripped, empty
+    // base_path → no prefix at all.
+    let path_template = {
+        let prefix = match config.base_path.as_deref() {
+            Some(bp) if !bp.is_empty() => {
+                let trimmed = bp.trim_end_matches('/');
+                if trimmed.starts_with('/') {
+                    trimmed.to_string()
+                } else {
+                    format!("/{}", trimmed)
+                }
+            }
+            _ => String::new(),
+        };
+        let path = if op.path.starts_with('/') {
+            op.path.clone()
+        } else {
+            format!("/{}", op.path)
+        };
+        format!("{prefix}{path}")
+    };
+
     // Round 18.5 — pre-compute the operation's effective headers
     // with the geo source IP baked in. Doing it once here keeps the
     // per-case `send_case` calls below unchanged. When `geo_ip` is
@@ -458,7 +486,7 @@ async fn test_operation(
         op.sample_body.as_deref(),
         op.query_params.clone(),
         op_headers.clone(),
-        &op.path,
+        &path_template,
     )
     .await;
 
@@ -485,7 +513,7 @@ async fn test_operation(
                 Some("{}"),
                 op.query_params.clone(),
                 op_headers.clone(),
-                &op.path,
+                &path_template,
             )
             .await,
         );
@@ -504,7 +532,7 @@ async fn test_operation(
                 Some("[]"),
                 op.query_params.clone(),
                 op_headers.clone(),
-                &op.path,
+                &path_template,
             )
             .await,
         );
@@ -562,7 +590,7 @@ async fn test_operation(
                         // override here wins because reqwest preserves
                         // the last-set header value.
                         vec![("Content-Type".to_string(), (*ct).to_string())],
-                        &op.path,
+                        &path_template,
                     )
                     .await,
                 );
@@ -581,7 +609,17 @@ async fn test_operation(
             // string-field behaviour.
             for (label, snippet) in EMBEDDED_CONTENT_VARIANTS {
                 let payload = op.sample_body.as_deref().unwrap_or("{}");
-                let body = embed_payload_in_first_string_field(payload, snippet);
+                // Round 34 (#829) — skip the probe entirely when the
+                // positive sample has no string leaf we can mutate.
+                // The previous round-27 fallback `{"data": <snippet>}`
+                // produced a body that doesn't match the spec's actual
+                // schema for endpoints like vCenter's `consolecli` PUT
+                // (which wants `{enabled: bool}`), so the server
+                // correctly 400'd and the bench misreported the
+                // mismatch as an expectation failure.
+                let Some(body) = embed_payload_in_first_string_field(payload, snippet) else {
+                    continue;
+                };
                 negatives.push(
                     send_case(
                         client,
@@ -596,7 +634,7 @@ async fn test_operation(
                         Some(&body),
                         op.query_params.clone(),
                         op_headers.clone(),
-                        &op.path,
+                        &path_template,
                     )
                     .await,
                 );
@@ -635,7 +673,7 @@ async fn test_operation(
                             // symmetric, otherwise a GEODB front-end sees
                             // the rotating IP only on positives).
                             op_headers.clone(),
-                            &op.path,
+                            &path_template,
                         )
                         .await,
                     );
@@ -669,7 +707,7 @@ async fn test_operation(
                 // `op_headers` (carries geo IP) instead of bare
                 // `op.header_params`.
                 op_headers.clone(),
-                &op.path,
+                &path_template,
             )
             .await,
         );
@@ -724,7 +762,7 @@ async fn test_operation(
                     op.sample_body.as_deref(),
                     op.query_params.clone(),
                     op_headers.clone(),
-                    &op.path,
+                    &path_template,
                 )
                 .await,
             );
@@ -746,7 +784,7 @@ async fn test_operation(
                 op.sample_body.as_deref(),
                 q,
                 op_headers.clone(),
-                &op.path,
+                &path_template,
             )
             .await,
         );
@@ -810,7 +848,7 @@ async fn test_operation(
                 req_query,
                 req_headers,
                 stripped_extra,
-                &op.path,
+                &path_template,
             )
             .await,
         );
@@ -838,7 +876,7 @@ async fn test_operation(
                 op.sample_body.as_deref(),
                 op.query_params.clone(),
                 h,
-                &op.path,
+                &path_template,
             )
             .await,
         );
@@ -879,7 +917,7 @@ async fn test_operation(
                 // tuned to a specific source IP would silently let
                 // them through.
                 op_headers.clone(),
-                &op.path,
+                &path_template,
             )
             .await,
         );
@@ -931,20 +969,19 @@ async fn test_operation(
 /// Round 27 (k variant b) — return a JSON body string identical to
 /// `sample` except that the first string-valued leaf has been
 /// replaced with `snippet`. Walks objects depth-first and stops at
-/// the first string. If `sample` is not parseable JSON, or has no
-/// string fields, falls back to wrapping the snippet under a `data`
-/// key so the probe still has a body to send: `{"data": <snippet>}`.
-/// The result is always valid JSON ready for `application/json`.
-fn embed_payload_in_first_string_field(sample: &str, snippet: &str) -> String {
-    let mut parsed: serde_json::Value = match serde_json::from_str(sample) {
-        Ok(v) => v,
-        Err(_) => return format!(r#"{{"data":{}}}"#, json_quote(snippet)),
-    };
+/// the first string. Returns `None` when `sample` is not parseable
+/// JSON or has no string field anywhere; the caller skips emitting
+/// a probe in that case (Round 34 #829: Srikanth on 0.3.178 found
+/// that the previous `{"data": <snippet>}` fallback envelope didn't
+/// match real-API schemas like vCenter's `{enabled: bool}` and the
+/// server correctly 400'd, which the bench then misreported as a
+/// `2xx-3xx` expectation miss).
+fn embed_payload_in_first_string_field(sample: &str, snippet: &str) -> Option<String> {
+    let mut parsed: serde_json::Value = serde_json::from_str(sample).ok()?;
     if !replace_first_string(&mut parsed, snippet) {
-        return format!(r#"{{"data":{}}}"#, json_quote(snippet));
+        return None;
     }
-    serde_json::to_string(&parsed)
-        .unwrap_or_else(|_| format!(r#"{{"data":{}}}"#, json_quote(snippet)))
+    serde_json::to_string(&parsed).ok()
 }
 
 /// Helper for `embed_payload_in_first_string_field`: recursively
@@ -977,14 +1014,6 @@ fn replace_first_string(v: &mut serde_json::Value, snippet: &str) -> bool {
         }
         _ => false,
     }
-}
-
-/// Helper for `embed_payload_in_first_string_field`'s fallback: take
-/// an arbitrary string and quote it for embedding inside a JSON
-/// literal. `serde_json::to_string(&value)` handles escaping
-/// correctly for unicode + control chars + quotes.
-fn json_quote(s: &str) -> String {
-    serde_json::to_string(s).unwrap_or_else(|_| "\"\"".to_string())
 }
 
 fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Option<String> {
@@ -1085,6 +1114,14 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
             focused_schema = prop_schema.clone();
         }
     }
+    // Round 34 (#827) — Srikanth on 0.3.178 hit the vCenter
+    // `enabled: boolean` case where the schema's multi-paragraph
+    // `description` (and other prose fields) ate the 300-char budget
+    // before the actually-useful `type` keyword could appear. Strip
+    // the noise-fields recursively before serializing so the type
+    // signal survives truncation; constraint keywords (`type`,
+    // `properties`, `required`, `format`, `items`, etc.) stay.
+    let focused_schema = strip_schema_noise(&focused_schema);
     let schema_str = serde_json::to_string(&focused_schema).unwrap_or_else(|_| "<schema>".into());
     let schema_str = if schema_str.len() > 300 {
         format!("{}...", &schema_str[..300])
@@ -1101,6 +1138,45 @@ fn validate_body_against_schema(body: &str, schema: &serde_json::Value) -> Optio
         format!("response body at {path}")
     };
     Some(format!("{location}: {kind_msg}; expected schema {schema_str}"))
+}
+
+/// Round 34 (#827) — drop the human-readable / documentation-only
+/// fields from a JSON Schema before printing it inside a
+/// `response_schema_error` message. The validator only cares about
+/// constraint keywords (`type`, `required`, `properties`, `items`,
+/// `format`, `enum`, `min*`/`max*`, `pattern`, `oneOf`/`anyOf`/
+/// `allOf`/`not`); the prose fields can be paragraphs long for real-
+/// world specs (vCenter's `enabled: bool` field has a multi-paragraph
+/// description) and were eating the 300-char truncation budget before
+/// the actually-useful type info could appear. Stripped fields:
+/// `description`, `example`, `examples`, `summary`, `title`,
+/// `externalDocs`, `xml`, `discriminator.description`.
+fn strip_schema_noise(schema: &serde_json::Value) -> serde_json::Value {
+    const NOISE_KEYS: &[&str] = &[
+        "description",
+        "example",
+        "examples",
+        "summary",
+        "title",
+        "externalDocs",
+        "xml",
+    ];
+    match schema {
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                if NOISE_KEYS.contains(&k.as_str()) {
+                    continue;
+                }
+                out.insert(k.clone(), strip_schema_noise(v));
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(strip_schema_noise).collect())
+        }
+        other => other.clone(),
+    }
 }
 
 /// Round 30 — walk a JSON-Pointer-style instance path through a JSON
@@ -2226,7 +2302,8 @@ mod tests {
     #[test]
     fn embed_payload_replaces_first_string_only() {
         let sample = r#"{"name":"alice","age":30,"tags":["admin","user"]}"#;
-        let mutated = embed_payload_in_first_string_field(sample, "<x/>");
+        let mutated = embed_payload_in_first_string_field(sample, "<x/>")
+            .expect("string field present so probe constructed");
         let v: serde_json::Value = serde_json::from_str(&mutated).unwrap();
         assert_eq!(v["name"], serde_json::json!("<x/>"));
         // age stays an integer (not stringified by the mutation).
@@ -2237,24 +2314,25 @@ mod tests {
         assert_eq!(v["tags"][1], serde_json::json!("user"));
     }
 
-    /// When the sample has NO string field, the helper falls back to
-    /// `{"data": "<snippet>"}` so the probe still has something to
-    /// POST. The fallback must produce valid JSON regardless of what
-    /// characters the snippet contains.
+    /// Round 34 (#829) — Srikanth on 0.3.178: when the positive
+    /// sample has NO string field, the previous `{"data": <snippet>}`
+    /// fallback produced an envelope that doesn't match real-API
+    /// schemas (e.g. vCenter's `consolecli` PUT wants
+    /// `{enabled: bool}`), so the server correctly 400'd and the
+    /// bench misreported the 2xx-3xx expectation. Now we return None
+    /// and the caller skips the probe.
     #[test]
-    fn embed_payload_falls_back_when_no_string_field() {
+    fn embed_payload_returns_none_when_no_string_field() {
         let no_strings = r#"{"a":1,"b":[2,3]}"#;
-        let mutated = embed_payload_in_first_string_field(no_strings, "<x><y></y></x>");
-        let v: serde_json::Value = serde_json::from_str(&mutated).unwrap();
-        assert_eq!(v["data"], serde_json::json!("<x><y></y></x>"));
+        assert!(embed_payload_in_first_string_field(no_strings, "<x><y></y></x>").is_none());
+        // The exact vCenter-style case Srikanth hit.
+        let bool_only = r#"{"enabled":true}"#;
+        assert!(embed_payload_in_first_string_field(bool_only, "<x/>").is_none());
     }
 
     #[test]
-    fn embed_payload_handles_invalid_json_sample() {
-        let not_json = "garbage";
-        let mutated = embed_payload_in_first_string_field(not_json, "a=1&b=2");
-        let v: serde_json::Value = serde_json::from_str(&mutated).unwrap();
-        assert_eq!(v["data"], serde_json::json!("a=1&b=2"));
+    fn embed_payload_returns_none_for_invalid_json_sample() {
+        assert!(embed_payload_in_first_string_field("garbage", "a=1&b=2").is_none());
     }
 
     /// Round 26 — Srikanth saw `at /: Type { kind: Single` in his
@@ -2427,6 +2505,84 @@ mod tests {
     fn response_schema_error_none_on_match() {
         let schema = serde_json::json!({"type": "string"});
         assert_eq!(validate_body_against_schema("\"hello\"", &schema), None);
+    }
+
+    /// Round 34 (#827) — Srikanth on 0.3.178 hit the vCenter
+    /// `consolecli` PUT where the `enabled: boolean` property has a
+    /// multi-paragraph description. The schema printout truncated
+    /// mid-description, hiding `type: boolean` past the 300-char cap.
+    /// Stripping `description` (and friends) before serializing must
+    /// keep the type info visible.
+    #[test]
+    fn response_schema_error_strips_description_so_type_survives_truncation() {
+        // Schema crafted so without stripping, `description` would
+        // push `type` past the 300-char truncation cap. The
+        // description we use here is intentionally close to the
+        // vCenter-spec wording Srikanth quoted.
+        let big_desc = "In the result of the #get and #list operations this property indicates whether proxying is enabled for a particular protocol. In the input to the test and set operations this property specifies whether proxying should be enabled for a particular protocol. This property was added in vSphere API 6.7. Defaults to enabled if both this field and the value field are unset.";
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["enabled"],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": big_desc,
+                    "example": true,
+                }
+            }
+        });
+        let body = r#"{}"#;
+        let err = validate_body_against_schema(body, &schema).expect("required-missing fires");
+        assert!(err.contains("required field missing: \"enabled\""), "{err}");
+        assert!(
+            err.contains(r#""type":"boolean""#),
+            "the `type: boolean` keyword must survive truncation: {err}"
+        );
+        // Description should NOT appear (we stripped it) so the
+        // suffix is type-focused, not prose.
+        assert!(
+            !err.contains("proxying is enabled"),
+            "description should be stripped from the printed schema: {err}"
+        );
+        assert!(
+            !err.contains("\"example\""),
+            "`example` field should be stripped from the printed schema: {err}"
+        );
+    }
+
+    /// Round 34 (#827) — strip_schema_noise should keep all
+    /// constraint keywords intact; only the prose noise goes.
+    #[test]
+    fn strip_schema_noise_preserves_constraint_keywords() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["a", "b"],
+            "description": "should be stripped",
+            "title": "should be stripped",
+            "example": {"a": 1, "b": 2},
+            "properties": {
+                "a": {"type": "string", "format": "uri", "minLength": 1, "description": "drop"},
+                "b": {"type": "integer", "minimum": 0, "maximum": 100, "summary": "drop"},
+            },
+        });
+        let stripped = strip_schema_noise(&schema);
+        let s = serde_json::to_string(&stripped).unwrap();
+        // Constraint keywords survive.
+        for keep in [
+            "\"type\"",
+            "\"required\"",
+            "\"properties\"",
+            "\"format\"",
+            "\"minLength\"",
+            "\"minimum\"",
+            "\"maximum\"",
+        ] {
+            assert!(s.contains(keep), "should keep {keep}: {s}");
+        }
+        // Noise fields are gone.
+        for drop in ["description", "title", "example", "summary"] {
+            assert!(!s.contains(&format!("\"{drop}\"")), "should strip {drop}: {s}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three bench-reporting bugs Srikanth surfaced retesting v0.3.178. All visible in his attached `bench-results.tar.gz`. Each tracked as its own issue and fixed in this PR.

- **#827.** `response_schema_error` printed schema was truncated mid-`description`, hiding the actually-useful `type:boolean` keyword. `strip_schema_noise` recursively drops `description`/`example`/`examples`/`summary`/`title`/`externalDocs`/`xml` before serializing, so the 300-char budget covers `type`, `required`, `properties`, `format`, etc.
- **#828.** Per-endpoint summary `path` column matches the URL the user actually sent. Bench builds `path_template = base_path + op.path` (same prefix logic `build_url_with_base` already uses) and threads it through all 12 `send_case` / `send_case_with_extra` callers.
- **#829.** Variant-b embedded-content probes used to fall back to `{"data": "<snippet>"}` when the positive sample had no string field, which doesn't match real-API schemas (vCenter's `{enabled: boolean}` consolecli case). Now `embed_payload_in_first_string_field` returns `Option<String>` and the loop `continue`s on `None`.

## Test plan
- [x] `cargo test -p mockforge-bench --lib` — 472 pass (was 469 on r33, gained 3: schema-noise strip, base-path prefix, embedded-content skip)
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Real-binary verify on locally-built r34 binary against vCenter spec:
  - #828: per-endpoint JSON shows `PUT /api/appliance/access/consolecli sent=13` and `GET /api/appliance/access/consolecli sent=4` (matches the URL with `/api/` prefix)
  - #829: 17 total consolecli probes, **0 embedded-content rows** (was 4 on v0.3.178)
- [ ] CI Security Audit + Registry E2E green

Closes #827, #828, #829.