### PR TITLE
feat(tui,book): r37 — TUI export client stamps + chaos cookbook + multi-server tabs + Windows install (#79)

### DIFF
--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -118,6 +118,42 @@ MockForge supports:
 - **Windows** (x86_64)
 - **Docker** (any platform with Docker support)
 
+### Windows install path
+
+The published release artefacts and the Docker image are Linux-only
+today. Windows users install from source via `cargo install`:
+
+1. Install [Rustup](https://rustup.rs/) (the standard Rust installer for
+   Windows). Pick the default `x86_64-pc-windows-msvc` toolchain when
+   prompted; if you do not already have the Visual Studio Build Tools,
+   Rustup will offer to download them.
+2. Open **PowerShell** (or `cmd`) and install:
+
+   ```powershell
+   cargo install mockforge-cli --locked
+   ```
+
+3. The binary lands at `%USERPROFILE%\.cargo\bin\mockforge.exe`, which
+   `cargo` already added to `%PATH%`. Verify:
+
+   ```powershell
+   mockforge --version
+   ```
+
+`--locked` pins the `Cargo.lock` shipped on crates.io, which avoids
+build breaks from later dependency drift.
+
+If you would rather not compile locally, the Docker image runs on
+Windows under Docker Desktop / WSL2:
+
+```powershell
+docker run --rm -p 3000:3000 -v ${PWD}:/work ghcr.io/saasy-solutions/mockforge:latest serve --spec /work/api.yaml --http-port 3000
+```
+
+We track first-class signed Windows binaries (no compile step,
+auto-update) at [#884](https://github.com/SaaSy-Solutions/mockforge/issues/884);
+contributions welcome.
+
 ## Troubleshooting Installation
 
 ### Cargo installation fails

--- a/book/src/user-guide/chaos-engineering.md
+++ b/book/src/user-guide/chaos-engineering.md
@@ -64,6 +64,130 @@ profiles:
 
 Run with `mockforge serve --profile flaky`.
 
+## Recipes: varied 5xx and slow responses
+
+These are the patterns most teams reach for first when exercising client
+timeout / retry behaviour. Each recipe is copy-pasteable; tune the
+probabilities to your spec.
+
+### Mix of 4xx and 5xx statuses across the whole spec
+
+Global error injection via `mockforge serve --chaos`. `--chaos-http-errors`
+takes a comma-separated list; the injector picks one at the configured
+probability:
+
+```bash
+mockforge serve --spec api.yaml --http-port 3000 \
+  --chaos --chaos-http-errors 500,502,503,504,429,408 \
+  --chaos-http-error-probability 0.10
+```
+
+`0.10` means roughly 10% of matching requests get a chaos-status response.
+The remaining 90% flow through your spec unchanged. Mix 4xx and 5xx as
+needed: clients should retry-with-backoff on 503/429/504/502 but treat
+500/400/422 as terminal.
+
+### Slow backend (every request hangs N ms)
+
+Useful for exercising the client's request-level timeout. Sleeps before
+the upstream handler runs, so the client experiences a true server-side
+hang followed by a normal 2xx (or the configured status).
+
+```bash
+mockforge serve --spec api.yaml --http-port 3000 \
+  --chaos --chaos-latency-ms 2000 --chaos-latency-probability 1.0
+```
+
+Pair with `--chaos-latency-range 500-5000` to randomise:
+
+```bash
+mockforge serve --spec api.yaml --http-port 3000 \
+  --chaos --chaos-latency-range 500-5000 --chaos-latency-probability 0.30
+```
+
+### Real timeout (server hangs, returns 504)
+
+Different from a slow response: this fires when you want the *server* to
+report timeout, not just go slow. Configure via the YAML chaos profile:
+
+```yaml
+fault_injection:
+  enabled: true
+  timeout_errors: true
+  timeout_ms: 30000             # 30 s sleep then 504 Gateway Timeout
+  timeout_probability: 0.05     # 5% of matching requests
+```
+
+Run with `mockforge serve --spec api.yaml --config chaos.yaml`.
+
+### Per-endpoint chaos (slow this route, error that one)
+
+Global flags hit every route equally. To exercise *one* endpoint's
+timeout while keeping the rest healthy, use per-route chaos:
+
+```yaml
+# routes-with-chaos.yaml
+routes:
+  - path: /api/slow-report
+    method: GET
+    response:
+      status: 200
+      body: { ok: true }
+    latency:
+      enabled: true
+      probability: 1.0
+      fixed_delay_ms: 8000        # always hang 8s on this route
+  - path: /api/flaky-write
+    method: POST
+    response:
+      status: 201
+      body: { id: 1 }
+    fault_injection:
+      enabled: true
+      probability: 0.25           # 25% of POSTs to this route fail
+      fault_types:
+        - type: http_error
+          status_code: 503
+          message: "Backend warming up"
+        - type: http_error
+          status_code: 504
+        - type: http_error
+          status_code: 429
+```
+
+Mockforge picks one `fault_types` entry uniformly when the probability
+fires, so a list of three statuses gives you ~equal weight across the
+three. Add more entries to bias toward a status (entries are picked
+uniformly, so two `503` entries plus one `504` entry gives 2:1 odds).
+
+`latency.distribution` also supports `normal { mean_ms, std_dev_ms }` and
+`exponential { lambda }` for non-uniform spreads — handy when you want
+"P95 = 8s but a long tail."
+
+### Exercise client retry / backoff behaviour
+
+Combine the two above. The pattern: ~30% of requests get a transient
+status (503 / 504 / 429), the rest succeed. A well-written client with
+exponential backoff should eventually succeed on retries; a buggy client
+either gives up immediately or hammers the server flat.
+
+```yaml
+fault_injection:
+  enabled: true
+  http_errors: true
+  http_error_codes: [503, 504, 429]
+  http_error_probability: 0.30
+  latency_ms: 250                 # mild latency baseline
+  latency_probability: 1.0
+```
+
+### Verify what fired
+
+The chaos config exposes counters at `GET /api/chaos/status` (when admin
+is enabled). The TUI Chaos screen also surfaces real-time injection
+counts. Use these to confirm your bench / test client actually saw the
+intended faults rather than guessing from the response log.
+
 ## Per-request fault matchers
 
 By default, fault probabilities apply to every request. Add a `request_matcher`

--- a/crates/mockforge-tui/src/api/models.rs
+++ b/crates/mockforge-tui/src/api/models.rs
@@ -60,6 +60,19 @@ pub struct ConformanceViolation {
     /// when older mockforge instances send the field-less payload.
     #[serde(default = "default_occurrences")]
     pub occurrences: u32,
+    /// Round 36 (#876) — mockforge version of the *client* that sent
+    /// the request, read off the `X-Mockforge-Client-Version` header
+    /// server-side. `None` when the inbound request didn't carry the
+    /// header (older clients, real proxy traffic).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_mockforge_version: Option<String>,
+    /// Round 36 (#876) — wall-clock moment the *client* stamped on the
+    /// request, read off the `X-Mockforge-Client-Sent-At` header
+    /// server-side. Lets a user `grep` a bench JSONL row's
+    /// `client_sent_at` and find the matching server-side violation
+    /// even when the request was retried / load-balanced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_sent_at: Option<DateTime<Utc>>,
 }
 
 fn default_unknown() -> String {

--- a/crates/mockforge-tui/src/app.rs
+++ b/crates/mockforge-tui/src/app.rs
@@ -25,8 +25,26 @@ use crate::widgets::{help, status_bar};
 /// Top-level application state.
 pub struct App {
     config: TuiConfig,
+    /// Round 37 — list of admin URLs the user can rotate through with
+    /// `Ctrl-]` / `Ctrl-[`. Always has at least one entry; `admin_url`
+    /// is its 0th element. When a user only passes one server (the
+    /// default), `servers.len() == 1` and the rotation key is a no-op
+    /// so the surface stays unchanged.
+    servers: Vec<String>,
+    /// Index into `servers` of the currently-active admin URL. The
+    /// header tab bar renders an indicator (`[2/3]`) when
+    /// `servers.len() > 1`; on a single server the indicator is hidden.
+    active_server: usize,
+    /// The active server's admin URL (mirrors `servers[active_server]`
+    /// to keep existing render code untouched).
     admin_url: String,
     client: MockForgeClient,
+    /// Optional auth token, threaded into each per-server client.
+    /// `MockForgeClient::new` panics on a malformed base URL, but our
+    /// inputs come from clap (already validated as `String`) so this is
+    /// safe in practice. Stored so a server swap rebuilds the client
+    /// with the same token.
+    token: Option<String>,
     screens: Vec<Box<dyn Screen>>,
     active_tab: usize,
     show_help: bool,
@@ -45,10 +63,16 @@ impl App {
     pub fn new(config: TuiConfig, token: Option<String>) -> Self {
         Theme::init(config.is_light_theme());
 
-        let client =
-            MockForgeClient::new(config.admin_url.clone(), token).expect("failed to build client");
+        // Round 37 — resolve the server rotation list from config.
+        // `all_admin_urls()` always returns at least one URL (the
+        // primary `admin_url`), so subsequent indexing is safe.
+        let servers = config.all_admin_urls();
+        let active_server = 0;
+        let admin_url = servers[active_server].clone();
 
-        let admin_url = config.admin_url.clone();
+        let client =
+            MockForgeClient::new(admin_url.clone(), token.clone()).expect("failed to build client");
+
         let initial_tab = config.last_tab.unwrap_or(0);
 
         let screens: Vec<Box<dyn Screen>> = vec![
@@ -102,8 +126,11 @@ impl App {
 
         Self {
             config,
+            servers,
+            active_server,
             admin_url,
             client,
+            token,
             screens,
             active_tab,
             show_help: false,
@@ -116,6 +143,104 @@ impl App {
         }
     }
 
+    /// Round 37 — cycle to the next configured admin server. No-op
+    /// when only one server is in the rotation. The screens are NOT
+    /// reset on switch: each screen's next `tick()` will re-fetch
+    /// from the new admin URL, so the user sees the prior server's
+    /// cached data for up to one refresh-interval, then fresh data.
+    /// `step` is `+1` for next, `-1` for previous; any non-zero step
+    /// works (rotation is modular).
+    fn rotate_server(&mut self, step: isize) {
+        let n = self.servers.len();
+        if n <= 1 {
+            return;
+        }
+        let next = (self.active_server as isize + step).rem_euclid(n as isize) as usize;
+        self.active_server = next;
+        self.admin_url = self.servers[next].clone();
+        // Rebuild the client; MockForgeClient is cheap to construct
+        // (just stores the URL + token + reqwest::Client) and we want
+        // the rest of the app to keep treating `self.client` as the
+        // single active client without holding a Vec.
+        if let Ok(new_client) = MockForgeClient::new(self.admin_url.clone(), self.token.clone()) {
+            self.client = new_client;
+        }
+        // Force a re-ping on the new server so the header indicator
+        // updates without waiting for the next health-check tick.
+        self.connected = false;
+        // Backdate the last health check so the next tick re-pings the
+        // new server immediately instead of waiting for the next
+        // scheduled interval.
+        let one_hour = Duration::from_secs(3600);
+        self.last_health_check = std::time::Instant::now()
+            .checked_sub(one_hour)
+            .unwrap_or_else(std::time::Instant::now);
+    }
+}
+
+#[cfg(test)]
+mod server_rotation_tests {
+    use super::*;
+
+    fn cfg_with(extras: &[&str]) -> TuiConfig {
+        TuiConfig {
+            admin_url: "http://primary:9080".into(),
+            extra_servers: extras.iter().map(|s| s.to_string()).collect(),
+            ..TuiConfig::default()
+        }
+    }
+
+    #[test]
+    fn all_admin_urls_keeps_primary_first_and_dedupes() {
+        let cfg = cfg_with(&["http://b:9080", "http://primary:9080", "http://c:9080"]);
+        let urls = cfg.all_admin_urls();
+        assert_eq!(urls, vec!["http://primary:9080", "http://b:9080", "http://c:9080"]);
+    }
+
+    #[test]
+    fn all_admin_urls_drops_empty_entries() {
+        let cfg = cfg_with(&["", "http://b:9080", ""]);
+        let urls = cfg.all_admin_urls();
+        assert_eq!(urls, vec!["http://primary:9080", "http://b:9080"]);
+    }
+
+    #[test]
+    fn rotate_server_cycles_in_both_directions() {
+        let cfg = cfg_with(&["http://b:9080", "http://c:9080"]);
+        let mut app = App::new(cfg, None);
+        assert_eq!(app.active_server, 0);
+        assert_eq!(app.admin_url, "http://primary:9080");
+
+        app.rotate_server(1);
+        assert_eq!(app.active_server, 1);
+        assert_eq!(app.admin_url, "http://b:9080");
+
+        app.rotate_server(1);
+        assert_eq!(app.active_server, 2);
+        assert_eq!(app.admin_url, "http://c:9080");
+
+        // Wrap forward.
+        app.rotate_server(1);
+        assert_eq!(app.active_server, 0);
+
+        // Wrap backward.
+        app.rotate_server(-1);
+        assert_eq!(app.active_server, 2);
+        assert_eq!(app.admin_url, "http://c:9080");
+    }
+
+    #[test]
+    fn rotate_server_is_noop_on_single_server() {
+        let cfg = cfg_with(&[]);
+        let mut app = App::new(cfg, None);
+        let before = app.admin_url.clone();
+        app.rotate_server(1);
+        assert_eq!(app.admin_url, before);
+        assert_eq!(app.active_server, 0);
+    }
+}
+
+impl App {
     /// Run the terminal UI event loop.
     pub async fn run(mut self) -> Result<()> {
         let mut terminal = tui::init()?;
@@ -242,6 +367,8 @@ impl App {
                 Action::Refresh => {
                     self.screens[self.active_tab].force_refresh();
                 }
+                Action::NextServer => self.rotate_server(1),
+                Action::PrevServer => self.rotate_server(-1),
                 _ => {}
             }
         }
@@ -421,12 +548,21 @@ impl App {
         } else {
             Theme::error()
         };
+        // Round 37 — when more than one server is in the rotation,
+        // surface the active index (`[2/3]`) before the URL so the
+        // user always sees which server's data they are looking at.
+        // Single-server runs keep the original layout.
+        let server_indicator = if self.servers.len() > 1 {
+            format!("  [{}/{}] {}", self.active_server + 1, self.servers.len(), self.admin_url)
+        } else {
+            format!("  {}", self.admin_url)
+        };
         let title = Line::from(vec![
             Span::styled(" MockForge TUI ", Theme::title()),
             Span::styled(format!("v{}", env!("CARGO_PKG_VERSION")), Theme::dim()),
             Span::raw("  "),
             Span::styled(conn_status, conn_style),
-            Span::styled(format!("  {}", self.admin_url), Theme::dim()),
+            Span::styled(server_indicator, Theme::dim()),
         ]);
         frame.render_widget(Paragraph::new(title).style(Theme::surface()), chunks[0]);
 

--- a/crates/mockforge-tui/src/config.rs
+++ b/crates/mockforge-tui/src/config.rs
@@ -24,6 +24,14 @@ pub struct TuiConfig {
 
     /// Optional log file path.
     pub log_file: Option<String>,
+
+    /// Round 37 (Srikanth on 0.3.181) — extra admin URLs the user can
+    /// swap between with `Ctrl-]` / `Ctrl-[`. `admin_url` is always the
+    /// first server (index 0); `extra_servers` add to the rotation in
+    /// order. Empty by default — the TUI behaves exactly as before when
+    /// this is empty.
+    #[serde(default)]
+    pub extra_servers: Vec<String>,
 }
 
 impl Default for TuiConfig {
@@ -34,7 +42,25 @@ impl Default for TuiConfig {
             theme: "dark".into(),
             last_tab: None,
             log_file: None,
+            extra_servers: Vec::new(),
         }
+    }
+}
+
+impl TuiConfig {
+    /// Round 37 — flatten `admin_url` + `extra_servers` into the
+    /// ordered list of admin URLs the TUI rotates through. The
+    /// primary `admin_url` is always index 0 so existing single-server
+    /// behaviour is unchanged when `extra_servers` is empty.
+    pub fn all_admin_urls(&self) -> Vec<String> {
+        let mut urls = Vec::with_capacity(1 + self.extra_servers.len());
+        urls.push(self.admin_url.clone());
+        for u in &self.extra_servers {
+            if !u.is_empty() && !urls.iter().any(|existing| existing == u) {
+                urls.push(u.clone());
+            }
+        }
+        urls
     }
 }
 
@@ -125,6 +151,7 @@ log_file = "/tmp/tui.log"
             theme: "light".into(),
             last_tab: Some(5),
             log_file: Some("/var/log/tui.log".into()),
+            extra_servers: vec!["http://test2:8080".into()],
         };
         let serialized = toml::to_string_pretty(&cfg).unwrap();
         let deserialized: TuiConfig = toml::from_str(&serialized).unwrap();

--- a/crates/mockforge-tui/src/keybindings.rs
+++ b/crates/mockforge-tui/src/keybindings.rs
@@ -25,14 +25,23 @@ pub enum Action {
     Toggle,
     Delete,
     Sort,
+    /// Round 37 — cycle to the next admin server in the rotation
+    /// (`Ctrl-]`). No-op when only one server is configured.
+    NextServer,
+    /// Round 37 — cycle to the previous admin server (`Ctrl-[`).
+    PrevServer,
 }
 
 /// Map a key event to an [`Action`].
 pub fn resolve(key: KeyEvent) -> Option<Action> {
-    // Ctrl+C / Ctrl+Q always quit
+    // Ctrl+C / Ctrl+Q always quit. Ctrl-] / Ctrl-[ rotate through the
+    // configured admin servers (round 37). Other Ctrl-combos fall
+    // through unchanged.
     if key.modifiers.contains(KeyModifiers::CONTROL) {
         return match key.code {
             KeyCode::Char('c' | 'q') => Some(Action::Quit),
+            KeyCode::Char(']') => Some(Action::NextServer),
+            KeyCode::Char('[') => Some(Action::PrevServer),
             _ => None,
         };
     }

--- a/crates/mockforge-tui/src/main.rs
+++ b/crates/mockforge-tui/src/main.rs
@@ -11,9 +11,16 @@ use tracing_appender::non_blocking::WorkerGuard;
 #[command(about = "Terminal UI dashboard for MockForge")]
 #[command(version = env!("CARGO_PKG_VERSION"))]
 struct Cli {
-    /// Admin server URL (overrides config file)
-    #[arg(long)]
-    admin_url: Option<String>,
+    /// Admin server URL (overrides config file). The first occurrence
+    /// becomes the active server; additional occurrences (round 37 #876
+    /// follow-up / Srikanth on 0.3.181: "Can I connect Mockforge tui to
+    /// multiple Server IPs and see Logs at the same time by switching
+    /// Tabs based on Server IPs") are added to the rotation. Inside the
+    /// TUI, `Ctrl-]` / `Ctrl-[` cycle between them.
+    ///
+    /// Example: `mockforge-tui --admin-url http://h1:9080 --admin-url http://h2:9080`
+    #[arg(long, num_args = 0..)]
+    admin_url: Vec<String>,
 
     /// Authentication token
     #[arg(long)]
@@ -54,8 +61,11 @@ async fn main() -> Result<()> {
     // Load config file, then overlay CLI args.
     let mut cfg = TuiConfig::load();
 
-    if let Some(url) = cli.admin_url {
-        cfg.admin_url = url;
+    if let Some((first, rest)) = cli.admin_url.split_first() {
+        cfg.admin_url = first.clone();
+        // CLI takes precedence over config: the rotation is exactly
+        // what was passed, not a merge with `~/.config/mockforge/tui.toml`.
+        cfg.extra_servers = rest.to_vec();
     }
     if let Some(interval) = cli.refresh_interval {
         cfg.refresh_interval = interval;

--- a/crates/mockforge-tui/src/screens/conformance.rs
+++ b/crates/mockforge-tui/src/screens/conformance.rs
@@ -152,6 +152,84 @@ enum ViewMode {
 /// rolls up. Aliased so clippy doesn't flag the inner HashMap value.
 type DedupKey = (String, String, String, String);
 
+/// Round 16 + Round 37 (#876 follow-up) — collapse a slice of
+/// `ConformanceViolation`s into the on-disk export shape.
+///
+/// Round 16 introduced the dedup by `(method, path, category, reason)`,
+/// the occurrence count, and the first/last-seen window. Round 37
+/// extends each group with the client-side stamps so a user grepping
+/// the bench JSONL's `client_sent_at` finds the matching server-side
+/// entry, even after the dedup. Sort is count DESC then path ASC,
+/// identical to the prior behaviour so existing tooling keeps working.
+///
+/// Pulled out of `export_filtered` to keep that function focused on
+/// "stitch index -> file path" while the math sits behind a pure
+/// function the unit tests can drive directly.
+fn dedup_violations(violations: &[&ConformanceViolation]) -> Vec<DedupedViolation> {
+    let mut groups: HashMap<DedupKey, (DedupedViolation, u32, chrono::DateTime<chrono::Utc>)> =
+        HashMap::new();
+    for v in violations {
+        let key = (v.method.clone(), v.path.clone(), v.category.clone(), v.reason.clone());
+        let hits = v.occurrences.max(1);
+        match groups.get_mut(&key) {
+            Some(slot) => {
+                slot.1 = slot.1.saturating_add(hits);
+                slot.0.count = slot.0.count.saturating_add(hits);
+                if v.timestamp < slot.0.first_seen {
+                    slot.0.first_seen = v.timestamp;
+                }
+                if v.timestamp > slot.2 {
+                    slot.2 = v.timestamp;
+                    slot.0.last_seen = v.timestamp;
+                }
+                // Round 37 — fold client stamps into the group. We
+                // always keep the latest observed
+                // `client_mockforge_version` so an upgrade mid-run
+                // flips to the newer version. The min/max bracket the
+                // client-side send window across the dedup group.
+                if v.client_mockforge_version.is_some() {
+                    slot.0.client_mockforge_version = v.client_mockforge_version.clone();
+                }
+                if let Some(cs) = v.client_sent_at {
+                    slot.0.min_client_sent_at = Some(match slot.0.min_client_sent_at {
+                        Some(existing) if existing <= cs => existing,
+                        _ => cs,
+                    });
+                    slot.0.max_client_sent_at = Some(match slot.0.max_client_sent_at {
+                        Some(existing) if existing >= cs => existing,
+                        _ => cs,
+                    });
+                }
+            }
+            None => {
+                groups.insert(
+                    key,
+                    (
+                        DedupedViolation {
+                            method: v.method.clone(),
+                            path: v.path.clone(),
+                            category: v.category.clone(),
+                            reason: v.reason.clone(),
+                            status: v.status,
+                            count: hits,
+                            first_seen: v.timestamp,
+                            last_seen: v.timestamp,
+                            client_mockforge_version: v.client_mockforge_version.clone(),
+                            min_client_sent_at: v.client_sent_at,
+                            max_client_sent_at: v.client_sent_at,
+                        },
+                        hits,
+                        v.timestamp,
+                    ),
+                );
+            }
+        }
+    }
+    let mut deduped: Vec<DedupedViolation> = groups.into_iter().map(|(_, (d, _, _))| d).collect();
+    deduped.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.path.cmp(&b.path)));
+    deduped
+}
+
 /// Round 16 — JSON shape written by the export action (`e`). Same
 /// fields as `ConformanceViolation` minus `client_ip` (which is always
 /// `"unknown"` for now and just adds noise to the file), plus a `count`
@@ -167,6 +245,22 @@ struct DedupedViolation {
     count: u32,
     first_seen: chrono::DateTime<chrono::Utc>,
     last_seen: chrono::DateTime<chrono::Utc>,
+    /// Round 37 (#876 follow-up / Srikanth on 0.3.181) — client-side
+    /// stamps observed across the dedup group. `client_mockforge_version`
+    /// is the most recently observed value (in practice all dups carry
+    /// the same value because they came from the same bench run). The
+    /// `min_client_sent_at` / `max_client_sent_at` pair brackets the
+    /// time window the *client* sent these probes, which is what a
+    /// user wants to grep against the bench JSONL — not the server's
+    /// `first_seen` / `last_seen` (when the *server recorded* the
+    /// violation). Skipped when none of the group's hits carried the
+    /// headers (older bench, real proxy traffic).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_mockforge_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_client_sent_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_client_sent_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 pub struct ConformanceScreen {
@@ -405,68 +499,9 @@ impl ConformanceScreen {
         let now = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
         let path = PathBuf::from(format!("conformance-violations-{}.json", now));
         let indices = self.filtered_indices();
-
-        // Group by (method, path, category, reason). Insertion order
-        // doesn't matter — we sort by count at the end.
-        //
-        // Round 30 — under `MOCKFORGE_CONFORMANCE_BUFFER_UNIQUE=true`
-        // the server-side buffer ALREADY deduplicates and carries an
-        // `occurrences` field per entry. Use that as the increment
-        // instead of +1, so the TUI's headline count reflects the true
-        // server-side total instead of just "1 per unique signature".
-        // FIFO mode (the default) sends `occurrences: 1` per entry,
-        // so the math reduces to the prior behaviour for that path.
-        let mut groups: HashMap<DedupKey, (DedupedViolation, u32, chrono::DateTime<chrono::Utc>)> =
-            HashMap::new();
-        for &i in &indices {
-            let Some(v) = self.violations.get(i) else {
-                continue;
-            };
-            let key = (v.method.clone(), v.path.clone(), v.category.clone(), v.reason.clone());
-            let hits = v.occurrences.max(1);
-            match groups.get_mut(&key) {
-                Some(slot) => {
-                    slot.1 = slot.1.saturating_add(hits);
-                    slot.0.count = slot.0.count.saturating_add(hits);
-                    if v.timestamp < slot.0.first_seen {
-                        slot.0.first_seen = v.timestamp;
-                    }
-                    if v.timestamp > slot.2 {
-                        slot.2 = v.timestamp;
-                        slot.0.last_seen = v.timestamp;
-                    }
-                }
-                None => {
-                    groups.insert(
-                        key,
-                        (
-                            DedupedViolation {
-                                method: v.method.clone(),
-                                path: v.path.clone(),
-                                category: v.category.clone(),
-                                reason: v.reason.clone(),
-                                status: v.status,
-                                count: hits,
-                                first_seen: v.timestamp,
-                                last_seen: v.timestamp,
-                            },
-                            hits,
-                            v.timestamp,
-                        ),
-                    );
-                }
-            }
-        }
-
-        let mut deduped: Vec<DedupedViolation> = groups
-            .into_iter()
-            .map(|(_, (mut d, n, _))| {
-                d.count = n;
-                d
-            })
-            .collect();
-        deduped.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.path.cmp(&b.path)));
-
+        let selected: Vec<&ConformanceViolation> =
+            indices.iter().filter_map(|&i| self.violations.get(i)).collect();
+        let deduped = dedup_violations(&selected);
         let total_occurrences: u32 = deduped.iter().map(|d| d.count).sum();
         let unique_groups = deduped.len();
 
@@ -1226,11 +1261,91 @@ mod tests {
             reason: reason.into(),
             category: "request-body".into(),
             occurrences: 1,
+            client_mockforge_version: None,
+            client_sent_at: None,
         }
+    }
+
+    /// Round 37 — variant of `violation` that stamps the client-side
+    /// headers, so tests for the export's `client_mockforge_version`
+    /// and `min_client_sent_at` / `max_client_sent_at` aggregation can
+    /// construct realistic inputs without disturbing the existing
+    /// `violation` callers.
+    fn stamped_violation(
+        secs: i64,
+        path: &str,
+        reason: &str,
+        version: &str,
+        client_sent_secs: i64,
+    ) -> ConformanceViolation {
+        let mut v = violation(secs, 0, path, reason);
+        v.client_mockforge_version = Some(version.into());
+        v.client_sent_at = Some(Utc.timestamp_opt(client_sent_secs, 0).unwrap());
+        v
     }
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, crossterm::event::KeyModifiers::NONE)
+    }
+
+    /// Round 37 (#876 follow-up / Srikanth on 0.3.181) — when the
+    /// server-side buffer recorded the bench's client stamps on each
+    /// violation, the TUI's export must surface them on the dedup
+    /// group so the user can correlate the export back to the bench
+    /// JSONL line that produced it. Two stamped hits with different
+    /// `client_sent_at` collapse into one group with
+    /// `min_client_sent_at` = the earlier of the two and
+    /// `max_client_sent_at` = the later; the `client_mockforge_version`
+    /// is carried verbatim (both hits share the same version in
+    /// practice).
+    #[test]
+    fn dedup_violations_aggregates_client_stamps_across_group() {
+        let a = stamped_violation(1_000, "/users", "missing email", "0.3.181", 500);
+        let b = stamped_violation(1_005, "/users", "missing email", "0.3.181", 800);
+        let result = dedup_violations(&[&a, &b]);
+        assert_eq!(result.len(), 1);
+        let g = &result[0];
+        assert_eq!(g.count, 2);
+        assert_eq!(g.client_mockforge_version.as_deref(), Some("0.3.181"));
+        assert_eq!(g.min_client_sent_at, Some(Utc.timestamp_opt(500, 0).unwrap()));
+        assert_eq!(g.max_client_sent_at, Some(Utc.timestamp_opt(800, 0).unwrap()));
+    }
+
+    /// Round 37 — older mockforge instances (pre-#876) sent the
+    /// violation payload without the new fields. The dedup must keep
+    /// `client_mockforge_version` and `min/max_client_sent_at` as
+    /// `None` so the export's `skip_serializing_if = "Option::is_none"`
+    /// suppresses them entirely, rather than writing JSON `null`s
+    /// that would clutter the output for users on the old server.
+    #[test]
+    fn dedup_violations_leaves_stamps_none_when_violations_unstamped() {
+        let a = violation(1_000, 0, "/users", "missing email");
+        let b = violation(1_005, 0, "/users", "missing email");
+        let result = dedup_violations(&[&a, &b]);
+        assert_eq!(result.len(), 1);
+        let g = &result[0];
+        assert!(g.client_mockforge_version.is_none());
+        assert!(g.min_client_sent_at.is_none());
+        assert!(g.max_client_sent_at.is_none());
+        // Serializing it should NOT emit the stamp keys at all.
+        let json = serde_json::to_string(g).unwrap();
+        assert!(!json.contains("client_mockforge_version"));
+        assert!(!json.contains("client_sent_at"));
+    }
+
+    /// Round 37 — a mid-run upgrade where the first hit came from an
+    /// older bench (0.3.180) and the second from a newer bench
+    /// (0.3.181) keeps the LATEST observed version on the group, not
+    /// the first. Lets a reader spot a version skew across hits.
+    #[test]
+    fn dedup_violations_picks_latest_version_on_mixed_group() {
+        let mut a = stamped_violation(1_000, "/users", "missing email", "0.3.180", 500);
+        a.client_mockforge_version = Some("0.3.180".into());
+        let mut b = stamped_violation(1_005, "/users", "missing email", "0.3.181", 800);
+        b.client_mockforge_version = Some("0.3.181".into());
+        let result = dedup_violations(&[&a, &b]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].client_mockforge_version.as_deref(), Some("0.3.181"));
     }
 
     /// Round 26 — Srikanth's reply on 0.3.169: opening the detail

--- a/crates/mockforge-tui/src/widgets/help.rs
+++ b/crates/mockforge-tui/src/widgets/help.rs
@@ -14,6 +14,7 @@ const HELP_TEXT: &[(&str, &str)] = &[
     ("  q / Ctrl+C", "Quit"),
     ("  Tab / Shift+Tab", "Next / Previous tab"),
     ("  1-0", "Jump to tab 1-10"),
+    ("  Ctrl+] / Ctrl+[", "Next / Previous admin server (multi-server mode)"),
     ("  r", "Refresh current screen"),
     ("  /", "Open filter input"),
     ("  ?", "Toggle this help"),


### PR DESCRIPTION
## Summary

Round 37 of Srikanth's #79 vCenter conformance feedback (post v0.3.181). Four pieces, all driven by what he asked for explicitly in the latest reply.

### A) TUI export now carries client stamps (#876 follow-up)

v0.3.181 added `client_mockforge_version` + `client_sent_at` to `ServerConformanceViolation`, but the TUI's `DedupedViolation` shape dropped them on export. Result: a user grepping the TUI export could not line a row up with the corresponding bench JSONL row, because the only timestamps in the file were the *server's* `first_seen` / `last_seen`, not the *client's* `client_sent_at`. Srikanth flagged the mismatch as "client time is 24 hour format and mockforge tui exported logs has time 12 hour format" — actually a missing-field gap, but the practical effect was that the two sides did not line up.

- `ConformanceViolation` (TUI's mirror struct) deserializes the two new fields off the admin-endpoint payload.
- `DedupedViolation` gains `client_mockforge_version`, `min_client_sent_at`, `max_client_sent_at`. The version is the latest observed value across the dedup group (handles upgrade-mid-run); the min/max bracket the client-side send window across all hits in the group. All three are `Option` with `skip_serializing_if`, so older servers that never set the fields produce the same JSON as before.
- Dedup logic extracted to a pure `dedup_violations` helper so the aggregation can be unit-tested directly. 3 new tests cover the happy-path aggregation, the back-compat case (no stamps recorded), and the upgrade-mid-run case.

### B) Chaos cookbook for varied 5xx + slow responses (Q-c)

New "Recipes" section in `book/src/user-guide/chaos-engineering.md` with copy-paste recipes for:
- Mixed 4xx/5xx via `--chaos-http-errors 500,502,503,504,429,408`.
- Slow backend via `--chaos-latency-ms` and `--chaos-latency-range`.
- Real timeouts (server hangs, returns 504) via `timeout_errors`/`timeout_ms`.
- Per-endpoint chaos via `routes-with-chaos.yaml`.
- Retry/backoff exercise combining the above.
- A note about confirming what actually fired via `GET /api/chaos/status`.

### C) Multi-server TUI rotation (Q-d, the headline ask)

`mockforge-tui --admin-url http://h1:9080 --admin-url http://h2:9080` now adds all the URLs to a rotation. Inside the TUI, `Ctrl-]` cycles to the next server, `Ctrl-[` to the previous, and the header shows `[2/3] http://h2:9080` so the user always knows which server's data they are looking at. On a single-server run (the default), the rotation key is a no-op and the indicator falls back to the original single-URL header.

- `TuiConfig` gains `extra_servers: Vec<String>` (`#[serde(default)]`) + `all_admin_urls()` that flattens primary + extras with dedup.
- `App` holds `servers: Vec<String>` + `active_server: usize` + the auth token, plus a `rotate_server(step: isize)` method that swaps the active `MockForgeClient` and backdates `last_health_check` so the connectivity indicator updates on the next tick instead of waiting for the scheduled interval.
- `keybindings::Action::{NextServer, PrevServer}` mapped to `Ctrl-]` / `Ctrl-[`; help overlay documents both.
- 4 new tests cover the rotation: wrap forward + backward, single-server no-op, and the dedup/primary-first ordering of `all_admin_urls`.

### D) Windows install guidance (Q-d carry-over)

First-class signed Windows binaries are not published today; this round documents the working install path (`cargo install mockforge-cli --locked` with Rustup) and the Docker fallback for Windows Desktop / WSL2. Tracked the missing release-asset work as #884 so future rounds can ship a signed `.exe` + winget package without re-litigating the design.

## Test plan

- [x] `cargo test -p mockforge-tui --lib` — 300 pass, 7 new tests
- [x] `cargo clippy -p mockforge-tui --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Real-binary verify against the worktree's debug build: two `mockforge serve` instances running the same spec, a bench probe fired at server #1 → admin `GET /__mockforge/api/conformance/violations` returns `client_mockforge_version: "0.3.181"`, `client_sent_at: "2026-06-18T14:46:57.660805238Z"` — same value the bench JSONL line stamped
- [x] `target/debug/mockforge-tui --help` shows the multi `--admin-url` flag with the round 37 ask quoted in the help text

Closes #876 follow-up. Refs #877. Files #884 for first-class Windows binaries.