### PR TITLE
feat(bench,foundation,openapi): stamp client send time + mockforge version (#876)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7800,6 +7800,7 @@ dependencies = [
  "jsonschema",
  "mockforge-core",
  "mockforge-data",
+ "mockforge-foundation",
  "mockforge-openapi",
  "mockforge-recorder",
  "mockito",

--- a/crates/mockforge-bench/Cargo.toml
+++ b/crates/mockforge-bench/Cargo.toml
@@ -18,6 +18,10 @@ mockforge-core = { version = "0.3.103", path = "../mockforge-core" }
 mockforge-openapi = { path = "../mockforge-openapi" }
 mockforge-data = { version = "0.3.103", path = "../mockforge-data" }
 mockforge-recorder = { version = "0.3.103", path = "../mockforge-recorder", optional = true }
+# Round 36 (#876) — shared constants for the client/server stamp
+# headers (`X-Mockforge-Client-Version`, `X-Mockforge-Client-Sent-At`)
+# so bench and openapi don't drift on the wire format.
+mockforge-foundation = { version = "0.3.180", path = "../mockforge-foundation" }
 
 # OpenAPI and spec parsing
 openapiv3 = "2.0"

--- a/crates/mockforge-bench/src/conformance/capture_html.rs
+++ b/crates/mockforge-bench/src/conformance/capture_html.rs
@@ -282,6 +282,22 @@ function renderCard(c) {
   html += '<span class="label">' + escapeHtml(c.label) + '</span> ';
   html += '<code class="url">' + escapeHtml(c.url) + '</code>';
   html += '</summary><div class="body">';
+  // Round 36 (#876) — surface the client stamps in a dedicated row so
+  // a reader can spot them without expanding the request-headers
+  // section. Older captures without these fields skip the row.
+  if (c.mockforge_version || c.client_sent_at) {
+    html += '<div class="stamps"><strong>Client:</strong> ';
+    if (c.mockforge_version) {
+      html += 'mockforge ' + escapeHtml(c.mockforge_version);
+    }
+    if (c.mockforge_version && c.client_sent_at) {
+      html += ' &middot; ';
+    }
+    if (c.client_sent_at) {
+      html += 'sent ' + escapeHtml(c.client_sent_at);
+    }
+    html += '</div>';
+  }
   html += renderKv('Request headers', c.request_headers);
   html += renderBody('Request body', c.request_body, c.request_body_truncated);
   html += renderKv('Response headers', c.response_headers);
@@ -398,6 +414,8 @@ mod tests {
                 expected_status_range: "2xx-3xx".to_string(),
                 path_template: String::new(),
                 spec_label: None,
+                mockforge_version: String::new(),
+                client_sent_at: String::new(),
             },
             CaseCapture {
                 label: "owasp:sqli".to_string(),
@@ -415,6 +433,8 @@ mod tests {
                 expected_status_range: "2xx-3xx".to_string(),
                 path_template: String::new(),
                 spec_label: None,
+                mockforge_version: String::new(),
+                client_sent_at: String::new(),
             },
         ]
     }
@@ -453,6 +473,8 @@ mod tests {
                 expected_status_range: "2xx-3xx".to_string(),
                 path_template: String::new(),
                 spec_label: None,
+                mockforge_version: String::new(),
+                client_sent_at: String::new(),
             });
         }
         let html = render_capture_html(&entries);
@@ -590,6 +612,8 @@ mod tests {
             expected_status_range: "2xx-3xx".to_string(),
             path_template: String::new(),
             spec_label: None,
+            mockforge_version: String::new(),
+            client_sent_at: String::new(),
         };
         let html = render_capture_html(&[entry]);
         assert!(

--- a/crates/mockforge-bench/src/conformance/per_endpoint_summary.rs
+++ b/crates/mockforge-bench/src/conformance/per_endpoint_summary.rs
@@ -305,6 +305,8 @@ mod tests {
             expected_status_range: "2xx-3xx".to_string(),
             path_template: path_template.to_string(),
             spec_label: None,
+            mockforge_version: String::new(),
+            client_sent_at: String::new(),
         }
     }
 

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -130,7 +130,7 @@ pub struct SelfTestConfig {
 /// `BTreeMap` for stable ordering. Bodies are truncated to
 /// `CAPTURE_BODY_CAP_BYTES`; `*_truncated` flags whether more was
 /// dropped.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CaseCapture {
     pub label: String,
     pub method: String,
@@ -172,6 +172,21 @@ pub struct CaseCapture {
     /// the bench didn't track a spec path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spec_label: Option<String>,
+    /// Round 36 (#876) — mockforge version that ran the probe.
+    /// Stamped from `CARGO_PKG_VERSION` at compile time. Also sent
+    /// as the `X-Mockforge-Client-Version` request header so a
+    /// matching `ServerConformanceViolation.client_mockforge_version`
+    /// can be cross-correlated. Empty string when the capture
+    /// pre-dates this field.
+    #[serde(default)]
+    pub mockforge_version: String,
+    /// Round 36 (#876) — wall-clock moment the bench driver sent the
+    /// request, as RFC3339 / ISO-8601. Also sent as the
+    /// `X-Mockforge-Client-Sent-At` request header so the server-side
+    /// `ServerConformanceViolation.client_sent_at` carries the same
+    /// value. Empty string when the capture pre-dates this field.
+    #[serde(default)]
+    pub client_sent_at: String,
 }
 
 impl Default for SelfTestConfig {
@@ -1523,6 +1538,14 @@ async fn send_case_with_extra(
     for (k, v) in &query {
         req = req.query(&[(k.as_str(), v.as_str())]);
     }
+    // Round 36 (#876) — stamp the client side first so the same
+    // `client_sent_at` string flows into both the request headers
+    // (so the server-side `ServerConformanceViolation` records it
+    // verbatim) and the on-disk `CaseCapture` JSONL line. Don't
+    // re-call `Utc::now()` after `req.send()` — that would record
+    // a different timestamp than the server sees.
+    let mockforge_version = env!("CARGO_PKG_VERSION").to_string();
+    let client_sent_at = chrono::Utc::now().to_rfc3339();
     // Round 28 — reqwest's `.header(k, v)` APPENDS rather than replaces
     // (.headers().insert() would replace but isn't on the builder).
     // The previous round-25 fix relied on "last-write-wins" semantics
@@ -1556,6 +1579,28 @@ async fn send_case_with_extra(
             final_headers.insert(hn, hv);
         }
         capture_headers.insert(k.clone(), v.clone());
+    }
+    // Round 36 (#876) — outbound client stamps. Inserted last so
+    // they can't be clobbered by user-supplied extra-headers, and
+    // recorded in `capture_headers` so the JSONL line shows the
+    // exact bytes that went on the wire.
+    {
+        let v_header = mockforge_foundation::conformance_violations::CLIENT_VERSION_HEADER;
+        let s_header = mockforge_foundation::conformance_violations::CLIENT_SENT_AT_HEADER;
+        if let (Ok(hn), Ok(hv)) = (
+            reqwest::header::HeaderName::from_bytes(v_header.as_bytes()),
+            reqwest::header::HeaderValue::from_str(&mockforge_version),
+        ) {
+            final_headers.insert(hn, hv);
+        }
+        if let (Ok(hn), Ok(hv)) = (
+            reqwest::header::HeaderName::from_bytes(s_header.as_bytes()),
+            reqwest::header::HeaderValue::from_str(&client_sent_at),
+        ) {
+            final_headers.insert(hn, hv);
+        }
+        capture_headers.insert(v_header.to_string(), mockforge_version.clone());
+        capture_headers.insert(s_header.to_string(), client_sent_at.clone());
     }
     if let Some(b) = body {
         req = req.body(b.to_string());
@@ -1628,6 +1673,13 @@ async fn send_case_with_extra(
             // spec_label is constant per run, read from the config.
             path_template: path_template.to_string(),
             spec_label: config.spec_label.clone(),
+            // Round 36 (#876) — same values that went on the wire as
+            // request headers, so a server-side
+            // `ServerConformanceViolation` recorded with
+            // `client_mockforge_version` + `client_sent_at` matches
+            // the JSONL line byte-for-byte.
+            mockforge_version: mockforge_version.clone(),
+            client_sent_at: client_sent_at.clone(),
         };
         if let Ok(mut guard) = sink.lock() {
             guard.push(entry);
@@ -1784,6 +1836,61 @@ mod tests {
             request_body_schema: None,
             security_schemes: Vec::new(),
         }
+    }
+
+    /// Round 36 (#876) — older JSONL lines (written before the stamp
+    /// fields existed) must still deserialise without error and
+    /// default to empty strings. Prevents a back-compat regression
+    /// the next time we extend `CaseCapture`.
+    #[test]
+    fn case_capture_back_compat_when_stamp_fields_missing() {
+        let pre_r36 = serde_json::json!({
+            "label": "positive",
+            "method": "GET",
+            "url": "http://api/users",
+            "request_headers": {},
+            "request_body_truncated": false,
+            "response_status": 200,
+            "response_headers": {},
+            "response_body_truncated": false,
+        });
+        let capture: CaseCapture =
+            serde_json::from_value(pre_r36).expect("pre-r36 payload must deserialise");
+        assert!(capture.mockforge_version.is_empty(), "default to empty");
+        assert!(capture.client_sent_at.is_empty(), "default to empty");
+    }
+
+    /// Round 36 (#876) — when the bench stamps fields itself (the
+    /// happy path), they round-trip through serde unchanged. Pins
+    /// the on-wire shape so tooling that grep's `mockforge_version`
+    /// out of the JSONL stays valid.
+    #[test]
+    fn case_capture_stamps_round_trip_through_serde() {
+        let stamped = CaseCapture {
+            label: "positive".into(),
+            method: "GET".into(),
+            url: "http://api/users".into(),
+            request_headers: BTreeMap::new(),
+            request_body: None,
+            request_body_truncated: false,
+            response_status: 200,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+            response_body_truncated: false,
+            error: None,
+            response_schema_error: None,
+            expected_status_range: "2xx-3xx".into(),
+            path_template: "/users".into(),
+            spec_label: None,
+            mockforge_version: "0.3.183".into(),
+            client_sent_at: "2026-06-17T12:34:56+00:00".into(),
+        };
+        let json = serde_json::to_string(&stamped).unwrap();
+        assert!(json.contains("\"mockforge_version\":\"0.3.183\""));
+        assert!(json.contains("\"client_sent_at\":\"2026-06-17T12:34:56+00:00\""));
+        let back: CaseCapture = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.mockforge_version, "0.3.183");
+        assert_eq!(back.client_sent_at, "2026-06-17T12:34:56+00:00");
     }
 
     #[test]

--- a/crates/mockforge-foundation/src/conformance_violations.rs
+++ b/crates/mockforge-foundation/src/conformance_violations.rs
@@ -50,6 +50,47 @@ pub struct ServerConformanceViolation {
     /// older payloads that don't carry the field.
     #[serde(default = "one")]
     pub occurrences: u32,
+    /// Round 36 (#876) — mockforge version the *client* (the bench
+    /// driver) was running when it sent the request, as read from the
+    /// `X-Mockforge-Client-Version` header. `None` when the inbound
+    /// request didn't carry the header (older client, real proxy
+    /// traffic, etc.). Lets users cross-correlate a client-side
+    /// `CaseCapture` JSONL line with the matching server-side
+    /// violation when both sides log against the same code base.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_mockforge_version: Option<String>,
+    /// Round 36 (#876) — wall-clock timestamp the *client* stamped on
+    /// its `CaseCapture`, as read from the `X-Mockforge-Client-Sent-At`
+    /// header (RFC3339). Server-side `timestamp` is when the
+    /// violation was *received*; this is when the probe was *sent*.
+    /// Grep both for the same value to line up client + server
+    /// records of the same probe.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_sent_at: Option<DateTime<Utc>>,
+}
+
+/// Header set by the bench client (round 36, #876) carrying the
+/// mockforge version that sent the request.
+pub const CLIENT_VERSION_HEADER: &str = "x-mockforge-client-version";
+
+/// Header set by the bench client (round 36, #876) carrying the
+/// RFC3339 timestamp the request was sent at.
+pub const CLIENT_SENT_AT_HEADER: &str = "x-mockforge-client-sent-at";
+
+/// Parse the client-stamp headers off a raw `(name, value)` lookup
+/// function. Accepts a closure so the same helper can read from
+/// `axum::http::HeaderMap`, `reqwest::header::HeaderMap`, or a plain
+/// `HashMap<String, String>` without forcing a particular type on
+/// the caller. Header names are looked up case-insensitively.
+pub fn read_client_stamps<F>(get: F) -> (Option<String>, Option<DateTime<Utc>>)
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let version = get(CLIENT_VERSION_HEADER).filter(|s| !s.is_empty());
+    let sent_at = get(CLIENT_SENT_AT_HEADER)
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|d| d.with_timezone(&Utc));
+    (version, sent_at)
 }
 
 fn one() -> u32 {
@@ -249,7 +290,53 @@ mod tests {
             reason: "test".into(),
             category: "parameters".into(),
             occurrences: 1,
+            client_mockforge_version: None,
+            client_sent_at: None,
         }
+    }
+
+    /// Round 36 (#876) — `read_client_stamps` returns both fields
+    /// when the headers are present and RFC3339-parsable.
+    #[test]
+    fn read_client_stamps_roundtrips_when_headers_present() {
+        let stamped_at = "2026-06-17T12:34:56Z";
+        let (version, sent_at) = read_client_stamps(|name| match name {
+            CLIENT_VERSION_HEADER => Some("0.3.183".to_string()),
+            CLIENT_SENT_AT_HEADER => Some(stamped_at.to_string()),
+            _ => None,
+        });
+        assert_eq!(version.as_deref(), Some("0.3.183"));
+        let sent_at = sent_at.expect("should parse RFC3339 timestamp");
+        assert_eq!(sent_at.to_rfc3339(), "2026-06-17T12:34:56+00:00");
+    }
+
+    /// Missing or malformed headers should yield `None`, not panic
+    /// or fall back to "now" (we don't want to fabricate timestamps).
+    #[test]
+    fn read_client_stamps_returns_none_when_headers_absent_or_garbage() {
+        let (v, s) = read_client_stamps(|_| None);
+        assert!(v.is_none());
+        assert!(s.is_none());
+
+        let (v, s) = read_client_stamps(|name| {
+            if name == CLIENT_SENT_AT_HEADER {
+                Some("not-a-timestamp".to_string())
+            } else {
+                None
+            }
+        });
+        assert!(v.is_none());
+        assert!(s.is_none(), "garbage timestamp must not be invented");
+
+        // Empty version string treated as absent.
+        let (v, _) = read_client_stamps(|name| {
+            if name == CLIENT_VERSION_HEADER {
+                Some(String::new())
+            } else {
+                None
+            }
+        });
+        assert!(v.is_none());
     }
 
     #[test]

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -715,6 +715,15 @@ impl OpenApiRouteRegistry {
                                     .and_then(|s| s.parse::<u16>().ok())
                                     .unwrap_or(415)
                             });
+                        let (client_mockforge_version, client_sent_at) =
+                            mockforge_foundation::conformance_violations::read_client_stamps(
+                                |name| {
+                                    headers
+                                        .get(name)
+                                        .and_then(|v| v.to_str().ok())
+                                        .map(|s| s.to_string())
+                                },
+                            );
                         mockforge_foundation::conformance_violations::record(
                             mockforge_foundation::conformance_violations::ServerConformanceViolation {
                                 timestamp: Utc::now(),
@@ -725,6 +734,8 @@ impl OpenApiRouteRegistry {
                                 reason: ct_err.clone(),
                                 category: "content-types".to_string(),
                                 occurrences: 1,
+                                client_mockforge_version,
+                                client_sent_at,
                             },
                         );
                         let status = axum::http::StatusCode::from_u16(status_code)
@@ -816,6 +827,15 @@ impl OpenApiRouteRegistry {
                                     .to_string()
                             });
                         let category = classify_validation_reason(&reason);
+                        let (client_mockforge_version, client_sent_at) =
+                            mockforge_foundation::conformance_violations::read_client_stamps(
+                                |name| {
+                                    headers
+                                        .get(name)
+                                        .and_then(|v| v.to_str().ok())
+                                        .map(|s| s.to_string())
+                                },
+                            );
                         mockforge_foundation::conformance_violations::record(
                             mockforge_foundation::conformance_violations::ServerConformanceViolation {
                                 timestamp: Utc::now(),
@@ -826,6 +846,8 @@ impl OpenApiRouteRegistry {
                                 reason,
                                 category,
                                 occurrences: 1,
+                                client_mockforge_version,
+                                client_sent_at,
                             },
                         );
 
@@ -1259,6 +1281,13 @@ impl OpenApiRouteRegistry {
             reason = %reason,
             "request conformance violation"
         );
+        let (client_mockforge_version, client_sent_at) =
+            mockforge_foundation::conformance_violations::read_client_stamps(|name| {
+                header_map
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case(name))
+                    .and_then(|(_, v)| v.as_str().map(|s| s.to_string()))
+            });
         mockforge_foundation::conformance_violations::record(
             mockforge_foundation::conformance_violations::ServerConformanceViolation {
                 timestamp: Utc::now(),
@@ -1269,6 +1298,8 @@ impl OpenApiRouteRegistry {
                 reason,
                 category,
                 occurrences: 1,
+                client_mockforge_version,
+                client_sent_at,
             },
         );
 
@@ -1865,6 +1896,15 @@ impl OpenApiRouteRegistry {
                                         .and_then(|s| s.parse::<u16>().ok())
                                         .unwrap_or(415)
                                 });
+                            let (client_mockforge_version, client_sent_at) =
+                                mockforge_foundation::conformance_violations::read_client_stamps(
+                                    |name| {
+                                        headers
+                                            .get(name)
+                                            .and_then(|v| v.to_str().ok())
+                                            .map(|s| s.to_string())
+                                    },
+                                );
                             mockforge_foundation::conformance_violations::record(
                                 mockforge_foundation::conformance_violations::ServerConformanceViolation {
                                     timestamp: Utc::now(),
@@ -1875,6 +1915,8 @@ impl OpenApiRouteRegistry {
                                     reason: ct_err.clone(),
                                     category: "content-types".to_string(),
                                     occurrences: 1,
+                                    client_mockforge_version,
+                                    client_sent_at,
                                 },
                             );
                             let status = axum::http::StatusCode::from_u16(status_code)

--- a/crates/mockforge-openapi/src/route.rs
+++ b/crates/mockforge-openapi/src/route.rs
@@ -496,6 +496,14 @@ impl OpenApiRoute {
                         ),
                         category: "response-shape".to_string(),
                         occurrences: 1,
+                        // Round 36 (#876) — response-shape mismatches are
+                        // detected during response synthesis, after the
+                        // inbound request headers are out of scope. The
+                        // fields stay `None`; client correlation isn't
+                        // meaningful here anyway (this is a server-side
+                        // discovery, not a wire-level conformance issue).
+                        client_mockforge_version: None,
+                        client_sent_at: None,
                     },
                 );
             }


### PR DESCRIPTION
## Summary

Closes #876. Adds a round-trip stamp of the client's mockforge version + send-time onto every conformance probe (client side, `CaseCapture`) and the matching server-side violation (`ServerConformanceViolation`), so the two sides can be cross-correlated.

**Wire format**

- `X-Mockforge-Client-Version: <pkg version>` and `X-Mockforge-Client-Sent-At: <RFC3339>` are set on every request `mockforge bench --conformance-self-test` makes.
- Header constants live in `mockforge-foundation` (`CLIENT_VERSION_HEADER` / `CLIENT_SENT_AT_HEADER`) so bench and openapi cannot drift on the wire format.
- The shared `read_client_stamps` helper accepts a closure (`Fn(&str) -> Option<String>`) so axum `HeaderMap`, reqwest `HeaderMap`, and `serde_json::Map<String, Value>` all flow through one parser.

**Client side (mockforge-bench)**

- `CaseCapture` grows two `#[serde(default)]` string fields: `mockforge_version` and `client_sent_at`. The struct now also derives `Deserialize` so the JSONL round-trips through serde for tooling.
- `send_case_with_extra` stamps once before `req.send()` and inserts the two outbound headers (and the equivalent `capture_headers` entries).

**Server side (mockforge-foundation + mockforge-openapi)**

- `ServerConformanceViolation` gains `client_mockforge_version: Option<String>` + `client_sent_at: Option<DateTime<Utc>>`, both `#[serde(default, skip_serializing_if = "Option::is_none")]` so older snapshots round-trip unchanged.
- Four `ServerConformanceViolation` callsites in `openapi_routes.rs` (content-type mismatch + body validation, in both routers) populate the new fields from `read_client_stamps`. The fifth callsite (response-shape mismatch in `route.rs:484`) is detected during synthesis where request headers are out of scope; it explicitly passes `None` with a comment.

**Capture HTML viewer**

- Each card gets a `<div class="stamps"><strong>Client:</strong> mockforge X.Y.Z &middot; sent &lt;timestamp&gt;</div>` row, so the reader spots client version + send-time without expanding `request_headers`.

**Tests**

- `read_client_stamps_roundtrips_when_headers_present` and `read_client_stamps_returns_none_when_headers_absent_or_garbage` in `mockforge-foundation` — covers the happy path and confirms garbage timestamps are NOT silently invented.
- `case_capture_back_compat_when_stamp_fields_missing` and `case_capture_stamps_round_trip_through_serde` in `mockforge-bench` — pins the JSONL on-wire shape and back-compat with pre-r36 payloads.

**Real-binary verify (dev build of this branch)**

- `mockforge bench --conformance --conformance-self-test --conformance-self-test-capture` against `mockforge serve --spec`:
  - JSONL first row: `mockforge_version: "0.3.180"`, `client_sent_at: "2026-06-17T22:16:57.757281677+00:00"`, plus the same values in `x-mockforge-client-*` request headers.
  - `GET /__mockforge/api/conformance/violations` returns `client_mockforge_version: "0.3.180"` and `client_sent_at: <timestamp>` on every entry.
  - Capture HTML embeds the new `Client:` row.

**Drive-by**

- `TcpServerConfig` literal in `mockforge-cli/src/serve.rs` was missing `max_message_bytes` (a recent `mockforge-tcp::TcpConfig` field add). Added with the same 1 MiB default `default_tcp_max_message_bytes()` uses so workspace clippy passes from this branch too.

## Test plan
- [x] `cargo test -p mockforge-foundation` (7 passing, 1 ignored)
- [x] `cargo test -p mockforge-bench --lib` (477 passing)
- [x] `cargo test -p mockforge-openapi --lib` (175 passing)
- [x] `cargo clippy -p mockforge-foundation --all-targets -- -D warnings`
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings`
- [x] `cargo clippy -p mockforge-openapi --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Real-binary end-to-end verify above