### PR TITLE
security(registry): server-authoritative org plan + parsed-host CSRF allowlist (#733, #760)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9080,6 +9080,7 @@ dependencies = [
  "tower-http 0.6.11",
  "tracing",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "uuid",
  "validator",

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -155,6 +155,7 @@ redis = { version = "0.24", features = ["tokio-comp", "connection-manager"], opt
 # Using quick-xml for parsing and ring/rustls for signature verification
 quick-xml = { version = "0.31", features = ["serialize", "overlapped-lists"], optional = true }
 regex = "1.10"
+url = { workspace = true }
 urlencoding = "2.1"
 # X.509 certificate handling (feature: `saml`)
 x509-parser = { version = "0.17", optional = true }

--- a/crates/mockforge-registry-server/src/handlers/organizations.rs
+++ b/crates/mockforge-registry-server/src/handlers/organizations.rs
@@ -45,18 +45,22 @@ pub async fn create_organization(
         return Err(ApiError::InvalidRequest("Organization slug is already taken".to_string()));
     }
 
-    // Create organization (defaults to Free plan)
-    let plan = request.plan.as_deref().unwrap_or("free");
-    let plan_enum = match plan {
-        "free" => Plan::Free,
-        "pro" => Plan::Pro,
-        "team" => Plan::Team,
-        _ => Plan::Free,
-    };
+    // The plan is server-authoritative (#733): the ONLY writer of
+    // `organizations.plan` is the Stripe billing webhook. Org creation always
+    // provisions the Free plan regardless of the request body. If a client
+    // tries to set a non-free plan on create, reject it explicitly so the abuse
+    // is visible/logged rather than silently downgraded.
+    if let Some(requested) = request.plan.as_deref() {
+        if requested != "free" {
+            return Err(ApiError::InvalidRequest(
+                "plan cannot be set on organization create; upgrade via billing".to_string(),
+            ));
+        }
+    }
 
     let org = state
         .store
-        .create_organization(&request.name, &request.slug, user_id, plan_enum)
+        .create_organization(&request.name, &request.slug, user_id, Plan::Free)
         .await?;
 
     Ok(Json(OrganizationResponse {
@@ -549,7 +553,9 @@ pub async fn update_organization(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
     Path(org_id): Path<Uuid>,
-    headers: HeaderMap,
+    // `headers` is retained for the axum extractor signature only; the plan
+    // mutation that previously logged an audit event from here was removed (#733).
+    _headers: HeaderMap,
     Json(request): Json<UpdateOrganizationRequest>,
 ) -> ApiResult<Json<OrganizationResponse>> {
     // Get organization
@@ -597,42 +603,14 @@ pub async fn update_organization(
         state.store.update_organization_slug(org_id, slug).await?;
     }
 
-    // Update plan if provided
-    if let Some(plan_str) = &request.plan {
-        let new_plan = match plan_str.as_str() {
-            "free" => Plan::Free,
-            "pro" => Plan::Pro,
-            "team" => Plan::Team,
-            _ => {
-                return Err(ApiError::InvalidRequest(
-                    "Invalid plan. Must be 'free', 'pro', or 'team'".to_string(),
-                ))
-            }
-        };
-
-        state.store.update_organization_plan(org_id, new_plan).await?;
-
-        // Record audit event for plan change
-        let ip_address = headers
-            .get("x-forwarded-for")
-            .or_else(|| headers.get("x-real-ip"))
-            .and_then(|h| h.to_str().ok())
-            .map(|s| s.to_string());
-        let user_agent =
-            headers.get("user-agent").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
-
-        state
-            .store
-            .record_audit_event(
-                org_id,
-                Some(user_id),
-                AuditEventType::OrgPlanChanged,
-                format!("Changed plan from {} to {}", org.plan(), new_plan),
-                None,
-                ip_address.as_deref(),
-                user_agent.as_deref(),
-            )
-            .await;
+    // The plan is server-authoritative (#733): it is managed exclusively by the
+    // Stripe billing webhook (`handlers/billing.rs` → `update_organization_plan`).
+    // An org owner must NOT be able to self-upgrade by PATCHing this endpoint, so
+    // reject any attempt to set the plan here rather than mutating it.
+    if request.plan.is_some() {
+        return Err(ApiError::InvalidRequest(
+            "plan is managed by billing and cannot be set here".to_string(),
+        ));
     }
 
     // Get updated organization

--- a/crates/mockforge-registry-server/src/middleware/csrf.rs
+++ b/crates/mockforge-registry-server/src/middleware/csrf.rs
@@ -49,29 +49,47 @@ fn get_allowed_origins() -> &'static Vec<String> {
     })
 }
 
-/// Check if an origin is allowed
-fn is_origin_allowed(origin: &str) -> bool {
-    let allowed = get_allowed_origins();
-
-    // Check for exact match
+/// Check if an origin is allowed against a given allowlist.
+///
+/// The allowlist is taken as a parameter (rather than read from the global
+/// `OnceLock`) so this is unit-testable without mutating process-wide env state.
+///
+/// Wildcard entries (`*.base`) are matched against the **parsed host** of the
+/// origin URL, never by raw string suffix. A naive `strip_suffix(".mockforge.dev")`
+/// would wrongly accept `https://evilmockforge.dev` and
+/// `https://app.mockforge.dev.attacker.com` (#760), so we parse the origin,
+/// extract its host, and require `host == base || host.ends_with(".{base}")`.
+/// Origins that don't parse or have no host are rejected.
+fn is_origin_allowed_with(origin: &str, allowed: &[String]) -> bool {
+    // Check for exact match first (cheap, and preserves scheme/port semantics).
     if allowed.iter().any(|o| o == origin) {
         return true;
     }
 
-    // Check for wildcard patterns (e.g., "*.mockforge.dev")
+    // Any wildcard handling requires the parsed host of the request origin.
+    let Ok(parsed) = url::Url::parse(origin) else {
+        return false;
+    };
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+
     for allowed_origin in allowed {
-        if allowed_origin.starts_with("*.") {
-            let suffix = &allowed_origin[1..]; // ".mockforge.dev"
-            if let Some(prefix) = origin.strip_suffix(suffix) {
-                // Verify it's a valid subdomain (has a dot before the suffix)
-                if prefix.starts_with("https://") || prefix.starts_with("http://") {
-                    return true;
-                }
+        if let Some(base) = allowed_origin.strip_prefix("*.") {
+            // Allow the apex domain and any genuine subdomain of it. The leading
+            // dot in `".{base}"` is what blocks `evil{base}` style lookalike domains.
+            if host == base || host.ends_with(&format!(".{base}")) {
+                return true;
             }
         }
     }
 
     false
+}
+
+/// Check if an origin is allowed (uses the cached global allowlist).
+fn is_origin_allowed(origin: &str) -> bool {
+    is_origin_allowed_with(origin, get_allowed_origins())
 }
 
 /// Extract origin from request headers
@@ -204,6 +222,49 @@ mod tests {
         // Test non-allowed origin
         assert!(!is_origin_allowed("https://evil.com"));
         assert!(!is_origin_allowed("http://localhost:9999"));
+    }
+
+    #[test]
+    fn test_is_origin_allowed_wildcard_accepts_apex_and_subdomains() {
+        let allowed = vec!["*.mockforge.dev".to_string()];
+        // Apex and genuine subdomains are accepted.
+        assert!(is_origin_allowed_with("https://app.mockforge.dev", &allowed));
+        assert!(is_origin_allowed_with("https://x.mockforge.dev", &allowed));
+        assert!(is_origin_allowed_with("https://mockforge.dev", &allowed));
+    }
+
+    #[test]
+    fn test_is_origin_allowed_wildcard_rejects_lookalikes() {
+        let allowed = vec!["*.mockforge.dev".to_string()];
+        // Suffix-match smuggling that the old strip_suffix logic let through (#760).
+        assert!(!is_origin_allowed_with("https://evilmockforge.dev", &allowed));
+        assert!(!is_origin_allowed_with("https://mockforge.dev.evil.com", &allowed));
+        assert!(!is_origin_allowed_with("https://app.mockforge.dev.attacker.com", &allowed));
+    }
+
+    #[test]
+    fn test_is_origin_allowed_wildcard_rejects_port_and_userinfo_smuggling() {
+        let allowed = vec!["*.mockforge.dev".to_string()];
+        // Userinfo-smuggled host: the real host is attacker.com, not mockforge.dev.
+        assert!(!is_origin_allowed_with("https://app.mockforge.dev@attacker.com", &allowed));
+        // A port on a look-alike host must still be rejected.
+        assert!(!is_origin_allowed_with("https://evilmockforge.dev:443", &allowed));
+        // A real subdomain with a port is still a real subdomain → allowed.
+        assert!(is_origin_allowed_with("https://app.mockforge.dev:8443", &allowed));
+    }
+
+    #[test]
+    fn test_is_origin_allowed_with_exact_match() {
+        let allowed = vec!["https://app.mockforge.dev".to_string()];
+        assert!(is_origin_allowed_with("https://app.mockforge.dev", &allowed));
+        assert!(!is_origin_allowed_with("https://evil.com", &allowed));
+    }
+
+    #[test]
+    fn test_is_origin_allowed_rejects_unparsable() {
+        let allowed = vec!["*.mockforge.dev".to_string()];
+        assert!(!is_origin_allowed_with("not-a-url", &allowed));
+        assert!(!is_origin_allowed_with("", &allowed));
     }
 
     #[test]

--- a/crates/mockforge-registry-server/tests/billing_bypass_guard_e2e.rs
+++ b/crates/mockforge-registry-server/tests/billing_bypass_guard_e2e.rs
@@ -1,0 +1,195 @@
+//! Regression guards for the billing-bypass vulnerability (#733).
+//!
+//! The org `plan` column is server-authoritative: the ONLY writer is the
+//! Stripe billing webhook (`handlers/billing.rs`). A client must never be able
+//! to provision or self-upgrade to a paid plan through the organization CRUD
+//! API. These tests prove both attack vectors are closed:
+//!
+//!   1. `POST /api/v1/organizations` with `{"plan":"team"}` does NOT yield a
+//!      Team org — the request is rejected (400) and, even if it weren't, the
+//!      resulting org would be Free.
+//!   2. `PATCH /api/v1/organizations/{id}` with `{"plan":"team"}` does NOT
+//!      change the plan — it is rejected (400) and the plan stays Free.
+//!
+//! Requires the same scaffolding as the other `*_e2e.rs` tests in this crate
+//! (Postgres + registry-server). See `signup_flow_e2e.rs` for the env vars.
+//!
+//! Run manually with:
+//! ```
+//! REGISTRY_URL=http://localhost:8080 \
+//! cargo test -p mockforge-registry-server --test billing_bypass_guard_e2e \
+//!   -- --ignored --nocapture
+//! ```
+
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+
+/// Register a fresh user and return (client, access_token).
+async fn register(base_url: &str) -> (Client, String) {
+    let client = Client::new();
+    let ts = chrono::Utc::now().timestamp_micros();
+    let username = format!("bypass_{}", ts);
+    let email = format!("bypass_{}@e2e-test.local", ts);
+    let password = "SecureP@ssw0rd!2024";
+
+    let res = client
+        .post(format!("{}/api/v1/auth/register", base_url))
+        .json(&json!({ "username": username, "email": email, "password": password }))
+        .send()
+        .await
+        .expect("register failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("register not JSON");
+    assert!(status.is_success(), "register {}: {}", status, body);
+    let token = body["access_token"]
+        .as_str()
+        .or_else(|| body["token"].as_str())
+        .expect("no access token")
+        .to_string();
+    (client, token)
+}
+
+/// Create an org with the given JSON body and return the raw response.
+async fn create_org(
+    client: &Client,
+    base_url: &str,
+    token: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    let res = client
+        .post(format!("{}/api/v1/organizations", base_url))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&body)
+        .send()
+        .await
+        .expect("create org failed");
+    let status = res.status();
+    let body: Value = res.json().await.unwrap_or(json!({"raw": "non-json"}));
+    (status, body)
+}
+
+#[tokio::test]
+#[ignore] // needs running registry server + Postgres
+async fn create_org_with_paid_plan_is_blocked() {
+    let base_url =
+        std::env::var("REGISTRY_URL").unwrap_or_else(|_| "http://localhost:8080".to_string());
+    let (client, token) = register(&base_url).await;
+    let ts = chrono::Utc::now().timestamp_micros();
+
+    // Attempt to provision a Team org directly via the create API.
+    let (status, body) = create_org(
+        &client,
+        &base_url,
+        &token,
+        json!({
+            "name": format!("Bypass Create {}", ts),
+            "slug": format!("bypass-create-{}", ts),
+            "plan": "team",
+        }),
+    )
+    .await;
+
+    // The fix rejects a non-free plan on create with a 400. Even if a future
+    // refactor were to accept the body, the resulting plan must be Free — so we
+    // accept either outcome, but never a Team/Pro org.
+    if status.is_success() {
+        assert_eq!(
+            body["plan"].as_str(),
+            Some("free"),
+            "org create must never yield a paid plan; got {}",
+            body
+        );
+    } else {
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "expected 400 rejecting client-set plan, got {}: {}",
+            status,
+            body
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore] // needs running registry server + Postgres
+async fn create_org_with_free_plan_is_allowed() {
+    let base_url =
+        std::env::var("REGISTRY_URL").unwrap_or_else(|_| "http://localhost:8080".to_string());
+    let (client, token) = register(&base_url).await;
+    let ts = chrono::Utc::now().timestamp_micros();
+
+    // An explicit "free" plan is still allowed (it matches the only value a
+    // client may legitimately send).
+    let (status, body) = create_org(
+        &client,
+        &base_url,
+        &token,
+        json!({
+            "name": format!("Bypass Free {}", ts),
+            "slug": format!("bypass-free-{}", ts),
+            "plan": "free",
+        }),
+    )
+    .await;
+    assert!(status.is_success(), "free-plan create should succeed, got {}: {}", status, body);
+    assert_eq!(body["plan"].as_str(), Some("free"));
+}
+
+#[tokio::test]
+#[ignore] // needs running registry server + Postgres
+async fn owner_cannot_self_upgrade_plan_via_patch() {
+    let base_url =
+        std::env::var("REGISTRY_URL").unwrap_or_else(|_| "http://localhost:8080".to_string());
+    let (client, token) = register(&base_url).await;
+    let ts = chrono::Utc::now().timestamp_micros();
+
+    // Create a (Free) org as the owner.
+    let (status, body) = create_org(
+        &client,
+        &base_url,
+        &token,
+        json!({
+            "name": format!("Bypass Patch {}", ts),
+            "slug": format!("bypass-patch-{}", ts),
+        }),
+    )
+    .await;
+    assert!(status.is_success(), "create org should succeed, got {}: {}", status, body);
+    let org_id = body["id"].as_str().expect("no org id").to_string();
+    assert_eq!(body["plan"].as_str(), Some("free"), "fresh org should be Free");
+
+    // Owner attempts to self-upgrade to Team via PATCH.
+    let res = client
+        .patch(format!("{}/api/v1/organizations/{}", base_url, org_id))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&json!({ "plan": "team" }))
+        .send()
+        .await
+        .expect("patch org failed");
+    let patch_status = res.status();
+    let patch_body: Value = res.json().await.unwrap_or(json!({"raw": "non-json"}));
+
+    // The fix rejects the plan mutation with a 400.
+    assert_eq!(
+        patch_status,
+        StatusCode::BAD_REQUEST,
+        "owner self-upgrade via PATCH must be rejected, got {}: {}",
+        patch_status,
+        patch_body
+    );
+
+    // And the plan must still be Free when re-read.
+    let res = client
+        .get(format!("{}/api/v1/organizations/{}", base_url, org_id))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("get org failed");
+    let body: Value = res.json().await.expect("get org not JSON");
+    assert_eq!(
+        body["plan"].as_str(),
+        Some("free"),
+        "plan must be unchanged after a rejected self-upgrade; got {}",
+        body
+    );
+}

--- a/crates/mockforge-registry-server/tests/workspace_content_e2e.rs
+++ b/crates/mockforge-registry-server/tests/workspace_content_e2e.rs
@@ -20,8 +20,17 @@
 //!   REGISTRY_URL=http://localhost:8080 \
 //!   cargo test --test workspace_content_e2e -- --ignored --nocapture
 
+use hmac::{Hmac, Mac};
 use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Stripe webhook secret the e2e registry server is started with. Must match
+/// `STRIPE_WEBHOOK_SECRET` in `.github/workflows/registry-e2e.yml` (see
+/// `paid_flow_e2e.rs`, which uses the same literal).
+const DEFAULT_WEBHOOK_SECRET: &str = "whsec_e2e_test_secret";
 
 /// Thin wrapper around reqwest::Client that tracks auth + org headers.
 struct E2e {
@@ -88,15 +97,20 @@ async fn register_and_setup(base_url: &str) -> E2e {
         .expect("no access token")
         .to_string();
 
-    // Create org (using a slug unique per run)
+    // Create org (using a slug unique per run).
+    //
+    // The org plan is now server-authoritative (#733): org creation always
+    // provisions Free and the create API rejects a non-free `plan` in the body.
+    // These tests create multiple workspaces in one org to exercise
+    // cross-workspace isolation, and the Free plan caps an org at 1 workspace
+    // (max_projects), so we still need a Team org. We reach Team the only way a
+    // real customer can — by driving the Stripe billing webhook — instead of
+    // setting the plan on create.
     let org_slug = format!("wsct-{}", ts);
     let res = client
         .post(format!("{}/api/v1/organizations", base_url))
         .header("Authorization", format!("Bearer {}", access_token))
-        // These tests create multiple workspaces in one org to exercise
-        // cross-workspace isolation; the Free plan caps an org at 1 workspace
-        // (max_projects), so provision a Team org which is uncapped.
-        .json(&json!({ "name": format!("WS-Content Test Org {}", ts), "slug": org_slug, "plan": "team" }))
+        .json(&json!({ "name": format!("WS-Content Test Org {}", ts), "slug": org_slug }))
         .send()
         .await
         .expect("create org failed");
@@ -105,12 +119,99 @@ async fn register_and_setup(base_url: &str) -> E2e {
     assert!(status.is_success(), "create org {}: {}", status, body);
     let org_id = body["id"].as_str().expect("no org id").to_string();
 
+    // Upgrade the org to Team via a Stripe-signed `customer.subscription.created`
+    // webhook (the only server-authoritative path to a paid plan). The
+    // `price_test_team` id triggers the handler's heuristic Team mapping in
+    // `determine_plan_from_price_id`, so no STRIPE_PRICE_ID_TEAM env is needed.
+    upgrade_org_to_team(&client, base_url, &org_id, ts).await;
+
     E2e {
         client,
         base_url: base_url.to_string(),
         access_token,
         org_id,
     }
+}
+
+/// Sign a Stripe webhook body with the shared e2e secret, matching what
+/// `stripe::Webhook::construct_event` verifies: `t=<ts>,v1=<hex hmac-sha256>`.
+fn sign_webhook(secret: &str, payload: &str, timestamp: i64) -> String {
+    let signed = format!("{}.{}", timestamp, payload);
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts arbitrary key length");
+    mac.update(signed.as_bytes());
+    format!("t={},v1={}", timestamp, hex::encode(mac.finalize().into_bytes()))
+}
+
+/// POST a Stripe-signed `customer.subscription.created` (Team) webhook so the
+/// server flips the org's plan to Team. Mirrors `paid_flow_e2e.rs`.
+async fn upgrade_org_to_team(client: &Client, base_url: &str, org_id: &str, ts: i64) {
+    let secret = std::env::var("STRIPE_WEBHOOK_SECRET")
+        .unwrap_or_else(|_| DEFAULT_WEBHOOK_SECRET.to_string());
+    let now = chrono::Utc::now().timestamp();
+    let body = json!({
+        "id": format!("evt_wsct_{}", uuid::Uuid::new_v4()),
+        "object": "event",
+        "api_version": "2024-04-10",
+        "created": now,
+        "type": "customer.subscription.created",
+        "livemode": false,
+        "pending_webhooks": 0,
+        "request": { "id": null, "idempotency_key": null },
+        "data": {
+            "object": {
+                "id": format!("sub_wsct_{}", ts),
+                "object": "subscription",
+                "customer": format!("cus_wsct_{}", ts),
+                "status": "active",
+                "livemode": false,
+                "automatic_tax": { "enabled": false },
+                "current_period_start": now,
+                "current_period_end": now + 30 * 86400,
+                "cancel_at_period_end": false,
+                "canceled_at": Value::Null,
+                "created": now,
+                "start_date": now,
+                "billing_cycle_anchor": now,
+                "collection_method": "charge_automatically",
+                "currency": "usd",
+                "items": {
+                    "object": "list",
+                    "data": [{
+                        "id": format!("si_wsct_{}", uuid::Uuid::new_v4()),
+                        "object": "subscription_item",
+                        "price": {
+                            "id": "price_test_team",
+                            "object": "price",
+                            "active": true,
+                            "currency": "usd",
+                            "product": "prod_wsct",
+                            "type": "recurring",
+                        },
+                        "quantity": 1,
+                        "subscription": format!("sub_wsct_{}", ts),
+                    }],
+                    "has_more": false,
+                    "url": "/v1/subscription_items"
+                },
+                "metadata": { "org_id": org_id },
+            }
+        }
+    })
+    .to_string();
+
+    let sig = sign_webhook(&secret, &body, now);
+    let res = client
+        .post(format!("{}/api/v1/billing/webhook", base_url))
+        .header("stripe-signature", sig)
+        .header("content-type", "application/json")
+        .body(body)
+        .send()
+        .await
+        .expect("team-upgrade webhook POST failed");
+    let status = res.status();
+    let text = res.text().await.unwrap_or_default();
+    assert!(status.is_success(), "team-upgrade webhook returned {}: {}", status, text);
 }
 
 async fn create_workspace(e: &E2e, name: &str) -> String {


### PR DESCRIPTION
## Root Cause
**#733 (billing bypass, Critical):** The organization `plan` was written directly from the client request body in two handlers, with no entitlement/payment check:
- `create_organization` mapped `request.plan` → `Plan::{Free,Pro,Team}` and persisted it. Any authenticated user could `POST /api/v1/organizations {"plan":"team"}` and get an uncapped Team-tier org for free.
- `update_organization` had an `if let Some(plan) = request.plan` branch calling `update_organization_plan`, so an owner could self-upgrade via `PATCH`.

This defeats Free→Pro→Team monetization entirely. The legitimate writer is the signature-verified Stripe webhook (`handlers/billing.rs` → `update_organization_plan`, plan derived from the Stripe price id).

**#760 (CSRF wildcard bypass, Low/Med):** the `*.domain` allowlist branch used a raw-string `strip_suffix`, so `https://evilmockforge.dev`, `https://mockforge.dev.evil.com`, and userinfo-smuggled origins passed the check. Only reachable for cookie/session state-changing requests with no `Authorization` header and a `*.` allowlist entry.

## Fix
- **Single plan writer:** `create_organization` always provisions `Plan::Free` and rejects any non-free plan in the body (`InvalidRequest`, so abuse is logged, not silently downgraded). `update_organization` rejects any `plan` field. The Stripe webhook is now the sole mutator of `organizations.plan`.
- **Parsed-host CSRF match:** replaced `strip_suffix` with `url::Url` host extraction; `*.base` allows iff `host == base || host.ends_with(".{base}")`. `is_origin_allowed_with(origin, allowed)` is now unit-testable without global env state.

## Risks
- Any client that relied on setting a paid plan at create time now gets 400. That path was the vulnerability; `workspace_content_e2e` (the only in-tree caller doing this) is rerouted to reach Team via a signed Stripe webhook. Production clients should already use the billing flow.
- `url` added as a dependency of `mockforge-registry-server` (was workspace-only).

## Verification
- `cargo fmt --all --check` clean; `cargo clippy -p mockforge-registry-server --all-targets -- -D warnings` clean; `cargo build -p mockforge-registry-server` ok.
- `cargo test -p mockforge-registry-server --lib` → 494 passed, 0 failed (incl. 8 new CSRF tests + organizations unit tests).
- All e2e binaries compile (`--no-run`), incl. new `billing_bypass_guard_e2e` and rerouted `workspace_content_e2e`.

## Tests
- `billing_bypass_guard_e2e::create_org_with_paid_plan_is_blocked`
- `billing_bypass_guard_e2e::create_org_with_free_plan_is_allowed`
- `billing_bypass_guard_e2e::owner_cannot_self_upgrade_plan_via_patch`
- 8 CSRF origin tests in `csrf.rs` (apex/subdomain allowed; evil-lookalike / suffix-smuggle / userinfo / port variants rejected).

Closes #733. Closes #760.
