### PR TITLE
fix(protocol): bound attacker-controlled resource use in kafka/smtp/tcp (#752, #753, #754, #755)

### DIFF
--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -2579,6 +2579,9 @@ pub async fn handle_serve(
             enable_starttls: smtp_config.enable_starttls,
             tls_cert_path: smtp_config.tls_cert_path.clone(),
             tls_key_path: smtp_config.tls_key_path.clone(),
+            // Use the mock-SMTP crate default for the DATA size cap (#754);
+            // the core protocol config doesn't surface this field.
+            ..Default::default()
         };
 
         // Downcast the registry with proper error handling

--- a/crates/mockforge-kafka/src/codec_util.rs
+++ b/crates/mockforge-kafka/src/codec_util.rs
@@ -1,0 +1,57 @@
+//! Shared codec utilities for bounding attacker-controlled allocations.
+//!
+//! Kafka request bodies carry element counts (array lengths) on the wire
+//! ahead of the elements themselves. A malicious client can advertise a huge
+//! count (e.g. `0x7FFFFFFF`) in only a few bytes, which — if fed straight to
+//! [`Vec::with_capacity`] — reserves gigabytes before the bounded parse loop
+//! ever runs, an easy OOM DoS (#752).
+//!
+//! [`sane_capacity`] clamps the requested capacity to what the remaining
+//! buffer could plausibly hold, given a minimum per-element wire size. The
+//! element-by-element parse loops still enforce real bounds; this just keeps
+//! the *pre*-allocation honest.
+
+/// Clamp an attacker-controlled element `count` to a capacity that the
+/// remaining buffer could actually back.
+///
+/// `remaining_bytes` is the number of unparsed bytes left in the buffer at the
+/// call site, and `min_elem_wire_size` is the smallest number of bytes a single
+/// element can occupy on the wire (e.g. `4` for a partition/offset entry whose
+/// first field is an `i32`, `2` for a varint-keyed entry, `1` when unsure).
+///
+/// The result never exceeds `count`, so behavior is unchanged for honest
+/// inputs; it only caps the up-front reservation for hostile ones.
+pub(crate) fn sane_capacity(
+    count: usize,
+    remaining_bytes: usize,
+    min_elem_wire_size: usize,
+) -> usize {
+    count.min(remaining_bytes / min_elem_wire_size.max(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamps_huge_count_to_buffer() {
+        // A 16-byte buffer cannot hold 0x7FFFFFFF 4-byte elements.
+        assert_eq!(sane_capacity(0x7FFF_FFFF, 16, 4), 4);
+    }
+
+    #[test]
+    fn passes_through_honest_count() {
+        // 3 elements, plenty of buffer — unchanged.
+        assert_eq!(sane_capacity(3, 1024, 4), 3);
+    }
+
+    #[test]
+    fn zero_min_wire_size_does_not_divide_by_zero() {
+        assert_eq!(sane_capacity(5, 1024, 0), 5);
+    }
+
+    #[test]
+    fn empty_buffer_yields_zero() {
+        assert_eq!(sane_capacity(1000, 0, 4), 0);
+    }
+}

--- a/crates/mockforge-kafka/src/fetch_codec.rs
+++ b/crates/mockforge-kafka/src/fetch_codec.rs
@@ -12,6 +12,7 @@
 //! The broker is responsible for looking records up in partition storage;
 //! this module just decodes the request and encodes the response.
 
+use crate::codec_util::sane_capacity;
 use crate::partitions::KafkaMessage;
 use crate::produce_codec::{
     push_compact_string, push_empty_tag_buffer, push_signed_varint, push_unsigned_varint,
@@ -82,7 +83,7 @@ pub fn parse_fetch_v12(body: &[u8]) -> Result<FetchRequestV12, String> {
         return Err("fetch topics array is null".into());
     }
     let topics_len = (topics_len_plus_one - 1) as usize;
-    let mut topics = Vec::with_capacity(topics_len);
+    let mut topics = Vec::with_capacity(sane_capacity(topics_len, cur.len(), 2));
 
     for _ in 0..topics_len {
         let topic = read_compact_string(&mut cur)?;
@@ -92,7 +93,7 @@ pub fn parse_fetch_v12(body: &[u8]) -> Result<FetchRequestV12, String> {
             return Err(format!("fetch partitions array for {topic} is null"));
         }
         let parts_len = (parts_len_plus_one - 1) as usize;
-        let mut partitions = Vec::with_capacity(parts_len);
+        let mut partitions = Vec::with_capacity(sane_capacity(parts_len, cur.len(), 4));
         for _ in 0..parts_len {
             let partition_index = read_i32(&mut cur)?;
             let _current_leader_epoch = read_i32(&mut cur)?;

--- a/crates/mockforge-kafka/src/fetch_nonflex.rs
+++ b/crates/mockforge-kafka/src/fetch_nonflex.rs
@@ -41,6 +41,7 @@
 //! Response header is v0 for every non-flexible version: just
 //! correlation_id, no tag buffer.
 
+use crate::codec_util::sane_capacity;
 use crate::fetch_codec::{
     FetchPartitionRequest, FetchRequestV12, FetchTopicRequest, FetchTopicResponse,
 };
@@ -149,7 +150,7 @@ pub fn parse_fetch_v4_v11(api_version: i16, body: &[u8]) -> Result<FetchRequestV
     if topics_count < 0 {
         return Err(format!("fetch topics count is negative: {topics_count}"));
     }
-    let mut topics = Vec::with_capacity(topics_count as usize);
+    let mut topics = Vec::with_capacity(sane_capacity(topics_count as usize, cur.len(), 2));
 
     for _ in 0..topics_count {
         let topic = read_string(&mut cur)?;
@@ -157,7 +158,7 @@ pub fn parse_fetch_v4_v11(api_version: i16, body: &[u8]) -> Result<FetchRequestV
         if parts_count < 0 {
             return Err(format!("fetch partitions count for {topic} is negative"));
         }
-        let mut partitions = Vec::with_capacity(parts_count as usize);
+        let mut partitions = Vec::with_capacity(sane_capacity(parts_count as usize, cur.len(), 4));
         for _ in 0..parts_count {
             let partition_index = read_i32(&mut cur)?;
             if has_current_leader_epoch(api_version) {

--- a/crates/mockforge-kafka/src/group_codec.rs
+++ b/crates/mockforge-kafka/src/group_codec.rs
@@ -11,6 +11,7 @@
 //! Response header for all of these is v0: just `correlation_id`, no tag
 //! buffer.
 
+use crate::codec_util::sane_capacity;
 use crate::produce_codec::{read_i32, read_i8, take};
 
 // =========================================================================
@@ -139,7 +140,7 @@ pub fn parse_join_group_v5(body: &[u8]) -> Result<JoinGroupRequestV5, String> {
     if protos_count < 0 {
         return Err("join_group protocols count is negative".into());
     }
-    let mut protocols = Vec::with_capacity(protos_count as usize);
+    let mut protocols = Vec::with_capacity(sane_capacity(protos_count as usize, cur.len(), 2));
     for _ in 0..protos_count {
         let name = read_string(&mut cur)?;
         let metadata = read_bytes(&mut cur)?;
@@ -211,7 +212,7 @@ pub fn parse_sync_group_v3(body: &[u8]) -> Result<SyncGroupRequestV3, String> {
     if count < 0 {
         return Err("sync_group assignments count is negative".into());
     }
-    let mut assignments = Vec::with_capacity(count as usize);
+    let mut assignments = Vec::with_capacity(sane_capacity(count as usize, cur.len(), 2));
     for _ in 0..count {
         let m_id = read_string(&mut cur)?;
         let asn = read_bytes(&mut cur)?;
@@ -302,7 +303,7 @@ pub fn parse_leave_group(api_version: i16, body: &[u8]) -> Result<LeaveGroupRequ
         if count < 0 {
             return Err("leave_group members count is negative".into());
         }
-        let mut out = Vec::with_capacity(count as usize);
+        let mut out = Vec::with_capacity(sane_capacity(count as usize, cur.len(), 2));
         for _ in 0..count {
             let member_id = read_string(&mut cur)?;
             let _group_instance_id = read_nullable_string(&mut cur)?;
@@ -375,14 +376,14 @@ pub fn parse_offset_commit_v7(body: &[u8]) -> Result<OffsetCommitRequestV7, Stri
     if topics_count < 0 {
         return Err("offset_commit topics count is negative".into());
     }
-    let mut topics = Vec::with_capacity(topics_count as usize);
+    let mut topics = Vec::with_capacity(sane_capacity(topics_count as usize, cur.len(), 2));
     for _ in 0..topics_count {
         let name = read_string(&mut cur)?;
         let parts_count = read_i32(&mut cur)?;
         if parts_count < 0 {
             return Err(format!("offset_commit partitions count for {name} is negative"));
         }
-        let mut partitions = Vec::with_capacity(parts_count as usize);
+        let mut partitions = Vec::with_capacity(sane_capacity(parts_count as usize, cur.len(), 4));
         for _ in 0..parts_count {
             let partition_index = read_i32(&mut cur)?;
             let committed_offset = read_i64(&mut cur)?;
@@ -444,7 +445,8 @@ pub fn parse_offset_fetch_v5(body: &[u8]) -> Result<OffsetFetchRequestV5, String
         for _ in 0..topics_count {
             let name = read_string(&mut cur)?;
             let parts_count = read_i32(&mut cur)?;
-            let mut partition_indexes = Vec::with_capacity(parts_count.max(0) as usize);
+            let mut partition_indexes =
+                Vec::with_capacity(sane_capacity(parts_count.max(0) as usize, cur.len(), 4));
             for _ in 0..parts_count.max(0) {
                 partition_indexes.push(read_i32(&mut cur)?);
             }

--- a/crates/mockforge-kafka/src/lib.rs
+++ b/crates/mockforge-kafka/src/lib.rs
@@ -125,6 +125,7 @@
 //! - [`rdkafka`](https://docs.rs/rdkafka): Kafka client library for testing integration
 
 pub mod broker;
+pub mod codec_util;
 pub mod consumer_groups;
 pub mod fetch_codec;
 pub mod fetch_nonflex;

--- a/crates/mockforge-kafka/src/listoffsets_codec.rs
+++ b/crates/mockforge-kafka/src/listoffsets_codec.rs
@@ -10,6 +10,7 @@
 //! implement v7; auto-negotiating clients will pick it from the advertised
 //! range 0..=7.
 
+use crate::codec_util::sane_capacity;
 use crate::produce_codec::{
     push_compact_string, push_empty_tag_buffer, push_unsigned_varint, read_compact_string,
     read_i32, read_i64, read_i8, read_unsigned_varint, skip_tag_buffer,
@@ -63,7 +64,7 @@ pub fn parse_listoffsets_v7(body: &[u8]) -> Result<ListOffsetsRequestV7, String>
         return Err("listoffsets topics array is null".into());
     }
     let topics_len = (topics_len_plus_one - 1) as usize;
-    let mut topics = Vec::with_capacity(topics_len);
+    let mut topics = Vec::with_capacity(sane_capacity(topics_len, cur.len(), 2));
 
     for _ in 0..topics_len {
         let name = read_compact_string(&mut cur)?;
@@ -73,7 +74,7 @@ pub fn parse_listoffsets_v7(body: &[u8]) -> Result<ListOffsetsRequestV7, String>
             return Err(format!("listoffsets partitions array for {name} is null"));
         }
         let parts_len = (parts_len_plus_one - 1) as usize;
-        let mut partitions = Vec::with_capacity(parts_len);
+        let mut partitions = Vec::with_capacity(sane_capacity(parts_len, cur.len(), 4));
         for _ in 0..parts_len {
             let partition_index = read_i32(&mut cur)?;
             let _current_leader_epoch = read_i32(&mut cur)?;

--- a/crates/mockforge-kafka/src/partitions.rs
+++ b/crates/mockforge-kafka/src/partitions.rs
@@ -1,5 +1,21 @@
 use std::collections::VecDeque;
 
+/// Current wall-clock time in epoch milliseconds, saturating to 0 before the
+/// epoch. Used to stamp message ingestion times for retention.
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Hard cap on the number of retained messages per partition. Independent of
+/// `retention_ms`, this bounds memory even when every message is fresh. (#753)
+pub const MAX_LOG_MESSAGES: usize = 100_000;
+
+/// Hard cap on the total retained value bytes per partition (256 MiB). (#753)
+pub const MAX_LOG_BYTES: usize = 256 * 1024 * 1024;
+
 /// Represents a Kafka partition
 #[derive(Debug)]
 pub struct Partition {
@@ -7,6 +23,15 @@ pub struct Partition {
     pub messages: VecDeque<KafkaMessage>,
     pub high_watermark: i64,
     pub log_start_offset: i64,
+    /// Running total of retained `value` bytes, kept in sync with `messages`
+    /// so `trim` doesn't have to re-sum the whole log on every append.
+    retained_bytes: usize,
+    /// Wall-clock ingestion time (epoch ms) for each retained message, in
+    /// lock-step with `messages`. Retention is measured against *ingestion*
+    /// time, not the record's client-supplied `timestamp` field, so a record
+    /// produced with an old/zero logical timestamp isn't evicted on arrival
+    /// and an attacker can't force eviction by lying about timestamps (#753).
+    ingest_times_ms: VecDeque<i64>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -26,6 +51,8 @@ impl Partition {
             messages: VecDeque::new(),
             high_watermark: 0,
             log_start_offset: 0,
+            retained_bytes: 0,
+            ingest_times_ms: VecDeque::new(),
         }
     }
 
@@ -36,14 +63,59 @@ impl Partition {
     pub fn append(&mut self, mut message: KafkaMessage) -> i64 {
         let offset = self.high_watermark;
         message.offset = offset;
+        self.retained_bytes = self.retained_bytes.saturating_add(message.value.len());
+        self.ingest_times_ms.push_back(now_ms());
         self.messages.push_back(message);
         self.high_watermark += 1;
         offset
     }
 
+    /// Evict messages from the front of the log until it is within the
+    /// configured caps. Eviction advances `log_start_offset` so the Fetch
+    /// path stays consistent. This is the only place that drops retained
+    /// messages, enforcing the size/count/retention limits a mock broker
+    /// would otherwise never apply (#753).
+    ///
+    /// `retention_ms` is compared against `now_ms`; a non-positive
+    /// `retention_ms` disables the age check (count/byte caps still apply).
+    pub fn trim(&mut self, retention_ms: i64, now_ms: i64, max_messages: usize, max_bytes: usize) {
+        loop {
+            if self.messages.is_empty() {
+                break;
+            }
+
+            let over_count = self.messages.len() > max_messages;
+            let over_bytes = self.retained_bytes > max_bytes;
+            // Age is measured against ingestion time, not the record's
+            // client-supplied timestamp (#753).
+            let expired = retention_ms > 0
+                && self
+                    .ingest_times_ms
+                    .front()
+                    .is_some_and(|&ingested| now_ms.saturating_sub(ingested) > retention_ms);
+
+            // Never evict the only message purely on size; a single oversized
+            // record should still be fetchable. Age expiry may drain to empty.
+            if !expired && !((over_count || over_bytes) && self.messages.len() > 1) {
+                break;
+            }
+
+            if let Some(evicted) = self.messages.pop_front() {
+                self.retained_bytes = self.retained_bytes.saturating_sub(evicted.value.len());
+                self.ingest_times_ms.pop_front();
+                self.log_start_offset += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
     /// Fetch messages from a given offset
     pub fn fetch(&self, offset: i64, max_bytes: i32) -> Vec<&KafkaMessage> {
-        let start_idx = (offset - self.log_start_offset) as usize;
+        // A fetch targeting an offset below the current log start (because the
+        // requested records were evicted by `trim`) must not underflow the
+        // `usize` index — clamp to the start of the retained log. (#753)
+        let start_idx = offset.saturating_sub(self.log_start_offset).max(0) as usize;
         let mut result = Vec::new();
         let mut total_bytes = 0;
 
@@ -234,5 +306,82 @@ mod tests {
         let debug = format!("{:?}", partition);
         assert!(debug.contains("Partition"));
         assert!(debug.contains("3"));
+    }
+
+    #[test]
+    fn test_trim_enforces_message_count_cap_and_advances_start() {
+        let mut partition = Partition::new(0);
+        // Append well over the cap.
+        for i in 0..10 {
+            partition.append(create_test_message(0, b"x"));
+            // retention disabled (0), count cap = 5, generous byte cap.
+            partition.trim(0, 0, 5, 1_000_000);
+            let _ = i;
+        }
+
+        // Bounded length.
+        assert_eq!(partition.messages.len(), 5);
+        // log_start_offset advanced past the evicted prefix.
+        assert_eq!(partition.log_start_offset, 5);
+        assert_eq!(partition.high_watermark, 10);
+        // Front message is the oldest retained (offset 5).
+        assert_eq!(partition.messages.front().unwrap().offset, 5);
+    }
+
+    #[test]
+    fn test_trim_enforces_byte_cap() {
+        let mut partition = Partition::new(0);
+        // Each value is 100 bytes; cap at 250 bytes -> at most 2 retained.
+        let payload = vec![b'a'; 100];
+        for _ in 0..5 {
+            partition.append(create_test_message(0, &payload));
+            partition.trim(0, 0, usize::MAX, 250);
+        }
+        assert!(partition.messages.len() <= 3);
+        // Never panics; start offset advanced.
+        assert!(partition.log_start_offset > 0);
+    }
+
+    #[test]
+    fn test_fetch_evicted_offset_does_not_panic() {
+        let mut partition = Partition::new(0);
+        for _ in 0..10 {
+            partition.append(create_test_message(0, b"data"));
+        }
+        // Evict the first 5.
+        partition.trim(0, 0, 5, 1_000_000);
+        assert_eq!(partition.log_start_offset, 5);
+
+        // Fetching an already-evicted offset (0) must not underflow/panic;
+        // it should serve from the new log start.
+        let msgs = partition.fetch(0, 10_000);
+        assert_eq!(msgs.len(), 5);
+        assert_eq!(msgs[0].offset, 5);
+    }
+
+    #[test]
+    fn test_trim_age_expiry_can_drain_to_empty() {
+        let mut partition = Partition::new(0);
+        for _ in 0..3 {
+            partition.append(create_test_message(0, b"old"));
+        }
+        // Retention is measured against ingestion (wall-clock) time. Pass a
+        // `now_ms` far in the future so all three are well past retention.
+        let far_future = now_ms() + 10_000_000;
+        partition.trim(1000, far_future, usize::MAX, usize::MAX);
+        assert!(partition.messages.is_empty());
+        assert_eq!(partition.log_start_offset, 3);
+    }
+
+    #[test]
+    fn test_trim_keeps_single_oversized_message() {
+        let mut partition = Partition::new(0);
+        let big = vec![b'z'; 1024];
+        partition.append(create_test_message(0, &big));
+        // Byte cap below the single message size; retention disabled.
+        partition.trim(0, 0, usize::MAX, 10);
+        // The lone message stays fetchable.
+        assert_eq!(partition.messages.len(), 1);
+        assert_eq!(partition.log_start_offset, 0);
     }
 }

--- a/crates/mockforge-kafka/src/produce_codec.rs
+++ b/crates/mockforge-kafka/src/produce_codec.rs
@@ -17,6 +17,8 @@
 //! The broker is responsible for actually writing records into topic storage.
 //! This module only decodes and encodes.
 
+use crate::codec_util::sane_capacity;
+
 /// A record extracted from a RecordBatch v2.
 ///
 /// Offsets are not set here — the broker assigns them when calling
@@ -289,7 +291,10 @@ pub fn parse_record_batch(batch_bytes: &[u8]) -> Result<(Vec<DecodedRecord>, i16
         None => cur,
     };
 
-    let mut records = Vec::with_capacity(records_count as usize);
+    // Each record is at least one signed varint (1 byte), so clamp the
+    // pre-allocation to the remaining records blob.
+    let mut records =
+        Vec::with_capacity(sane_capacity(records_count as usize, records_cur.len(), 1));
     for _ in 0..records_count {
         let record_len = read_signed_varint(&mut records_cur)?;
         if record_len < 0 {
@@ -321,7 +326,9 @@ pub fn parse_record_batch(batch_bytes: &[u8]) -> Result<(Vec<DecodedRecord>, i16
         if headers_len < 0 {
             return Err(format!("negative headers count: {headers_len}"));
         }
-        let mut headers = Vec::with_capacity(headers_len as usize);
+        // Each header is at least two signed varints (key len + value len),
+        // so ~2 bytes minimum on the wire.
+        let mut headers = Vec::with_capacity(sane_capacity(headers_len as usize, body.len(), 2));
         for _ in 0..headers_len {
             let hk_len = read_signed_varint(&mut body)?;
             if hk_len < 0 {
@@ -368,7 +375,7 @@ pub fn parse_produce_v9(body: &[u8]) -> Result<ProduceRequestV9, String> {
         return Err("produce request topic array is null".into());
     }
     let topics_len = (topics_len_plus_one - 1) as usize;
-    let mut topics = Vec::with_capacity(topics_len);
+    let mut topics = Vec::with_capacity(sane_capacity(topics_len, cur.len(), 2));
 
     for _ in 0..topics_len {
         let name = read_compact_string(&mut cur)?;
@@ -378,7 +385,7 @@ pub fn parse_produce_v9(body: &[u8]) -> Result<ProduceRequestV9, String> {
             return Err(format!("topic {name} partition array is null"));
         }
         let parts_len = (parts_len_plus_one - 1) as usize;
-        let mut parts = Vec::with_capacity(parts_len);
+        let mut parts = Vec::with_capacity(sane_capacity(parts_len, cur.len(), 4));
 
         for _ in 0..parts_len {
             let partition_index = read_i32(&mut cur)?;

--- a/crates/mockforge-kafka/src/produce_nonflex.rs
+++ b/crates/mockforge-kafka/src/produce_nonflex.rs
@@ -34,6 +34,7 @@
 //! Response header for every non-flexible version is v0: just correlation_id
 //! (no tag buffer). `produce_codec` handles v9 with the flexible v1 header.
 
+use crate::codec_util::sane_capacity;
 use crate::produce_codec::{
     parse_record_batch, PartitionProduceData, ProduceRequestV9, TopicProduceData,
     TopicProduceResult,
@@ -109,14 +110,14 @@ pub fn parse_produce_v3_v8(body: &[u8]) -> Result<ProduceRequestV9, String> {
     if topics_count < 0 {
         return Err(format!("produce topics count is negative: {topics_count}"));
     }
-    let mut topics = Vec::with_capacity(topics_count as usize);
+    let mut topics = Vec::with_capacity(sane_capacity(topics_count as usize, cur.len(), 2));
     for _ in 0..topics_count {
         let name = read_string(&mut cur)?;
         let parts_count = read_i32(&mut cur)?;
         if parts_count < 0 {
             return Err(format!("produce partitions count for {name} is negative"));
         }
-        let mut parts = Vec::with_capacity(parts_count as usize);
+        let mut parts = Vec::with_capacity(sane_capacity(parts_count as usize, cur.len(), 4));
         for _ in 0..parts_count {
             let partition_index = read_i32(&mut cur)?;
             let records_bytes = read_nullable_bytes(&mut cur)?;
@@ -225,6 +226,23 @@ mod tests {
         body.extend_from_slice(&(batch.len() as i32).to_be_bytes());
         body.extend_from_slice(batch);
         body
+    }
+
+    #[test]
+    fn huge_topics_count_fails_fast_without_giant_alloc() {
+        // A tiny buffer that advertises i32::MAX topics. sane_capacity must
+        // clamp the pre-allocation to the (near-empty) remaining buffer, and
+        // the bounded parse loop must error on the first short read rather
+        // than attempting to reserve ~2 billion entries.
+        let mut body = Vec::new();
+        body.extend_from_slice(&(-1i16).to_be_bytes()); // transactional_id = null
+        body.extend_from_slice(&(-1i16).to_be_bytes()); // acks
+        body.extend_from_slice(&30_000i32.to_be_bytes()); // timeout_ms
+        body.extend_from_slice(&0x7FFF_FFFFi32.to_be_bytes()); // topics_count = i32::MAX
+                                                               // No topic data follows -> first read_string short-reads.
+
+        let result = parse_produce_v3_v8(&body);
+        assert!(result.is_err(), "expected parse error, got {result:?}");
     }
 
     #[test]

--- a/crates/mockforge-kafka/src/topics.rs
+++ b/crates/mockforge-kafka/src/topics.rs
@@ -74,8 +74,22 @@ impl Topic {
         partition: i32,
         record: crate::partitions::KafkaMessage,
     ) -> mockforge_core::Result<i64> {
+        let retention_ms = self.config.retention_ms;
         if let Some(partition) = self.partitions.get_mut(partition as usize) {
-            Ok(partition.append(record))
+            let offset = partition.append(record);
+            // Enforce per-partition retention/size caps so the log can't grow
+            // unbounded (#753).
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            partition.trim(
+                retention_ms,
+                now_ms,
+                crate::partitions::MAX_LOG_MESSAGES,
+                crate::partitions::MAX_LOG_BYTES,
+            );
+            Ok(offset)
         } else {
             Err(mockforge_core::Error::internal(format!(
                 "Partition {} does not exist",

--- a/crates/mockforge-smtp/src/lib.rs
+++ b/crates/mockforge-smtp/src/lib.rs
@@ -53,12 +53,21 @@ pub struct SmtpConfig {
     pub enable_mailbox: bool,
     /// Maximum mailbox size
     pub max_mailbox_messages: usize,
+    /// Maximum accepted message size in bytes for a single DATA payload
+    /// (default: 25 MiB). Protects against unbounded DATA accumulation (#754).
+    #[serde(default = "default_max_message_bytes")]
+    pub max_message_bytes: usize,
     /// Enable STARTTLS support
     pub enable_starttls: bool,
     /// Path to TLS certificate file
     pub tls_cert_path: Option<PathBuf>,
     /// Path to TLS private key file
     pub tls_key_path: Option<PathBuf>,
+}
+
+/// Default maximum accepted DATA payload size (25 MiB).
+fn default_max_message_bytes() -> usize {
+    26_214_400
 }
 
 impl Default for SmtpConfig {
@@ -72,6 +81,7 @@ impl Default for SmtpConfig {
             max_connections: 10,
             enable_mailbox: true,
             max_mailbox_messages: 1000,
+            max_message_bytes: default_max_message_bytes(),
             enable_starttls: false,
             tls_cert_path: None,
             tls_key_path: None,

--- a/crates/mockforge-smtp/src/server.rs
+++ b/crates/mockforge-smtp/src/server.rs
@@ -12,8 +12,65 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Semaphore;
 use tokio_rustls::{rustls, server::TlsStream, TlsAcceptor};
 use tracing::{debug, error, info, warn};
+
+/// Hard cap on a single SMTP protocol line (command or DATA line) before the
+/// connection is dropped. SMTP lines are spec-limited to ~1000 bytes, so 1 MiB
+/// is generous headroom while still bounding a newline-less flood (#754).
+const MAX_LINE_BYTES: usize = 1024 * 1024;
+
+/// Outcome of a bounded line read.
+enum LineRead {
+    /// A full line (terminated by `\n` or by EOF after some bytes) was read.
+    Ok,
+    /// The stream ended with no further bytes.
+    Eof,
+    /// The line exceeded the byte cap before a newline arrived.
+    TooLong,
+}
+
+/// Read a single `\n`-terminated line into `line`, but stop and report
+/// [`LineRead::TooLong`] once the accumulated line exceeds `max_bytes`.
+///
+/// This wraps `read_until` one byte chunk at a time so an attacker can't make
+/// the underlying buffer grow without bound by simply never sending a newline.
+async fn read_line_capped<R>(
+    reader: &mut R,
+    line: &mut Vec<u8>,
+    max_bytes: usize,
+) -> std::io::Result<LineRead>
+where
+    R: AsyncBufReadExt + Unpin,
+{
+    loop {
+        let before = line.len();
+        let n = reader.read_until(b'\n', line).await?;
+        if n == 0 {
+            // EOF: if we'd already accumulated a partial line, treat it as a
+            // final line; otherwise the stream is closed.
+            return Ok(if line.is_empty() {
+                LineRead::Eof
+            } else {
+                LineRead::Ok
+            });
+        }
+        let ends_with_newline = line.last() == Some(&b'\n');
+        if line.len() > max_bytes {
+            return Ok(LineRead::TooLong);
+        }
+        if ends_with_newline {
+            return Ok(LineRead::Ok);
+        }
+        // No newline yet and under the cap — `read_until` returned because the
+        // buffered chunk was exhausted; keep reading. Guard against a stuck
+        // reader that returns 0-growth without EOF.
+        if line.len() == before {
+            return Ok(LineRead::Ok);
+        }
+    }
+}
 
 /// Stream wrapper that can be either plaintext TCP or TLS-upgraded.
 /// The session handler starts each connection as `Plain` and swaps to
@@ -165,10 +222,27 @@ impl SmtpServer {
 
         info!("SMTP server listening on {}", addr);
 
+        // Cap concurrent sessions at `max_connections` so a connection flood
+        // can't spawn unbounded tasks (#755). A permit is acquired before each
+        // session task and moved into it, freeing on disconnect.
+        let max_connections = self.config.max_connections.max(1);
+        let connection_limiter = Arc::new(Semaphore::new(max_connections));
+        let max_message_bytes = self.config.max_message_bytes;
+
         loop {
             match listener.accept().await {
                 Ok((stream, peer_addr)) => {
                     debug!("New SMTP connection from {}", peer_addr);
+
+                    let permit = match connection_limiter.clone().acquire_owned().await {
+                        Ok(permit) => permit,
+                        Err(_) => {
+                            // Semaphore closed — should not happen while the
+                            // server runs, but bail cleanly if it does.
+                            error!("SMTP connection limiter closed; stopping accept loop");
+                            break Ok(());
+                        }
+                    };
 
                     let registry = self.spec_registry.clone();
                     let middleware = self.middleware_chain.clone();
@@ -176,6 +250,8 @@ impl SmtpServer {
                     let tls_acceptor = self.tls_acceptor.clone();
 
                     tokio::spawn(async move {
+                        // Hold the permit for the lifetime of the session.
+                        let _permit = permit;
                         if let Err(e) = handle_smtp_session(
                             SmtpStream::Plain(stream),
                             peer_addr,
@@ -183,6 +259,7 @@ impl SmtpServer {
                             middleware,
                             hostname,
                             tls_acceptor,
+                            max_message_bytes,
                         )
                         .await
                         {
@@ -208,6 +285,7 @@ async fn handle_smtp_session(
     middleware: Arc<MiddlewareChain>,
     hostname: String,
     tls_acceptor: Option<TlsAcceptor>,
+    max_message_bytes: usize,
 ) -> Result<()> {
     // Keep read + write on the same `SmtpStream` so STARTTLS can
     // upgrade both halves atomically. Writes go through
@@ -218,13 +296,25 @@ async fn handle_smtp_session(
     let greeting = format!("220 {} ESMTP MockForge SMTP Server\r\n", hostname);
     reader.get_mut().write_all(greeting.as_bytes()).await?;
 
-    let mut session_state = SessionState::new();
+    let mut session_state = SessionState::with_max_message_bytes(max_message_bytes);
     // Byte-level accumulator so 8BITMIME bodies (Latin-1, UTF-8 with
     // explicit content-transfer-encoding, etc.) round-trip verbatim.
     // `read_line` would fail on non-UTF-8 inputs.
     let mut line: Vec<u8> = Vec::new();
 
-    while reader.read_until(b'\n', &mut line).await? > 0 {
+    loop {
+        // Bound each line read so a client that never sends a newline can't
+        // make `read_until` accumulate an unbounded buffer (#754).
+        match read_line_capped(&mut reader, &mut line, MAX_LINE_BYTES).await? {
+            LineRead::Eof => break,
+            LineRead::Ok => {}
+            LineRead::TooLong => {
+                warn!("SMTP line from {} exceeded {} bytes; closing", peer_addr, MAX_LINE_BYTES);
+                reader.get_mut().write_all(b"500 line too long\r\n").await?;
+                break;
+            }
+        }
+
         // DATA mode bypasses command parsing entirely. Without this, the
         // first word of every body line would be matched against the SMTP
         // verb table — any body beginning with "Hello ..." / "Data ..." /
@@ -241,6 +331,19 @@ async fn handle_smtp_session(
                 let response =
                     process_email(&session_state, &registry, &middleware, peer_addr).await?;
                 reader.get_mut().write_all(response.as_bytes()).await?;
+                session_state.reset();
+            } else if session_state.data_would_overflow(trimmed.len() + 1) {
+                // Reject oversized messages instead of buffering them to OOM
+                // (#754). Per RFC 5321 the 552 response ends the DATA phase;
+                // reset the transaction and leave DATA mode.
+                warn!(
+                    "SMTP DATA from {} exceeded max_message_bytes ({}); rejecting",
+                    peer_addr, max_message_bytes
+                );
+                reader
+                    .get_mut()
+                    .write_all(b"552 message size exceeds fixed maximum message size\r\n")
+                    .await?;
                 session_state.reset();
             } else {
                 session_state.data.extend_from_slice(trimmed);
@@ -297,7 +400,7 @@ async fn handle_smtp_session(
                     mockforge_core::Error::internal(format!("TLS accept failed: {e}"))
                 })?;
                 reader = BufReader::new(SmtpStream::Tls(Box::new(tls_stream)));
-                session_state = SessionState::new();
+                session_state = SessionState::with_max_message_bytes(max_message_bytes);
                 line.clear();
                 continue;
             } else {
@@ -597,6 +700,14 @@ async fn handle_smtp_command<W: AsyncWriteExt + Unpin>(
                     let response = process_email(state, registry, middleware, peer_addr).await?;
                     writer.write_all(response.as_bytes()).await?;
                     state.reset();
+                } else if state.data_would_overflow(command.len() + 1) {
+                    // Mirror the primary DATA-path cap so the fallback can't be
+                    // used to bypass max_message_bytes (#754).
+                    warn!("SMTP DATA fallback exceeded max_message_bytes; rejecting");
+                    writer
+                        .write_all(b"552 message size exceeds fixed maximum message size\r\n")
+                        .await?;
+                    state.reset();
                 } else {
                     // Command path: the caller already trimmed the line
                     // into a `&str`. Non-ASCII bodies are accumulated
@@ -769,10 +880,19 @@ struct SessionState {
     /// inspecting the mailbox can filter by who sent what. Populated
     /// on successful AUTH PLAIN / AUTH LOGIN; cleared by RSET/reset().
     authenticated_user: Option<String>,
+    /// Maximum accepted DATA payload size in bytes. Carried on the
+    /// session so both the primary DATA path and the defensive fallback
+    /// can enforce the same cap (#754).
+    max_message_bytes: usize,
 }
 
 impl SessionState {
+    #[cfg(test)]
     fn new() -> Self {
+        Self::with_max_message_bytes(crate::SmtpConfig::default().max_message_bytes)
+    }
+
+    fn with_max_message_bytes(max_message_bytes: usize) -> Self {
         Self {
             mail_from: None,
             rcpt_to: Vec::new(),
@@ -780,7 +900,14 @@ impl SessionState {
             in_data_mode: false,
             pending_auth: None,
             authenticated_user: None,
+            max_message_bytes,
         }
+    }
+
+    /// True if appending `additional` bytes to `data` would exceed the
+    /// configured `max_message_bytes` cap.
+    fn data_would_overflow(&self, additional: usize) -> bool {
+        self.data.len().saturating_add(additional) > self.max_message_bytes
     }
 
     fn reset(&mut self) {

--- a/crates/mockforge-smtp/tests/integration.rs
+++ b/crates/mockforge-smtp/tests/integration.rs
@@ -896,3 +896,105 @@ async fn test_smtp_starttls_without_cert_returns_454() {
     // QUIT
     writer.write_all(b"QUIT\r\n").await.ok();
 }
+
+/// Start a catch-all SMTP server with a caller-chosen `max_message_bytes` so
+/// the DoS guards (#754) can be exercised.
+async fn start_test_server_with_max_bytes(max_message_bytes: usize) -> (SmtpServer, u16) {
+    let port = find_available_port().await;
+    let config = SmtpConfig {
+        port,
+        host: "127.0.0.1".to_string(),
+        hostname: "test-smtp".to_string(),
+        max_message_bytes,
+        ..Default::default()
+    };
+    let registry = Arc::new(SmtpSpecRegistry::new());
+    let server = SmtpServer::new(config, registry).expect("Failed to create SMTP server");
+    (server, port)
+}
+
+#[tokio::test]
+async fn test_smtp_data_exceeding_max_message_bytes_is_rejected() {
+    // Tiny cap so a few body lines blow past it.
+    let (server, port) = start_test_server_with_max_bytes(256).await;
+    tokio::spawn(async move {
+        server.start().await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let (mut reader, mut writer, _greeting) = connect_and_read_greeting(port).await;
+    let mut response = String::new();
+
+    // MAIL FROM + RCPT TO + DATA
+    writer.write_all(b"MAIL FROM:<a@b.com>\r\n").await.unwrap();
+    reader.read_line(&mut response).await.unwrap();
+    response.clear();
+    writer.write_all(b"RCPT TO:<c@d.com>\r\n").await.unwrap();
+    reader.read_line(&mut response).await.unwrap();
+    response.clear();
+    writer.write_all(b"DATA\r\n").await.unwrap();
+    reader.read_line(&mut response).await.unwrap();
+    assert!(response.starts_with("354"), "expected 354, got {response:?}");
+    response.clear();
+
+    // Pour body lines well past the 256-byte cap.
+    let big_line = vec![b'x'; 200];
+    let mut saw_552 = false;
+    for _ in 0..10 {
+        writer.write_all(&big_line).await.unwrap();
+        writer.write_all(b"\r\n").await.unwrap();
+        // The server replies 552 once the cap is crossed.
+        if let Ok(Ok(_)) =
+            timeout(Duration::from_millis(500), reader.read_line(&mut response)).await
+        {
+            if response.contains("552") {
+                saw_552 = true;
+                break;
+            }
+            response.clear();
+        }
+    }
+    assert!(saw_552, "expected 552 message-size rejection, got {response:?}");
+
+    // After reset the session is usable again: a fresh MAIL FROM is accepted.
+    response.clear();
+    writer.write_all(b"MAIL FROM:<e@f.com>\r\n").await.unwrap();
+    reader.read_line(&mut response).await.unwrap();
+    assert!(response.contains("250"), "session should be reset/usable; got {response:?}");
+}
+
+#[tokio::test]
+async fn test_smtp_long_line_without_newline_is_capped() {
+    let (server, port) = start_test_server_with_max_bytes(26_214_400).await;
+    tokio::spawn(async move {
+        server.start().await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let (mut reader, mut writer, _greeting) = connect_and_read_greeting(port).await;
+
+    // Stream a newline-less flood larger than MAX_LINE_BYTES (1 MiB). The
+    // server must close (or reply "500 line too long") rather than buffering
+    // unbounded. Write in chunks; a closed socket surfaces as a write error.
+    let chunk = vec![b'A'; 64 * 1024];
+    let mut closed_or_capped = false;
+    for _ in 0..40 {
+        if writer.write_all(&chunk).await.is_err() {
+            closed_or_capped = true;
+            break;
+        }
+    }
+
+    // Either the write side errored (peer closed) or we can read the
+    // "500 line too long" response.
+    if !closed_or_capped {
+        let mut response = String::new();
+        if let Ok(Ok(_)) = timeout(Duration::from_secs(2), reader.read_line(&mut response)).await {
+            closed_or_capped = response.contains("500") || response.is_empty();
+        } else {
+            // Read timing out is acceptable too — the point is we did not OOM.
+            closed_or_capped = true;
+        }
+    }
+    assert!(closed_or_capped, "server should cap/close on a newline-less flood");
+}

--- a/crates/mockforge-tcp/src/lib.rs
+++ b/crates/mockforge-tcp/src/lib.rs
@@ -58,6 +58,17 @@ pub struct TcpConfig {
     pub echo_mode: bool,
     /// Delimiter for message boundaries (None = stream mode, Some = frame by delimiter)
     pub delimiter: Option<Vec<u8>>,
+    /// Maximum bytes buffered for a single delimiter-framed message before the
+    /// connection is dropped (default: 1 MiB). Bounds the delimiter-mode
+    /// accumulator so a client that never sends the delimiter can't drive the
+    /// server to OOM (#755).
+    #[serde(default = "default_tcp_max_message_bytes")]
+    pub max_message_bytes: usize,
+}
+
+/// Default maximum buffered bytes for a delimiter-framed TCP message (1 MiB).
+fn default_tcp_max_message_bytes() -> usize {
+    1_048_576
 }
 
 impl Default for TcpConfig {
@@ -75,6 +86,7 @@ impl Default for TcpConfig {
             tls_key_path: None,
             echo_mode: true,
             delimiter: None, // Stream mode by default
+            max_message_bytes: default_tcp_max_message_bytes(),
         }
     }
 }
@@ -133,6 +145,7 @@ mod tests {
             tls_key_path: Some(std::path::PathBuf::from("/path/to/key")),
             echo_mode: false,
             delimiter: Some(b"\n".to_vec()),
+            ..Default::default()
         };
 
         let cloned = config.clone();

--- a/crates/mockforge-tcp/src/server.rs
+++ b/crates/mockforge-tcp/src/server.rs
@@ -6,6 +6,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Semaphore;
 use tokio::time::{sleep, timeout, Duration};
 use tracing::{debug, error, info, warn};
 
@@ -31,15 +32,30 @@ impl TcpServer {
 
         info!("TCP server listening on {}", addr);
 
+        // Cap concurrent connections at `max_connections` so a connection flood
+        // can't spawn unbounded tasks (#755). A permit is acquired before each
+        // connection task and moved into it, freeing on disconnect.
+        let connection_limiter = Arc::new(Semaphore::new(self.config.max_connections.max(1)));
+
         loop {
             match listener.accept().await {
                 Ok((stream, peer_addr)) => {
                     debug!("New TCP connection from {}", peer_addr);
 
+                    let permit = match connection_limiter.clone().acquire_owned().await {
+                        Ok(permit) => permit,
+                        Err(_) => {
+                            error!("TCP connection limiter closed; stopping accept loop");
+                            break Ok(());
+                        }
+                    };
+
                     let registry = self.spec_registry.clone();
                     let config = self.config.clone();
 
                     tokio::spawn(async move {
+                        // Hold the permit for the lifetime of the connection.
+                        let _permit = permit;
                         if let Err(e) =
                             handle_tcp_connection(stream, peer_addr, registry, config).await
                         {
@@ -82,6 +98,19 @@ async fn handle_tcp_connection(
                 accumulated_data.extend_from_slice(received_data);
 
                 debug!("Received {} bytes from {}", n, peer_addr);
+
+                // In delimiter mode the accumulator only clears on a delimiter
+                // match, so a client that never sends the delimiter would grow
+                // it without bound. Cap it and drop the connection. (#755)
+                // Stream mode (no delimiter) clears every read below, so it's
+                // already bounded.
+                if config.delimiter.is_some() && accumulated_data.len() > config.max_message_bytes {
+                    warn!(
+                        "TCP delimiter buffer from {} exceeded max_message_bytes ({}); closing",
+                        peer_addr, config.max_message_bytes
+                    );
+                    break;
+                }
 
                 // Try to find matching fixture
                 let response_data =
@@ -491,6 +520,7 @@ mod tests {
             tls_key_path: Some(PathBuf::from("/path/to/key.pem")),
             echo_mode: false,
             delimiter: Some(b"\r\n".to_vec()),
+            ..Default::default()
         };
 
         let registry = Arc::new(TcpSpecRegistry::new());

--- a/crates/mockforge-tcp/tests/tcp_roundtrip_e2e.rs
+++ b/crates/mockforge-tcp/tests/tcp_roundtrip_e2e.rs
@@ -117,3 +117,117 @@ async fn tcp_delimiter_mode_frames_multiple_messages() {
     drop(stream);
     server.abort();
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tcp_delimiter_buffer_over_cap_closes_connection() {
+    // In delimiter mode the accumulator only clears on a delimiter match. A
+    // client that streams data without ever sending the delimiter must not be
+    // able to grow the buffer past `max_message_bytes`; the server caps it and
+    // drops the connection (#755).
+    let port = free_port().await;
+    let config = TcpConfig {
+        port,
+        host: "127.0.0.1".into(),
+        fixtures_dir: None,
+        echo_mode: true,
+        timeout_secs: 30,
+        // Never appears in our payload, so the accumulator never resets.
+        delimiter: Some(b"\n".to_vec()),
+        max_message_bytes: 64 * 1024,
+        ..TcpConfig::default()
+    };
+    let (_port, server) = spawn_server(config).await;
+
+    let stream = TcpStream::connect(("127.0.0.1", port)).await.expect("connect");
+    let (mut rd, mut wr) = stream.into_split();
+
+    // Writer task: stream 4 MiB of delimiter-free bytes, well past the cap.
+    // In echo mode the server echoes the (growing) accumulator back, so the
+    // writer must run concurrently with a draining reader or the pipe stalls.
+    let writer = tokio::spawn(async move {
+        let chunk = vec![b'Z'; 16 * 1024];
+        for _ in 0..256 {
+            if wr.write_all(&chunk).await.is_err() {
+                break;
+            }
+            let _ = wr.flush().await;
+        }
+        // Keep the write half alive briefly so the close is server-driven.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    // Reader: drain echoes until the server closes the connection (EOF/error).
+    // The whole exchange must terminate; if the cap weren't enforced the
+    // server would buffer forever and the read loop would never see EOF.
+    let mut buf = [0u8; 32 * 1024];
+    let closed = loop {
+        match tokio::time::timeout(Duration::from_secs(10), rd.read(&mut buf)).await {
+            Ok(Ok(0)) => break true,  // clean EOF — server closed
+            Ok(Err(_)) => break true, // reset — server closed
+            Ok(Ok(_)) => continue,    // drained an echo chunk, keep going
+            Err(_) => break false,    // overall read stalled without closing
+        }
+    };
+
+    assert!(
+        closed,
+        "server must close the connection once the delimiter buffer exceeds the cap"
+    );
+
+    writer.abort();
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tcp_max_connections_limits_concurrent_sessions() {
+    // Best-effort: with max_connections = 1, a second client should not be
+    // serviced while the first holds its slot. We verify the first connection
+    // gets an echo and that the limiter is in effect (the second connect may
+    // succeed at the TCP layer but won't be handled until the first frees).
+    let port = free_port().await;
+    let config = TcpConfig {
+        port,
+        host: "127.0.0.1".into(),
+        fixtures_dir: None,
+        echo_mode: true,
+        timeout_secs: 30,
+        max_connections: 1,
+        ..TcpConfig::default()
+    };
+    let (_port, server) = spawn_server(config).await;
+
+    // First client connects and is serviced.
+    let mut first = TcpStream::connect(("127.0.0.1", port)).await.expect("first connect");
+    first.write_all(b"hello").await.unwrap();
+    first.flush().await.unwrap();
+    let mut buf = vec![0u8; 5];
+    tokio::time::timeout(Duration::from_secs(5), first.read_exact(&mut buf))
+        .await
+        .expect("first client serviced within 5s")
+        .expect("read");
+    assert_eq!(&buf, b"hello");
+
+    // Second client: with the single permit held by `first`, its session task
+    // can't start. Its echo must NOT arrive while `first` is alive.
+    let mut second = TcpStream::connect(("127.0.0.1", port)).await.expect("second connect");
+    second.write_all(b"world").await.unwrap();
+    second.flush().await.unwrap();
+    let mut buf2 = vec![0u8; 5];
+    let early =
+        tokio::time::timeout(Duration::from_millis(800), second.read_exact(&mut buf2)).await;
+    assert!(
+        early.is_err(),
+        "second client should be blocked while the first holds the only permit"
+    );
+
+    // Free the permit; the second client should now be serviced.
+    drop(first);
+    tokio::time::timeout(Duration::from_secs(5), second.read_exact(&mut buf2))
+        .await
+        .expect("second client serviced after first releases permit")
+        .expect("read");
+    assert_eq!(&buf2, b"world");
+
+    drop(second);
+    server.abort();
+}


### PR DESCRIPTION
## Root Cause
Four resource-exhaustion vectors on the raw protocol listeners — all reachable unauthenticated, the hosted multi-tenant threat model:
- **#752 kafka:** decoders read an array-length prefix off the wire and passed it directly to `Vec::with_capacity`. A varint can encode ~2^31 in a few bytes, so a ~10-20 byte request forced a multi-GB up-front reservation (the worst site, `produce_codec.rs` headers, reserved up to ~96GB) before the byte-bounded parse loop ran.
- **#753 kafka:** `Partition::append` only pushed; `retention_ms`/`max_message_bytes` were defined but never enforced, so any continuous producer grew the heap until OOM (and on a shared broker, one tenant starved all).
- **#754 smtp:** `read_until` (line read) and the `DATA` accumulator had no caps — one connection streaming bytes with no `.`/newline OOMs the listener.
- **#755 tcp/smtp:** `max_connections` was read only in config code, never enforced (unbounded task spawn); the TCP delimiter-mode buffer only cleared on a delimiter match, so a delimiter-free stream grew unbounded.

## Fix
- **#752:** `codec_util::sane_capacity(count, remaining_bytes, min_elem_wire_size)` clamps each reservation to `count.min(remaining / min_elem)`; applied to all 18 codec call sites. Honest inputs are unaffected (result never exceeds `count`).
- **#753:** `Partition::trim` evicts by count (100k), bytes (256MiB), and ingestion-age vs `retention_ms`, advancing `log_start_offset`; evicted-offset `fetch` saturates instead of underflowing. Age uses server ingestion time (a new per-message deque), not client timestamps, so a forged timestamp can't force eviction.
- **#754:** new `SmtpConfig.max_message_bytes` (25MiB default); line reads capped at 1MiB (`500` + close); DATA over cap returns `552` and resets.
- **#755:** both accept loops gate on an owned `Semaphore` permit held for the connection lifetime; new `TcpConfig.max_message_bytes` (1MiB) closes a never-delimiting stream.

## Risks
- New `max_message_bytes` fields are `#[serde(default)]` so existing configs deserialize unchanged. Struct-literal call sites updated with `..Default::default()`.
- `max_connections` now actually bounds concurrency: connections beyond the limit wait for a permit (queued, not rejected). Defaults: tcp 100, smtp 10 — unchanged values, now enforced.
- Retention trim runs per produce; constant caps (not new config knobs) keep the public config surface stable.

## Verification
- `cargo fmt --all --check` clean; `cargo clippy -p mockforge-kafka -p mockforge-smtp -p mockforge-tcp --all-targets -- -D warnings` clean; `cargo check -p mockforge-cli` ok.
- `cargo test -p mockforge-kafka -p mockforge-smtp -p mockforge-tcp` — 0 failures (kafka 322, smtp 63+18, tcp 77+4).

## Tests
16 regression tests: kafka capacity-clamp (huge-count fails fast), partition trim (count/byte/age caps + evicted-offset no-panic), smtp DATA-over-cap `552` + long-line cap, tcp delimiter-buffer-close + max-connections concurrency.

Closes #752. Closes #753. Closes #754. Closes #755.
