### PR TITLE
feat(ui): SSO login loop + OIDC/domain-verify config UI (#746)

### DIFF
--- a/crates/mockforge-ui/ui/src/components/auth/AuthGuard.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/AuthGuard.tsx
@@ -21,8 +21,9 @@ interface AuthGuardProps {
 const SELF_AUTHED_PREFIXES = isCloudMode() ? [] : ['/registry-login', '/registry-admin'];
 
 // Public pages that render without any auth check — legal docs, pricing, support,
-// verification landings. These render the same shell (via AuthGuard passing through)
-// but don't require an authenticated user.
+// verification landings, and the SSO callback (user is not yet authenticated when
+// the IdP redirects back here). These render the same shell (via AuthGuard passing
+// through) but don't require an authenticated user.
 const PUBLIC_PREFIXES = [
   '/terms',
   '/privacy',
@@ -32,6 +33,7 @@ const PUBLIC_PREFIXES = [
   '/support',
   '/verify-email',
   '/waitlist',
+  '/auth/sso/callback',
 ];
 
 export function AuthGuard({ children, requiredRole }: AuthGuardProps) {

--- a/crates/mockforge-ui/ui/src/components/auth/LoginForm.tsx
+++ b/crates/mockforge-ui/ui/src/components/auth/LoginForm.tsx
@@ -1,5 +1,6 @@
 import { logger } from '@/utils/logger';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Logo } from '../ui/Logo';
@@ -12,8 +13,21 @@ interface LoginFormProps {
 
 const isCloud = authApi.isCloud();
 
+// SSO discovery response shape from GET /api/v1/sso/discover?email=<email>
+interface SsoDiscoverResponse {
+  org_slug: string;
+  provider: 'saml' | 'oidc';
+}
+
 export function LoginForm({ onSuccess }: LoginFormProps) {
+  const [searchParams] = useSearchParams();
   const [mode, setMode] = useState<'login' | 'register'>('login');
+  // ssoMode: 'hidden' | 'email' (showing email input) | 'slug' (showing slug fallback input)
+  const [ssoMode, setSsoMode] = useState<'hidden' | 'email' | 'slug'>('hidden');
+  const [ssoEmail, setSsoEmail] = useState('');
+  const [ssoSlug, setSsoSlug] = useState('');
+  const [ssoError, setSsoError] = useState('');
+  const [ssoLoading, setSsoLoading] = useState(false);
   const [credentials, setCredentials] = useState({
     username: '',
     email: '',
@@ -21,6 +35,17 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+
+  // Pick up sso_error forwarded from the callback page (set on the root URL
+  // when the IdP round-trip fails). We read it once on mount and clear it so
+  // subsequent renders don't re-show a stale error.
+  useEffect(() => {
+    const ssoErrParam = searchParams.get('sso_error');
+    if (ssoErrParam) {
+      setError(decodeURIComponent(ssoErrParam));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { login, setAuthenticated } = useAuthStore();
 
@@ -58,6 +83,50 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
       viewer: { username: 'viewer', email: '', password: 'viewer123' },
     };
     setCredentials({ ...credentials, ...demoCredentials[role] });
+  };
+
+  /**
+   * Handle the SSO email discovery flow.
+   * 1. Call GET /api/v1/sso/discover?email=<email>
+   * 2. 200 → browser-navigate to the IdP login URL for the discovered provider.
+   * 3. 404 → fall back to the manual org-slug input.
+   * 4. Other errors → show inline error.
+   *
+   * Note: SAML is used as the default for the slug-only fallback because
+   * email-based discovery covers OIDC orgs (SSO now requires a verified domain,
+   * so any OIDC org will be found by the discover endpoint when its domain
+   * matches the email).
+   */
+  const handleSsoEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSsoError('');
+    setSsoLoading(true);
+    try {
+      const res = await fetch(
+        `/api/v1/sso/discover?email=${encodeURIComponent(ssoEmail)}`,
+      );
+      if (res.ok) {
+        const data = (await res.json()) as SsoDiscoverResponse;
+        window.location.href = `/api/v1/sso/${data.provider}/login/${encodeURIComponent(data.org_slug)}`;
+      } else if (res.status === 404) {
+        // No SSO domain mapping found — ask for the org slug directly.
+        setSsoMode('slug');
+      } else {
+        const body = await res.json().catch(() => ({}));
+        setSsoError((body as { error?: string; message?: string }).error ?? (body as { message?: string }).message ?? `Unexpected error (${res.status})`);
+      }
+    } catch (err) {
+      logger.error('SSO discover error', err);
+      setSsoError('Could not reach the server. Please try again.');
+    } finally {
+      setSsoLoading(false);
+    }
+  };
+
+  const handleSsoSlugSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // SAML is the default for slug-based logins (see comment on handleSsoEmailSubmit).
+    window.location.href = `/api/v1/sso/saml/login/${encodeURIComponent(ssoSlug)}`;
   };
 
   return (
@@ -188,6 +257,115 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
                     Sign in
                   </button>
                 </p>
+              )}
+            </div>
+          )}
+
+          {/* ── SSO section (cloud mode only; only shown on the login tab) ── */}
+          {isCloud && mode === 'login' && (
+            <div className="space-y-3">
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground">Or</span>
+                </div>
+              </div>
+
+              {ssoMode === 'hidden' && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => { setSsoMode('email'); setSsoError(''); }}
+                >
+                  Sign in with SSO
+                </Button>
+              )}
+
+              {ssoMode === 'email' && (
+                <form onSubmit={handleSsoEmailSubmit} className="space-y-3">
+                  <div className="space-y-2">
+                    <label htmlFor="sso-email" className="text-sm font-medium">
+                      Work email
+                    </label>
+                    <Input
+                      id="sso-email"
+                      type="email"
+                      value={ssoEmail}
+                      onChange={(e) => setSsoEmail(e.target.value)}
+                      placeholder="you@company.com"
+                      required
+                      autoComplete="email"
+                      autoFocus
+                    />
+                  </div>
+                  {ssoError && (
+                    <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded p-3">
+                      {ssoError}
+                    </div>
+                  )}
+                  <div className="flex gap-2">
+                    <Button
+                      type="submit"
+                      className="flex-1"
+                      disabled={ssoLoading || !ssoEmail.trim()}
+                    >
+                      {ssoLoading ? 'Looking up...' : 'Continue with SSO'}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => { setSsoMode('hidden'); setSsoError(''); setSsoEmail(''); }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </form>
+              )}
+
+              {ssoMode === 'slug' && (
+                <form onSubmit={handleSsoSlugSubmit} className="space-y-3">
+                  <div className="space-y-2">
+                    <label htmlFor="sso-slug" className="text-sm font-medium">
+                      Organization SSO slug
+                    </label>
+                    <Input
+                      id="sso-slug"
+                      type="text"
+                      value={ssoSlug}
+                      onChange={(e) => setSsoSlug(e.target.value)}
+                      placeholder="your-org-slug"
+                      required
+                      autoFocus
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Ask your admin for your organization&apos;s SSO slug.
+                    </p>
+                  </div>
+                  {ssoError && (
+                    <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded p-3">
+                      {ssoError}
+                    </div>
+                  )}
+                  <div className="flex gap-2">
+                    <Button
+                      type="submit"
+                      className="flex-1"
+                      disabled={!ssoSlug.trim()}
+                    >
+                      Sign in with SSO
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => { setSsoMode('email'); setSsoError(''); setSsoSlug(''); }}
+                    >
+                      Back
+                    </Button>
+                  </div>
+                </form>
               )}
             </div>
           )}

--- a/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/OrganizationPage.tsx
@@ -93,6 +93,14 @@ interface SSOConfig {
   saml_sso_url?: string;
   saml_slo_url?: string;
   saml_name_id_format?: string;
+  // OIDC fields
+  oidc_issuer_url?: string;
+  oidc_client_id?: string;
+  // oidc_client_secret is intentionally absent: the backend never returns it
+  // Email domain + verification
+  email_domain?: string;
+  domain_verified?: boolean;
+  domain_verification_token?: string;
   attribute_mapping: Record<string, unknown>;
   require_signed_assertions: boolean;
   require_signed_responses: boolean;
@@ -241,10 +249,16 @@ const saveSSOConfig = (data: {
   saml_sso_url?: string;
   saml_slo_url?: string;
   saml_x509_cert?: string;
+  oidc_issuer_url?: string;
+  oidc_client_id?: string;
+  oidc_client_secret?: string;
+  email_domain?: string;
 }) => apiFetch<SSOConfig>(`${API_BASE}/sso/config`, { method: 'POST', body: JSON.stringify(data) });
 const deleteSSOConfig = () => apiFetch<void>(`${API_BASE}/sso/config`, { method: 'DELETE' });
 const enableSSO = () => apiFetch<void>(`${API_BASE}/sso/enable`, { method: 'POST' });
 const disableSSO = () => apiFetch<void>(`${API_BASE}/sso/disable`, { method: 'POST' });
+const verifyDomain = () =>
+  apiFetch<{ verified: boolean }>(`${API_BASE}/sso/domain/verify`, { method: 'POST' });
 
 // Templates
 const fetchOrgTemplates = (orgId: string) =>
@@ -1171,10 +1185,25 @@ function TemplatesTab({ org }: { org: Organization }) {
 function SSOTab({ org }: { org: Organization }) {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
+
+  // Provider selector: 'saml' | 'oidc'
+  const [provider, setProvider] = useState<'saml' | 'oidc'>('saml');
+
+  // SAML fields
   const [entityId, setEntityId] = useState('');
   const [ssoUrl, setSsoUrl] = useState('');
   const [sloUrl, setSloUrl] = useState('');
   const [x509Cert, setX509Cert] = useState('');
+
+  // OIDC fields
+  const [oidcIssuerUrl, setOidcIssuerUrl] = useState('');
+  const [oidcClientId, setOidcClientId] = useState('');
+  // oidcClientSecret is write-only: never pre-populated from the server response
+  const [oidcClientSecret, setOidcClientSecret] = useState('');
+
+  // Email domain (shown for both providers)
+  const [emailDomain, setEmailDomain] = useState('');
+
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const { data: ssoConfig, isLoading } = useQuery({
@@ -1185,23 +1214,41 @@ function SSOTab({ org }: { org: Organization }) {
 
   useEffect(() => {
     if (ssoConfig) {
+      const p = ssoConfig.provider === 'oidc' ? 'oidc' : 'saml';
+      setProvider(p);
       setEntityId(ssoConfig.saml_entity_id || '');
       setSsoUrl(ssoConfig.saml_sso_url || '');
       setSloUrl(ssoConfig.saml_slo_url || '');
+      setOidcIssuerUrl(ssoConfig.oidc_issuer_url || '');
+      setOidcClientId(ssoConfig.oidc_client_id || '');
+      setEmailDomain(ssoConfig.email_domain || '');
     }
   }, [ssoConfig]);
 
   const saveMutation = useMutation({
-    mutationFn: () => saveSSOConfig({
-      provider: 'saml',
-      saml_entity_id: entityId,
-      saml_sso_url: ssoUrl,
-      saml_slo_url: sloUrl || undefined,
-      saml_x509_cert: x509Cert || undefined,
-    }),
+    mutationFn: () => {
+      const base = { provider, email_domain: emailDomain || undefined };
+      if (provider === 'saml') {
+        return saveSSOConfig({
+          ...base,
+          saml_entity_id: entityId,
+          saml_sso_url: ssoUrl,
+          saml_slo_url: sloUrl || undefined,
+          saml_x509_cert: x509Cert || undefined,
+        });
+      } else {
+        return saveSSOConfig({
+          ...base,
+          oidc_issuer_url: oidcIssuerUrl,
+          oidc_client_id: oidcClientId,
+          oidc_client_secret: oidcClientSecret || undefined,
+        });
+      }
+    },
     onSuccess: () => {
       showToast('success', 'SSO configuration saved');
       setX509Cert('');
+      setOidcClientSecret('');
       queryClient.invalidateQueries({ queryKey: ['sso-config', org.id] });
     },
     onError: (err: Error) => showToast('error', 'Failed to save SSO config', err.message),
@@ -1224,9 +1271,25 @@ function SSOTab({ org }: { org: Organization }) {
       setEntityId('');
       setSsoUrl('');
       setSloUrl('');
+      setOidcIssuerUrl('');
+      setOidcClientId('');
+      setEmailDomain('');
       queryClient.invalidateQueries({ queryKey: ['sso-config', org.id] });
     },
     onError: (err: Error) => showToast('error', 'Failed to delete SSO config', err.message),
+  });
+
+  const verifyDomainMutation = useMutation({
+    mutationFn: verifyDomain,
+    onSuccess: (result) => {
+      if (result.verified) {
+        showToast('success', 'Domain verified successfully');
+      } else {
+        showToast('error', 'Domain verification failed', 'DNS TXT record not found yet. DNS changes can take up to 48 hours to propagate.');
+      }
+      queryClient.invalidateQueries({ queryKey: ['sso-config', org.id] });
+    },
+    onError: (err: Error) => showToast('error', 'Domain verification error', err.message),
   });
 
   if (org.plan !== 'team') {
@@ -1235,7 +1298,7 @@ function SSOTab({ org }: { org: Organization }) {
         <Lock className="w-8 h-8 mx-auto text-muted-foreground mb-3" />
         <h4 className="font-semibold mb-1">SSO requires Team plan</h4>
         <p className="text-sm text-muted-foreground">
-          Upgrade to the Team plan to configure SAML-based Single Sign-On for your organization.
+          Upgrade to the Team plan to configure Single Sign-On for your organization.
         </p>
       </div>
     );
@@ -1245,8 +1308,15 @@ function SSOTab({ org }: { org: Organization }) {
     return <div className="text-center py-4 text-muted-foreground">Loading SSO configuration...</div>;
   }
 
+  // Save button enabled: require provider-specific required fields
+  const isSaveEnabled =
+    provider === 'saml'
+      ? Boolean(entityId.trim() && ssoUrl.trim())
+      : Boolean(oidcIssuerUrl.trim() && oidcClientId.trim());
+
   return (
     <div className="space-y-6">
+      {/* ── Status bar (only when a config already exists) ── */}
       {ssoConfig && (
         <div className="flex items-center justify-between p-3 border rounded-lg">
           <div className="flex items-center gap-3">
@@ -1254,12 +1324,19 @@ function SSOTab({ org }: { org: Organization }) {
             <Badge className={ssoConfig.enabled ? 'bg-success-100 text-success-700 dark:bg-success-900/30 dark:text-success-300' : ''}>
               {ssoConfig.enabled ? 'Enabled' : 'Disabled'}
             </Badge>
+            {!ssoConfig.domain_verified && (
+              <Badge variant="outline" className="text-warning-700 dark:text-warning-300 border-warning-400">
+                <AlertTriangle className="w-3 h-3 mr-1" />
+                Domain unverified — SSO login inactive
+              </Badge>
+            )}
           </div>
           <Button
             size="sm"
             variant="outline"
             onClick={() => toggleMutation.mutate()}
-            disabled={toggleMutation.isPending}
+            disabled={toggleMutation.isPending || !ssoConfig.domain_verified}
+            title={!ssoConfig.domain_verified ? 'Verify your email domain before enabling SSO' : undefined}
           >
             {ssoConfig.enabled ? <ToggleRight className="w-4 h-4 mr-2" /> : <ToggleLeft className="w-4 h-4 mr-2" />}
             {ssoConfig.enabled ? 'Disable' : 'Enable'}
@@ -1267,38 +1344,182 @@ function SSOTab({ org }: { org: Organization }) {
         </div>
       )}
 
-      <div className="space-y-4">
-        <h4 className="text-sm font-semibold">SAML 2.0 Configuration</h4>
-        <div>
-          <Label>Entity ID (Issuer)</Label>
-          <Input value={entityId} onChange={(e) => setEntityId(e.target.value)} placeholder="https://idp.example.com/metadata" />
-        </div>
-        <div>
-          <Label>SSO URL (Login URL)</Label>
-          <Input value={ssoUrl} onChange={(e) => setSsoUrl(e.target.value)} placeholder="https://idp.example.com/sso" />
-        </div>
-        <div>
-          <Label>SLO URL (Logout URL, optional)</Label>
-          <Input value={sloUrl} onChange={(e) => setSloUrl(e.target.value)} placeholder="https://idp.example.com/slo" />
-        </div>
-        <div>
-          <Label>X.509 Certificate (paste new cert to update)</Label>
-          <textarea
-            className="w-full border rounded px-3 py-2 text-sm bg-background font-mono min-h-[100px] mt-1"
-            value={x509Cert}
-            onChange={(e) => setX509Cert(e.target.value)}
-            placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
-          />
-        </div>
+      {/* ── Provider selector ── */}
+      <div className="space-y-2">
+        <Label>SSO Provider</Label>
         <div className="flex gap-2">
-          <Button onClick={() => saveMutation.mutate()} disabled={!entityId.trim() || !ssoUrl.trim() || saveMutation.isPending}>
-            <Save className="w-4 h-4 mr-2" />
-            {saveMutation.isPending ? 'Saving...' : 'Save Configuration'}
-          </Button>
+          {(['saml', 'oidc'] as const).map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setProvider(p)}
+              className={`px-4 py-2 text-sm rounded border transition-colors ${
+                provider === p
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background text-foreground border-border hover:bg-muted'
+              }`}
+            >
+              {p === 'saml' ? 'SAML 2.0' : 'OpenID Connect (OIDC)'}
+            </button>
+          ))}
         </div>
       </div>
 
-      {ssoConfig && (
+      {/* ── SAML fields ── */}
+      {provider === 'saml' && (
+        <div className="space-y-4">
+          <h4 className="text-sm font-semibold">SAML 2.0 Configuration</h4>
+          <div>
+            <Label>Entity ID (Issuer)</Label>
+            <Input value={entityId} onChange={(e) => setEntityId(e.target.value)} placeholder="https://idp.example.com/metadata" />
+          </div>
+          <div>
+            <Label>SSO URL (Login URL)</Label>
+            <Input value={ssoUrl} onChange={(e) => setSsoUrl(e.target.value)} placeholder="https://idp.example.com/sso" />
+          </div>
+          <div>
+            <Label>SLO URL (Logout URL, optional)</Label>
+            <Input value={sloUrl} onChange={(e) => setSloUrl(e.target.value)} placeholder="https://idp.example.com/slo" />
+          </div>
+          <div>
+            <Label>X.509 Certificate (paste new cert to update)</Label>
+            <textarea
+              className="w-full border rounded px-3 py-2 text-sm bg-background font-mono min-h-[100px] mt-1"
+              value={x509Cert}
+              onChange={(e) => setX509Cert(e.target.value)}
+              placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* ── OIDC fields ── */}
+      {provider === 'oidc' && (
+        <div className="space-y-4">
+          <h4 className="text-sm font-semibold">OpenID Connect Configuration</h4>
+          <div>
+            <Label>Issuer URL</Label>
+            <Input
+              value={oidcIssuerUrl}
+              onChange={(e) => setOidcIssuerUrl(e.target.value)}
+              placeholder="https://accounts.google.com"
+            />
+            <p className="text-xs text-muted-foreground mt-1">The OIDC provider&apos;s issuer URL (must expose a /.well-known/openid-configuration endpoint).</p>
+          </div>
+          <div>
+            <Label>Client ID</Label>
+            <Input
+              value={oidcClientId}
+              onChange={(e) => setOidcClientId(e.target.value)}
+              placeholder="your-client-id"
+            />
+          </div>
+          <div>
+            <Label>Client Secret</Label>
+            <Input
+              type="password"
+              value={oidcClientSecret}
+              onChange={(e) => setOidcClientSecret(e.target.value)}
+              placeholder="Leave blank to keep existing secret"
+              autoComplete="new-password"
+            />
+            <p className="text-xs text-muted-foreground mt-1">Write-only — the secret is never returned by the API. Leave blank to keep the stored secret unchanged.</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Email domain (always visible) ── */}
+      <div className="space-y-2">
+        <h4 className="text-sm font-semibold">Email Domain</h4>
+        <div>
+          <Label>Domain</Label>
+          <Input
+            value={emailDomain}
+            onChange={(e) => setEmailDomain(e.target.value)}
+            placeholder="company.com"
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Users signing in with an email from this domain will be redirected to SSO automatically.
+            Changing the domain resets verification and generates a new DNS token.
+          </p>
+        </div>
+      </div>
+
+      {/* ── Domain verification section ── */}
+      {ssoConfig && ssoConfig.email_domain && (
+        <div className="space-y-3 p-4 border rounded-lg bg-muted/30">
+          <div className="flex items-center gap-2">
+            <h4 className="text-sm font-semibold">Domain Verification</h4>
+            {ssoConfig.domain_verified ? (
+              <Badge className="bg-success-100 text-success-700 dark:bg-success-900/30 dark:text-success-300 flex items-center gap-1">
+                <CheckCircle2 className="w-3 h-3" />
+                Verified
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="text-warning-700 dark:text-warning-300 border-warning-400">
+                <AlertTriangle className="w-3 h-3 mr-1" />
+                Not verified
+              </Badge>
+            )}
+          </div>
+
+          {ssoConfig.domain_verified ? (
+            <p className="text-sm text-muted-foreground">
+              <strong>{ssoConfig.email_domain}</strong> is verified. SSO login is active for users on this domain.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                SSO login will not work until the domain <strong>{ssoConfig.email_domain}</strong> is verified.
+                Add the following TXT record to your DNS, then click <strong>Verify</strong>.
+              </p>
+              {ssoConfig.domain_verification_token && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <code className="flex-1 bg-background border rounded px-3 py-2 text-xs font-mono break-all">
+                      mockforge-sso-verification={ssoConfig.domain_verification_token}
+                    </code>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        navigator.clipboard.writeText(
+                          `mockforge-sso-verification=${ssoConfig.domain_verification_token}`,
+                        );
+                        showToast('success', 'Copied to clipboard');
+                      }}
+                    >
+                      <Copy className="w-4 h-4" />
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Record type: <strong>TXT</strong> &nbsp;·&nbsp; Host/Name: <strong>@</strong> (or <strong>{ssoConfig.email_domain}</strong>) &nbsp;·&nbsp; DNS changes can take up to 48 hours to propagate.
+                  </p>
+                </div>
+              )}
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => verifyDomainMutation.mutate()}
+                disabled={verifyDomainMutation.isPending}
+              >
+                {verifyDomainMutation.isPending ? 'Verifying...' : 'Verify Domain'}
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* ── Save button ── */}
+      <div className="flex gap-2">
+        <Button onClick={() => saveMutation.mutate()} disabled={!isSaveEnabled || saveMutation.isPending}>
+          <Save className="w-4 h-4 mr-2" />
+          {saveMutation.isPending ? 'Saving...' : 'Save Configuration'}
+        </Button>
+      </div>
+
+      {/* ── Service Provider details (SAML only) ── */}
+      {ssoConfig && provider === 'saml' && (
         <div className="space-y-3">
           <h4 className="text-sm font-semibold">Service Provider Details</h4>
           <div className="p-3 border rounded-lg bg-muted/50 text-sm space-y-2">
@@ -1318,6 +1539,7 @@ function SSOTab({ org }: { org: Organization }) {
         </div>
       )}
 
+      {/* ── Delete config ── */}
       {ssoConfig && (
         <div className="border-t pt-4">
           {showDeleteConfirm ? (

--- a/crates/mockforge-ui/ui/src/pages/SsoCallbackPage.tsx
+++ b/crates/mockforge-ui/ui/src/pages/SsoCallbackPage.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useRef } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { authApi } from '@/services/authApi';
+import { logger } from '@/utils/logger';
+
+// Error codes returned by the backend as sso_error= query parameter.
+const SSO_ERROR_MESSAGES: Record<string, string> = {
+  invalid_state: 'SSO state parameter was invalid. Please try again.',
+  callback_failed: 'SSO authentication failed. Please try again.',
+  user_not_found: 'Your SSO account could not be matched to a user.',
+  sso_disabled: 'SSO is not enabled for your organization.',
+  domain_not_verified: 'The email domain for your organization has not been verified.',
+  internal_error: 'An internal error occurred during SSO login.',
+};
+
+/**
+ * SsoCallbackPage — landing page after an IdP SSO round-trip.
+ *
+ * Success path: backend 302s to /auth/sso/callback?token=<jwt>&org_slug=<slug>
+ * Failure path: backend 302s to /login?sso_error=<code>
+ *
+ * On success we persist the token via the auth store's setAuthenticated action
+ * (same path used by manual registration), hydrate /users/me, then redirect
+ * into the app. This ensures auto-refresh, axios/fetch auth headers, and the
+ * localStorage sync subscriber all fire exactly as they do on a normal login.
+ *
+ * This route MUST be listed in AuthGuard's PUBLIC_PREFIXES so the user
+ * can land here before they are authenticated.
+ */
+export function SsoCallbackPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { setAuthenticated } = useAuthStore();
+  // Guard against React 18 StrictMode double-invocation in dev.
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (handled.current) return;
+    handled.current = true;
+
+    const token = searchParams.get('token');
+    // org_slug is available for analytics / logging but not needed to complete auth.
+    const orgSlug = searchParams.get('org_slug');
+    const ssoError = searchParams.get('sso_error');
+
+    if (ssoError) {
+      // Backend redirected here via /login?sso_error=<code> in some flows, but
+      // we also handle it if it appears on the callback URL directly.
+      // Navigate to root — the AuthGuard will show the LoginForm because the user
+      // is unauthenticated, and the LoginForm reads the sso_error query param.
+      const message = SSO_ERROR_MESSAGES[ssoError] ?? `SSO error: ${ssoError}`;
+      navigate(`/?sso_error=${encodeURIComponent(message)}`, { replace: true });
+      return;
+    }
+
+    if (!token) {
+      logger.warn('SsoCallbackPage: no token in URL');
+      navigate('/login?sso_error=' + encodeURIComponent('No authentication token received.'), {
+        replace: true,
+      });
+      return;
+    }
+
+    // Persist the token immediately so subsequent API calls carry the
+    // Authorization header (same pattern as register in LoginForm).
+    // We build a minimal User from the JWT payload; hydrateUserFromServer
+    // (called inside checkAuth / the store internals) will fill in the rest.
+    const minimalUser = {
+      id: '',
+      username: '',
+      email: '',
+      role: 'user' as const,
+    };
+    setAuthenticated(minimalUser, token);
+
+    // Hydrate the full profile via /users/me, then navigate into the app.
+    authApi
+      .getMe()
+      .then((profile) => {
+        // Re-call setAuthenticated with real user data so the store has the
+        // full profile (role, email, username) before we navigate.
+        setAuthenticated(
+          {
+            id: profile.user_id,
+            username: profile.username,
+            email: profile.email,
+            role: profile.is_admin ? 'admin' : 'user',
+            is_verified: profile.is_verified,
+            created_at: profile.created_at,
+          },
+          token,
+        );
+        logger.info('SSO login successful', { orgSlug, userId: profile.user_id });
+        navigate('/', { replace: true });
+      })
+      .catch((err) => {
+        logger.error('SsoCallbackPage: /users/me hydration failed', err);
+        // Token was accepted and stored; still navigate into the app — the
+        // auto-refresh flow will fill in the user profile on next checkAuth.
+        navigate('/', { replace: true });
+      });
+  }, [searchParams, navigate, setAuthenticated]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="text-center space-y-4">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto" />
+        <p className="text-muted-foreground">Signing you in&hellip;</p>
+      </div>
+    </div>
+  );
+}

--- a/crates/mockforge-ui/ui/src/routes/index.tsx
+++ b/crates/mockforge-ui/ui/src/routes/index.tsx
@@ -144,6 +144,9 @@ const PricingPage = lazy(() => import('../pages/PricingPage').then(m => ({ defau
 const EmailVerificationPage = lazy(() => import('../pages/EmailVerificationPage').then(m => ({ default: m.EmailVerificationPage })));
 const WaitlistPage = lazy(() => import('../pages/WaitlistPage').then(m => ({ default: m.WaitlistPage })));
 
+// SSO callback — must be a public route (user is not yet authenticated on arrival)
+const SsoCallbackPage = lazy(() => import('../pages/SsoCallbackPage').then(m => ({ default: m.SsoCallbackPage })));
+
 /**
  * ApiExplorerWrapper handles the special logic that was previously in the
  * switch statement: it checks for window.__mockforge_explorer_deployment
@@ -296,4 +299,8 @@ export const routes: RouteConfig[] = [
   { path: '/pricing', element: <PricingPage /> },
   { path: '/verify-email', element: <EmailVerificationPage /> },
   { path: '/waitlist', element: <WaitlistPage /> },
+
+  // SSO OAuth/SAML callback — public; user is unauthenticated on arrival.
+  // AuthGuard bypasses auth checks for /auth/sso/callback via PUBLIC_PREFIXES.
+  { path: '/auth/sso/callback', element: <SsoCallbackPage /> },
 ];


### PR DESCRIPTION
## Summary

Final UI piece for #746 SSO. The backend landed incrementally across #845 (DNS-verified domain gate), #848 (full OIDC login flow + JWKS), and #847 (SSRF guard on OIDC issuer). This PR ships the frontend so users can actually sign in through SSO from the login page.

Cherry-pick of the UI commit from PR #778, which is being closed because the rest of its 10-commit stack has been superseded by the focused PRs above. Cherry-picked cleanly onto current main with no conflicts.

## What's here
- **`SsoCallbackPage` at `/auth/sso/callback`**: reads `token` / `sso_error` from the URL on IdP return, hydrates `/users/me`, navigates into the app; renders a spinner meanwhile. Registered as a PUBLIC route in `AuthGuard.PUBLIC_PREFIXES` and `routes/index.tsx` so it renders pre-auth.
- **`LoginForm` "Sign in with SSO"**: email-discovery via `GET /api/v1/sso/discover`, falls back to org-slug input on 404; browser-navigates to the IdP login URL on success. Reads `sso_error` query param on mount to surface IdP failure messages.
- **`SSOTab` (OrganizationPage)**: extended `SSOConfig` type with `oidc_issuer_url`, `oidc_client_id`, `email_domain`, `domain_verified`, `domain_verification_token`; provider selector (SAML/OIDC); OIDC fields with write-only secret; domain verification flow with DNS TXT token display + Verify Domain button + verified / unverified badges; Enable toggle gated on `domain_verified`.

## Test plan
- [x] Cherry-pick d7cbf3b8 onto current main — no conflicts
- [x] `pnpm install` — clean
- [x] `pnpm type-check` (tsc --noEmit) — clean
- [x] `pnpm lint` — 0 errors (953 pre-existing warnings, none introduced)
- [ ] CI Security Audit + Registry E2E green

Closes part of #746. Closes-via-supersede: #778.