### PR TITLE
security(sso): SSRF-guarded OIDC issuer config + admin domain-verification status (#833, #746)

### DIFF
--- a/crates/mockforge-registry-core/src/models/sso.rs
+++ b/crates/mockforge-registry-core/src/models/sso.rs
@@ -53,6 +53,9 @@ pub struct SSOConfiguration {
     // OIDC fields (for future use)
     pub oidc_issuer_url: Option<String>,
     pub oidc_client_id: Option<String>,
+    // Write-only: a stored OIDC client secret is a credential and must never be
+    // serialized back into an API response. (FromRow still reads it from the DB.)
+    #[serde(skip_serializing)]
     pub oidc_client_secret: Option<String>,
 
     // Attribute mapping
@@ -109,6 +112,9 @@ impl SSOConfiguration {
         require_signed_assertions: bool,
         require_signed_responses: bool,
         allow_unsolicited_responses: bool,
+        oidc_issuer_url: Option<&str>,
+        oidc_client_id: Option<&str>,
+        oidc_client_secret: Option<&str>,
     ) -> sqlx::Result<Self> {
         let attribute_mapping = attribute_mapping.unwrap_or_else(|| serde_json::json!({}));
 
@@ -117,9 +123,10 @@ impl SSOConfiguration {
             INSERT INTO sso_configurations (
                 org_id, provider, saml_entity_id, saml_sso_url, saml_slo_url,
                 saml_x509_cert, saml_name_id_format, attribute_mapping,
-                require_signed_assertions, require_signed_responses, allow_unsolicited_responses
+                require_signed_assertions, require_signed_responses, allow_unsolicited_responses,
+                oidc_issuer_url, oidc_client_id, oidc_client_secret
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
             ON CONFLICT (org_id) DO UPDATE SET
                 provider = EXCLUDED.provider,
                 saml_entity_id = EXCLUDED.saml_entity_id,
@@ -131,6 +138,9 @@ impl SSOConfiguration {
                 require_signed_assertions = EXCLUDED.require_signed_assertions,
                 require_signed_responses = EXCLUDED.require_signed_responses,
                 allow_unsolicited_responses = EXCLUDED.allow_unsolicited_responses,
+                oidc_issuer_url = EXCLUDED.oidc_issuer_url,
+                oidc_client_id = EXCLUDED.oidc_client_id,
+                oidc_client_secret = EXCLUDED.oidc_client_secret,
                 updated_at = NOW()
             RETURNING *
             "#,
@@ -146,6 +156,9 @@ impl SSOConfiguration {
         .bind(require_signed_assertions)
         .bind(require_signed_responses)
         .bind(allow_unsolicited_responses)
+        .bind(oidc_issuer_url)
+        .bind(oidc_client_id)
+        .bind(oidc_client_secret)
         .fetch_one(pool)
         .await
     }

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1398,6 +1398,9 @@ pub trait RegistryStore: Send + Sync + 'static {
         require_signed_assertions: bool,
         require_signed_responses: bool,
         allow_unsolicited_responses: bool,
+        oidc_issuer_url: Option<&str>,
+        oidc_client_id: Option<&str>,
+        oidc_client_secret: Option<&str>,
     ) -> StoreResult<SSOConfiguration>;
 
     async fn enable_sso_config(&self, org_id: Uuid) -> StoreResult<()>;

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -1123,6 +1123,9 @@ impl RegistryStore for PgRegistryStore {
         require_signed_assertions: bool,
         require_signed_responses: bool,
         allow_unsolicited_responses: bool,
+        oidc_issuer_url: Option<&str>,
+        oidc_client_id: Option<&str>,
+        oidc_client_secret: Option<&str>,
     ) -> StoreResult<SSOConfiguration> {
         SSOConfiguration::upsert(
             &self.pool,
@@ -1137,6 +1140,9 @@ impl RegistryStore for PgRegistryStore {
             require_signed_assertions,
             require_signed_responses,
             allow_unsolicited_responses,
+            oidc_issuer_url,
+            oidc_client_id,
+            oidc_client_secret,
         )
         .await
         .map_err(Into::into)

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -1901,6 +1901,9 @@ impl RegistryStore for SqliteRegistryStore {
         require_signed_assertions: bool,
         require_signed_responses: bool,
         allow_unsolicited_responses: bool,
+        oidc_issuer_url: Option<&str>,
+        oidc_client_id: Option<&str>,
+        oidc_client_secret: Option<&str>,
     ) -> StoreResult<SSOConfiguration> {
         Err(StoreError::NotFound)
     }

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -3,7 +3,7 @@
 //! Handles SAML 2.0 SSO setup and authentication for Team plan organizations
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::HeaderMap,
     response::{IntoResponse, Redirect, Response},
     Form, Json,
@@ -38,6 +38,11 @@ pub struct CreateSSOConfigRequest {
     pub require_signed_assertions: Option<bool>,
     pub require_signed_responses: Option<bool>,
     pub allow_unsolicited_responses: Option<bool>,
+    // OIDC fields (used when provider == "oidc"). The full OIDC login flow lands
+    // with #746; this stores + SSRF-validates the issuer so the config exists.
+    pub oidc_issuer_url: Option<String>,
+    pub oidc_client_id: Option<String>,
+    pub oidc_client_secret: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -117,6 +122,26 @@ pub async fn create_sso_config(
         ));
     }
 
+    // OIDC completeness: an OIDC provider needs an issuer and client_id.
+    if provider == SSOProvider::Oidc {
+        let issuer = request.oidc_issuer_url.as_deref().filter(|s| !s.is_empty());
+        let client_id = request.oidc_client_id.as_deref().filter(|s| !s.is_empty());
+        if issuer.is_none() || client_id.is_none() {
+            return Err(ApiError::InvalidRequest(
+                "OIDC configuration requires oidc_issuer_url and oidc_client_id".to_string(),
+            ));
+        }
+    }
+
+    // SSRF guard: the issuer URL is tenant-supplied and will be fetched
+    // (discovery/JWKS) once the OIDC login flow lands (#746). Validate it
+    // whenever it is present, regardless of provider, so an unvalidated issuer
+    // can never be persisted (a SAML config carrying an oidc_issuer_url must not
+    // smuggle a loopback/metadata URL into storage).
+    if let Some(issuer) = request.oidc_issuer_url.as_deref().filter(|s| !s.is_empty()) {
+        crate::sso_domain::validate_issuer_url(issuer)?;
+    }
+
     // Create or update SSO configuration
     let config = state
         .store
@@ -132,6 +157,9 @@ pub async fn create_sso_config(
             request.require_signed_assertions.unwrap_or(true),
             request.require_signed_responses.unwrap_or(true),
             request.allow_unsolicited_responses.unwrap_or(false),
+            request.oidc_issuer_url.as_deref(),
+            request.oidc_client_id.as_deref(),
+            request.oidc_client_secret.as_deref(),
         )
         .await?;
 
@@ -226,6 +254,69 @@ pub async fn get_sso_config(
     } else {
         Ok(Json(None))
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DomainStatusQuery {
+    pub domain: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DomainStatusResponse {
+    /// The email domain being checked (normalized).
+    pub domain: String,
+    /// DNS name where the ownership TXT record must be published.
+    pub record_name: String,
+    /// Exact TXT value the org must publish to prove ownership.
+    pub record_value: String,
+    /// Whether the record is currently resolvable and authorizes this org.
+    pub verified: bool,
+}
+
+/// Report SSO domain-verification status for `?domain=` (org admin only).
+///
+/// SSO provisioning (#833) only creates/attaches accounts whose email domain the
+/// org has proven it owns via a DNS TXT record. This endpoint tells an admin the
+/// exact record to publish and whether it currently verifies, so they can
+/// self-serve enabling a domain for their SAML/OIDC users.
+pub async fn get_domain_verification_status(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
+    Query(query): Query<DomainStatusQuery>,
+) -> ApiResult<Json<DomainStatusResponse>> {
+    let org_ctx = resolve_org_context(&state, user_id, &headers, None)
+        .await
+        .map_err(|_| ApiError::InvalidRequest("Organization context required".to_string()))?;
+
+    use crate::models::OrgRole;
+    let is_admin = org_ctx.org.owner_id == user_id || {
+        if let Ok(Some(member)) = state.store.find_org_member(org_ctx.org_id, user_id).await {
+            matches!(member.role(), OrgRole::Admin | OrgRole::Owner)
+        } else {
+            false
+        }
+    };
+    if !is_admin {
+        return Err(ApiError::PermissionDenied);
+    }
+
+    // Validate the requested domain (must be a plausible dotted host).
+    let domain = crate::sso_domain::normalize_domain(&query.domain);
+    if domain.is_empty() || !domain.contains('.') || domain.contains('@') {
+        return Err(ApiError::InvalidRequest(
+            "A valid email domain (e.g. acme.com) is required".to_string(),
+        ));
+    }
+
+    let verified = crate::sso_domain::domain_ownership_verified(org_ctx.org_id, &domain).await;
+
+    Ok(Json(DomainStatusResponse {
+        record_name: crate::sso_domain::verification_record_name(&domain),
+        record_value: crate::sso_domain::expected_txt_value(org_ctx.org_id),
+        domain,
+        verified,
+    }))
 }
 
 /// Enable SSO (org admin only)

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -284,6 +284,10 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route("/api/v1/sso/config", delete(handlers::sso::delete_sso_config))
         .route("/api/v1/sso/enable", post(handlers::sso::enable_sso))
         .route("/api/v1/sso/disable", post(handlers::sso::disable_sso))
+        .route(
+            "/api/v1/sso/domain/status",
+            get(handlers::sso::get_domain_verification_status),
+        )
         .route("/api/v1/sso/saml/metadata/{org_slug}", get(handlers::sso::get_saml_metadata))
         // Billing routes
         .route("/api/v1/billing/subscription", get(handlers::billing::get_subscription))
@@ -1202,6 +1206,7 @@ mod tests {
             "/api/v1/sso/config",
             "/api/v1/sso/enable",
             "/api/v1/sso/disable",
+            "/api/v1/sso/domain/status",
             "/api/v1/sso/saml/metadata/{org_slug}",
             "/api/v1/sso/saml/login/{org_slug}",
             "/api/v1/sso/saml/acs/{org_slug}",

--- a/crates/mockforge-registry-server/src/sso_domain.rs
+++ b/crates/mockforge-registry-server/src/sso_domain.rs
@@ -97,28 +97,36 @@ impl DomainOwnershipVerifier for DnsDomainVerifier {
             tracing::warn!("SSO domain gate: assertion email has no usable domain; failing closed");
             return false;
         };
-        let name = verification_record_name(&domain);
-        match lookup_txt_records(&name).await {
-            Ok(records) => {
-                let authorized = txt_records_authorize(&records, org_id);
-                if !authorized {
-                    tracing::warn!(
-                        org_id = %org_id,
-                        domain = %domain,
-                        "SSO domain gate: no authorizing TXT record at {name}; rejecting"
-                    );
-                }
-                authorized
-            }
-            Err(e) => {
+        domain_ownership_verified(org_id, &domain).await
+    }
+}
+
+/// Live DNS check that `org_id` owns `domain` (the org published the expected
+/// `_mockforge-verify.<domain>` TXT record). Fails closed on any DNS error.
+/// Shared by the SSO provisioning gate and the admin domain-status endpoint.
+pub async fn domain_ownership_verified(org_id: Uuid, domain: &str) -> bool {
+    let domain = normalize_domain(domain);
+    let name = verification_record_name(&domain);
+    match lookup_txt_records(&name).await {
+        Ok(records) => {
+            let authorized = txt_records_authorize(&records, org_id);
+            if !authorized {
                 tracing::warn!(
                     org_id = %org_id,
                     domain = %domain,
-                    error = %e,
-                    "SSO domain gate: TXT lookup failed; failing closed"
+                    "SSO domain check: no authorizing TXT record at {name}"
                 );
-                false
             }
+            authorized
+        }
+        Err(e) => {
+            tracing::warn!(
+                org_id = %org_id,
+                domain = %domain,
+                error = %e,
+                "SSO domain check: TXT lookup failed; failing closed"
+            );
+            false
         }
     }
 }

--- a/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
@@ -246,6 +246,18 @@ const deleteSSOConfig = () => apiFetch<void>(`${API_BASE}/sso/config`, { method:
 const enableSSO = () => apiFetch<void>(`${API_BASE}/sso/enable`, { method: 'POST' });
 const disableSSO = () => apiFetch<void>(`${API_BASE}/sso/disable`, { method: 'POST' });
 
+// SSO domain verification (#833): SSO only provisions users whose email domain
+// the org has proven it owns via a DNS TXT record. This reports the exact record
+// to publish and whether it currently verifies.
+interface DomainStatus {
+  domain: string;
+  record_name: string;
+  record_value: string;
+  verified: boolean;
+}
+const fetchDomainStatus = (domain: string) =>
+  apiFetch<DomainStatus>(`${API_BASE}/sso/domain/status?domain=${encodeURIComponent(domain)}`);
+
 // Templates
 const fetchOrgTemplates = (orgId: string) =>
   apiFetch<{ templates: OrgTemplate[] }>(`${API_BASE}/organizations/${orgId}/templates`);
@@ -1168,6 +1180,92 @@ function TemplatesTab({ org }: { org: Organization }) {
   );
 }
 
+function DomainVerificationCard() {
+  const { showToast } = useToast();
+  const [domain, setDomain] = useState('');
+  const [status, setStatus] = useState<DomainStatus | null>(null);
+
+  const checkMutation = useMutation({
+    mutationFn: () => fetchDomainStatus(domain.trim()),
+    onSuccess: (data) => {
+      setStatus(data);
+      showToast(
+        data.verified ? 'success' : 'info',
+        data.verified ? `${data.domain} is verified` : `${data.domain} is not verified yet`,
+      );
+    },
+    onError: (err: Error) => showToast('error', 'Domain check failed', err.message),
+  });
+
+  const copy = (text: string) => {
+    navigator.clipboard?.writeText(text);
+    showToast('success', 'Copied to clipboard');
+  };
+
+  return (
+    <div className="space-y-3 border-t pt-4">
+      <h4 className="text-sm font-semibold flex items-center gap-2">
+        <Shield className="w-4 h-4" /> Domain Verification
+      </h4>
+      <p className="text-sm text-muted-foreground">
+        SSO only creates or links accounts for email domains your organization has verified.
+        Enter a domain, publish the DNS TXT record shown, then check.
+      </p>
+      <div className="flex gap-2">
+        <Input
+          value={domain}
+          onChange={(e) => {
+            setDomain(e.target.value);
+            setStatus(null);
+          }}
+          placeholder="acme.com"
+        />
+        <Button onClick={() => checkMutation.mutate()} disabled={!domain.trim() || checkMutation.isPending}>
+          {checkMutation.isPending ? 'Checking...' : 'Check'}
+        </Button>
+      </div>
+      {status && (
+        <div className="p-3 border rounded-lg bg-muted/50 text-sm space-y-2">
+          <div className="flex items-center gap-2">
+            {status.verified ? (
+              <Badge className="bg-success-100 text-success-700 dark:bg-success-900/30 dark:text-success-300">
+                <CheckCircle2 className="w-3.5 h-3.5 mr-1" /> Verified
+              </Badge>
+            ) : (
+              <Badge className="bg-warning-100 text-warning-700 dark:bg-warning-900/30 dark:text-warning-300">
+                <AlertTriangle className="w-3.5 h-3.5 mr-1" /> Pending
+              </Badge>
+            )}
+            <span className="text-muted-foreground">{status.domain}</span>
+          </div>
+          <div className="space-y-1">
+            <div className="text-muted-foreground text-xs">Add this DNS TXT record:</div>
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs w-12">Name</span>
+              <code className="text-xs flex-1 break-all">{status.record_name}</code>
+              <Button size="sm" variant="ghost" onClick={() => copy(status.record_name)}>
+                <Copy className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs w-12">Value</span>
+              <code className="text-xs flex-1 break-all">{status.record_value}</code>
+              <Button size="sm" variant="ghost" onClick={() => copy(status.record_value)}>
+                <Copy className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+          </div>
+          {!status.verified && (
+            <p className="text-xs text-muted-foreground">
+              DNS changes can take a few minutes to propagate. Check again after publishing.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function SSOTab({ org }: { org: Organization }) {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
@@ -1317,6 +1415,8 @@ function SSOTab({ org }: { org: Organization }) {
           </div>
         </div>
       )}
+
+      <DomainVerificationCard />
 
       {ssoConfig && (
         <div className="border-t pt-4">


### PR DESCRIPTION
The verifiable subset of the remaining #833/#746 SSO work, chosen to ship now with full confidence. The complete OIDC login/callback flow stays tracked under #746 (it needs a mock-IdP integration test to verify without a live IdP).

## What is in this PR

### OIDC config + SSRF guard (wires the guard from #845 onto a real field)
- Adds `oidc_issuer_url` / `oidc_client_id` / `oidc_client_secret` to the SSO config API (request, `upsert_sso_config` trait, Postgres model upsert, SQLite stub).
- `oidc_client_secret` is `#[serde(skip_serializing)]` so a stored client secret is never returned in any response.
- `create_sso_config` requires issuer + client_id for an OIDC provider, and runs `sso_domain::validate_issuer_url` on **any** supplied issuer URL regardless of provider, so an unvalidated loopback/metadata issuer can never be persisted.

### Admin domain-verification surface (self-serve for the #845 gate)
- `GET /api/v1/sso/domain/status?domain=` (org-admin only, org-scoped): returns the exact TXT record (`_mockforge-verify.<domain>` + `mockforge-verify=<org_id>`) and a live DNS-verified bool. The token embeds the caller's own org_id from org context (no IDOR / cross-tenant token leak).
- Shared, fail-closed `sso_domain::domain_ownership_verified` refactored out of the SAML gate so the gate and the status endpoint use identical semantics.
- Admin UI: a Domain Verification card in the Organization SSO tab to enter a domain, copy the TXT record, and check verified/pending.

## Not in this PR (tracked: #746)
The OIDC login flow itself: discovery, authorization redirect, code/token exchange, JWKS + ID-token + nonce validation, and wiring the same domain gate into the OIDC callback. That needs a mock-IdP integration test and is its own focused effort.

## Review
- `auth-sentinel`: APPROVE (SSRF guard reachable + pre-persistence, endpoint org-admin-scoped, no IDOR, gate still fail-closed).
- `security-auditor`: clean (no unsafe, bound SQL params, secret never logged/echoed, query param encodeURIComponent'd, no XSS).
- Both nits they raised (validate issuer regardless of provider; write-only client_secret) are fixed in this PR.

## Verification
- registry-core (272) + registry-server sso (10) + routes (17) tests pass.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, UI `tsc --noEmit` + `eslint` all clean.
- Note: SSO end-to-end against a live IdP was not driven; the SSRF guard, the domain gate, and the status logic are unit-verified and compile into the SaaS binary.