### PR TITLE
feat(sso): re-land OIDC login flow + /sso/discover endpoint (#746)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,6 +1,15 @@
 # Typos configuration for MockForge
 # Allows common technical acronyms and terms
 
+[default]
+# Throwaway RSA test-key material in the OIDC SSO tests (handlers/oidc.rs and
+# tests/oidc_flow.rs). The base64 PEM + modulus blobs trip false positives like
+# "Fo"/"Opf"; ignore the PEM block and the test modulus wherever they appear.
+extend-ignore-re = [
+  "(?s)-----BEGIN PRIVATE KEY-----.*?-----END PRIVATE KEY-----",
+  "tlVSZ3rda5uMJ625[A-Za-z0-9_-]+",
+]
+
 [default.extend-words]
 # Technical acronyms and library names
 ratatui = "ratatui"  # Rust TUI library (not ratatouille)

--- a/crates/mockforge-registry-core/src/models/sso.rs
+++ b/crates/mockforge-registry-core/src/models/sso.rs
@@ -58,6 +58,10 @@ pub struct SSOConfiguration {
     #[serde(skip_serializing)]
     pub oidc_client_secret: Option<String>,
 
+    // Email domain used by the pre-login discovery endpoint to route a user to
+    // this org/provider. Routing key only; ownership is still DNS-verified.
+    pub email_domain: Option<String>,
+
     // Attribute mapping
     pub attribute_mapping: serde_json::Value,
 
@@ -68,6 +72,16 @@ pub struct SSOConfiguration {
 
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// Internal row type for `find_by_email_domain`: an SSO config plus the joined
+/// org slug, so discovery can return the slug without a second query.
+#[cfg(feature = "postgres")]
+#[derive(Debug, FromRow)]
+struct SsoConfigWithSlug {
+    #[sqlx(flatten)]
+    config: SSOConfiguration,
+    org_slug: String,
 }
 
 /// SSO session
@@ -115,8 +129,13 @@ impl SSOConfiguration {
         oidc_issuer_url: Option<&str>,
         oidc_client_id: Option<&str>,
         oidc_client_secret: Option<&str>,
+        email_domain: Option<&str>,
     ) -> sqlx::Result<Self> {
         let attribute_mapping = attribute_mapping.unwrap_or_else(|| serde_json::json!({}));
+        // Normalize the routing domain to lowercase so discovery matching is
+        // case-insensitive and consistent with the partial unique index.
+        let email_domain =
+            email_domain.map(|d| d.trim().to_ascii_lowercase()).filter(|d| !d.is_empty());
 
         sqlx::query_as::<_, Self>(
             r#"
@@ -124,9 +143,9 @@ impl SSOConfiguration {
                 org_id, provider, saml_entity_id, saml_sso_url, saml_slo_url,
                 saml_x509_cert, saml_name_id_format, attribute_mapping,
                 require_signed_assertions, require_signed_responses, allow_unsolicited_responses,
-                oidc_issuer_url, oidc_client_id, oidc_client_secret
+                oidc_issuer_url, oidc_client_id, oidc_client_secret, email_domain
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
             ON CONFLICT (org_id) DO UPDATE SET
                 provider = EXCLUDED.provider,
                 saml_entity_id = EXCLUDED.saml_entity_id,
@@ -141,6 +160,7 @@ impl SSOConfiguration {
                 oidc_issuer_url = EXCLUDED.oidc_issuer_url,
                 oidc_client_id = EXCLUDED.oidc_client_id,
                 oidc_client_secret = EXCLUDED.oidc_client_secret,
+                email_domain = EXCLUDED.email_domain,
                 updated_at = NOW()
             RETURNING *
             "#,
@@ -159,8 +179,37 @@ impl SSOConfiguration {
         .bind(oidc_issuer_url)
         .bind(oidc_client_id)
         .bind(oidc_client_secret)
+        .bind(email_domain)
         .fetch_one(pool)
         .await
+    }
+
+    /// Find an enabled SSO configuration by its routing email domain, returning
+    /// the config together with the org's slug. Used by the pre-login discovery
+    /// endpoint. Only `enabled` configs match (a disabled config is invisible).
+    pub async fn find_by_email_domain(
+        pool: &sqlx::PgPool,
+        domain: &str,
+    ) -> sqlx::Result<Option<(Self, String)>> {
+        let domain = domain.trim().to_ascii_lowercase();
+        if domain.is_empty() {
+            return Ok(None);
+        }
+        let row = sqlx::query_as::<_, SsoConfigWithSlug>(
+            r#"
+            SELECT c.*, o.slug AS org_slug
+            FROM sso_configurations c
+            JOIN organizations o ON o.id = c.org_id
+            WHERE c.enabled = TRUE
+              AND c.email_domain IS NOT NULL
+              AND LOWER(c.email_domain) = $1
+            LIMIT 1
+            "#,
+        )
+        .bind(&domain)
+        .fetch_optional(pool)
+        .await?;
+        Ok(row.map(|r| (r.config, r.org_slug)))
     }
 
     /// Enable SSO for an organization

--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -1384,6 +1384,17 @@ pub trait RegistryStore: Send + Sync + 'static {
 
     async fn find_sso_config_by_org(&self, org_id: Uuid) -> StoreResult<Option<SSOConfiguration>>;
 
+    /// Find an enabled SSO config by its routing email domain, returning the
+    /// config and the owning org's slug. Used by the pre-login discovery
+    /// endpoint. Default impl returns `None` (e.g. the SQLite store, which does
+    /// not back SSO discovery).
+    async fn find_sso_config_by_email_domain(
+        &self,
+        _domain: &str,
+    ) -> StoreResult<Option<(SSOConfiguration, String)>> {
+        Ok(None)
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn upsert_sso_config(
         &self,
@@ -1401,6 +1412,7 @@ pub trait RegistryStore: Send + Sync + 'static {
         oidc_issuer_url: Option<&str>,
         oidc_client_id: Option<&str>,
         oidc_client_secret: Option<&str>,
+        email_domain: Option<&str>,
     ) -> StoreResult<SSOConfiguration>;
 
     async fn enable_sso_config(&self, org_id: Uuid) -> StoreResult<()>;

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -1110,6 +1110,15 @@ impl RegistryStore for PgRegistryStore {
         SSOConfiguration::find_by_org(&self.pool, org_id).await.map_err(Into::into)
     }
 
+    async fn find_sso_config_by_email_domain(
+        &self,
+        domain: &str,
+    ) -> StoreResult<Option<(SSOConfiguration, String)>> {
+        SSOConfiguration::find_by_email_domain(&self.pool, domain)
+            .await
+            .map_err(Into::into)
+    }
+
     async fn upsert_sso_config(
         &self,
         org_id: Uuid,
@@ -1126,6 +1135,7 @@ impl RegistryStore for PgRegistryStore {
         oidc_issuer_url: Option<&str>,
         oidc_client_id: Option<&str>,
         oidc_client_secret: Option<&str>,
+        email_domain: Option<&str>,
     ) -> StoreResult<SSOConfiguration> {
         SSOConfiguration::upsert(
             &self.pool,
@@ -1143,6 +1153,7 @@ impl RegistryStore for PgRegistryStore {
             oidc_issuer_url,
             oidc_client_id,
             oidc_client_secret,
+            email_domain,
         )
         .await
         .map_err(Into::into)

--- a/crates/mockforge-registry-core/src/store/sqlite.rs
+++ b/crates/mockforge-registry-core/src/store/sqlite.rs
@@ -1904,6 +1904,7 @@ impl RegistryStore for SqliteRegistryStore {
         oidc_issuer_url: Option<&str>,
         oidc_client_id: Option<&str>,
         oidc_client_secret: Option<&str>,
+        email_domain: Option<&str>,
     ) -> StoreResult<SSOConfiguration> {
         Err(StoreError::NotFound)
     }

--- a/crates/mockforge-registry-server/migrations/20250101000079_sso_email_domain.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000079_sso_email_domain.sql
@@ -1,0 +1,15 @@
+-- Add an optional email_domain to SSO configurations so the pre-login
+-- discovery endpoint (GET /api/v1/sso/discover?email=...) can map a user's
+-- email domain to the org + provider to redirect them to. Domain OWNERSHIP is
+-- still verified live via DNS (the #833/#746/#778 gate); this column is only the
+-- routing key for discovery and is never trusted as proof of ownership.
+
+ALTER TABLE sso_configurations
+    ADD COLUMN email_domain VARCHAR(255);
+
+-- Normalize to lowercase for case-insensitive matching against the email domain.
+-- Partial unique index: a verified domain can only route to one org, but many
+-- rows may have NULL (no domain configured).
+CREATE UNIQUE INDEX idx_sso_configs_email_domain
+    ON sso_configurations (LOWER(email_domain))
+    WHERE email_domain IS NOT NULL;

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -29,6 +29,7 @@ pub mod mockai;
 pub mod notification_channels;
 pub mod oauth;
 pub mod observability;
+pub mod oidc;
 pub mod org_templates;
 pub mod organization_settings;
 pub mod organizations;

--- a/crates/mockforge-registry-server/src/handlers/oidc.rs
+++ b/crates/mockforge-registry-server/src/handlers/oidc.rs
@@ -1,0 +1,738 @@
+//! OpenID Connect (OIDC) SSO login flow (#746).
+//!
+//! Completes the OIDC side of SSO: discovery, the authorization-code redirect
+//! with PKCE + state + nonce, code/token exchange, and ID-token validation
+//! against the issuer's JWKS (RS256 signature + iss + aud + exp + nonce). On
+//! success it provisions the user through the SAME domain-ownership gate as the
+//! SAML path (`super::sso::provision_sso_user`, #833/#746/#778), so an OIDC IdP
+//! can never create or absorb an account for an email domain the org has not
+//! proven it owns.
+//!
+//! Security properties:
+//! - Every URL the server FETCHES (issuer discovery, token endpoint, JWKS) is
+//!   SSRF-guarded via `sso_domain::fetch_url_is_safe`, including the endpoints
+//!   the IdP-controlled discovery document points at.
+//! - Flow state (state, nonce, PKCE verifier, resolved endpoints) is carried in
+//!   a short-lived HS256-signed cookie keyed by the server's jwt_secret, so it
+//!   is tamper-evident and needs no shared store.
+//! - `state` is compared in constant time (CSRF); `nonce` binds the ID token to
+//!   this exact login attempt (replay defense).
+
+use axum::{
+    extract::{Path, Query, State},
+    http::{header, HeaderMap, HeaderValue},
+    response::{IntoResponse, Redirect, Response},
+};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use chrono::Utc;
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::time::Duration;
+
+use crate::{error::ApiError, sso_domain, AppState};
+
+const FLOW_COOKIE: &str = "mf_oidc_flow";
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+const FLOW_TTL_SECS: i64 = 600;
+
+/// Discovered OIDC endpoints (the subset we use).
+#[derive(Debug, Clone, Deserialize)]
+pub struct OidcDiscovery {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub jwks_uri: String,
+}
+
+/// A single JWK (RSA public key) from the issuer's JWKS.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Jwk {
+    pub kty: String,
+    #[serde(default)]
+    pub kid: Option<String>,
+    #[serde(default)]
+    pub alg: Option<String>,
+    #[serde(default)]
+    pub n: Option<String>,
+    #[serde(default)]
+    pub e: Option<String>,
+}
+
+/// A JSON Web Key Set.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Jwks {
+    pub keys: Vec<Jwk>,
+}
+
+/// ID-token claims read AFTER signature + iss/aud/exp/nonce validation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct IdTokenClaims {
+    pub sub: String,
+    #[serde(default)]
+    pub email: Option<String>,
+    #[serde(default)]
+    pub email_verified: Option<serde_json::Value>,
+    #[serde(default)]
+    pub nonce: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub preferred_username: Option<String>,
+    #[serde(default)]
+    pub exp: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    id_token: String,
+}
+
+/// Flow state carried in the signed cookie between initiate and callback.
+#[derive(Debug, Serialize, Deserialize)]
+struct FlowState {
+    org_id: String,
+    org_slug: String,
+    state: String,
+    nonce: String,
+    pkce_verifier: String,
+    issuer: String,
+    token_endpoint: String,
+    jwks_uri: String,
+    client_id: String,
+    redirect_uri: String,
+    exp: i64,
+}
+
+fn http_client() -> Result<reqwest::Client, ApiError> {
+    reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        // Never auto-follow redirects: a 3xx to an internal host would defeat
+        // the per-URL SSRF guard.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("http client build: {e}")))
+}
+
+/// Fetch and validate the issuer's discovery document. SSRF-guards the issuer
+/// and every endpoint the (IdP-controlled) document points at.
+pub async fn discover(client: &reqwest::Client, issuer: &str) -> Result<OidcDiscovery, ApiError> {
+    if !sso_domain::fetch_url_is_safe(issuer) {
+        return Err(ApiError::InvalidRequest("OIDC issuer URL is not allowed".into()));
+    }
+    let url = format!("{}/.well-known/openid-configuration", issuer.trim_end_matches('/'));
+    let disc: OidcDiscovery = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| ApiError::InvalidRequest(format!("OIDC discovery request failed: {e}")))?
+        .error_for_status()
+        .map_err(|e| ApiError::InvalidRequest(format!("OIDC discovery HTTP error: {e}")))?
+        .json()
+        .await
+        .map_err(|e| ApiError::InvalidRequest(format!("OIDC discovery parse error: {e}")))?;
+
+    // OIDC Discovery 1.0: the document's `issuer` MUST equal the requested issuer
+    // (ignoring a trailing slash). Prevents an issuer impersonating another.
+    if disc.issuer.trim_end_matches('/') != issuer.trim_end_matches('/') {
+        return Err(ApiError::InvalidRequest(
+            "OIDC discovery issuer does not match the configured issuer".into(),
+        ));
+    }
+
+    for ep in [
+        &disc.authorization_endpoint,
+        &disc.token_endpoint,
+        &disc.jwks_uri,
+    ] {
+        if !sso_domain::fetch_url_is_safe(ep) {
+            return Err(ApiError::InvalidRequest(
+                "OIDC discovery returned a disallowed (internal) endpoint URL".into(),
+            ));
+        }
+    }
+    Ok(disc)
+}
+
+/// Fetch the issuer's JWKS (SSRF-guarded).
+pub async fn fetch_jwks(client: &reqwest::Client, jwks_uri: &str) -> Result<Jwks, ApiError> {
+    if !sso_domain::fetch_url_is_safe(jwks_uri) {
+        return Err(ApiError::InvalidRequest("JWKS URL is not allowed".into()));
+    }
+    client
+        .get(jwks_uri)
+        .send()
+        .await
+        .map_err(|e| ApiError::InvalidRequest(format!("JWKS request failed: {e}")))?
+        .error_for_status()
+        .map_err(|e| ApiError::InvalidRequest(format!("JWKS HTTP error: {e}")))?
+        .json()
+        .await
+        .map_err(|e| ApiError::InvalidRequest(format!("JWKS parse error: {e}")))
+}
+
+/// Exchange an authorization code for tokens at the token endpoint (SSRF-guarded),
+/// returning the raw ID token. PKCE `code_verifier` is included.
+#[allow(clippy::too_many_arguments)]
+pub async fn exchange_code(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    code: &str,
+    redirect_uri: &str,
+    client_id: &str,
+    client_secret: &str,
+    pkce_verifier: &str,
+) -> Result<String, ApiError> {
+    if !sso_domain::fetch_url_is_safe(token_endpoint) {
+        return Err(ApiError::InvalidRequest("token endpoint URL is not allowed".into()));
+    }
+    let params = [
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("client_id", client_id),
+        ("client_secret", client_secret),
+        ("code_verifier", pkce_verifier),
+    ];
+    let resp: TokenResponse = client
+        .post(token_endpoint)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| ApiError::InvalidRequest(format!("token exchange request failed: {e}")))?
+        .error_for_status()
+        .map_err(|e| ApiError::InvalidRequest(format!("token exchange HTTP error: {e}")))?
+        .json()
+        .await
+        .map_err(|e| ApiError::InvalidRequest(format!("token response parse error: {e}")))?;
+    Ok(resp.id_token)
+}
+
+/// Validate an OIDC ID token: RS256 signature via the JWKS, plus iss, aud, exp,
+/// and nonce. Returns the validated claims. This is the security-critical step.
+pub fn validate_id_token(
+    id_token: &str,
+    jwks: &Jwks,
+    issuer: &str,
+    client_id: &str,
+    expected_nonce: &str,
+) -> Result<IdTokenClaims, ApiError> {
+    let header = decode_header(id_token)
+        .map_err(|e| ApiError::InvalidRequest(format!("ID token header invalid: {e}")))?;
+    if header.alg != Algorithm::RS256 {
+        return Err(ApiError::InvalidRequest("ID token must be signed with RS256".into()));
+    }
+
+    let jwk = select_rsa_jwk(jwks, header.kid.as_deref())
+        .ok_or_else(|| ApiError::InvalidRequest("no matching JWKS key for ID token".into()))?;
+    let (n, e) = match (&jwk.n, &jwk.e) {
+        (Some(n), Some(e)) => (n, e),
+        _ => return Err(ApiError::InvalidRequest("JWKS key missing RSA modulus/exponent".into())),
+    };
+    let key = DecodingKey::from_rsa_components(n, e)
+        .map_err(|e| ApiError::InvalidRequest(format!("invalid JWKS RSA key: {e}")))?;
+
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_issuer(&[issuer]);
+    validation.set_audience(&[client_id]);
+    validation.validate_exp = true;
+
+    let data = decode::<IdTokenClaims>(id_token, &key, &validation)
+        .map_err(|e| ApiError::InvalidRequest(format!("ID token validation failed: {e}")))?;
+
+    // Nonce binds the token to THIS login attempt (replay / token-injection defense).
+    if data.claims.nonce.as_deref() != Some(expected_nonce) {
+        return Err(ApiError::InvalidRequest("ID token nonce mismatch".into()));
+    }
+    Ok(data.claims)
+}
+
+/// True only if `email_verified` is present and explicitly false. Different IdPs
+/// encode it as a JSON bool or the string "false"; an absent claim is not
+/// treated as unverified (the domain-ownership gate is the backstop there).
+fn email_explicitly_unverified(value: &Option<serde_json::Value>) -> bool {
+    match value {
+        Some(serde_json::Value::Bool(b)) => !b,
+        Some(serde_json::Value::String(s)) => s.eq_ignore_ascii_case("false"),
+        _ => false,
+    }
+}
+
+/// Select the JWK to verify with. If the token names a `kid`, require an exact
+/// match (never fall back to an arbitrary key); otherwise use the sole RSA key.
+fn select_rsa_jwk<'a>(jwks: &'a Jwks, kid: Option<&str>) -> Option<&'a Jwk> {
+    match kid {
+        Some(kid) => jwks.keys.iter().find(|k| k.kty == "RSA" && k.kid.as_deref() == Some(kid)),
+        None => jwks.keys.iter().find(|k| k.kty == "RSA"),
+    }
+}
+
+/// Constant-time byte comparison (for the CSRF `state` check).
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// 256 bits of URL-safe randomness for state / nonce.
+fn random_token() -> String {
+    format!("{}{}", uuid::Uuid::new_v4().simple(), uuid::Uuid::new_v4().simple())
+}
+
+/// PKCE (S256): a high-entropy verifier and its base64url-SHA256 challenge.
+fn generate_pkce() -> (String, String) {
+    let verifier = format!(
+        "{}{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    );
+    let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+    (verifier, challenge)
+}
+
+fn encode_flow(secret: &str, flow: &FlowState) -> Result<String, ApiError> {
+    jsonwebtoken::encode(
+        &Header::default(),
+        flow,
+        &jsonwebtoken::EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .map_err(|e| ApiError::Internal(anyhow::anyhow!("flow-state encode: {e}")))
+}
+
+fn decode_flow(secret: &str, token: &str) -> Result<FlowState, ApiError> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+    jsonwebtoken::decode::<FlowState>(
+        token,
+        &DecodingKey::from_secret(secret.as_bytes()),
+        &validation,
+    )
+    .map(|d| d.claims)
+    .map_err(|_| ApiError::InvalidRequest("OIDC login session expired or invalid".into()))
+}
+
+fn set_flow_cookie(token: &str) -> String {
+    format!(
+        "{FLOW_COOKIE}={token}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age={FLOW_TTL_SECS}"
+    )
+}
+
+fn clear_flow_cookie() -> String {
+    format!("{FLOW_COOKIE}=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0")
+}
+
+fn read_flow_cookie(headers: &HeaderMap) -> Option<String> {
+    let raw = headers.get(header::COOKIE)?.to_str().ok()?;
+    let prefix = format!("{FLOW_COOKIE}=");
+    raw.split(';')
+        .map(str::trim)
+        .find_map(|kv| kv.strip_prefix(&prefix).map(str::to_string))
+}
+
+fn app_base_url() -> String {
+    std::env::var("APP_BASE_URL").unwrap_or_else(|_| "https://app.mockforge.dev".to_string())
+}
+
+/// Begin OIDC login: discover the issuer, then redirect the user to the IdP's
+/// authorization endpoint with PKCE + state + nonce, stashing flow state in a
+/// signed cookie.
+pub async fn initiate_oidc_login(
+    State(state): State<AppState>,
+    Path(org_slug): Path<String>,
+) -> Result<Response, ApiError> {
+    use crate::models::{sso::SSOProvider, Plan};
+
+    let org = state
+        .store
+        .find_organization_by_slug(&org_slug)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Organization not found".into()))?;
+    if org.plan() != Plan::Team {
+        return Err(ApiError::InvalidRequest("SSO is only available for Team plans".into()));
+    }
+    let config = state
+        .store
+        .find_sso_config_by_org(org.id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("SSO not configured".into()))?;
+    if !config.enabled {
+        return Err(ApiError::InvalidRequest("SSO is not enabled".into()));
+    }
+    if config.provider() != SSOProvider::Oidc {
+        return Err(ApiError::InvalidRequest("SSO provider is not OIDC".into()));
+    }
+    let issuer = config
+        .oidc_issuer_url
+        .clone()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| ApiError::InvalidRequest("OIDC issuer not configured".into()))?;
+    let client_id = config
+        .oidc_client_id
+        .clone()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| ApiError::InvalidRequest("OIDC client_id not configured".into()))?;
+
+    // SSRF guard at the boundary, before the discovery fetch.
+    sso_domain::validate_issuer_url(&issuer)?;
+
+    let client = http_client()?;
+    let disc = discover(&client, &issuer).await?;
+
+    let state_tok = random_token();
+    let nonce = random_token();
+    let (verifier, challenge) = generate_pkce();
+    let redirect_uri = format!("{}/api/v1/sso/oidc/callback/{}", app_base_url(), org_slug);
+
+    let flow = FlowState {
+        org_id: org.id.to_string(),
+        org_slug: org_slug.clone(),
+        state: state_tok.clone(),
+        nonce: nonce.clone(),
+        pkce_verifier: verifier,
+        issuer: disc.issuer.clone(),
+        token_endpoint: disc.token_endpoint.clone(),
+        jwks_uri: disc.jwks_uri.clone(),
+        client_id: client_id.clone(),
+        redirect_uri: redirect_uri.clone(),
+        exp: (Utc::now() + chrono::Duration::seconds(FLOW_TTL_SECS)).timestamp(),
+    };
+    let cookie = encode_flow(&state.config.jwt_secret, &flow)?;
+
+    let auth_url = format!(
+        "{}?response_type=code&client_id={}&redirect_uri={}&scope={}&state={}&nonce={}&code_challenge={}&code_challenge_method=S256",
+        disc.authorization_endpoint,
+        urlencoding::encode(&client_id),
+        urlencoding::encode(&redirect_uri),
+        urlencoding::encode("openid email profile"),
+        urlencoding::encode(&state_tok),
+        urlencoding::encode(&nonce),
+        urlencoding::encode(&challenge),
+    );
+
+    let mut resp = Redirect::to(&auth_url).into_response();
+    let cookie_value = HeaderValue::from_str(&set_flow_cookie(&cookie))
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("cookie header: {e}")))?;
+    resp.headers_mut().insert(header::SET_COOKIE, cookie_value);
+    Ok(resp)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OidcCallbackQuery {
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
+    pub state: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// OIDC redirect callback: verify state (CSRF), exchange the code, validate the
+/// ID token against the JWKS, run the domain-ownership gate, provision the user,
+/// mint a session, and redirect into the app.
+pub async fn oidc_callback(
+    State(state): State<AppState>,
+    Path(org_slug): Path<String>,
+    headers: HeaderMap,
+    Query(params): Query<OidcCallbackQuery>,
+) -> Result<Response, ApiError> {
+    use crate::models::sso::SSOProvider;
+
+    if let Some(err) = params.error.filter(|e| !e.is_empty()) {
+        return Err(ApiError::InvalidRequest(format!("OIDC provider returned an error: {err}")));
+    }
+    let code = params
+        .code
+        .ok_or_else(|| ApiError::InvalidRequest("missing authorization code".into()))?;
+    let state_param = params
+        .state
+        .ok_or_else(|| ApiError::InvalidRequest("missing state parameter".into()))?;
+
+    let cookie = read_flow_cookie(&headers)
+        .ok_or_else(|| ApiError::InvalidRequest("missing OIDC login session cookie".into()))?;
+    let flow = decode_flow(&state.config.jwt_secret, &cookie)?;
+
+    // CSRF: the IdP-returned state must equal the state we issued.
+    if !constant_time_eq(state_param.as_bytes(), flow.state.as_bytes()) {
+        return Err(ApiError::InvalidRequest("OIDC state mismatch (possible CSRF)".into()));
+    }
+    if flow.org_slug != org_slug {
+        return Err(ApiError::InvalidRequest(
+            "OIDC session does not match this organization".into(),
+        ));
+    }
+    let org_id = uuid::Uuid::parse_str(&flow.org_id)
+        .map_err(|_| ApiError::InvalidRequest("invalid org in OIDC session".into()))?;
+
+    let org = state
+        .store
+        .find_organization_by_slug(&org_slug)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Organization not found".into()))?;
+    if org.id != org_id {
+        return Err(ApiError::InvalidRequest("OIDC session org mismatch".into()));
+    }
+    let config = state
+        .store
+        .find_sso_config_by_org(org.id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("SSO not configured".into()))?;
+    if !config.enabled || config.provider() != SSOProvider::Oidc {
+        return Err(ApiError::InvalidRequest("OIDC SSO is not enabled".into()));
+    }
+    // client_secret lives only in config (never in the cookie).
+    let client_secret = config.oidc_client_secret.clone().unwrap_or_default();
+
+    let client = http_client()?;
+    let id_token = exchange_code(
+        &client,
+        &flow.token_endpoint,
+        &code,
+        &flow.redirect_uri,
+        &flow.client_id,
+        &client_secret,
+        &flow.pkce_verifier,
+    )
+    .await?;
+    let jwks = fetch_jwks(&client, &flow.jwks_uri).await?;
+    let claims = validate_id_token(&id_token, &jwks, &flow.issuer, &flow.client_id, &flow.nonce)?;
+
+    // Reject an email the IdP explicitly marks unverified. The domain-ownership
+    // gate is the primary backstop, but an `email_verified: false` claim means
+    // the IdP itself does not vouch for the address, so we must not provision it.
+    if email_explicitly_unverified(&claims.email_verified) {
+        return Err(ApiError::InvalidRequest("OIDC email is not verified by the IdP".into()));
+    }
+
+    let email = claims
+        .email
+        .clone()
+        .filter(|e| !e.is_empty())
+        .ok_or_else(|| ApiError::InvalidRequest("OIDC ID token has no email claim".into()))?;
+    let username_hint = claims.preferred_username.clone().or_else(|| claims.name.clone());
+
+    // Domain-ownership gate + provisioning, identical to the SAML path (#833).
+    let user =
+        super::sso::provision_sso_user(&state, &org, &email, username_hint.as_deref()).await?;
+
+    // Mirror saml_acs: create an SSO session and mint a short-lived app token.
+    let session_expires = Utc::now() + chrono::Duration::hours(8);
+    let _session = crate::models::SSOSession::create(
+        state.db.pool(),
+        org.id,
+        user.id,
+        None,
+        Some(&email),
+        session_expires,
+    )
+    .await
+    .map_err(ApiError::Database)?;
+
+    let token = crate::auth::create_token(&user.id.to_string(), &state.config.jwt_secret)
+        .map_err(ApiError::Internal)?;
+    let redirect_url =
+        format!("{}/auth/sso/callback?token={}&org_slug={}", app_base_url(), token, org_slug);
+
+    let mut resp = Redirect::to(&redirect_url).into_response();
+    let clear = HeaderValue::from_str(&clear_flow_cookie())
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("cookie header: {e}")))?;
+    resp.headers_mut().insert(header::SET_COOKIE, clear);
+    Ok(resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::EncodingKey;
+
+    // Throwaway RSA test key (2048-bit). NOT used anywhere but these tests.
+    const TEST_PRIVATE_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2VVJnet1rm4wn
+rbmtew8EKznxOgTLTCxYGHlkUHVpKxp5CfMqlbzRU6jxMTlTKhvq/NZw+qb2wMj2
+nAwQLC31MG9HKoOu3AZeZMv7Y5Sl8QG2Y6cMFpjo7WnRh2Uk8vsy0C9VWRTsqJTT
+q3vxFMbMCiMx3Kpw4mQf9k2RACkDLjL3SkxtU/BExdXI69lVjULWsvLDlvlBNpAc
+uLhcxqZ1XAakgBNWzzgQFiHSKE5y+lm13k8eypCnjXznL4t5h1KkTYFkOwTtJf/k
+RBQzpL2OgMlJWQ6V73qtQ+5XZrwDYaw9ccKT2lBrGS15zv3ww+hXApxeDpQ6l8Xw
+GcNWJWwlAgMBAAECggEASSrl/YaNchAiZw3M0/Ps67RY9RdeMyKnLNbtZ7bt1r0o
+S2gVv4IFGk8jHV6ubVQZjevWNdIvzBdCzcuC/75q1tiP3xQNcc7zc0+pl4C3dvvG
+vyUwNKagx9/1tdJKYVBsQ1DNncc4oVtpFaPcAbtfpyNuSiUN9Gy01yqkp8pTquVh
+GoNtd+QR2dLo6TdNi8eY5wSBPnm5UTidKp5x/niMK7bRcAqMLcNsa0sl1jPjNsIP
+gktfHli4Ebo3lEVPmOFxOPy2pMDg5uOeVJ6rXC1cWxT8Nna8HzofyPR7xWCsZhUj
+KHQiJ33IlU9uSxu7PUI22KUZzyfz7tP2qPv/Sg9SRQKBgQD4DV2kw8D1TcIddgBO
+2EFM6oSfNuUT2tyd0S4CMqz4uXdBceIJGFzTPogh8oTZeXaEI6s0LlCTnFBIrMP6
+SPsTc4nJFADRifKNupzOecK1rBQztl5V0xSagaWOprpVFVQsGFo565lxCYed3d1v
+qUvcjDwKz6B7YW9Sdl8twx9HTwKBgQC8LOZ+THOSD3MhcUJwylJ3V7h2RY6/dNYm
+tieaA5Eo6vfoAjWSAQIlmP5PwkNqR7yGEX68bESfGD2/A4ouueqobr4s0U7AxPnd
+rznrHx8Wm6czaPUR90B4tGayX7WuUq4GbC2TbUs9IWGOQrW3WRBgLejMo/lkiysk
+iBSViOn4SwKBgFgXFwxuYFY9ORSRVWaqsfYIyvRn4E5+yR5arQYmzPq/krRxJx6n
+wj9a06mKoNdCpW4j5KbxU7g4KOLGSArYZCHyRBpeujOv0621ef5xi05NQBdlSncc
+MRL1u7+/Qij5HB1UwKYVHzbfdYQAyKTg8InwW1pTheCLJ6eXVhHAW5lNAoGBAK82
+J4/l455WYF79NF4NJOgWd504ewft5BC7fvg65ghxcE9I71R5N+SGJhVhzp/BF9rF
+o3oSXXq9eZDH3PxRBBu8sbrNUUTQo880fvtcSPgmCnMmATqvPAqn/w+LaoFcXsmA
+JJenJm1PDaUGnGiRt1u2o5MYAvkJVCx5wKDTkPctAoGBALmd6dGutwK69GAlkJTa
+NM0NtyMGQAoLIXurbECjBksLdf+hQGIJcZkjMeHnkneP2JqjB7efpfvNAHrZ7L4M
+pc8kGe5L8vP15KTflqbCciQCQrPX+hQ+vPFLeG02G7KkdG51ERvcggcCm07FZ764
+DwzWpw1tFHUYMntWNYCKWcbI
+-----END PRIVATE KEY-----";
+
+    // The matching public RSA params (n base64url, e=AQAB) for the JWKS.
+    const TEST_N: &str = "tlVSZ3rda5uMJ625rXsPBCs58ToEy0wsWBh5ZFB1aSsaeQnzKpW80VOo8TE5Uyob6vzWcPqm9sDI9pwMECwt9TBvRyqDrtwGXmTL-2OUpfEBtmOnDBaY6O1p0YdlJPL7MtAvVVkU7KiU06t78RTGzAojMdyqcOJkH_ZNkQApAy4y90pMbVPwRMXVyOvZVY1C1rLyw5b5QTaQHLi4XMamdVwGpIATVs84EBYh0ihOcvpZtd5PHsqQp4185y-LeYdSpE2BZDsE7SX_5EQUM6S9joDJSVkOle96rUPuV2a8A2GsPXHCk9pQaxktec798MPoVwKcXg6UOpfF8BnDViVsJQ";
+
+    const ISSUER: &str = "https://idp.example.com";
+    const CLIENT_ID: &str = "mockforge-client";
+    const NONCE: &str = "test-nonce-123";
+
+    fn jwks(kid: Option<&str>) -> Jwks {
+        Jwks {
+            keys: vec![Jwk {
+                kty: "RSA".into(),
+                kid: kid.map(str::to_string),
+                alg: Some("RS256".into()),
+                n: Some(TEST_N.into()),
+                e: Some("AQAB".into()),
+            }],
+        }
+    }
+
+    fn sign(kid: Option<&str>, claims: serde_json::Value) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = kid.map(str::to_string);
+        let key = EncodingKey::from_rsa_pem(TEST_PRIVATE_PEM.as_bytes()).expect("test key");
+        jsonwebtoken::encode(&header, &claims, &key).expect("sign")
+    }
+
+    fn valid_claims() -> serde_json::Value {
+        let exp = (Utc::now() + chrono::Duration::hours(1)).timestamp();
+        serde_json::json!({
+            "iss": ISSUER,
+            "aud": CLIENT_ID,
+            "exp": exp,
+            "sub": "user-1",
+            "email": "alice@acme.com",
+            "nonce": NONCE,
+        })
+    }
+
+    #[test]
+    fn valid_id_token_passes() {
+        let token = sign(Some("k1"), valid_claims());
+        let claims = validate_id_token(&token, &jwks(Some("k1")), ISSUER, CLIENT_ID, NONCE)
+            .expect("should validate");
+        assert_eq!(claims.email.as_deref(), Some("alice@acme.com"));
+        assert_eq!(claims.sub, "user-1");
+    }
+
+    #[test]
+    fn nonce_mismatch_rejected() {
+        let token = sign(Some("k1"), valid_claims());
+        let err = validate_id_token(&token, &jwks(Some("k1")), ISSUER, CLIENT_ID, "wrong-nonce")
+            .unwrap_err();
+        assert!(err.to_string().contains("nonce"), "got: {err}");
+    }
+
+    #[test]
+    fn wrong_audience_rejected() {
+        let token = sign(Some("k1"), valid_claims());
+        assert!(
+            validate_id_token(&token, &jwks(Some("k1")), ISSUER, "other-client", NONCE).is_err()
+        );
+    }
+
+    #[test]
+    fn wrong_issuer_rejected() {
+        let token = sign(Some("k1"), valid_claims());
+        assert!(validate_id_token(
+            &token,
+            &jwks(Some("k1")),
+            "https://evil.example.com",
+            CLIENT_ID,
+            NONCE
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn expired_token_rejected() {
+        let mut claims = valid_claims();
+        claims["exp"] = serde_json::json!((Utc::now() - chrono::Duration::hours(1)).timestamp());
+        let token = sign(Some("k1"), claims);
+        assert!(validate_id_token(&token, &jwks(Some("k1")), ISSUER, CLIENT_ID, NONCE).is_err());
+    }
+
+    #[test]
+    fn tampered_signature_rejected() {
+        let mut token = sign(Some("k1"), valid_claims());
+        // Flip the last char of the signature segment.
+        let last = token.pop().unwrap();
+        token.push(if last == 'A' { 'B' } else { 'A' });
+        assert!(validate_id_token(&token, &jwks(Some("k1")), ISSUER, CLIENT_ID, NONCE).is_err());
+    }
+
+    #[test]
+    fn unknown_kid_rejected() {
+        // Token signed under kid "k1" but JWKS only advertises "other".
+        let token = sign(Some("k1"), valid_claims());
+        assert!(validate_id_token(&token, &jwks(Some("other")), ISSUER, CLIENT_ID, NONCE).is_err());
+    }
+
+    #[test]
+    fn pkce_challenge_is_sha256_of_verifier() {
+        let (verifier, challenge) = generate_pkce();
+        assert!(verifier.len() >= 43 && verifier.len() <= 128);
+        let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        assert_eq!(challenge, expected);
+    }
+
+    #[test]
+    fn flow_cookie_roundtrips_and_rejects_tamper() {
+        let secret = "test-secret";
+        let flow = FlowState {
+            org_id: "11111111-1111-1111-1111-111111111111".into(),
+            org_slug: "acme".into(),
+            state: "s".into(),
+            nonce: "n".into(),
+            pkce_verifier: "v".into(),
+            issuer: ISSUER.into(),
+            token_endpoint: format!("{ISSUER}/token"),
+            jwks_uri: format!("{ISSUER}/jwks"),
+            client_id: CLIENT_ID.into(),
+            redirect_uri: "https://app/cb".into(),
+            exp: (Utc::now() + chrono::Duration::minutes(5)).timestamp(),
+        };
+        let cookie = encode_flow(secret, &flow).unwrap();
+        let back = decode_flow(secret, &cookie).unwrap();
+        assert_eq!(back.org_slug, "acme");
+        // A different secret must reject the cookie.
+        assert!(decode_flow("other-secret", &cookie).is_err());
+    }
+
+    #[test]
+    fn email_verified_only_rejects_explicit_false() {
+        assert!(email_explicitly_unverified(&Some(serde_json::json!(false))));
+        assert!(email_explicitly_unverified(&Some(serde_json::json!("false"))));
+        assert!(email_explicitly_unverified(&Some(serde_json::json!("False"))));
+        // Verified, or absent, must NOT be treated as unverified.
+        assert!(!email_explicitly_unverified(&Some(serde_json::json!(true))));
+        assert!(!email_explicitly_unverified(&Some(serde_json::json!("true"))));
+        assert!(!email_explicitly_unverified(&None));
+    }
+
+    #[test]
+    fn constant_time_eq_works() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
+    }
+
+    #[test]
+    fn read_flow_cookie_parses_among_others() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::COOKIE, "other=1; mf_oidc_flow=abc.def.ghi; x=2".parse().unwrap());
+        assert_eq!(read_flow_cookie(&headers).as_deref(), Some("abc.def.ghi"));
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -43,6 +43,9 @@ pub struct CreateSSOConfigRequest {
     pub oidc_issuer_url: Option<String>,
     pub oidc_client_id: Option<String>,
     pub oidc_client_secret: Option<String>,
+    // Email domain that the pre-login discovery endpoint maps to this org. Only a
+    // routing key; ownership is still DNS-verified at provisioning time.
+    pub email_domain: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -59,8 +62,81 @@ pub struct SSOConfigResponse {
     pub require_signed_assertions: bool,
     pub require_signed_responses: bool,
     pub allow_unsolicited_responses: bool,
+    pub email_domain: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+}
+
+/// Query for the pre-login SSO discovery endpoint.
+#[derive(Debug, Deserialize)]
+pub struct DiscoverSsoQuery {
+    pub email: String,
+}
+
+/// Response body for a successful SSO discovery: which provider to use and the
+/// org slug to address in the follow-up `/api/v1/sso/{provider}/login/{slug}`.
+#[derive(Debug, Serialize)]
+pub struct DiscoverSsoResponse {
+    pub provider: String,
+    pub org_slug: String,
+}
+
+/// Extract + normalize the email domain for SSO discovery: the part after the
+/// last `@`, lowercased, requiring a plausible dotted host. Returns `None` for
+/// anything that isn't a usable mail domain so a malformed input is a clean 404.
+fn extract_sso_domain(email: &str) -> Option<String> {
+    let (_, raw) = email.rsplit_once('@')?;
+    let domain = crate::sso_domain::normalize_domain(raw);
+    if domain.is_empty() || !domain.contains('.') || domain.contains('@') {
+        return None;
+    }
+    Some(domain)
+}
+
+/// Pre-login SSO discovery (PUBLIC, no auth): map an email's domain to the org
+/// and provider configured for it, so the login UI can redirect into the SSO
+/// flow. Returns 200 `{provider, org_slug}` when an enabled, domain-matched SSO
+/// config exists, or a clean 404 otherwise.
+///
+/// Privacy: this only reveals whether SSO is configured for a *domain*; it never
+/// reveals whether a given user exists. A domain with no enabled config and a
+/// domain that exists but is unverified/disabled return the SAME 404, so the UI
+/// falls back to manual org-slug entry without leaking anything.
+pub async fn discover_sso(
+    State(state): State<AppState>,
+    Query(query): Query<DiscoverSsoQuery>,
+) -> Response {
+    let not_found = || {
+        (
+            axum::http::StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "No SSO configured for this email domain" })),
+        )
+            .into_response()
+    };
+
+    // Extract + normalize the email domain (everything after the last '@').
+    let Some(domain) = extract_sso_domain(&query.email) else {
+        return not_found();
+    };
+
+    // Only an enabled, domain-matched config resolves. The store method filters
+    // on `enabled = TRUE`, so disabled configs are invisible here.
+    match state.store.find_sso_config_by_email_domain(&domain).await {
+        Ok(Some((config, org_slug))) => (
+            axum::http::StatusCode::OK,
+            Json(serde_json::json!(DiscoverSsoResponse {
+                provider: config.provider().to_string(),
+                org_slug,
+            })),
+        )
+            .into_response(),
+        Ok(None) => not_found(),
+        Err(e) => {
+            // Fail closed AND opaque: never surface store internals pre-login.
+            tracing::warn!(domain = %domain, error = %e, "SSO discovery lookup failed");
+            not_found()
+        }
+    }
 }
 
 /// Create or update SSO configuration (Team plan only, org admin only)
@@ -160,6 +236,7 @@ pub async fn create_sso_config(
             request.oidc_issuer_url.as_deref(),
             request.oidc_client_id.as_deref(),
             request.oidc_client_secret.as_deref(),
+            request.email_domain.as_deref().map(str::trim).filter(|s| !s.is_empty()),
         )
         .await?;
 
@@ -200,6 +277,7 @@ pub async fn create_sso_config(
         require_signed_assertions: config.require_signed_assertions,
         require_signed_responses: config.require_signed_responses,
         allow_unsolicited_responses: config.allow_unsolicited_responses,
+        email_domain: config.email_domain,
         created_at: config.created_at.to_rfc3339(),
         updated_at: config.updated_at.to_rfc3339(),
     }))
@@ -248,6 +326,7 @@ pub async fn get_sso_config(
             require_signed_assertions: config.require_signed_assertions,
             require_signed_responses: config.require_signed_responses,
             allow_unsolicited_responses: config.allow_unsolicited_responses,
+            email_domain: config.email_domain,
             created_at: config.created_at.to_rfc3339(),
             updated_at: config.updated_at.to_rfc3339(),
         })))
@@ -1261,69 +1340,62 @@ fn generate_saml_logout_response(slo_url: &str) -> String {
     )
 }
 
-/// Find or create user from SAML attributes
+/// Find or create user from SAML attributes (thin wrapper over the shared,
+/// domain-gated SSO provisioning path).
 async fn find_or_create_user_from_saml(
     state: &AppState,
     user_info: &SAMLUserInfo,
     org: &Organization,
 ) -> Result<User, ApiError> {
-    // Try to find user by email
-    let user = if let Some(email) = &user_info.email {
-        state.store.find_user_by_email(email).await?
-    } else {
-        None
-    };
+    let email = user_info
+        .email
+        .as_deref()
+        .ok_or_else(|| ApiError::InvalidRequest("Email not found in SAML assertion".to_string()))?;
+    provision_sso_user(state, org, email, user_info.username.as_deref()).await
+}
 
+/// Provision (or attach) an SSO user for `org`, gated on DNS-verified domain
+/// ownership. Shared by the SAML (`saml_acs`) and OIDC (`oidc_callback`) paths so
+/// the #833/#746/#778 cross-tenant takeover gate lives in exactly one place.
+///
+/// - Existing account already a member of `org`: normal login, NOT gated.
+/// - Existing account NOT a member: attaching it requires the org to own the
+///   email's domain (prevents absorbing a foreign account).
+/// - No account: JIT-create, also gated on domain ownership.
+///
+/// Always fail-closed: any domain-verification failure rejects provisioning.
+pub(crate) async fn provision_sso_user(
+    state: &AppState,
+    org: &Organization,
+    email: &str,
+    username_hint: Option<&str>,
+) -> Result<User, ApiError> {
     use crate::models::organization::OrgRole;
-    // Domain-ownership gate (#833/#746/#778). SSO must not be able to provision
-    // or absorb an account for an email domain the org has not proven it owns,
-    // or a malicious org's IdP could mint an assertion for victim@othercorp.com
-    // and take over / squat that account. Verified live via DNS, fail-closed.
-    let domain_verifier = crate::sso_domain::DnsDomainVerifier;
 
-    let user = if let Some(user) = user {
-        // Existing account. A normal SSO login for a current member needs no
-        // gate; only *attaching* a foreign account to this org does.
+    let verifier = crate::sso_domain::DnsDomainVerifier;
+    let existing = state.store.find_user_by_email(email).await?;
+
+    if let Some(user) = existing {
+        // Existing member -> normal login (no gate). Otherwise attaching a
+        // foreign account to this org requires verified domain ownership.
         if state.store.find_org_member(org.id, user.id).await?.is_none() {
-            let email = user_info.email.as_deref().ok_or_else(|| {
-                ApiError::InvalidRequest("Email not found in SAML assertion".to_string())
-            })?;
-            crate::sso_domain::assert_email_in_verified_domain(&domain_verifier, org.id, email)
-                .await?;
+            crate::sso_domain::assert_email_in_verified_domain(&verifier, org.id, email).await?;
             state.store.create_org_member(org.id, user.id, OrgRole::Member).await?;
         }
+        return Ok(user);
+    }
 
-        user
-    } else {
-        // Create new user from SAML attributes
-        let email = user_info.email.as_ref().ok_or_else(|| {
-            ApiError::InvalidRequest("Email not found in SAML assertion".to_string())
-        })?;
+    // JIT-provision a new user; gated on domain ownership.
+    crate::sso_domain::assert_email_in_verified_domain(&verifier, org.id, email).await?;
 
-        // JIT provisioning requires the org to own the email's domain.
-        crate::sso_domain::assert_email_in_verified_domain(&domain_verifier, org.id, email).await?;
-
-        let username = user_info.username.as_ref().cloned().unwrap_or_else(|| {
-            // Generate username from email
-            email.split('@').next().unwrap_or("user").to_string()
-        });
-
-        // Generate a random password (user won't need it for SSO login)
-        let password_hash = crate::auth::hash_password(&uuid::Uuid::new_v4().to_string())
-            .map_err(ApiError::Internal)?;
-
-        // Create user
-        let user = state.store.create_user(&username, email, &password_hash).await?;
-
-        // Mark user as verified (SSO users are pre-verified)
-        state.store.mark_user_verified(user.id).await?;
-
-        // Add user to organization as member
-        state.store.create_org_member(org.id, user.id, OrgRole::Member).await?;
-
-        user
-    };
-
+    let username = username_hint
+        .map(str::to_string)
+        .unwrap_or_else(|| email.split('@').next().unwrap_or("user").to_string());
+    let password_hash = crate::auth::hash_password(&uuid::Uuid::new_v4().to_string())
+        .map_err(ApiError::Internal)?;
+    let user = state.store.create_user(&username, email, &password_hash).await?;
+    state.store.mark_user_verified(user.id).await?;
+    state.store.create_org_member(org.id, user.id, OrgRole::Member).await?;
     Ok(user)
 }
 
@@ -1379,4 +1451,36 @@ fn validate_saml_timestamps(user_info: &SAMLUserInfo) -> Result<(), ApiError> {
 
     tracing::debug!("SAML timestamp validation passed");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_sso_domain_lowercases_and_takes_part_after_at() {
+        assert_eq!(extract_sso_domain("alice@Acme.com").as_deref(), Some("acme.com"));
+        assert_eq!(
+            extract_sso_domain("BOB@Sub.Example.CO.UK").as_deref(),
+            Some("sub.example.co.uk")
+        );
+    }
+
+    #[test]
+    fn extract_sso_domain_uses_last_at_for_quoted_locals() {
+        // Only the final '@' separates local-part from domain.
+        assert_eq!(extract_sso_domain("weird@name@acme.com").as_deref(), Some("acme.com"));
+    }
+
+    #[test]
+    fn extract_sso_domain_rejects_malformed() {
+        // No '@' at all.
+        assert!(extract_sso_domain("not-an-email").is_none());
+        // Empty domain.
+        assert!(extract_sso_domain("user@").is_none());
+        // Domain without a dot is not a usable mail domain.
+        assert!(extract_sso_domain("user@localhost").is_none());
+        // Empty input.
+        assert!(extract_sso_domain("").is_none());
+    }
 }

--- a/crates/mockforge-registry-server/src/routes.rs
+++ b/crates/mockforge-registry-server/src/routes.rs
@@ -1105,11 +1105,15 @@ pub fn create_router(state: AppState) -> Router<AppState> {
         .route_layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
         .route_layer(middleware::from_fn(rate_limit_middleware));
 
-    // Public SSO routes (no auth required - these handle SAML redirects)
+    // Public SSO routes (no auth required - these handle SAML/OIDC redirects and
+    // the pre-login provider-discovery lookup).
     let sso_public_routes = Router::new()
+        .route("/api/v1/sso/discover", get(handlers::sso::discover_sso))
         .route("/api/v1/sso/saml/login/{org_slug}", get(handlers::sso::initiate_saml_login))
         .route("/api/v1/sso/saml/acs/{org_slug}", post(handlers::sso::saml_acs))
         .route("/api/v1/sso/saml/slo/{org_slug}", post(handlers::sso::saml_slo))
+        .route("/api/v1/sso/oidc/login/{org_slug}", get(handlers::oidc::initiate_oidc_login))
+        .route("/api/v1/sso/oidc/callback/{org_slug}", get(handlers::oidc::oidc_callback))
         .route_layer(middleware::from_fn(rate_limit_middleware));
 
     // Public OAuth routes (no auth required - these handle OAuth redirects)
@@ -1207,10 +1211,13 @@ mod tests {
             "/api/v1/sso/enable",
             "/api/v1/sso/disable",
             "/api/v1/sso/domain/status",
+            "/api/v1/sso/discover",
             "/api/v1/sso/saml/metadata/{org_slug}",
             "/api/v1/sso/saml/login/{org_slug}",
             "/api/v1/sso/saml/acs/{org_slug}",
             "/api/v1/sso/saml/slo/{org_slug}",
+            "/api/v1/sso/oidc/login/{org_slug}",
+            "/api/v1/sso/oidc/callback/{org_slug}",
         ];
 
         for route in routes {

--- a/crates/mockforge-registry-server/src/sso_domain.rs
+++ b/crates/mockforge-registry-server/src/sso_domain.rs
@@ -225,10 +225,34 @@ pub fn issuer_url_is_safe(raw: &str) -> bool {
     !host_is_blocked(host)
 }
 
+/// Escape hatch for integration tests / local dev against a mock IdP on
+/// localhost. OFF by default; the production SSRF guard always applies unless
+/// `MOCKFORGE_SSO_ALLOW_INSECURE_ISSUERS=1` is explicitly set. When on, a loud
+/// warning is logged so it can never be mistaken for normal operation.
+pub fn allow_insecure_issuers() -> bool {
+    match std::env::var("MOCKFORGE_SSO_ALLOW_INSECURE_ISSUERS") {
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true") => {
+            tracing::warn!(
+                "MOCKFORGE_SSO_ALLOW_INSECURE_ISSUERS is set: the OIDC issuer SSRF guard is \
+                 RELAXED (localhost/http allowed). This must only be used in tests/dev."
+            );
+            true
+        }
+        _ => false,
+    }
+}
+
+/// SSRF decision for any URL the server will FETCH during the OIDC flow
+/// (issuer discovery, token endpoint, JWKS). Strict by default; honors the
+/// insecure-issuers escape hatch for tests.
+pub fn fetch_url_is_safe(raw: &str) -> bool {
+    issuer_url_is_safe(raw) || allow_insecure_issuers()
+}
+
 /// Validate an OIDC issuer URL, returning a descriptive `InvalidRequest` when
 /// it fails the SSRF guard.
 pub fn validate_issuer_url(raw: &str) -> Result<(), ApiError> {
-    if issuer_url_is_safe(raw) {
+    if fetch_url_is_safe(raw) {
         Ok(())
     } else {
         Err(ApiError::InvalidRequest(

--- a/crates/mockforge-registry-server/tests/oidc_flow.rs
+++ b/crates/mockforge-registry-server/tests/oidc_flow.rs
@@ -1,0 +1,180 @@
+//! Integration test for the OIDC SSO client layer (#746) against a real, local
+//! mock IdP (an axum server that serves discovery + JWKS + token and signs an
+//! RS256 ID token). Exercises discovery, code/token exchange, JWKS fetch, and
+//! full ID-token validation (signature + iss + aud + exp + nonce) end-to-end
+//! over HTTP.
+//!
+//! Requires the SSRF escape hatch (`MOCKFORGE_SSO_ALLOW_INSECURE_ISSUERS`) so the
+//! guard permits the localhost mock IdP. Every test in this binary needs the
+//! relaxed guard, so it is set once per test (the production guard is unit-tested
+//! separately in `sso_domain`).
+
+use std::sync::Arc;
+
+use axum::{
+    extract::State as AxState,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{Duration, Utc};
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use serde_json::json;
+
+use mockforge_registry_server::handlers::oidc::{
+    discover, exchange_code, fetch_jwks, validate_id_token,
+};
+
+const CLIENT_ID: &str = "mockforge-client-1";
+const ID_TOKEN_NONCE: &str = "nonce-xyz-789";
+const KID: &str = "k1";
+
+// Throwaway RSA test key (2048-bit) + matching public modulus. Test-only.
+const TEST_PRIVATE_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2VVJnet1rm4wn
+rbmtew8EKznxOgTLTCxYGHlkUHVpKxp5CfMqlbzRU6jxMTlTKhvq/NZw+qb2wMj2
+nAwQLC31MG9HKoOu3AZeZMv7Y5Sl8QG2Y6cMFpjo7WnRh2Uk8vsy0C9VWRTsqJTT
+q3vxFMbMCiMx3Kpw4mQf9k2RACkDLjL3SkxtU/BExdXI69lVjULWsvLDlvlBNpAc
+uLhcxqZ1XAakgBNWzzgQFiHSKE5y+lm13k8eypCnjXznL4t5h1KkTYFkOwTtJf/k
+RBQzpL2OgMlJWQ6V73qtQ+5XZrwDYaw9ccKT2lBrGS15zv3ww+hXApxeDpQ6l8Xw
+GcNWJWwlAgMBAAECggEASSrl/YaNchAiZw3M0/Ps67RY9RdeMyKnLNbtZ7bt1r0o
+S2gVv4IFGk8jHV6ubVQZjevWNdIvzBdCzcuC/75q1tiP3xQNcc7zc0+pl4C3dvvG
+vyUwNKagx9/1tdJKYVBsQ1DNncc4oVtpFaPcAbtfpyNuSiUN9Gy01yqkp8pTquVh
+GoNtd+QR2dLo6TdNi8eY5wSBPnm5UTidKp5x/niMK7bRcAqMLcNsa0sl1jPjNsIP
+gktfHli4Ebo3lEVPmOFxOPy2pMDg5uOeVJ6rXC1cWxT8Nna8HzofyPR7xWCsZhUj
+KHQiJ33IlU9uSxu7PUI22KUZzyfz7tP2qPv/Sg9SRQKBgQD4DV2kw8D1TcIddgBO
+2EFM6oSfNuUT2tyd0S4CMqz4uXdBceIJGFzTPogh8oTZeXaEI6s0LlCTnFBIrMP6
+SPsTc4nJFADRifKNupzOecK1rBQztl5V0xSagaWOprpVFVQsGFo565lxCYed3d1v
+qUvcjDwKz6B7YW9Sdl8twx9HTwKBgQC8LOZ+THOSD3MhcUJwylJ3V7h2RY6/dNYm
+tieaA5Eo6vfoAjWSAQIlmP5PwkNqR7yGEX68bESfGD2/A4ouueqobr4s0U7AxPnd
+rznrHx8Wm6czaPUR90B4tGayX7WuUq4GbC2TbUs9IWGOQrW3WRBgLejMo/lkiysk
+iBSViOn4SwKBgFgXFwxuYFY9ORSRVWaqsfYIyvRn4E5+yR5arQYmzPq/krRxJx6n
+wj9a06mKoNdCpW4j5KbxU7g4KOLGSArYZCHyRBpeujOv0621ef5xi05NQBdlSncc
+MRL1u7+/Qij5HB1UwKYVHzbfdYQAyKTg8InwW1pTheCLJ6eXVhHAW5lNAoGBAK82
+J4/l455WYF79NF4NJOgWd504ewft5BC7fvg65ghxcE9I71R5N+SGJhVhzp/BF9rF
+o3oSXXq9eZDH3PxRBBu8sbrNUUTQo880fvtcSPgmCnMmATqvPAqn/w+LaoFcXsmA
+JJenJm1PDaUGnGiRt1u2o5MYAvkJVCx5wKDTkPctAoGBALmd6dGutwK69GAlkJTa
+NM0NtyMGQAoLIXurbECjBksLdf+hQGIJcZkjMeHnkneP2JqjB7efpfvNAHrZ7L4M
+pc8kGe5L8vP15KTflqbCciQCQrPX+hQ+vPFLeG02G7KkdG51ERvcggcCm07FZ764
+DwzWpw1tFHUYMntWNYCKWcbI
+-----END PRIVATE KEY-----";
+
+const TEST_N: &str = "tlVSZ3rda5uMJ625rXsPBCs58ToEy0wsWBh5ZFB1aSsaeQnzKpW80VOo8TE5Uyob6vzWcPqm9sDI9pwMECwt9TBvRyqDrtwGXmTL-2OUpfEBtmOnDBaY6O1p0YdlJPL7MtAvVVkU7KiU06t78RTGzAojMdyqcOJkH_ZNkQApAy4y90pMbVPwRMXVyOvZVY1C1rLyw5b5QTaQHLi4XMamdVwGpIATVs84EBYh0ihOcvpZtd5PHsqQp4185y-LeYdSpE2BZDsE7SX_5EQUM6S9joDJSVkOle96rUPuV2a8A2GsPXHCk9pQaxktec798MPoVwKcXg6UOpfF8BnDViVsJQ";
+
+async fn discovery(AxState(base): AxState<Arc<String>>) -> Json<serde_json::Value> {
+    Json(json!({
+        "issuer": *base,
+        "authorization_endpoint": format!("{base}/authorize"),
+        "token_endpoint": format!("{base}/token"),
+        "jwks_uri": format!("{base}/jwks"),
+    }))
+}
+
+async fn jwks() -> Json<serde_json::Value> {
+    Json(json!({
+        "keys": [{
+            "kty": "RSA",
+            "kid": KID,
+            "alg": "RS256",
+            "use": "sig",
+            "n": TEST_N,
+            "e": "AQAB",
+        }]
+    }))
+}
+
+async fn token(AxState(base): AxState<Arc<String>>) -> Json<serde_json::Value> {
+    let exp = (Utc::now() + Duration::hours(1)).timestamp();
+    let claims = json!({
+        "iss": *base,
+        "aud": CLIENT_ID,
+        "exp": exp,
+        "iat": Utc::now().timestamp(),
+        "sub": "subject-1",
+        "email": "bob@acme.com",
+        "email_verified": true,
+        "preferred_username": "bob",
+        "nonce": ID_TOKEN_NONCE,
+    });
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(KID.to_string());
+    let id_token = jsonwebtoken::encode(
+        &header,
+        &claims,
+        &EncodingKey::from_rsa_pem(TEST_PRIVATE_PEM.as_bytes()).unwrap(),
+    )
+    .unwrap();
+    Json(json!({ "id_token": id_token, "access_token": "access-1", "token_type": "Bearer" }))
+}
+
+/// Spawn the mock IdP on an ephemeral localhost port; returns its base URL.
+async fn spawn_mock_idp() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = Router::new()
+        .route("/.well-known/openid-configuration", get(discovery))
+        .route("/jwks", get(jwks))
+        .route("/token", post(token))
+        .with_state(Arc::new(base.clone()));
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    base
+}
+
+#[tokio::test]
+async fn oidc_full_flow_against_mock_idp() {
+    std::env::set_var("MOCKFORGE_SSO_ALLOW_INSECURE_ISSUERS", "1");
+    let base = spawn_mock_idp().await;
+    let client = reqwest::Client::new();
+
+    // Discovery resolves the endpoints.
+    let disc = discover(&client, &base).await.expect("discovery should succeed");
+    assert_eq!(disc.issuer, base);
+    assert_eq!(disc.token_endpoint, format!("{base}/token"));
+
+    // Code -> token exchange returns an ID token.
+    let id_token = exchange_code(
+        &client,
+        &disc.token_endpoint,
+        "auth-code-123",
+        "https://app.example.com/cb",
+        CLIENT_ID,
+        "client-secret",
+        "pkce-verifier",
+    )
+    .await
+    .expect("token exchange should succeed");
+
+    // JWKS fetch + full ID-token validation.
+    let jwks = fetch_jwks(&client, &disc.jwks_uri).await.expect("jwks fetch should succeed");
+    let claims = validate_id_token(&id_token, &jwks, &disc.issuer, CLIENT_ID, ID_TOKEN_NONCE)
+        .expect("ID token should validate");
+    assert_eq!(claims.email.as_deref(), Some("bob@acme.com"));
+    assert_eq!(claims.sub, "subject-1");
+    assert_eq!(claims.preferred_username.as_deref(), Some("bob"));
+}
+
+#[tokio::test]
+async fn oidc_rejects_wrong_nonce_from_idp() {
+    std::env::set_var("MOCKFORGE_SSO_ALLOW_INSECURE_ISSUERS", "1");
+    let base = spawn_mock_idp().await;
+    let client = reqwest::Client::new();
+    let disc = discover(&client, &base).await.unwrap();
+    let id_token = exchange_code(
+        &client,
+        &disc.token_endpoint,
+        "code",
+        "https://app/cb",
+        CLIENT_ID,
+        "secret",
+        "verifier",
+    )
+    .await
+    .unwrap();
+    let jwks = fetch_jwks(&client, &disc.jwks_uri).await.unwrap();
+    // The IdP minted the token with ID_TOKEN_NONCE; validating with a different
+    // expected nonce must fail (replay / token-injection defense).
+    let err =
+        validate_id_token(&id_token, &jwks, &disc.issuer, CLIENT_ID, "attacker-nonce").unwrap_err();
+    assert!(err.to_string().to_lowercase().contains("nonce"), "got: {err}");
+}

--- a/crates/mockforge-registry-server/tests/sso_discover.rs
+++ b/crates/mockforge-registry-server/tests/sso_discover.rs
@@ -1,0 +1,94 @@
+//! Integration test for the pre-login SSO discovery store lookup
+//! (`find_sso_config_by_email_domain`), which backs `GET /api/v1/sso/discover`.
+//!
+//! Exercises the three contractual outcomes against a real Postgres store:
+//!   1. configured + enabled + domain-matched -> Some((config, org_slug))
+//!   2. unknown domain                        -> None (UI falls back to manual)
+//!   3. disabled config                       -> None (invisible to discovery)
+//!
+//! Postgres-gated and `#[ignore]` (mirrors the other `*_e2e` tests): run with
+//!   TEST_DATABASE_URL=postgres://postgres:password@localhost:5433/mockforge_registry \
+//!   cargo test -p mockforge-registry-server --test sso_discover -- --ignored --nocapture
+
+use mockforge_registry_server::database::Database;
+use mockforge_registry_server::models::sso::SSOProvider;
+use mockforge_registry_server::models::Plan;
+use mockforge_registry_server::store::{PgRegistryStore, RegistryStore};
+
+/// Build a migrated Postgres-backed store, or skip (return None) when no
+/// `TEST_DATABASE_URL` is configured so the suite is a no-op in plain CI.
+async fn store_or_skip() -> Option<PgRegistryStore> {
+    let url = std::env::var("TEST_DATABASE_URL").ok()?;
+    let db = Database::connect(&url).await.expect("connect to test db");
+    db.migrate().await.expect("run migrations");
+    Some(PgRegistryStore::new(db.pool().clone()))
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres (TEST_DATABASE_URL)"]
+async fn discover_resolves_enabled_domain_and_hides_disabled_and_unknown() {
+    let Some(store) = store_or_skip().await else {
+        eprintln!("TEST_DATABASE_URL not set; skipping");
+        return;
+    };
+
+    // Unique slug/email-domain per run so repeated local runs don't collide on
+    // the partial-unique email_domain index.
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let email_domain = format!("acme-{suffix}.example.com");
+    let slug = format!("acme-{suffix}");
+    let owner_email = format!("owner@{email_domain}");
+
+    let owner = store
+        .create_user(&format!("owner-{suffix}"), &owner_email, "x")
+        .await
+        .expect("create owner");
+    let org = store
+        .create_organization("Acme", &slug, owner.id, Plan::Team)
+        .await
+        .expect("create org");
+
+    // Upsert an OIDC config carrying the routing email_domain, then enable it.
+    store
+        .upsert_sso_config(
+            org.id,
+            SSOProvider::Oidc,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            true,
+            true,
+            false,
+            Some("https://idp.example.com"),
+            Some("client-1"),
+            Some("secret-1"),
+            Some(&email_domain),
+        )
+        .await
+        .expect("upsert sso config");
+    store.enable_sso_config(org.id).await.expect("enable sso");
+
+    // 1. Enabled + matched -> Some, case-insensitively, returning the org slug.
+    let hit = store
+        .find_sso_config_by_email_domain(&email_domain.to_uppercase())
+        .await
+        .expect("lookup ok");
+    let (config, org_slug) = hit.expect("should resolve an enabled, matched config");
+    assert_eq!(org_slug, slug);
+    assert_eq!(config.provider(), SSOProvider::Oidc);
+
+    // 2. Unknown domain -> None.
+    let miss = store
+        .find_sso_config_by_email_domain("not-configured.example.org")
+        .await
+        .expect("lookup ok");
+    assert!(miss.is_none(), "unknown domain must not resolve");
+
+    // 3. Disabled config -> None (invisible to discovery).
+    store.disable_sso_config(org.id).await.expect("disable sso");
+    let disabled = store.find_sso_config_by_email_domain(&email_domain).await.expect("lookup ok");
+    assert!(disabled.is_none(), "disabled config must not resolve");
+}


### PR DESCRIPTION
## Summary
Re-lands the OIDC login backend from #848 (orphaned when the #847 branch was reset) onto current main, and adds the `/sso/discover` endpoint the held login UI (#853) depends on. This completes the backend half of #746; the UI (#853) can rebase on this.

## OIDC flow (`handlers/oidc.rs`, recovered from `30b539d2`)
- `initiate_oidc_login`: Team-plan/enabled/provider checks, SSRF-guarded issuer discovery, PKCE-S256 redirect, signed flow-state cookie.
- `oidc_callback`: constant-time state/CSRF check, code/token exchange, JWKS fetch, RS256 + iss/aud/exp/nonce validation, `email_verified=false` rejection.
- **Cross-tenant gate intact:** `oidc_callback` provisions via the shared `provision_sso_user`, which runs `assert_email_in_verified_domain` on **both** the JIT-create and account-attach branches — the same #833/#746/#778 DNS-verified-domain gate SAML uses. Verified: 2 gate calls in `provision_sso_user`, OIDC callback routes through it.
- Mock-IdP integration test (`tests/oidc_flow.rs`): localhost axum IdP serving discovery + JWKS + an RS256 ID token; full path + wrong-nonce rejection, no Postgres.

## `/sso/discover` (`handlers/sso.rs`)
- `GET /api/v1/sso/discover?email=` (**public**, pre-login) → `{provider, org_slug}` so the UI routes to `/sso/{provider}/login/{slug}`.
- Migration `20250101000079_sso_email_domain.sql` adds nullable `email_domain` to `sso_configurations` (+ partial unique index) as a routing key; ownership stays DNS-gated at provisioning.
- **Fails closed + opaque:** unknown / disabled / error all return an identical 404; never reveals user existence. Disabled configs are invisible (store filters on `enabled`).

## Risks
- Migration prefix `...079`: free on main (max was `...078`). The #832 RLS *draft* (#863) also used `...079` — that draft must bump when it's reworked; this PR is unaffected.
- The discover 200-path is exercised by the Postgres-gated test; DB-free coverage is the domain-extraction unit tests + the SQLite `None`→404 path.

## Verification
- `cargo fmt --all --check`, `cargo clippy -p mockforge-registry-server -p mockforge-registry-core --all-targets -- -D warnings`, build — all clean.
- `cargo test -p mockforge-registry-server --lib` → 506 passed (incl. 12 OIDC unit + route-allowlist + discover domain tests); `--test oidc_flow` → 2 passed; `mockforge-registry-core --lib` → 272 passed.

## Tests
`oidc.rs` 12 inline units, `tests/oidc_flow.rs` (mock IdP, wrong-nonce), `extract_sso_domain_*` (3), `tests/sso_discover.rs` (Postgres-gated: enabled→200, unknown→404, disabled→404).

Closes #746.
