### PR TITLE
fix(bench): #79 round 35 — embedded-content variant-b probes treat 4xx as a pass (#859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.180] - 2026-06-16
+
+### Fixed
+
+- **[Contracts]** Embedded-content variant-b probes (`request-body:embedded-content:xml/yaml/multipart/urlencoded`) no longer flag 4xx responses as mismatches (#79 round 35 / #859 / Srikanth on 0.3.179: 4 noise rows on `POST /api/appliance/local-accounts` and ~268 similar rows across the vCenter spec). The round-27 design only ever wanted to catch 5xx server crashes; a 4xx from the server's pattern / format validator on the field we inject into is correct behavior. Replaced the older `expected_4xx: bool` flag on `send_case` / `send_case_with_extra` with a tristate `ExpectedOutcome` enum (`Success` / `ClientError` / `NotServerError`); variant-b probes opt into `NotServerError` so the pass calculation is `actual_status >= 200 && actual_status < 500`. `expected_status_range` on `CaseCapture` carries the new `"2xx-4xx"` value, which the HTML viewer + `jq` filters pick up automatically. `CaseOutcome.expected_4xx` keeps its old semantics (negative-probe flag), so `report_html.rs` is unchanged. Reproduced locally against the exact `POST /appliance/local-accounts` route Srikanth flagged: 4 embedded-content rows go from 4 misses to 4 passes on v0.3.180. Two new unit tests cover the pass-rule and the string-label table.
+
 ## [0.3.179] - 2026-06-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7822,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8053,7 +8053,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8184,7 +8184,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8217,7 +8217,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8240,7 +8240,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8290,7 +8290,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8372,7 +8372,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8453,7 +8453,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8471,7 +8471,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8500,7 +8500,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8535,7 +8535,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8557,7 +8557,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8584,7 +8584,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8609,7 +8609,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8632,7 +8632,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8674,7 +8674,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8704,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8723,7 +8723,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8753,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8782,7 +8782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8797,7 +8797,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8821,7 +8821,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8861,7 +8861,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8879,7 +8879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8898,7 +8898,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8923,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8975,7 +8975,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9090,7 +9090,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9110,7 +9110,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9123,7 +9123,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9145,7 +9145,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9182,7 +9182,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9210,7 +9210,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9240,7 +9240,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9267,7 +9267,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9290,14 +9290,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9324,7 +9324,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9335,7 +9335,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9357,7 +9357,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9375,7 +9375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9399,7 +9399,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9430,7 +9430,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9482,7 +9482,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9517,7 +9517,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9528,7 +9528,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9545,7 +9545,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15425,7 +15425,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.179"
+version = "0.3.180"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.179"
+version = "0.3.180"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.180] - 2026-06-16
+
+### Fixed
+
+- **[Contracts]** Embedded-content variant-b probes no longer flag 4xx responses as mismatches; only 5xx counts as failure (#79 round 35 / #859 / Srikanth).
+
 ## [0.3.179] - 2026-06-15
 
 ### Fixed

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -482,7 +482,7 @@ async fn test_operation(
         method.clone(),
         &url,
         "positive",
-        false,
+        ExpectedOutcome::Success,
         op.sample_body.as_deref(),
         op.query_params.clone(),
         op_headers.clone(),
@@ -509,7 +509,7 @@ async fn test_operation(
                 method.clone(),
                 &url,
                 "request-body:empty",
-                true,
+                ExpectedOutcome::ClientError,
                 Some("{}"),
                 op.query_params.clone(),
                 op_headers.clone(),
@@ -528,7 +528,7 @@ async fn test_operation(
                 method.clone(),
                 &url,
                 "request-body:wrong-type",
-                true,
+                ExpectedOutcome::ClientError,
                 Some("[]"),
                 op.query_params.clone(),
                 op_headers.clone(),
@@ -570,7 +570,7 @@ async fn test_operation(
                         method.clone(),
                         &url,
                         label,
-                        true,
+                        ExpectedOutcome::ClientError,
                         Some(payload),
                         op.query_params.clone(),
                         // Strip any Content-Type already on the operation
@@ -630,7 +630,7 @@ async fn test_operation(
                         // expected_4xx=false: any non-2xx is a probe
                         // failure. 5xx in particular is "server panicked
                         // on the embedded content".
-                        false,
+                        ExpectedOutcome::NotServerError,
                         Some(&body),
                         op.query_params.clone(),
                         op_headers.clone(),
@@ -663,7 +663,7 @@ async fn test_operation(
                             method.clone(),
                             &url,
                             &m.label,
-                            true,
+                            ExpectedOutcome::ClientError,
                             Some(&body_str),
                             op.query_params.clone(),
                             // Round 24 (f) — was `op.header_params`, which
@@ -700,7 +700,7 @@ async fn test_operation(
                 method.clone(),
                 &bad_url,
                 "parameters:uri-too-long",
-                true,
+                ExpectedOutcome::ClientError,
                 op.sample_body.as_deref(),
                 op.query_params.clone(),
                 // Round 24 (f) — see schema-mutation note above. Use
@@ -758,7 +758,7 @@ async fn test_operation(
                     method.clone(),
                     &bad_url,
                     "parameters:bad-path-param",
-                    true,
+                    ExpectedOutcome::ClientError,
                     op.sample_body.as_deref(),
                     op.query_params.clone(),
                     op_headers.clone(),
@@ -780,7 +780,7 @@ async fn test_operation(
                 method.clone(),
                 &url,
                 "parameters:missing-query",
-                true,
+                ExpectedOutcome::ClientError,
                 op.sample_body.as_deref(),
                 q,
                 op_headers.clone(),
@@ -843,7 +843,7 @@ async fn test_operation(
                 method.clone(),
                 &url,
                 &probe.label,
-                true,
+                ExpectedOutcome::ClientError,
                 op.sample_body.as_deref(),
                 req_query,
                 req_headers,
@@ -872,7 +872,7 @@ async fn test_operation(
                 method.clone(),
                 &url,
                 "parameters:missing-header",
-                true,
+                ExpectedOutcome::ClientError,
                 op.sample_body.as_deref(),
                 op.query_params.clone(),
                 h,
@@ -909,7 +909,7 @@ async fn test_operation(
                 method.clone(),
                 &url,
                 &probe.label,
-                true,
+                ExpectedOutcome::ClientError,
                 probe.body.as_deref(),
                 probe.query,
                 // Round 24 (f) — OWASP injection probes must also
@@ -1455,6 +1455,49 @@ fn strip_auth_query(
     query.iter().filter(|(k, _)| !apikey_query.contains(k)).cloned().collect()
 }
 
+/// Round 35 (#859) — Srikanth on 0.3.179: embedded-content variant-b
+/// probes were flagging well-behaved 4xx responses as mismatches when
+/// in reality only a 5xx (server CRASHED trying to parse the embedded
+/// XML/YAML/multipart/urlencoded payload) is the bug the probe was
+/// designed to find. Tristate replaces the older `expected_4xx: bool`
+/// so variant-b probes can opt into "anything but 5xx is fine".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExpectedOutcome {
+    /// Positive probe: spec-compliant request, expect 2xx or 3xx.
+    Success,
+    /// Negative probe: invalid request, expect 4xx.
+    ClientError,
+    /// Embedded-content variant-b probe: spec-shape envelope with a
+    /// non-JSON payload embedded in the first string field. Any
+    /// response that isn't a 5xx is fine; the probe is here to catch
+    /// server crashes on the embedded payload.
+    NotServerError,
+}
+
+impl ExpectedOutcome {
+    /// Whether `actual_status` counts as a pass for this outcome.
+    fn passes(self, actual_status: u16) -> bool {
+        match self {
+            ExpectedOutcome::Success => (200..400).contains(&actual_status),
+            ExpectedOutcome::ClientError => (400..500).contains(&actual_status),
+            ExpectedOutcome::NotServerError => {
+                actual_status >= 200 && !(500..600).contains(&actual_status)
+            }
+        }
+    }
+
+    /// Human-readable hint persisted in the JSONL capture + HTML
+    /// viewer's "show mismatches only" filter; also what users `jq`
+    /// against.
+    fn as_str(self) -> &'static str {
+        match self {
+            ExpectedOutcome::Success => "2xx-3xx",
+            ExpectedOutcome::ClientError => "4xx",
+            ExpectedOutcome::NotServerError => "2xx-4xx",
+        }
+    }
+}
+
 /// Variant of `send_case` that takes an explicit `extra_headers`
 /// (rather than reading them from `config`). Used by security probes
 /// to substitute or strip the configured Authorization header.
@@ -1465,7 +1508,7 @@ async fn send_case_with_extra(
     method: Method,
     url: &str,
     label: &str,
-    expected_4xx: bool,
+    expected: ExpectedOutcome,
     body: Option<&str>,
     query: Vec<(String, String)>,
     headers: Vec<(String, String)>,
@@ -1543,11 +1586,7 @@ async fn send_case_with_extra(
             }
         }
     };
-    let passed = if expected_4xx {
-        (400..500).contains(&actual_status)
-    } else {
-        (200..400).contains(&actual_status)
-    };
+    let passed = expected.passes(actual_status);
     if let Some((resp_body, resp_headers, error, sink)) = response_capture {
         let (request_body, request_body_truncated) = match body {
             Some(b) => {
@@ -1577,13 +1616,12 @@ async fn send_case_with_extra(
             // the schema map.
             response_schema_error: None,
             // Round 28 — derive the expected range from the probe's
-            // `expected_4xx` flag so the JSONL line and HTML viewer
-            // can show mismatches without re-deriving on the read side.
-            expected_status_range: if expected_4xx {
-                "4xx".into()
-            } else {
-                "2xx-3xx".into()
-            },
+            // outcome shape so the JSONL line and HTML viewer can
+            // filter mismatches without re-deriving on the read side.
+            // Round 35 (#859) — add a third value `"2xx-4xx"` for
+            // embedded-content variant-b probes whose only failure
+            // mode is a 5xx server crash.
+            expected_status_range: expected.as_str().to_string(),
             // Round 33 (#823) — path_template carries the spec's
             // pre-substitution path so the per-endpoint summary can
             // collapse `/users/X` and `/users/Y` into one row.
@@ -1595,6 +1633,13 @@ async fn send_case_with_extra(
             guard.push(entry);
         }
     }
+    // Round 35 (#859) — keep the `expected_4xx` field on `CaseOutcome`
+    // semantically tied to "negative probe expecting 400-class", so
+    // downstream code in `report_html.rs` doesn't have to learn about
+    // the new tristate. `NotServerError` reports as `expected_4xx:
+    // false` (it's a positive probe in spirit) and instead carries
+    // its outcome through the per-capture `expected_status_range`.
+    let expected_4xx = matches!(expected, ExpectedOutcome::ClientError);
     CaseOutcome {
         label: label.to_string(),
         expected_4xx,
@@ -1615,7 +1660,7 @@ async fn send_case(
     method: Method,
     url: &str,
     label: &str,
-    expected_4xx: bool,
+    expected: ExpectedOutcome,
     body: Option<&str>,
     query: Vec<(String, String)>,
     headers: Vec<(String, String)>,
@@ -1630,7 +1675,7 @@ async fn send_case(
         method,
         url,
         label,
-        expected_4xx,
+        expected,
         body,
         query,
         headers,
@@ -2333,6 +2378,59 @@ mod tests {
     #[test]
     fn embed_payload_returns_none_for_invalid_json_sample() {
         assert!(embed_payload_in_first_string_field("garbage", "a=1&b=2").is_none());
+    }
+
+    /// Round 35 (#859) — Srikanth on 0.3.179 saw variant-b probes flag
+    /// every 4xx as a mismatch when the spec field had a `pattern` /
+    /// `format` validator that correctly rejected the embedded
+    /// payload. The probe was only ever meant to catch 5xx (server
+    /// crashed parsing the embedded content); 4xx is the well-behaved
+    /// outcome. Tristate `ExpectedOutcome::NotServerError` lets a
+    /// variant-b probe pass on 2xx-4xx and fail only on 5xx.
+    #[test]
+    fn expected_outcome_pass_rules() {
+        // Success (positive): 2xx-3xx pass, 4xx + 5xx fail.
+        assert!(ExpectedOutcome::Success.passes(200));
+        assert!(ExpectedOutcome::Success.passes(201));
+        assert!(ExpectedOutcome::Success.passes(204));
+        assert!(ExpectedOutcome::Success.passes(301));
+        assert!(!ExpectedOutcome::Success.passes(400));
+        assert!(!ExpectedOutcome::Success.passes(415));
+        assert!(!ExpectedOutcome::Success.passes(500));
+        assert!(!ExpectedOutcome::Success.passes(0));
+
+        // ClientError (negative): only 4xx pass.
+        assert!(!ExpectedOutcome::ClientError.passes(200));
+        assert!(ExpectedOutcome::ClientError.passes(400));
+        assert!(ExpectedOutcome::ClientError.passes(404));
+        assert!(ExpectedOutcome::ClientError.passes(422));
+        assert!(!ExpectedOutcome::ClientError.passes(500));
+
+        // NotServerError (variant-b): 2xx-4xx pass, 5xx fails.
+        assert!(ExpectedOutcome::NotServerError.passes(200));
+        assert!(ExpectedOutcome::NotServerError.passes(204));
+        assert!(ExpectedOutcome::NotServerError.passes(400), "Srikanth's vCenter consolecli case: 400 from a pattern validator should NOT be a probe failure");
+        assert!(ExpectedOutcome::NotServerError.passes(415));
+        assert!(ExpectedOutcome::NotServerError.passes(422));
+        assert!(
+            !ExpectedOutcome::NotServerError.passes(500),
+            "Server CRASH on embedded content is the only real failure"
+        );
+        assert!(!ExpectedOutcome::NotServerError.passes(502));
+        assert!(!ExpectedOutcome::NotServerError.passes(503));
+        // status 0 (network error / probe never reached the server) does not pass either
+        assert!(!ExpectedOutcome::NotServerError.passes(0));
+    }
+
+    /// Round 35 (#859) — the per-capture `expected_status_range`
+    /// string is what the HTML viewer's "show mismatches only"
+    /// filter and Srikanth's `jq` pipelines key off, so the new
+    /// tristate must surface a third distinct value.
+    #[test]
+    fn expected_outcome_string_labels() {
+        assert_eq!(ExpectedOutcome::Success.as_str(), "2xx-3xx");
+        assert_eq!(ExpectedOutcome::ClientError.as_str(), "4xx");
+        assert_eq!(ExpectedOutcome::NotServerError.as_str(), "2xx-4xx");
     }
 
     /// Round 26 — Srikanth saw `at /: Type { kind: Single` in his


### PR DESCRIPTION
## Summary

Srikanth on v0.3.179 saw round 34's skip-when-no-string-field fix wasn't enough. The actual bug is in the pass/fail rule for embedded-content variant-b probes (`request-body:embedded-content:xml/yaml/multipart/urlencoded`). For routes where the spec field has a `pattern` or `format` validator (vCenter's `username` on POST /appliance/local-accounts has both), the server correctly 400s, but round 27's pass rule `(200..400).contains(&actual_status)` flagged that as a mismatch. The probe was only ever meant to surface server CRASHES (5xx); 4xx is the well-behaved outcome.

## Reproducer (locally on v0.3.179, BEFORE the fix)

```
mockforge serve --no-config --spec vcenter.yaml --base-path /api ...
mockforge bench --conformance --conformance-self-test --conformance-self-test-capture \
  --spec vcenter.yaml --target http://127.0.0.1:24900 --base-path /api \
  --operations "POST /appliance/local-accounts"
```

Result on v0.3.179:
```
request-body:embedded-content:xml         status=400 expected=2xx-3xx  (FAIL)
request-body:embedded-content:yaml        status=400 expected=2xx-3xx  (FAIL)
request-body:embedded-content:multipart   status=400 expected=2xx-3xx  (FAIL)
request-body:embedded-content:urlencoded  status=400 expected=2xx-3xx  (FAIL)
```

Same scenario on r35 (this PR):
```
request-body:embedded-content:xml         status=400 expected=2xx-4xx  (PASS)
request-body:embedded-content:yaml        status=400 expected=2xx-4xx  (PASS)
request-body:embedded-content:multipart   status=400 expected=2xx-4xx  (PASS)
request-body:embedded-content:urlencoded  status=400 expected=2xx-4xx  (PASS)
```

## Approach

Replace the boolean `expected_4xx` parameter on `send_case` / `send_case_with_extra` with a tristate `ExpectedOutcome` enum:

- `Success` — positive probes, passes on 200-399
- `ClientError` — negative probes, passes on 400-499
- `NotServerError` — variant-b probes, passes on 200-499; only 5xx fails

`expected_status_range` on `CaseCapture` carries the new `"2xx-4xx"` value; the HTML viewer's "show mismatches only" filter and Srikanth's `jq` pipelines pick it up via the existing string field. `CaseOutcome.expected_4xx` keeps its old "is this a negative probe" semantics so `report_html.rs` is unchanged.

12 call sites updated (1 positive → `Success`, 10 negatives → `ClientError`, 1 variant-b loop → `NotServerError`).

## Test plan
- [x] `cargo test -p mockforge-bench --lib expected_outcome` — 2 pass (pass-rule table + string labels)
- [x] `cargo test -p mockforge-bench --lib` — 474 pass (472 prior + 2 new)
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Real-binary verify against POST /appliance/local-accounts on local r35 binary: `expected_status_range = "2xx-4xx"` and 0 misses on negatives (was 4 on v0.3.179)
- [ ] CI Security Audit + Registry E2E green

Closes #859.