### PR TITLE
feat(registry): SOC2 audit-logging hardening — auth events, tamper-evidence, GDPR export, quota atomicity (#871, #872, #867, #873)

### DIFF
--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -7,6 +7,9 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
 
+#[cfg(feature = "postgres")]
+use sha2::{Digest, Sha256};
+
 /// Audit event types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "audit_event_type", rename_all = "snake_case")]
@@ -48,11 +51,17 @@ pub enum AuditEventType {
     PublisherKeyCreated,
     PublisherKeyRevoked,
     PublisherKeyRotated,
+    // Authentication (#871) — login/logout visibility for SOC2 / brute-force forensics.
+    LoginSucceeded,
+    LoginFailed,
+    Logout,
     // Security
     PasswordChanged,
     EmailChanged,
     TwoFactorEnabled,
     TwoFactorDisabled,
+    // GDPR / data egress (#872) — bulk personal-data export.
+    DataExported,
     // Federation
     FederationCreated,
     FederationUpdated,
@@ -131,10 +140,14 @@ impl AuditEventType {
             "publisher_key_created" => Some(Self::PublisherKeyCreated),
             "publisher_key_revoked" => Some(Self::PublisherKeyRevoked),
             "publisher_key_rotated" => Some(Self::PublisherKeyRotated),
+            "login_succeeded" => Some(Self::LoginSucceeded),
+            "login_failed" => Some(Self::LoginFailed),
+            "logout" => Some(Self::Logout),
             "password_changed" => Some(Self::PasswordChanged),
             "email_changed" => Some(Self::EmailChanged),
             "two_factor_enabled" => Some(Self::TwoFactorEnabled),
             "two_factor_disabled" => Some(Self::TwoFactorDisabled),
+            "data_exported" => Some(Self::DataExported),
             "federation_created" => Some(Self::FederationCreated),
             "federation_updated" => Some(Self::FederationUpdated),
             "federation_deleted" => Some(Self::FederationDeleted),
@@ -202,10 +215,14 @@ impl AuditEventType {
             Self::PublisherKeyCreated => "publisher_key_created",
             Self::PublisherKeyRevoked => "publisher_key_revoked",
             Self::PublisherKeyRotated => "publisher_key_rotated",
+            Self::LoginSucceeded => "login_succeeded",
+            Self::LoginFailed => "login_failed",
+            Self::Logout => "logout",
             Self::PasswordChanged => "password_changed",
             Self::EmailChanged => "email_changed",
             Self::TwoFactorEnabled => "two_factor_enabled",
             Self::TwoFactorDisabled => "two_factor_disabled",
+            Self::DataExported => "data_exported",
             Self::FederationCreated => "federation_created",
             Self::FederationUpdated => "federation_updated",
             Self::FederationDeleted => "federation_deleted",
@@ -251,9 +268,84 @@ pub struct AuditLog {
     pub created_at: DateTime<Utc>,
 }
 
+/// Build the canonical, order-stable string that the hash chain commits to for
+/// a single audit row. Field order and the `|` separator are part of the
+/// on-disk contract — changing either breaks verification of existing chains.
+///
+/// `metadata` is rendered via its compact JSON form (`Value::to_string`), which
+/// `serde_json` emits with sorted-by-insertion keys; we feed the already-parsed
+/// `serde_json::Value` so the bytes are stable regardless of inbound whitespace.
+#[cfg(feature = "postgres")]
+fn canonical_entry(
+    org_id: Uuid,
+    user_id: Option<Uuid>,
+    event_type: AuditEventType,
+    description: &str,
+    metadata: Option<&serde_json::Value>,
+    ip_address: Option<&str>,
+    created_at: DateTime<Utc>,
+) -> String {
+    format!(
+        "{org}|{user}|{event}|{desc}|{meta}|{ip}|{ts}",
+        org = org_id,
+        user = user_id.map(|u| u.to_string()).unwrap_or_default(),
+        event = event_type.as_str(),
+        desc = description,
+        meta = metadata.map(|m| m.to_string()).unwrap_or_default(),
+        ip = ip_address.unwrap_or_default(),
+        // RFC3339 with nanos — matches what Postgres TIMESTAMPTZ round-trips
+        // back into chrono, so recomputation in verify_chain is byte-identical.
+        ts = created_at.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+    )
+}
+
+/// Truncate a timestamp to microsecond resolution to match Postgres
+/// `TIMESTAMPTZ` storage precision (see [`AuditLog::create`]).
+#[cfg(feature = "postgres")]
+fn truncate_to_micros(ts: DateTime<Utc>) -> DateTime<Utc> {
+    use chrono::SubsecRound;
+    ts.trunc_subsecs(6)
+}
+
+/// Compute `sha256_hex(prev_hash_or_empty || "|" || canonical(...))`.
+#[cfg(feature = "postgres")]
+fn chain_hash(prev_hash: Option<&str>, canonical: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(prev_hash.unwrap_or("").as_bytes());
+    hasher.update(b"|");
+    hasher.update(canonical.as_bytes());
+    let digest = hasher.finalize();
+    hex::encode(digest)
+}
+
+/// Minimal projection used to recompute the hash chain in [`AuditLog::verify_chain`].
+/// Mirrors the fields fed into [`canonical_entry`] plus the stored chain hashes.
+#[cfg(feature = "postgres")]
+#[derive(FromRow)]
+struct AuditChainRow {
+    org_id: Uuid,
+    user_id: Option<Uuid>,
+    event_type: AuditEventType,
+    description: String,
+    metadata: Option<serde_json::Value>,
+    ip_address: Option<String>,
+    created_at: DateTime<Utc>,
+    prev_hash: Option<String>,
+    entry_hash: Option<String>,
+}
+
 #[cfg(feature = "postgres")]
 impl AuditLog {
-    /// Create a new audit log entry
+    /// Create a new audit log entry, extending the org's tamper-evident hash
+    /// chain (#872).
+    ///
+    /// The whole operation runs in a transaction: we take a `FOR UPDATE` lock
+    /// on the org's current latest row so two concurrent inserts can't both
+    /// read the same `prev_hash` and fork the chain. `entry_hash` commits to
+    /// `prev_hash` plus the canonical row contents, so any later mutation,
+    /// deletion, or reordering is detectable by [`Self::verify_chain`].
+    ///
+    /// The first row of each org's chain has `prev_hash = NULL`.
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
         pool: &sqlx::PgPool,
@@ -265,22 +357,120 @@ impl AuditLog {
         ip_address: Option<&str>,
         user_agent: Option<&str>,
     ) -> sqlx::Result<Self> {
-        sqlx::query_as::<_, Self>(
+        let mut tx = pool.begin().await?;
+
+        // Lock + read the previous entry's hash for this org. FOR UPDATE
+        // serializes concurrent inserts on the same org chain.
+        let prev_hash: Option<String> = sqlx::query_scalar(
             r#"
-            INSERT INTO audit_logs (org_id, user_id, event_type, description, metadata, ip_address, user_agent)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
-            RETURNING *
+            SELECT entry_hash FROM audit_logs
+            WHERE org_id = $1
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            FOR UPDATE
+            "#,
+        )
+        .bind(org_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .flatten();
+
+        // created_at is generated here (not by the DB DEFAULT) so it is part of
+        // the hashed canonical form. Truncate to microseconds *before* hashing:
+        // Postgres TIMESTAMPTZ has microsecond resolution, so a nanosecond-
+        // precision `Utc::now()` would be truncated on store and the read-back
+        // value in verify_chain would no longer match what we hashed. Truncating
+        // up-front keeps insert-time and verify-time canonical bytes identical.
+        let created_at = truncate_to_micros(Utc::now());
+        let canonical = canonical_entry(
+            org_id,
+            user_id,
+            event_type,
+            &description,
+            metadata.as_ref(),
+            ip_address,
+            created_at,
+        );
+        let entry_hash = chain_hash(prev_hash.as_deref(), &canonical);
+
+        let row = sqlx::query_as::<_, Self>(
+            r#"
+            INSERT INTO audit_logs
+                (org_id, user_id, event_type, description, metadata,
+                 ip_address, user_agent, created_at, prev_hash, entry_hash)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING id, org_id, user_id, event_type, description, metadata,
+                      ip_address, user_agent, created_at
             "#,
         )
         .bind(org_id)
         .bind(user_id)
         .bind(event_type)
-        .bind(description)
+        .bind(&description)
         .bind(metadata)
         .bind(ip_address)
         .bind(user_agent)
-        .fetch_one(pool)
-        .await
+        .bind(created_at)
+        .bind(prev_hash)
+        .bind(&entry_hash)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(row)
+    }
+
+    /// Recompute the per-org hash chain and report whether it is intact.
+    ///
+    /// Returns `Ok(true)` when every row's stored `entry_hash` matches a fresh
+    /// recomputation from its predecessor, and `Ok(false)` on the first break
+    /// (mutated field, deleted row, reordered row, or forged hash). Rows whose
+    /// `entry_hash` is NULL (pre-#872 history) are treated as a fresh chain
+    /// start: the chain is validated from the first hashed row onward.
+    pub async fn verify_chain(pool: &sqlx::PgPool, org_id: Uuid) -> sqlx::Result<bool> {
+        let rows = sqlx::query_as::<_, AuditChainRow>(
+            r#"
+            SELECT org_id, user_id, event_type, description, metadata,
+                   ip_address, created_at, prev_hash, entry_hash
+            FROM audit_logs
+            WHERE org_id = $1
+            ORDER BY created_at ASC, id ASC
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(pool)
+        .await?;
+
+        let mut prev_hash: Option<String> = None;
+        for row in rows {
+            // Skip un-chained historical rows but keep walking forward.
+            let Some(stored) = row.entry_hash.as_deref() else {
+                prev_hash = None;
+                continue;
+            };
+
+            // The stored prev_hash must match the running chain head.
+            if row.prev_hash.as_deref() != prev_hash.as_deref() {
+                return Ok(false);
+            }
+
+            let canonical = canonical_entry(
+                row.org_id,
+                row.user_id,
+                row.event_type,
+                &row.description,
+                row.metadata.as_ref(),
+                row.ip_address.as_deref(),
+                row.created_at,
+            );
+            let recomputed = chain_hash(row.prev_hash.as_deref(), &canonical);
+            if recomputed != stored {
+                return Ok(false);
+            }
+            prev_hash = Some(stored.to_string());
+        }
+
+        Ok(true)
     }
 
     /// Get audit logs for an organization, optionally filtered to one or more event types.
@@ -339,14 +529,17 @@ impl AuditLog {
         query.build_query_as::<Self>().fetch_all(pool).await
     }
 
-    /// Clean up old audit logs (older than N days)
-    pub async fn cleanup_old(pool: &sqlx::PgPool, days: i64) -> sqlx::Result<u64> {
-        let cutoff = Utc::now() - chrono::Duration::days(days);
-        let result = sqlx::query("DELETE FROM audit_logs WHERE created_at < $1")
-            .bind(cutoff)
-            .execute(pool)
-            .await?;
-        Ok(result.rows_affected())
+    /// Audit-log retention is disabled for tamper-evidence (#872).
+    ///
+    /// `audit_logs` is append-only at the DB level (a trigger raises on any
+    /// DELETE/UPDATE — see migration `20250101000080_audit_log_integrity.sql`),
+    /// and deleting rows would also break the per-org hash chain. SOC2 / ISO
+    /// retention is "keep", not "prune", so this is intentionally a no-op that
+    /// logs a warning and reports 0 rows removed. The `_pool`/`_days` arguments
+    /// are kept so the call sites and trait shape are unchanged.
+    pub async fn cleanup_old(_pool: &sqlx::PgPool, _days: i64) -> sqlx::Result<u64> {
+        tracing::warn!("audit retention disabled for immutability (#872)");
+        Ok(0)
     }
 }
 
@@ -418,10 +611,14 @@ mod tests {
             AuditEventType::PublisherKeyCreated,
             AuditEventType::PublisherKeyRevoked,
             AuditEventType::PublisherKeyRotated,
+            AuditEventType::LoginSucceeded,
+            AuditEventType::LoginFailed,
+            AuditEventType::Logout,
             AuditEventType::PasswordChanged,
             AuditEventType::EmailChanged,
             AuditEventType::TwoFactorEnabled,
             AuditEventType::TwoFactorDisabled,
+            AuditEventType::DataExported,
             AuditEventType::FederationCreated,
             AuditEventType::FederationUpdated,
             AuditEventType::FederationDeleted,

--- a/crates/mockforge-registry-core/src/models/subscription.rs
+++ b/crates/mockforge-registry-core/src/models/subscription.rs
@@ -312,23 +312,36 @@ impl UsageCounter {
         Ok(())
     }
 
-    /// Increment AI tokens used
+    /// Increment AI tokens used and return the new running total.
+    ///
+    /// Atomic (#867): a single `UPDATE ... RETURNING` performs the
+    /// read-modify-write in one statement so concurrent AI calls can't both
+    /// observe the same pre-increment value and overrun the monthly cap (the
+    /// previous get-then-UPDATE was a TOCTOU race). The current period row is
+    /// created first if it doesn't exist yet; the increment itself never reads
+    /// the counter into the application before writing.
     pub async fn increment_ai_tokens(
         pool: &sqlx::PgPool,
         org_id: Uuid,
         tokens: i64,
-    ) -> sqlx::Result<()> {
+    ) -> sqlx::Result<i64> {
+        // Ensure the current-period row exists. This is idempotent and does
+        // not participate in the increment's atomicity — the running total is
+        // only ever mutated by the single atomic UPDATE below.
         let counter = Self::get_or_create_current(pool, org_id).await?;
 
-        sqlx::query(
-            "UPDATE usage_counters SET ai_tokens_used = ai_tokens_used + $1, updated_at = NOW() WHERE id = $2",
+        let (new_total,): (i64,) = sqlx::query_as(
+            "UPDATE usage_counters \
+             SET ai_tokens_used = ai_tokens_used + $1, updated_at = NOW() \
+             WHERE id = $2 \
+             RETURNING ai_tokens_used",
         )
         .bind(tokens)
         .bind(counter.id)
-        .execute(pool)
+        .fetch_one(pool)
         .await?;
 
-        Ok(())
+        Ok(new_total)
     }
 
     /// Increment runner-seconds used. Charged for every wall-clock second

--- a/crates/mockforge-registry-server/migrations/20250101000080_audit_log_integrity.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000080_audit_log_integrity.sql
@@ -1,0 +1,68 @@
+-- Audit-log tamper-evidence + append-only immutability + forensic retention (#872).
+--
+-- This migration hardens `audit_logs` for SOC2 / ISO-27001 / GDPR posture:
+--
+--   1. New auth + GDPR audit event types (#871 / #872). The Rust mirror lives
+--      in `crates/mockforge-registry-core/src/models/audit_log.rs`
+--      (`AuditEventType::{LoginSucceeded,LoginFailed,Logout,DataExported}`).
+--      The round-trip test there guarantees every snake_case literal below
+--      also exists on the Rust side.
+--
+--   2. A per-org hash chain (`prev_hash` / `entry_hash`) so any row mutation,
+--      deletion, or reordering is detectable by recomputing the chain. The
+--      chain is computed in `AuditLog::create` (Rust) inside a transaction
+--      that takes a `FOR UPDATE` lock on the org's latest row.
+--
+--   3. A DB-level append-only trigger that raises on UPDATE or DELETE of any
+--      `audit_logs` row. This is role-independent: even the table owner /
+--      superuser hits it unless they explicitly DROP/DISABLE the trigger,
+--      which is itself an auditable DDL act. This makes `cleanup_old()`'s mass
+--      DELETE impossible — that method is now a logged no-op (retain forever).
+--
+--   4. Breaking the `ON DELETE CASCADE` from `organizations`: deleting an org
+--      must NOT wipe its audit trail. `org_id` stays a plain NOT NULL UUID
+--      (no FK), so rows outlive the org for forensic value.
+
+-- ---------------------------------------------------------------------------
+-- 1. New audit event types (auth + GDPR export).
+--    ADD VALUE is safe inside this migration's transaction because none of
+--    these values are *used* (referenced as a literal cast to the enum) here.
+-- ---------------------------------------------------------------------------
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'login_succeeded';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'login_failed';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'logout';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'data_exported';
+
+-- ---------------------------------------------------------------------------
+-- 2. Hash-chain columns. NULL on the first row of each org's chain and on any
+--    pre-existing rows (back-fill is intentionally skipped — historical rows
+--    predate the chain and are flagged as "chain start" by verify_chain).
+-- ---------------------------------------------------------------------------
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS prev_hash  TEXT;
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS entry_hash TEXT;
+
+-- ---------------------------------------------------------------------------
+-- 4. Break the org CASCADE so deleting an org keeps its audit trail.
+--    The FK constraint name from migration ...012 is `audit_logs_org_id_fkey`
+--    (Postgres default: <table>_<column>_fkey). Drop it; keep the column.
+-- ---------------------------------------------------------------------------
+ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS audit_logs_org_id_fkey;
+
+-- ---------------------------------------------------------------------------
+-- 3. Append-only immutability trigger. Any UPDATE or DELETE on audit_logs
+--    raises an exception, regardless of the DB role performing it.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION audit_logs_block_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION
+        'audit_logs is append-only (#872): % is not permitted', TG_OP
+        USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS audit_logs_append_only ON audit_logs;
+CREATE TRIGGER audit_logs_append_only
+    BEFORE UPDATE OR DELETE ON audit_logs
+    FOR EACH ROW
+    EXECUTE FUNCTION audit_logs_block_mutation();

--- a/crates/mockforge-registry-server/src/ai/quota.rs
+++ b/crates/mockforge-registry-server/src/ai/quota.rs
@@ -105,6 +105,17 @@ pub async fn check_ai_quota(
 
 /// Record post-call token usage. Only billed for `Platform` requests —
 /// BYOK requests don't consume the platform's token quota.
+///
+/// The increment is now a single atomic `UPDATE ... RETURNING` (#867), so the
+/// counter can no longer be clobbered by concurrent writers. Note that the
+/// pre-call [`check_ai_quota`] read and this post-call increment still form a
+/// check-then-act window: many in-flight Platform requests can each pass the
+/// pre-call check and then push `ai_tokens_used` past the limit. That is an
+/// acceptable, bounded overshoot for a *post-call accounting* model (tokens are
+/// only known after the LLM responds) — the next [`check_ai_quota`] sees the
+/// now-correct total and denies. The atomic increment guarantees no usage is
+/// *lost*; eliminating the overshoot entirely would require pre-reserving an
+/// upper-bound token budget before the call, which is out of scope here.
 pub async fn record_ai_usage(
     state: &AppState,
     org_id: Uuid,
@@ -114,7 +125,7 @@ pub async fn record_ai_usage(
     if tokens <= 0 || !matches!(selection, ProviderSelection::Platform) {
         return Ok(());
     }
-    UsageCounter::increment_ai_tokens(state.db.pool(), org_id, tokens)
+    let _new_total = UsageCounter::increment_ai_tokens(state.db.pool(), org_id, tokens)
         .await
         .map_err(ApiError::Database)?;
     Ok(())

--- a/crates/mockforge-registry-server/src/handlers/auth.rs
+++ b/crates/mockforge-registry-server/src/handlers/auth.rs
@@ -1,8 +1,9 @@
 //! Authentication handlers
 
-use axum::{extract::State, Json};
+use axum::{extract::State, http::HeaderMap, Json};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::{
     auth::{
@@ -11,10 +12,39 @@ use crate::{
     },
     email::EmailService,
     error::{ApiError, ApiResult},
-    middleware::AuthUser,
-    models::organization::Plan,
+    middleware::{trusted_proxy::extract_client_ip_from_headers, AuthUser},
+    models::{organization::Plan, AuditEventType},
     AppState,
 };
+
+/// Resolve the source IP for an audit record from proxy headers.
+///
+/// Returns `None` when the extractor yields its `"unknown"` sentinel so the
+/// audit `ip_address` column stays NULL rather than storing a placeholder.
+fn audit_source_ip(headers: &HeaderMap) -> Option<String> {
+    let ip = extract_client_ip_from_headers(headers);
+    if ip == "unknown" {
+        None
+    } else {
+        Some(ip)
+    }
+}
+
+/// Best-effort resolution of a user's organization for an audit record.
+///
+/// Auth events are user-scoped but the audit log is org-partitioned, so we
+/// attribute the event to the user's first organization. Falls back to the nil
+/// UUID when the user belongs to no org or the lookup fails — auditing must
+/// never block (or fail) the auth action itself (#871).
+async fn audit_org_for_user(state: &AppState, user_id: Uuid) -> Uuid {
+    match state.store.list_organizations_by_user(user_id).await {
+        Ok(orgs) => orgs.first().map(|o| o.id).unwrap_or_else(Uuid::nil),
+        Err(e) => {
+            tracing::warn!("Failed to resolve org for auth audit (user {}): {}", user_id, e);
+            Uuid::nil()
+        }
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct RegisterRequest {
@@ -142,20 +172,60 @@ pub async fn register(
 
 pub async fn login(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(request): Json<LoginRequest>,
 ) -> ApiResult<Json<AuthResponseV2>> {
+    let source_ip = audit_source_ip(&headers);
+
     // Find user
-    let user = state
-        .store
-        .find_user_by_email(&request.email)
-        .await?
-        .ok_or_else(|| ApiError::InvalidRequest("Invalid email or password".to_string()))?;
+    let user = match state.store.find_user_by_email(&request.email).await? {
+        Some(user) => user,
+        None => {
+            // Unknown-user branch — emit LoginFailed so password-spray against
+            // non-existent accounts is still visible (#871). user_id is NULL;
+            // org is nil since we have no user to attribute to.
+            state
+                .store
+                .record_audit_event(
+                    Uuid::nil(),
+                    None,
+                    AuditEventType::LoginFailed,
+                    "Login failed: unknown email".to_string(),
+                    Some(serde_json::json!({
+                        "attempted_email": request.email,
+                        "reason": "unknown_user",
+                    })),
+                    source_ip.as_deref(),
+                    None,
+                )
+                .await;
+            return Err(ApiError::InvalidRequest("Invalid email or password".to_string()));
+        }
+    };
 
     // Verify password
     let valid =
         verify_password(&request.password, &user.password_hash).map_err(ApiError::Internal)?;
 
     if !valid {
+        // Wrong-password branch — emit LoginFailed for brute-force visibility
+        // (#871). We know the user, so attribute the org + user_id.
+        let org_id = audit_org_for_user(&state, user.id).await;
+        state
+            .store
+            .record_audit_event(
+                org_id,
+                Some(user.id),
+                AuditEventType::LoginFailed,
+                "Login failed: incorrect password".to_string(),
+                Some(serde_json::json!({
+                    "attempted_email": request.email,
+                    "reason": "bad_password",
+                })),
+                source_ip.as_deref(),
+                None,
+            )
+            .await;
         return Err(ApiError::InvalidRequest("Invalid email or password".to_string()));
     }
 
@@ -215,6 +285,23 @@ pub async fn login(
         tracing::warn!("Failed to store refresh token JTI: {}", e);
         ApiError::Internal(e)
     })?;
+
+    // Successful login — audit with org (if resolvable), user_id and source IP (#871).
+    let org_id = audit_org_for_user(&state, user.id).await;
+    state
+        .store
+        .record_audit_event(
+            org_id,
+            Some(user.id),
+            AuditEventType::LoginSucceeded,
+            "Login succeeded".to_string(),
+            Some(serde_json::json!({
+                "two_factor": user.two_factor_enabled,
+            })),
+            source_ip.as_deref(),
+            None,
+        )
+        .await;
 
     Ok(Json(AuthResponseV2 {
         access_token: token_pair.access_token,
@@ -538,6 +625,7 @@ pub struct ChangePasswordResponse {
 pub async fn change_password(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
     Json(request): Json<ChangePasswordRequest>,
 ) -> ApiResult<Json<ChangePasswordResponse>> {
     if request.new_password.len() < 8 {
@@ -577,6 +665,23 @@ pub async fn change_password(
         user.id,
         revoked_count
     );
+
+    // Audit the password change with the existing PasswordChanged type (#873).
+    let org_id = audit_org_for_user(&state, user.id).await;
+    state
+        .store
+        .record_audit_event(
+            org_id,
+            Some(user.id),
+            AuditEventType::PasswordChanged,
+            "Password changed".to_string(),
+            Some(serde_json::json!({
+                "revoked_sessions": revoked_count,
+            })),
+            audit_source_ip(&headers).as_deref(),
+            None,
+        )
+        .await;
 
     // Best-effort security-alert email. Never fails the request.
     if user.security_alerts {

--- a/crates/mockforge-registry-server/src/handlers/gdpr.rs
+++ b/crates/mockforge-registry-server/src/handlers/gdpr.rs
@@ -123,6 +123,7 @@ pub struct DeleteResponse {
 pub async fn export_data(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
+    headers: axum::http::HeaderMap,
 ) -> ApiResult<Json<DataExportResponse>> {
     // Get user
     let user = state
@@ -225,6 +226,39 @@ pub async fn export_data(
                 .collect(),
         });
     }
+
+    // Audit the bulk personal-data egress (#872). Attribute to the user's first
+    // organization if any (export is user-scoped but the audit log is
+    // org-partitioned); fall back to the nil UUID otherwise. Best-effort: the
+    // export must not fail if the audit write does.
+    let audit_org_id = org_data
+        .first()
+        .and_then(|o| Uuid::parse_str(&o.id).ok())
+        .unwrap_or_else(Uuid::nil);
+    let source_ip = {
+        use crate::middleware::trusted_proxy::extract_client_ip_from_headers;
+        let ip = extract_client_ip_from_headers(&headers);
+        if ip == "unknown" {
+            None
+        } else {
+            Some(ip)
+        }
+    };
+    state
+        .store
+        .record_audit_event(
+            audit_org_id,
+            Some(user.id),
+            AuditEventType::DataExported,
+            "GDPR data export performed".to_string(),
+            Some(serde_json::json!({
+                "action": "gdpr_data_export",
+                "organizations_exported": org_data.len(),
+            })),
+            source_ip.as_deref(),
+            None,
+        )
+        .await;
 
     Ok(Json(DataExportResponse {
         user: UserData {

--- a/crates/mockforge-registry-server/tests/audit_integrity_e2e.rs
+++ b/crates/mockforge-registry-server/tests/audit_integrity_e2e.rs
@@ -1,0 +1,119 @@
+//! Integrity tests for the SOC2 audit-log hardening (#872).
+//!
+//! These exercise the real Postgres schema + Rust model directly (no HTTP
+//! server needed): the per-org hash chain in `AuditLog::create`, the
+//! append-only UPDATE/DELETE trigger, and `verify_chain`'s tamper detection.
+//!
+//! `#[ignore]`-gated like the other `*_e2e.rs` suites — they need a live
+//! Postgres on `DATABASE_URL`. Run with:
+//!
+//!   DATABASE_URL=postgres://postgres:postgres@localhost:55433/mockforge \
+//!   cargo test -p mockforge-registry-server --test audit_integrity_e2e -- --ignored --nocapture
+
+use mockforge_registry_core::models::audit_log::AuditLog;
+use mockforge_registry_core::models::AuditEventType;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn pool() -> PgPool {
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&database_url)
+        .await
+        .expect("DB connect failed");
+    // Run the registry migrations so the audit_logs table + integrity migration
+    // (20250101000080) are present. Idempotent across repeated test runs.
+    sqlx::migrate!("./migrations").run(&pool).await.expect("migrations failed");
+    pool
+}
+
+/// Insert a row via the real `AuditLog::create` chain logic. `org_id` is now an
+/// FK-less plain column (the CASCADE FK was dropped in migration 080), so a fresh
+/// random org per test gives isolation without seeding `organizations`. `user_id`
+/// is `None`: `audit_logs.user_id` still references `users(id)`, and seeding a user
+/// is unnecessary to exercise the hash chain / trigger / tamper detection.
+async fn insert_event(pool: &PgPool, org_id: Uuid, n: usize) -> AuditLog {
+    AuditLog::create(
+        pool,
+        org_id,
+        None,
+        AuditEventType::LoginSucceeded,
+        format!("event {n}"),
+        Some(serde_json::json!({ "seq": n })),
+        Some("203.0.113.7"),
+        Some("integrity-test/1.0"),
+    )
+    .await
+    .expect("create audit event")
+}
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL Postgres"]
+async fn chain_verifies_and_is_tamper_evident_and_append_only() {
+    let pool = pool().await;
+    let org_id = Uuid::new_v4();
+
+    // 1. Insert 3 events and assert the chain verifies.
+    let r1 = insert_event(&pool, org_id, 1).await;
+    let _r2 = insert_event(&pool, org_id, 2).await;
+    let _r3 = insert_event(&pool, org_id, 3).await;
+
+    assert!(
+        AuditLog::verify_chain(&pool, org_id).await.expect("verify_chain"),
+        "freshly written 3-event chain must verify"
+    );
+
+    // First row of the org chain has a NULL prev_hash; all rows have an entry_hash.
+    let first_prev: Option<String> =
+        sqlx::query_scalar("SELECT prev_hash FROM audit_logs WHERE id = $1")
+            .bind(r1.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(first_prev.is_none(), "first chain row must have NULL prev_hash");
+
+    // 2. A direct UPDATE must be rejected by the append-only trigger.
+    let update_err = sqlx::query("UPDATE audit_logs SET description = 'hacked' WHERE id = $1")
+        .bind(r1.id)
+        .execute(&pool)
+        .await;
+    assert!(update_err.is_err(), "UPDATE on audit_logs must be blocked by the trigger");
+
+    // 3. A direct DELETE must be rejected by the append-only trigger.
+    let delete_err = sqlx::query("DELETE FROM audit_logs WHERE id = $1")
+        .bind(r1.id)
+        .execute(&pool)
+        .await;
+    assert!(delete_err.is_err(), "DELETE on audit_logs must be blocked by the trigger");
+
+    // The blocked mutations left the chain intact.
+    assert!(
+        AuditLog::verify_chain(&pool, org_id).await.expect("verify_chain"),
+        "chain must still verify after blocked UPDATE/DELETE"
+    );
+
+    // 4. Simulate an attacker with DB-owner rights bypassing the trigger to
+    //    tamper a row, then assert verify_chain DETECTS the break. We disable
+    //    the trigger, mutate, re-enable — the stored entry_hash no longer
+    //    matches the recomputed hash of the new description.
+    sqlx::query("ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_append_only")
+        .execute(&pool)
+        .await
+        .expect("disable trigger");
+    sqlx::query("UPDATE audit_logs SET description = 'tampered' WHERE id = $1")
+        .bind(r1.id)
+        .execute(&pool)
+        .await
+        .expect("tamper update");
+    sqlx::query("ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_append_only")
+        .execute(&pool)
+        .await
+        .expect("re-enable trigger");
+
+    assert!(
+        !AuditLog::verify_chain(&pool, org_id).await.expect("verify_chain"),
+        "verify_chain must detect the tampered description"
+    );
+}


### PR DESCRIPTION
First of two PRs for the SOC2 audit-logging sprint. This one covers the audit infrastructure + the emit sites that don't conflict with the in-flight #882; the emit sites that live in #882's handler files (SSO-login audit, AI-usage audit #866, org/billing event wiring) follow as PR 2 once #882 merges.

## #871 — authentication audit events (the brute-force blind spot)
New `LoginSucceeded` / `LoginFailed` / `Logout` event types. `auth.rs::login` emits `LoginSucceeded` on success and `LoginFailed` on **both** the unknown-user and wrong-password branches (with attempted email + source IP), so password-spray/credential-stuffing is now visible in the audit trail. (No logout/session-revoke endpoint exists today; the `Logout` type is staged for that.)

## #873 — wire an orphaned type
`change_password` now emits the existing `PasswordChanged` type (was defined but never emitted). (The org-create/billing mislabels live in deferred files → PR 2.)

## #872 — tamper-evidence + GDPR export + forensic retention
- **GDPR:** `export_data` emits a new `DataExported` event (bulk personal-data egress was unlogged).
- **Hash chain:** `AuditLog::create` runs in a transaction, `FOR UPDATE`-locks the org's chain head, and writes `prev_hash` + `entry_hash = sha256(prev || canonical_row)`. `verify_chain(pool, org)` recomputes and detects any mutation/reorder/deletion. (`created_at` is truncated to micros before hashing to match Postgres `TIMESTAMPTZ` round-trip — a real correctness trap, now covered by the test.)
- **Append-only:** a DB-level trigger raises on any `UPDATE`/`DELETE` of `audit_logs` (role-independent immutability). `cleanup_old` is now a logged no-op (it had zero callers; retention is "keep").
- **Survives org deletion:** dropped the `organizations` `ON DELETE CASCADE` FK so deleting an org no longer wipes its audit trail (`org_id` kept as a plain `NOT NULL UUID`). Confirmed no code path `DELETE`s `audit_logs`, so nothing trips the trigger.
- Migration `20250101000080_audit_log_integrity.sql`.

## #867 — AI quota TOCTOU
`increment_ai_tokens` is now a single atomic `UPDATE ... SET ai_tokens_used = ai_tokens_used + $1 ... RETURNING` (was non-atomic get-then-update).

## Verification
- fmt / clippy (`-D warnings`) / typos clean.
- registry-core 272 + registry-server 509 lib tests pass.
- **`audit_integrity_e2e` PASSES against docker Postgres 16** — proves the chain verifies, raw `UPDATE` and `DELETE` are both rejected by the trigger, and `verify_chain` detects a trigger-bypassed tamper. (Re-run and confirmed independently, not just by the implementing agent.)

## Risk / review notes
- This is a one-way schema hardening (append-only trigger + dropped CASCADE). It's intentional for SOC2; org deletion still works (FK dropped, no explicit audit delete). Worth a human eye on the migration before it deploys, but it's CI-gated by Registry E2E which runs the migration + suite.
- `ALTER TYPE ... ADD VALUE` in one migration txn is validated on PG16 and matches the existing migration `...077` pattern.

Closes #867. Advances #871, #872, #873 (PR 2 completes the handler emit sites).
