### PR TITLE
fix(registry): AI enqueue quota gate + subscription-status entitlement gating (#865, #870)

### DIFF
--- a/crates/mockforge-registry-core/src/models/test_generation_job.rs
+++ b/crates/mockforge-registry-core/src/models/test_generation_job.rs
@@ -236,6 +236,25 @@ impl TestGenerationJob {
         .rows_affected();
         Ok(rows > 0)
     }
+
+    /// Count the org's in-flight (queued + running) jobs. Used by the
+    /// create-job handler (#865) to cap pending AI jobs per org and prevent
+    /// queue flooding — each dequeued job burns platform tokens, so an
+    /// unbounded queue is a cost-exposure even with a per-job quota check.
+    pub async fn count_pending_for_org(pool: &PgPool, org_id: Uuid) -> sqlx::Result<i64> {
+        let count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM cloud_test_generation_jobs
+            WHERE org_id = $1
+              AND status IN ('queued', 'running')
+            "#,
+        )
+        .bind(org_id)
+        .fetch_one(pool)
+        .await?;
+        Ok(count)
+    }
 }
 
 #[cfg(test)]

--- a/crates/mockforge-registry-server/src/handlers/ai_studio.rs
+++ b/crates/mockforge-registry-server/src/handlers/ai_studio.rs
@@ -262,7 +262,9 @@ pub async fn quota(
         .await
         .map_err(|_| ApiError::InvalidRequest("Organization not found".into()))?;
     let byok = load_byok_config(&state, org_ctx.org_id).await?;
-    let is_paid_plan = matches!(org_ctx.org.plan(), Plan::Pro | Plan::Team);
+    // Effective plan (#870) so the quota banner reflects a lapsed subscription.
+    let effective = crate::handlers::entitlements::effective_plan(&state, &org_ctx.org).await?;
+    let is_paid_plan = matches!(effective, Plan::Pro | Plan::Team);
     let provider = pick_provider(is_paid_plan, byok);
     let selection = provider.selection();
     let q = check_ai_quota(&state, &org_ctx.org, selection).await?;
@@ -470,8 +472,11 @@ pub(crate) async fn run_completion_for_org(
     // 1. BYOK lookup.
     let byok = load_byok_config(state, org.id).await?;
 
-    // 2. Provider routing (pure).
-    let is_paid_plan = matches!(org.plan(), Plan::Pro | Plan::Team);
+    // 2. Provider routing (pure). Use the *effective* plan (#870) so a
+    //    canceled/past-due org loses platform-credit AI access (it falls back
+    //    to Disabled without BYOK), instead of keeping it on a stale `plan`.
+    let effective = crate::handlers::entitlements::effective_plan(state, org).await?;
+    let is_paid_plan = matches!(effective, Plan::Pro | Plan::Team);
     let provider = pick_provider(is_paid_plan, byok);
 
     // 3. Pre-call quota check.
@@ -513,7 +518,14 @@ pub(crate) async fn run_completion_for_org(
 }
 
 /// Read the org's BYOK config, returning `None` if missing or disabled.
-async fn load_byok_config(state: &AppState, org_id: uuid::Uuid) -> ApiResult<Option<BYOKConfig>> {
+///
+/// `pub(crate)` so the test-generation create-job handler (#865) can reuse the
+/// exact BYOK resolution the AI pipeline uses when running its pre-enqueue
+/// quota gate.
+pub(crate) async fn load_byok_config(
+    state: &AppState,
+    org_id: uuid::Uuid,
+) -> ApiResult<Option<BYOKConfig>> {
     let setting = state.store.get_org_setting(org_id, "byok").await?;
     let Some(setting) = setting else {
         return Ok(None);

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -850,6 +850,13 @@ async fn handle_subscription_deleted(
         .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
     let old_plan = org.plan();
 
+    // TODO(#870-followup): cancellation fairness. This downgrades the org to
+    // Free immediately on `customer.subscription.deleted`, ignoring
+    // `cancel_at_period_end` / `current_period_end` — a user who cancels
+    // mid-period loses paid features before the period they already paid for
+    // ends. The fix is to keep the paid plan until period end, then downgrade.
+    // Tracked separately from the entitlement-integrity work (#870); out of
+    // scope for the effective-plan gating change.
     // Downgrade org to free plan
     Organization::update_plan(pool, subscription_record.org_id, Plan::Free)
         .await

--- a/crates/mockforge-registry-server/src/handlers/entitlements.rs
+++ b/crates/mockforge-registry-server/src/handlers/entitlements.rs
@@ -1,0 +1,208 @@
+//! Subscription-aware entitlement gating (#870).
+//!
+//! Feature gates across the registry (SSO, AI, admin-role assignment,
+//! protocol selection) historically trusted `org.plan()` alone. But `plan`
+//! is only flipped by Stripe webhooks (`handlers::billing`). If a
+//! `customer.subscription.deleted` / `.updated` webhook is missed, dropped,
+//! or delayed, a canceled or past-due org would keep its paid tier
+//! *indefinitely* with no reconciliation.
+//!
+//! [`effective_plan`] is the single chokepoint that closes that gap: it
+//! returns the org's stored plan only when the org has an *active* (or
+//! *trialing*) subscription, honoring the same 24h past-due grace window
+//! that hosted-mock deployment already uses. Otherwise it downgrades the
+//! effective plan to [`Plan::Free`] for gating purposes — without mutating
+//! the stored `plan` column (that stays the webhook/reconciliation job's
+//! responsibility).
+//!
+//! Gates keep their existing `plan()`-based check and add this on top, so a
+//! plan that *was* always free stays free and a paid plan that lost its
+//! subscription loses its paid features.
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::error::ApiResult;
+use crate::models::{Organization, Plan, Subscription, SubscriptionStatus};
+use crate::AppState;
+
+/// Past-due grace window. Mirrors the constant in
+/// [`crate::handlers::hosted_mocks::create_deployment`] (#449): a `past_due`
+/// subscription keeps access for 24h after the status flip so a transient
+/// card-network blip during Stripe's smart-retry sequence doesn't cut a
+/// paying customer off mid-flight.
+pub const PAST_DUE_GRACE_SECONDS: i64 = 24 * 60 * 60;
+
+/// Resolve the *effective* plan to use for entitlement gating.
+///
+/// Rules:
+/// * No subscription row at all → trust the stored plan. Orgs are upgraded
+///   administratively (manual `update_plan`, seeded admin orgs, legacy
+///   imports) without a Stripe subscription, and the #870 threat model is a
+///   subscription that *exists* but wasn't reconciled. An org that was never
+///   billed through Stripe has no dropped-webhook risk, so we don't punish it
+///   (and this keeps the e2e suite — which seeds `Plan::Team` orgs directly —
+///   green). A warning is logged when a *paid* plan has no subscription so the
+///   anomaly is observable.
+/// * Subscription `active` / `trialing` → trust the stored plan (trials MUST
+///   keep their paid plan — do not break the 14-day trial).
+/// * Subscription `past_due` → trust the stored plan only within the 24h
+///   grace window (mirrors hosted_mocks); past the window, downgrade to Free.
+/// * Any other status (`canceled`, `unpaid`, `incomplete`,
+///   `incomplete_expired`) → downgrade to [`Plan::Free`] for gating.
+///
+/// Never mutates the stored `plan` column.
+pub async fn effective_plan(state: &AppState, org: &Organization) -> ApiResult<Plan> {
+    let stored = org.plan();
+    let sub = Subscription::find_by_org(state.db.pool(), org.id).await?;
+    Ok(resolve_effective_plan(stored, sub.as_ref(), Utc::now()))
+}
+
+/// Pure decision core for [`effective_plan`], split out so it's unit-testable
+/// without a database. `now` is injected for deterministic grace-window tests.
+fn resolve_effective_plan(
+    stored: Plan,
+    sub: Option<&Subscription>,
+    now: chrono::DateTime<Utc>,
+) -> Plan {
+    // Free is never elevated by subscription state, so short-circuit.
+    if stored == Plan::Free {
+        return Plan::Free;
+    }
+
+    let Some(sub) = sub else {
+        // Paid plan, no subscription row. See doc comment: trust it but log.
+        tracing::warn!(
+            org_plan = %stored,
+            "effective_plan: paid plan has no subscription row; trusting stored plan (legacy/manual/seed org)"
+        );
+        return stored;
+    };
+
+    match sub.status() {
+        SubscriptionStatus::Active | SubscriptionStatus::Trialing => stored,
+        SubscriptionStatus::PastDue => {
+            let elapsed = (now - sub.updated_at).num_seconds();
+            if elapsed > PAST_DUE_GRACE_SECONDS {
+                tracing::info!(
+                    org_plan = %stored,
+                    past_due_seconds = elapsed,
+                    "effective_plan: past_due beyond grace; downgrading to Free for gating"
+                );
+                Plan::Free
+            } else {
+                stored
+            }
+        }
+        other => {
+            tracing::info!(
+                org_plan = %stored,
+                status = %other,
+                "effective_plan: inactive subscription; downgrading to Free for gating"
+            );
+            Plan::Free
+        }
+    }
+}
+
+/// Convenience wrapper for gates that only have an `org_id` + stored plan.
+/// Loads the org, then delegates to [`effective_plan`]. Most call sites
+/// already hold the `Organization`, so [`effective_plan`] is preferred.
+pub async fn effective_plan_for_org_id(state: &AppState, org_id: Uuid) -> ApiResult<Plan> {
+    let org = Organization::find_by_id(state.db.pool(), org_id)
+        .await?
+        .ok_or_else(|| crate::error::ApiError::InvalidRequest("Organization not found".into()))?;
+    effective_plan(state, &org).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn sub_with(status: SubscriptionStatus, updated_at: chrono::DateTime<Utc>) -> Subscription {
+        Subscription {
+            id: Uuid::new_v4(),
+            org_id: Uuid::new_v4(),
+            stripe_subscription_id: "sub_test".into(),
+            stripe_customer_id: "cus_test".into(),
+            price_id: "price_test".into(),
+            plan: "team".into(),
+            status: status.to_string(),
+            current_period_start: Utc::now(),
+            current_period_end: Utc::now(),
+            cancel_at_period_end: false,
+            canceled_at: None,
+            created_at: Utc::now(),
+            updated_at,
+        }
+    }
+
+    #[test]
+    fn free_stays_free_regardless_of_subscription() {
+        let now = Utc::now();
+        assert_eq!(resolve_effective_plan(Plan::Free, None, now), Plan::Free);
+        let sub = sub_with(SubscriptionStatus::Active, now);
+        assert_eq!(resolve_effective_plan(Plan::Free, Some(&sub), now), Plan::Free);
+    }
+
+    #[test]
+    fn paid_with_no_subscription_trusts_stored_plan() {
+        let now = Utc::now();
+        // Legacy/manual/seed org: keep the paid plan (don't break e2e seeds).
+        assert_eq!(resolve_effective_plan(Plan::Team, None, now), Plan::Team);
+        assert_eq!(resolve_effective_plan(Plan::Pro, None, now), Plan::Pro);
+    }
+
+    #[test]
+    fn active_subscription_keeps_paid_plan() {
+        let now = Utc::now();
+        let sub = sub_with(SubscriptionStatus::Active, now);
+        assert_eq!(resolve_effective_plan(Plan::Team, Some(&sub), now), Plan::Team);
+    }
+
+    #[test]
+    fn trialing_subscription_keeps_paid_plan() {
+        // CRITICAL: trials MUST not be downgraded (14-day trial #870).
+        let now = Utc::now();
+        let sub = sub_with(SubscriptionStatus::Trialing, now);
+        assert_eq!(resolve_effective_plan(Plan::Pro, Some(&sub), now), Plan::Pro);
+    }
+
+    #[test]
+    fn canceled_subscription_downgrades_to_free() {
+        let now = Utc::now();
+        let sub = sub_with(SubscriptionStatus::Canceled, now);
+        assert_eq!(resolve_effective_plan(Plan::Team, Some(&sub), now), Plan::Free);
+    }
+
+    #[test]
+    fn unpaid_subscription_downgrades_to_free() {
+        let now = Utc::now();
+        let sub = sub_with(SubscriptionStatus::Unpaid, now);
+        assert_eq!(resolve_effective_plan(Plan::Team, Some(&sub), now), Plan::Free);
+    }
+
+    #[test]
+    fn incomplete_expired_subscription_downgrades_to_free() {
+        let now = Utc::now();
+        let sub = sub_with(SubscriptionStatus::IncompleteExpired, now);
+        assert_eq!(resolve_effective_plan(Plan::Pro, Some(&sub), now), Plan::Free);
+    }
+
+    #[test]
+    fn past_due_within_grace_keeps_paid_plan() {
+        let now = Utc::now();
+        // Flipped to past_due 1h ago — inside the 24h grace window.
+        let sub = sub_with(SubscriptionStatus::PastDue, now - Duration::hours(1));
+        assert_eq!(resolve_effective_plan(Plan::Team, Some(&sub), now), Plan::Team);
+    }
+
+    #[test]
+    fn past_due_beyond_grace_downgrades_to_free() {
+        let now = Utc::now();
+        // Flipped to past_due 25h ago — outside the 24h grace window.
+        let sub = sub_with(SubscriptionStatus::PastDue, now - Duration::hours(25));
+        assert_eq!(resolve_effective_plan(Plan::Team, Some(&sub), now), Plan::Free);
+    }
+}

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -154,7 +154,15 @@ pub async fn create_deployment(
     if !enabled_protocols.contains(&crate::models::Protocol::Http) {
         enabled_protocols.insert(0, crate::models::Protocol::Http);
     }
-    let plan = org_ctx.org.plan.clone();
+    // Gate protocols on the *effective* plan (#870): a canceled/past-due/
+    // unpaid Team org is treated as Free here, so a dropped Stripe webhook
+    // can't keep Team-only brokers (and Pro-only gRPC) deployable. This
+    // aligns the protocol gate with the past-due deploy block above and with
+    // the SSO/AI/RBAC gates. `protocols_allowed_on_plan` takes the plan as a
+    // string, so render the effective plan back to its wire form.
+    let effective_plan =
+        crate::handlers::entitlements::effective_plan(&state, &org_ctx.org).await?;
+    let plan = effective_plan.to_string();
     if !crate::models::protocols_allowed_on_plan(&enabled_protocols, &plan) {
         let blocked: Vec<String> = enabled_protocols
             .iter()

--- a/crates/mockforge-registry-server/src/handlers/mod.rs
+++ b/crates/mockforge-registry-server/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod cloud_services;
 pub mod cloud_workspaces;
 pub mod consistency;
 pub mod contract_verification;
+pub mod entitlements;
 pub mod faq;
 pub mod federations;
 pub mod flows;

--- a/crates/mockforge-registry-server/src/handlers/oidc.rs
+++ b/crates/mockforge-registry-server/src/handlers/oidc.rs
@@ -353,7 +353,12 @@ pub async fn initiate_oidc_login(
         .find_organization_by_slug(&org_slug)
         .await?
         .ok_or_else(|| ApiError::InvalidRequest("Organization not found".into()))?;
-    if org.plan() != Plan::Team {
+    // Gate on the *effective* plan (#870): a Team org whose subscription is
+    // canceled/past-due/unpaid is treated as Free, so a dropped Stripe
+    // webhook can't keep OIDC login working indefinitely.
+    if org.plan() != Plan::Team
+        || crate::handlers::entitlements::effective_plan(&state, &org).await? != Plan::Team
+    {
         return Err(ApiError::InvalidRequest("SSO is only available for Team plans".into()));
     }
     let config = state

--- a/crates/mockforge-registry-server/src/handlers/organizations.rs
+++ b/crates/mockforge-registry-server/src/handlers/organizations.rs
@@ -315,8 +315,11 @@ pub async fn add_organization_member(
         }
     };
 
-    // RBAC entitlement: Admin role is Team-only (#749).
-    require_role_allowed_on_plan(role, org.plan())?;
+    // RBAC entitlement: Admin role is Team-only (#749). Gate on the
+    // *effective* plan (#870) so a canceled/past-due Team org can't mint new
+    // Admin grants while its subscription is lapsed.
+    let effective = crate::handlers::entitlements::effective_plan(&state, &org).await?;
+    require_role_allowed_on_plan(role, effective)?;
 
     // Add member
     let member = state.store.create_org_member(org_id, target_user.id, role).await?;
@@ -490,8 +493,10 @@ pub async fn update_organization_member_role(
         }
     };
 
-    // RBAC entitlement: promoting to Admin is Team-only (#749).
-    require_role_allowed_on_plan(new_role, org.plan())?;
+    // RBAC entitlement: promoting to Admin is Team-only (#749). Effective
+    // plan (#870) so a lapsed subscription blocks the promotion.
+    let effective = crate::handlers::entitlements::effective_plan(&state, &org).await?;
+    require_role_allowed_on_plan(new_role, effective)?;
 
     // Update role
     state.store.update_org_member_role(org_id, member_user_id, new_role).await?;
@@ -840,8 +845,10 @@ pub async fn create_invitation(
     require_org_admin(&state, &org, user_id).await?;
 
     // RBAC entitlement: don't let lower plans mint Admin invitations (#749).
+    // Effective plan (#870) so a lapsed Team subscription blocks the invite.
     if role == "admin" {
-        require_role_allowed_on_plan(OrgRole::Admin, org.plan())?;
+        let effective = crate::handlers::entitlements::effective_plan(&state, &org).await?;
+        require_role_allowed_on_plan(OrgRole::Admin, effective)?;
     }
 
     use base64::Engine;

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -173,8 +173,13 @@ pub async fn create_sso_config(
         .await?
         .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
 
-    // Check if organization is on Team plan
-    if org.plan() != Plan::Team {
+    // Check if organization is on Team plan. Gate on the *effective* plan
+    // (#870): a Team org whose subscription is canceled/past-due/unpaid is
+    // treated as Free here, so a dropped Stripe webhook can't leave SSO
+    // enabled indefinitely. Trials and active subs keep Team.
+    if org.plan() != Plan::Team
+        || crate::handlers::entitlements::effective_plan(&state, &org).await? != Plan::Team
+    {
         return Err(ApiError::InvalidRequest(
             "SSO is only available for Team plans. Please upgrade to Team plan to enable SSO."
                 .to_string(),
@@ -431,8 +436,10 @@ pub async fn enable_sso(
         .await?
         .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
 
-    // Check if organization is on Team plan
-    if org.plan() != Plan::Team {
+    // Check if organization is on Team plan (effective plan; see #870).
+    if org.plan() != Plan::Team
+        || crate::handlers::entitlements::effective_plan(&state, &org).await? != Plan::Team
+    {
         return Err(ApiError::InvalidRequest("SSO is only available for Team plans".to_string()));
     }
 
@@ -652,8 +659,11 @@ pub async fn initiate_saml_login(
         .await?
         .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
 
-    // Check if organization is on Team plan
-    if org.plan() != Plan::Team {
+    // Check if organization is on Team plan (effective plan; see #870). A
+    // canceled/past-due Team org can no longer start a SAML login.
+    if org.plan() != Plan::Team
+        || crate::handlers::entitlements::effective_plan(&state, &org).await? != Plan::Team
+    {
         return Err(ApiError::InvalidRequest("SSO is only available for Team plans".to_string()));
     }
 

--- a/crates/mockforge-registry-server/src/handlers/test_generation.rs
+++ b/crates/mockforge-registry-server/src/handlers/test_generation.rs
@@ -32,13 +32,16 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::{
+    ai::{provider::pick_provider, quota::check_ai_quota},
     error::{ApiError, ApiResult},
+    handlers::{ai_studio::load_byok_config, entitlements::effective_plan},
     middleware::{resolve_org_context, AuthUser},
     AppState,
 };
 use mockforge_registry_core::models::{
+    organization::Plan,
     test_generation_job::{CreateTestGenerationJob, TestGenerationJob},
-    CloudWorkspace,
+    CloudWorkspace, Organization,
 };
 
 /// Hard cap on the list page size. The TestGeneratorPage is a poll-based
@@ -70,6 +73,16 @@ pub struct CreateJobRequest {
 /// `MAX_PROMPT_BYTES` — anything larger is almost certainly abuse and
 /// would never round-trip through Phase 2's worker anyway.
 const MAX_FILTER_BYTES: usize = 16 * 1024;
+
+/// Cap on in-flight (queued + running) jobs per org (#865). Each dequeued
+/// job burns platform AI tokens up to the moment the quota counter crosses
+/// the limit, and there's no per-org queue-depth bound in the worker. Without
+/// this cap a single org could enqueue thousands of jobs in a burst; even
+/// with the per-job quota check the worker would still drain a large backlog
+/// before the counter catches up. 20 is generous for the interactive UI
+/// (the TestGeneratorPage queues one job at a time) while bounding cost
+/// exposure and DB-scan depth.
+const MAX_PENDING_JOBS_PER_ORG: i64 = 20;
 
 // --- POST /jobs -----------------------------------------------------------
 
@@ -104,6 +117,18 @@ pub async fn create_job(
     } else {
         body.captures_filter
     };
+
+    // --- Pre-enqueue gates (#865) -----------------------------------------
+    //
+    // The worker (`workers::test_generation_worker::process_job`) runs a
+    // per-job `check_ai_quota` before each LLM call. But that check only
+    // fires *after* a job is dequeued — `create_job` historically enqueued
+    // with no gate at all, so a user could queue unlimited jobs and each one
+    // would burn platform tokens up to the moment the counter crossed the
+    // limit. We replicate the worker's pre-call check here so a doomed job
+    // never gets persisted, and cap pending depth so a burst can't flood the
+    // queue. The worker keeps its own check as defense in depth.
+    enforce_pre_enqueue_gates(&state, workspace.org_id).await?;
 
     let row = TestGenerationJob::create(
         state.db.pool(),
@@ -323,6 +348,47 @@ async fn advance_job_stream(
 
 // --- helpers --------------------------------------------------------------
 
+/// Enforce the per-org gates that must pass before an AI test-generation job
+/// is persisted (#865):
+///
+///   1. **Pending-job cap** — reject if the org already has
+///      [`MAX_PENDING_JOBS_PER_ORG`] queued/running jobs, so a burst can't
+///      flood the queue (429-style: `RateLimitExceeded`).
+///   2. **AI quota / availability** — replicate the worker's pre-call check
+///      (`pick_provider` → `check_ai_quota`) so a job that the worker would
+///      immediately fail (Disabled provider, i.e. Free without BYOK; or
+///      Platform quota exhausted) is never enqueued in the first place
+///      (403-style: `ResourceLimitExceeded`, via `QuotaCheck::into_error`).
+///
+/// Uses the *effective* plan (#870) so a canceled/past-due Team or Pro org is
+/// gated as Free here too. BYOK orgs pass the quota check (they pay their own
+/// provider bill); the pending cap still applies to bound queue depth.
+async fn enforce_pre_enqueue_gates(state: &AppState, org_id: Uuid) -> ApiResult<()> {
+    // 1. Pending-job cap.
+    let pending = TestGenerationJob::count_pending_for_org(state.db.pool(), org_id).await?;
+    if pending >= MAX_PENDING_JOBS_PER_ORG {
+        return Err(ApiError::RateLimitExceeded(format!(
+            "Too many pending test-generation jobs ({pending}/{MAX_PENDING_JOBS_PER_ORG}). \
+             Wait for in-flight jobs to finish or cancel some before queuing more."
+        )));
+    }
+
+    // 2. AI quota / provider availability — mirror the worker's pre-call gate.
+    let org = Organization::find_by_id(state.db.pool(), org_id)
+        .await?
+        .ok_or_else(|| ApiError::InvalidRequest("Organization not found".into()))?;
+    let effective = effective_plan(state, &org).await?;
+    let is_paid_plan = matches!(effective, Plan::Pro | Plan::Team);
+    let byok = load_byok_config(state, org_id).await?;
+    let provider = pick_provider(is_paid_plan, byok);
+    let quota = check_ai_quota(state, &org, provider.selection()).await?;
+    if !quota.allowed {
+        // Disabled (Free w/o BYOK) or Platform quota exhausted → don't enqueue.
+        return Err(quota.into_error());
+    }
+    Ok(())
+}
+
 /// Resolve `workspace_id` and check the caller's org owns it. Returns
 /// the workspace so callers can read `workspace.org_id` without a second
 /// fetch. Mirrors the helper in `handlers::captures` but returns the
@@ -385,5 +451,13 @@ mod tests {
         // once produces noisy UI and unbounded scans without a useful
         // value.
         assert_eq!(LIST_LIMIT, 100);
+    }
+
+    #[test]
+    fn pending_jobs_cap_is_20() {
+        // #865: guards against an accidental "let's set it to 10000" change
+        // that would reopen the queue-flooding cost exposure. Keep it modest
+        // — the UI queues one job at a time.
+        assert_eq!(MAX_PENDING_JOBS_PER_ORG, 20);
     }
 }

--- a/crates/mockforge-registry-server/tests/entitlement_subscription_gate_e2e.rs
+++ b/crates/mockforge-registry-server/tests/entitlement_subscription_gate_e2e.rs
@@ -1,0 +1,231 @@
+//! End-to-end tests for the #870 effective-plan entitlement gate.
+//!
+//! Before #870, feature gates trusted `org.plan()` alone. `plan` is only
+//! flipped by Stripe webhooks, so a missed/dropped `customer.subscription.*`
+//! webhook would leave a canceled or past-due org at its paid tier
+//! indefinitely. The gates now resolve the *effective* plan
+//! (`handlers::entitlements::effective_plan`): a Team org keeps Team only
+//! while its subscription is `active`/`trialing` (or `past_due` within the
+//! 24h grace); otherwise it's gated as Free.
+//!
+//! These tests drive the SSO-config gate (`POST /api/v1/sso/config`, Team-
+//! only) end-to-end with the org's plan forced to Team in the DB and a
+//! subscription row seeded at the status under test. They assert:
+//!   (a) `trialing`  → Team kept → SSO config allowed.
+//!   (b) `active`    → Team kept → SSO config allowed.
+//!   (c) `canceled`  → gated as Free → SSO config denied.
+//!   (d) `unpaid`    → gated as Free → SSO config denied.
+//!
+//! The pure decision core (`resolve_effective_plan`, incl. the past-due grace
+//! window) is unit-tested without a DB in
+//! `mockforge-registry-server::handlers::entitlements::tests`.
+//!
+//! Same `#[ignore]` + `REGISTRY_URL`/`DATABASE_URL` shape as the sibling
+//! `*_e2e.rs` suites.
+//!
+//! Run with:
+//!   REGISTRY_URL=http://localhost:8080 \
+//!   DATABASE_URL=postgres://postgres:password@localhost:55432/mockforge_registry \
+//!   cargo test -p mockforge-registry-server --test entitlement_subscription_gate_e2e -- --ignored --nocapture
+
+use chrono::Utc;
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+struct E2e {
+    client: Client,
+    base_url: String,
+    access_token: String,
+    org_id: String,
+}
+
+async fn pool_or_skip() -> Option<(String, PgPool)> {
+    let base_url = std::env::var("REGISTRY_URL").ok()?;
+    let database_url = std::env::var("DATABASE_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+    Some((base_url, pool))
+}
+
+async fn register_and_setup(base_url: &str) -> E2e {
+    let client = Client::new();
+    let ts = Utc::now().timestamp_micros();
+    let username = format!("entgate_{}", ts);
+    let email = format!("entgate_{}@e2e-test.local", ts);
+    let password = "SecureP@ssw0rd!2024";
+
+    let res = client
+        .post(format!("{}/api/v1/auth/register", base_url))
+        .json(&json!({ "username": username, "email": email, "password": password }))
+        .send()
+        .await
+        .expect("register failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("register not JSON");
+    assert!(status.is_success(), "register {}: {}", status, body);
+    let access_token = body["access_token"]
+        .as_str()
+        .or_else(|| body["token"].as_str())
+        .expect("no access token")
+        .to_string();
+
+    let org_slug = format!("entgate-{}", ts);
+    let res = client
+        .post(format!("{}/api/v1/organizations", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .json(&json!({ "name": format!("EntGate Org {}", ts), "slug": org_slug }))
+        .send()
+        .await
+        .expect("create org failed");
+    let body: Value = res.json().await.expect("org not JSON");
+    let org_id = body["id"].as_str().expect("no org id").to_string();
+
+    E2e {
+        client,
+        base_url: base_url.to_string(),
+        access_token,
+        org_id,
+    }
+}
+
+/// Force an org onto the Team plan (bypassing Stripe) so the only variable
+/// under test is the subscription status the effective-plan gate reads.
+async fn force_team_plan(pool: &PgPool, org_id: Uuid) {
+    sqlx::query("UPDATE organizations SET plan = 'team' WHERE id = $1")
+        .bind(org_id)
+        .execute(pool)
+        .await
+        .expect("force team plan");
+}
+
+/// Seed a subscription row for the org at the given status. `updated_at` is
+/// NOW(), so a `past_due` row would still be inside its grace window; the
+/// statuses exercised here are terminal (canceled/unpaid) or active/trialing,
+/// where the grace window is irrelevant.
+async fn seed_subscription(pool: &PgPool, org_id: Uuid, status: &str) {
+    let ts = Utc::now().timestamp_micros();
+    sqlx::query(
+        r#"
+        INSERT INTO subscriptions
+            (org_id, stripe_subscription_id, stripe_customer_id, price_id,
+             plan, status, current_period_start, current_period_end)
+        VALUES ($1, $2, $3, 'price_test', 'team', $4, NOW(), NOW() + INTERVAL '30 days')
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("sub_entgate_{ts}"))
+    .bind(format!("cus_entgate_{ts}"))
+    .bind(status)
+    .execute(pool)
+    .await
+    .expect("seed subscription");
+}
+
+/// Attempt to create an SSO config (Team-only gate). Returns the HTTP status.
+async fn try_create_sso_config(e: &E2e) -> StatusCode {
+    e.client
+        .post(format!("{}/api/v1/sso/config", e.base_url))
+        .header("Authorization", format!("Bearer {}", e.access_token))
+        .header("X-Organization-Id", &e.org_id)
+        .json(&json!({
+            "provider": "oidc",
+            "oidc_issuer_url": "https://idp.example.com",
+            "oidc_client_id": "client-1",
+            "oidc_client_secret": "secret-1",
+        }))
+        .send()
+        .await
+        .expect("sso config post failed")
+        .status()
+}
+
+/// Active subscription → Team kept → SSO config gate passes (non-403/plan).
+#[tokio::test]
+#[ignore = "requires Postgres + running registry (REGISTRY_URL / DATABASE_URL)"]
+async fn active_subscription_keeps_team_sso_allowed() {
+    let Some((base_url, pool)) = pool_or_skip().await else {
+        eprintln!("REGISTRY_URL/DATABASE_URL not set; skipping");
+        return;
+    };
+    let e = register_and_setup(&base_url).await;
+    let org_uuid: Uuid = e.org_id.parse().unwrap();
+    force_team_plan(&pool, org_uuid).await;
+    seed_subscription(&pool, org_uuid, "active").await;
+
+    let status = try_create_sso_config(&e).await;
+    assert!(
+        status.is_success(),
+        "active Team subscription must keep SSO available, got {status}"
+    );
+}
+
+/// Trialing subscription → Team kept → SSO config allowed. MUST not break the
+/// 14-day trial.
+#[tokio::test]
+#[ignore = "requires Postgres + running registry (REGISTRY_URL / DATABASE_URL)"]
+async fn trialing_subscription_keeps_team_sso_allowed() {
+    let Some((base_url, pool)) = pool_or_skip().await else {
+        eprintln!("REGISTRY_URL/DATABASE_URL not set; skipping");
+        return;
+    };
+    let e = register_and_setup(&base_url).await;
+    let org_uuid: Uuid = e.org_id.parse().unwrap();
+    force_team_plan(&pool, org_uuid).await;
+    seed_subscription(&pool, org_uuid, "trialing").await;
+
+    let status = try_create_sso_config(&e).await;
+    assert!(
+        status.is_success(),
+        "trialing Team subscription MUST keep SSO available (do not break trials), got {status}"
+    );
+}
+
+/// Canceled subscription → gated as Free → SSO config denied.
+#[tokio::test]
+#[ignore = "requires Postgres + running registry (REGISTRY_URL / DATABASE_URL)"]
+async fn canceled_subscription_blocks_team_sso() {
+    let Some((base_url, pool)) = pool_or_skip().await else {
+        eprintln!("REGISTRY_URL/DATABASE_URL not set; skipping");
+        return;
+    };
+    let e = register_and_setup(&base_url).await;
+    let org_uuid: Uuid = e.org_id.parse().unwrap();
+    force_team_plan(&pool, org_uuid).await;
+    seed_subscription(&pool, org_uuid, "canceled").await;
+
+    // Stored plan is still Team, but the effective plan is Free → the
+    // "SSO is only available for Team plans" gate must reject (400).
+    let status = try_create_sso_config(&e).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "canceled subscription must downgrade gating to Free and block SSO"
+    );
+}
+
+/// Unpaid subscription → gated as Free → SSO config denied.
+#[tokio::test]
+#[ignore = "requires Postgres + running registry (REGISTRY_URL / DATABASE_URL)"]
+async fn unpaid_subscription_blocks_team_sso() {
+    let Some((base_url, pool)) = pool_or_skip().await else {
+        eprintln!("REGISTRY_URL/DATABASE_URL not set; skipping");
+        return;
+    };
+    let e = register_and_setup(&base_url).await;
+    let org_uuid: Uuid = e.org_id.parse().unwrap();
+    force_team_plan(&pool, org_uuid).await;
+    seed_subscription(&pool, org_uuid, "unpaid").await;
+
+    let status = try_create_sso_config(&e).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "unpaid subscription must downgrade gating to Free and block SSO"
+    );
+}

--- a/crates/mockforge-registry-server/tests/test_generation_quota_gate_e2e.rs
+++ b/crates/mockforge-registry-server/tests/test_generation_quota_gate_e2e.rs
@@ -1,0 +1,236 @@
+//! End-to-end tests for the #865 pre-enqueue quota + pending-cap gate on
+//! `POST /api/v1/workspaces/{id}/test-generation/jobs`.
+//!
+//! Before #865, `create_job` enqueued AI test-generation jobs with NO quota
+//! check — quota was only consulted per-job in the worker. A user could
+//! enqueue unlimited jobs, each burning platform tokens up to the moment the
+//! counter crossed the limit, with no cap on queue depth. The gate now
+//! replicates the worker's `pick_provider` → `check_ai_quota` decision before
+//! persisting, and caps in-flight jobs per org.
+//!
+//! Same e2e shape as the other `*_e2e.rs` suites: `#[ignore]`-gated, runs
+//! against a live registry server with Postgres reachable on `DATABASE_URL`.
+//!
+//! Scenarios:
+//!   1. `free_org_without_byok_is_rejected_before_enqueue`
+//!      — A Free org (default: `ai_tokens_per_month = 0`, no BYOK) →
+//!      provider is Disabled → 403 and NO row is persisted.
+//!   2. `pending_cap_rejects_when_queue_is_full`
+//!      — Pre-seed the cap's worth of queued jobs directly in the DB, then
+//!      a paid-plan org with platform quota gets a 429 (queue full).
+//!   3. `under_quota_paid_org_succeeds`
+//!      — A Team org with platform quota and an empty queue enqueues OK.
+//!
+//! Run with:
+//!   REGISTRY_URL=http://localhost:8080 \
+//!   DATABASE_URL=postgres://postgres:password@localhost:55432/mockforge_registry \
+//!   cargo test -p mockforge-registry-server --test test_generation_quota_gate_e2e -- --ignored --nocapture
+
+use chrono::Utc;
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+struct E2e {
+    client: Client,
+    base_url: String,
+    access_token: String,
+    org_id: String,
+    workspace_id: String,
+}
+
+async fn register_and_setup(base_url: &str) -> E2e {
+    let client = Client::new();
+    let ts = Utc::now().timestamp_micros();
+    let username = format!("testgen_{}", ts);
+    let email = format!("testgen_{}@e2e-test.local", ts);
+    let password = "SecureP@ssw0rd!2024";
+
+    let res = client
+        .post(format!("{}/api/v1/auth/register", base_url))
+        .json(&json!({ "username": username, "email": email, "password": password }))
+        .send()
+        .await
+        .expect("register failed");
+    let status = res.status();
+    let body: Value = res.json().await.expect("register not JSON");
+    assert!(status.is_success(), "register {}: {}", status, body);
+    let access_token = body["access_token"]
+        .as_str()
+        .or_else(|| body["token"].as_str())
+        .expect("no access token")
+        .to_string();
+
+    let org_slug = format!("testgen-{}", ts);
+    let res = client
+        .post(format!("{}/api/v1/organizations", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .json(&json!({ "name": format!("TestGen Org {}", ts), "slug": org_slug }))
+        .send()
+        .await
+        .expect("create org failed");
+    let body: Value = res.json().await.expect("org not JSON");
+    let org_id = body["id"].as_str().expect("no org id").to_string();
+
+    let res = client
+        .post(format!("{}/api/v1/workspaces", base_url))
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("X-Organization-Id", &org_id)
+        .json(&json!({ "name": "testgen-e2e", "description": "e2e fixture" }))
+        .send()
+        .await
+        .expect("create workspace failed");
+    let body: Value = res.json().await.expect("ws not JSON");
+    let workspace_id = body["id"].as_str().expect("no ws id").to_string();
+
+    E2e {
+        client,
+        base_url: base_url.to_string(),
+        access_token,
+        org_id,
+        workspace_id,
+    }
+}
+
+async fn pool_or_skip() -> Option<(String, PgPool)> {
+    let base_url = std::env::var("REGISTRY_URL").ok()?;
+    let database_url = std::env::var("DATABASE_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+    Some((base_url, pool))
+}
+
+/// Force an org onto the Team plan + a generous platform AI quota, bypassing
+/// the Stripe webhook path (we just need the plan + limits for gating).
+async fn set_team_plan_with_ai_quota(pool: &PgPool, org_id: Uuid) {
+    sqlx::query(
+        r#"
+        UPDATE organizations
+        SET plan = 'team',
+            limits_json = jsonb_set(limits_json, '{ai_tokens_per_month}', '1000000')
+        WHERE id = $1
+        "#,
+    )
+    .bind(org_id)
+    .execute(pool)
+    .await
+    .expect("force team plan");
+}
+
+fn create_job_url(e: &E2e) -> String {
+    format!("{}/api/v1/workspaces/{}/test-generation/jobs", e.base_url, e.workspace_id)
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres + running registry (REGISTRY_URL / DATABASE_URL)"]
+async fn free_org_without_byok_is_rejected_before_enqueue() {
+    let Some((base_url, pool)) = pool_or_skip().await else {
+        eprintln!("REGISTRY_URL/DATABASE_URL not set; skipping");
+        return;
+    };
+    let e = register_and_setup(&base_url).await;
+    let org_uuid: Uuid = e.org_id.parse().unwrap();
+
+    // Default org is Free with ai_tokens_per_month = 0 and no BYOK →
+    // pick_provider(false, None) = Disabled → quota not allowed.
+    let res = e
+        .client
+        .post(create_job_url(&e))
+        .header("Authorization", format!("Bearer {}", e.access_token))
+        .header("X-Organization-Id", &e.org_id)
+        .json(&json!({ "prompt": "gen tests", "captures_filter": {} }))
+        .send()
+        .await
+        .expect("post failed");
+    assert_eq!(
+        res.status(),
+        StatusCode::FORBIDDEN,
+        "Free-without-BYOK org must be rejected before enqueue"
+    );
+
+    // No row should have been persisted.
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM cloud_test_generation_jobs WHERE org_id = $1")
+            .bind(org_uuid)
+            .fetch_one(&pool)
+            .await
+            .expect("count");
+    assert_eq!(count, 0, "no job row should be persisted on a rejected enqueue");
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres + running registry (REGISTRY_URL / DATABASE_URL)"]
+async fn under_quota_paid_org_succeeds() {
+    let Some((base_url, pool)) = pool_or_skip().await else {
+        eprintln!("REGISTRY_URL/DATABASE_URL not set; skipping");
+        return;
+    };
+    let e = register_and_setup(&base_url).await;
+    let org_uuid: Uuid = e.org_id.parse().unwrap();
+    set_team_plan_with_ai_quota(&pool, org_uuid).await;
+
+    let res = e
+        .client
+        .post(create_job_url(&e))
+        .header("Authorization", format!("Bearer {}", e.access_token))
+        .header("X-Organization-Id", &e.org_id)
+        .json(&json!({ "prompt": "gen tests", "captures_filter": {} }))
+        .send()
+        .await
+        .expect("post failed");
+    assert!(
+        res.status().is_success(),
+        "Team org under quota with an empty queue should enqueue OK, got {}",
+        res.status()
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres + running registry (REGISTRY_URL / DATABASE_URL)"]
+async fn pending_cap_rejects_when_queue_is_full() {
+    let Some((base_url, pool)) = pool_or_skip().await else {
+        eprintln!("REGISTRY_URL/DATABASE_URL not set; skipping");
+        return;
+    };
+    let e = register_and_setup(&base_url).await;
+    let org_uuid: Uuid = e.org_id.parse().unwrap();
+    let ws_uuid: Uuid = e.workspace_id.parse().unwrap();
+    set_team_plan_with_ai_quota(&pool, org_uuid).await;
+
+    // Pre-seed MAX_PENDING_JOBS_PER_ORG (20) queued jobs directly, so the
+    // cap is already saturated before the request under test.
+    for _ in 0..20 {
+        sqlx::query(
+            r#"
+            INSERT INTO cloud_test_generation_jobs
+                (workspace_id, org_id, prompt, captures_filter, status)
+            VALUES ($1, $2, '', '{}'::jsonb, 'queued')
+            "#,
+        )
+        .bind(ws_uuid)
+        .bind(org_uuid)
+        .execute(&pool)
+        .await
+        .expect("seed queued job");
+    }
+
+    let res = e
+        .client
+        .post(create_job_url(&e))
+        .header("Authorization", format!("Bearer {}", e.access_token))
+        .header("X-Organization-Id", &e.org_id)
+        .json(&json!({ "prompt": "one too many", "captures_filter": {} }))
+        .send()
+        .await
+        .expect("post failed");
+    assert_eq!(
+        res.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "21st pending job must be rejected with 429 (queue full)"
+    );
+}


### PR DESCRIPTION
Closes the last two genuine launch-blocker-class items from the launch-readiness audit.

## #865 — AI test-generation enqueue had no pre-quota gate (cost exposure)
`create_job` enqueued AI jobs with no quota check; quota was consulted only per-job in the worker, so a user could enqueue unlimited jobs and burn platform tokens up to (and past, via queue depth) the limit.
**Fix:** `create_job` now calls `enforce_pre_enqueue_gates`: (1) a per-org pending-job cap (`MAX_PENDING_JOBS_PER_ORG = 20` → 429) and (2) the worker's `effective_plan → pick_provider → check_ai_quota` pre-check (403 when Free-without-BYOK or Platform quota exhausted). The worker's execution-time check stays as defense in depth.

## #870 — feature gates checked plan tier but not subscription status
Gates trusted `org.plan()` only, so a missed/dropped Stripe webhook left a canceled or past-due org at its paid tier indefinitely.
**Fix:** new `entitlements::effective_plan(state, org)` resolves the gating plan from subscription status:
- `active` / **`trialing`** → keep stored plan (**trials are preserved** — this was the key correctness risk).
- `past_due` → keep within a 24h grace (mirrors the existing hosted-mock grace), else Free.
- `canceled` / `unpaid` / `incomplete` / `incomplete_expired` → Free.
- Paid plan with **no subscription row** → trust the stored plan (legacy/manual/seed orgs were never billed through Stripe, so there's no dropped-webhook risk; downgrading them would break the e2e suite, which seeds Team orgs directly). Logs a warning. The stored `plan` column is never mutated.

Applied at SSO config-create/enable + `initiate_saml_login` + `initiate_oidc_login`, the AI quota gate + `run_completion_for_org`, the admin-role/member gates, and protocol gating. Existing app-layer `plan()` checks are kept (this ANDs the subscription condition).

**Out of scope (TODO note left at `billing.rs:853`):** the separate cancellation-fairness bug where cancellation downgrades immediately ignoring `cancel_at_period_end`.

## Gates intentionally left ungated
`disable_sso`/`delete_sso_config` (turning SSO off must keep working for a lapsed org), `saml_acs`/`oidc_callback` (completing an in-flight login; the verified-domain provisioning guard is plan-independent), and read/metadata endpoints. Paid-feature *access grants* (enable/initiate/config-create) are all covered.

## Verification
- `cargo fmt --all --check`, `cargo clippy -p mockforge-registry-server -p mockforge-registry-core --all-targets -- -D warnings` — clean.
- `cargo test -p mockforge-registry-server --lib` → 519 passed; `mockforge-registry-core --lib` → 272 passed; e2e suites compile (`--no-run`).

## Tests
9 `resolve_effective_plan` unit tests (free-stays-free, no-sub-trusts-stored, active/trialing keep, canceled/unpaid/incomplete-expired → Free, past-due within/beyond grace), pending-cap unit test, and DB-gated e2e suites (`test_generation_quota_gate_e2e`, `entitlement_subscription_gate_e2e`).

Closes #865. Closes #870.
