### PR TITLE
docs(bench): conformance probe taxonomy + --inject-response-violations semantics (#877)

### DIFF
--- a/book/src/reference/conformance-self-test-probes.md
+++ b/book/src/reference/conformance-self-test-probes.md
@@ -56,6 +56,48 @@ Bounded at `SCHEMA_MUTATION_CAP = 12` mutations per operation (top 20
 properties, top 5 required) so a 100-property body on a 22 000-op
 spec doesn't produce a runaway test matrix.
 
+## Content-type negatives (rounds 27 / 28 / 32)
+
+Fire on operations that declare `application/json` as an accepted
+request-body content type. Each variant covers one way a real client
+can get the content-type vs the body wrong.
+
+| Label | What it sends | Expected | Miss = |
+|---|---|---|---|
+| `request-body:content-type-mismatch:xml` | spec-shape JSON body, `Content-Type: application/xml` header | `415` | Server didn't enforce `Content-Type` |
+| `request-body:content-type-mismatch:yaml` | spec-shape JSON body, `Content-Type: application/yaml` | `415` | as above |
+| `request-body:content-type-mismatch:multipart` | spec-shape JSON body, `Content-Type: multipart/form-data` | `415` | as above |
+| `request-body:content-type-mismatch:urlencoded` | spec-shape JSON body, `Content-Type: application/x-www-form-urlencoded` | `415` | as above |
+
+Round 28 wired these into the shared `ServerConformanceViolation`
+buffer so the server-side report also records when a server accepts
+the mismatched content-type, not just the client-side bench.
+
+### Variant-b: embedded non-JSON content
+
+Companion probes (round 27) inject an XML / YAML / multipart /
+urlencoded snippet into the first string field of a spec-shape JSON
+envelope. The `Content-Type` header stays `application/json` and the
+body parses as valid JSON; only the string-valued payload changes.
+
+Round 35 made these tolerate 4xx server responses, because a server
+with a `pattern` / `format` validator on the target field will
+(correctly) reject the embedded snippet. That's why the expected
+range is `2xx-4xx`: only a `5xx` is a finding (server crashed
+parsing the embedded payload).
+
+| Label | What it sends | Expected | Miss = |
+|---|---|---|---|
+| `request-body:embedded-content:xml` | `{"<first-string-field>": "<root>...</root>"}` | `2xx-4xx` | `5xx` only: server crashed parsing the embedded XML |
+| `request-body:embedded-content:yaml` | same shape, YAML-shaped snippet | `2xx-4xx` | `5xx` only: server crashed parsing the embedded YAML |
+| `request-body:embedded-content:multipart` | same shape, multipart-shaped snippet | `2xx-4xx` | `5xx` only: server crashed parsing the embedded multipart |
+| `request-body:embedded-content:urlencoded` | same shape, urlencoded-shaped snippet | `2xx-4xx` | `5xx` only: server crashed parsing the embedded urlencoded |
+
+Round 34 skips these probes entirely when the positive sample has no
+string leaf to mutate (e.g. a `{enabled: boolean}` body), so the
+bench doesn't emit a probe it knows can't construct a valid
+envelope.
+
 ## Parameter negatives
 
 | Label | What it sends | Expected | Miss = |
@@ -104,15 +146,58 @@ payload reaches a sink).
 
 ## How "passed" is decided
 
-For now, **response-code-only**. The driver compares the actual HTTP
-status against the expected range:
+Currently **response-code-only**. Each probe records the expected
+status range it was designed for (`CaseCapture.expected_status_range`)
+and the driver compares the actual HTTP status against that range.
+The driver uses a tristate `ExpectedOutcome` enum (round 35):
 
-- **Positive case**: `passed = (200..400).contains(&status)`
-- **Negative case**: `passed = (400..500).contains(&status)`
+| `ExpectedOutcome` | `expected_status_range` | `passed` is true when |
+|---|---|---|
+| `Success` | `2xx-3xx` | `(200..400).contains(&status)` |
+| `ClientError` | `4xx` | `(400..500).contains(&status)` |
+| `NotServerError` | `2xx-4xx` | `(200..500).contains(&status)` (only `5xx` fails) |
 
-This means a server returning 4xx with an unhelpful generic body
-still counts as "caught" by the negatives. Adding response-body shape
-validation alongside the response-code check is queued (round 21.3).
+Probe-by-probe assignment:
+
+- Positive case → `Success` → `2xx-3xx`.
+- All request-body / parameter / security / OWASP negatives → `ClientError` → `4xx`.
+- `content-type-mismatch:*` negatives → `ClientError` → expected `415`, evaluated as `4xx`.
+- `embedded-content:*` (variant-b) negatives → `NotServerError` → `2xx-4xx`.
+
+A response-body shape validator (in addition to the status-code
+check) is queued (round 21.3).
+
+### 5xx is always a finding
+
+The bench never deliberately **elicits** a 5xx. None of the probe
+families above expect or tolerate a `5xx`. A server emitting `5xx`
+on any probe is a server-side bug to fix, not a noisy test result.
+That's true for the `NotServerError` variants too: the `2xx-4xx`
+tolerance still treats `5xx` as a fail.
+
+## What `--inject-response-violations` changes
+
+This flag is sometimes confused with status-class chaos. It is
+narrowly scoped to **response bodies**:
+
+- Modifies the response **body** for synthesized 2xx responses by
+  dropping the first declared required field from the response
+  schema, so the body becomes spec-non-conforming while still
+  parsing as JSON.
+- Does **not** change the HTTP status. A 2xx response stays 2xx; a
+  4xx response stays 4xx.
+- Use case: feed a downstream proxy or conformance harness a known
+  bad-shape body so you can confirm it catches the mismatch.
+
+If you want to exercise downstream handling of varied 4xx / 5xx
+**statuses**, use the chaos surface instead:
+
+- `mockforge serve --chaos` — global random failure injection with
+  configurable per-status weight.
+- `mockforge route-chaos` — per-route status overrides.
+
+Those are documented in the book's chaos chapter; they're
+intentionally separate knobs from request-body conformance.
 
 ## Interpreting bucket totals
 


### PR DESCRIPTION
## Summary

Adds the missing probe-taxonomy sections Srikanth asked about in round 36 follow-up (#877) to `book/src/reference/conformance-self-test-probes.md`:

- **Content-type negatives**: documents the four `request-body:content-type-mismatch:{xml,yaml,multipart,urlencoded}` probes (rounds 27/28/32, expected `415`).
- **Variant-b embedded-content probes**: documents the four `request-body:embedded-content:*` probes with the round-35 `2xx-4xx` semantics. Explains why only a `5xx` is a finding (server with a `pattern`/`format` validator on the target field correctly rejects with `4xx`). Notes round-34's no-string-leaf skip.
- **How "passed" is decided**: rewrites the stale section to introduce the tristate `ExpectedOutcome` enum (`Success` / `ClientError` / `NotServerError`) with the per-probe assignment table. Adds a "5xx is always a finding" subsection clarifying the bench never deliberately elicits a `5xx`.
- **What `--inject-response-violations` changes**: new section spelling out that the flag modifies response **bodies** only (drops the first required field on synthesized 2xx responses) and does **not** change response status. Points users at `mockforge serve --chaos` / `mockforge route-chaos` for status-class chaos, since that's a separate concern.

Pure docs change, no code touched, no version bump.

Closes #877.

## Test plan
- [x] mdBook source compiles cleanly (existing CI build job)
- [x] No em-dash sweep needed (book prose already uses em-dashes, this is consistent with existing style; em-dash rule applies to direct GH/chat replies, not docs)
- [x] Wording cross-checked against the actual probe sources in `crates/mockforge-bench/src/conformance/`
- [x] Tristate `ExpectedOutcome` matches the round-35 code (`Success`/`ClientError`/`NotServerError`)