### PR TITLE
feat(registry): emit audit events at SSO/AI/org/billing sites (#866, #873)

### DIFF
--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -28,6 +28,10 @@ pub enum AuditEventType {
     BillingUpgrade,
     BillingDowngrade,
     BillingCanceled,
+    // Payment failure (#873) — distinct from cancellation. The Stripe
+    // `invoice.payment_failed` webhook previously reused `BillingCanceled`,
+    // which conflated a past-due dunning state with a real cancellation.
+    PaymentFailed,
     // API tokens
     ApiTokenCreated,
     ApiTokenDeleted,
@@ -62,6 +66,9 @@ pub enum AuditEventType {
     TwoFactorDisabled,
     // GDPR / data egress (#872) — bulk personal-data export.
     DataExported,
+    // AI usage (#866) — every metered platform LLM call is logged for
+    // SOC2 cost-attribution / abuse forensics.
+    AiUsage,
     // Federation
     FederationCreated,
     FederationUpdated,
@@ -122,6 +129,7 @@ impl AuditEventType {
             "billing_upgrade" => Some(Self::BillingUpgrade),
             "billing_downgrade" => Some(Self::BillingDowngrade),
             "billing_canceled" => Some(Self::BillingCanceled),
+            "payment_failed" => Some(Self::PaymentFailed),
             "api_token_created" => Some(Self::ApiTokenCreated),
             "api_token_deleted" => Some(Self::ApiTokenDeleted),
             "api_token_rotated" => Some(Self::ApiTokenRotated),
@@ -148,6 +156,7 @@ impl AuditEventType {
             "two_factor_enabled" => Some(Self::TwoFactorEnabled),
             "two_factor_disabled" => Some(Self::TwoFactorDisabled),
             "data_exported" => Some(Self::DataExported),
+            "ai_usage" => Some(Self::AiUsage),
             "federation_created" => Some(Self::FederationCreated),
             "federation_updated" => Some(Self::FederationUpdated),
             "federation_deleted" => Some(Self::FederationDeleted),
@@ -197,6 +206,7 @@ impl AuditEventType {
             Self::BillingUpgrade => "billing_upgrade",
             Self::BillingDowngrade => "billing_downgrade",
             Self::BillingCanceled => "billing_canceled",
+            Self::PaymentFailed => "payment_failed",
             Self::ApiTokenCreated => "api_token_created",
             Self::ApiTokenDeleted => "api_token_deleted",
             Self::ApiTokenRotated => "api_token_rotated",
@@ -223,6 +233,7 @@ impl AuditEventType {
             Self::TwoFactorEnabled => "two_factor_enabled",
             Self::TwoFactorDisabled => "two_factor_disabled",
             Self::DataExported => "data_exported",
+            Self::AiUsage => "ai_usage",
             Self::FederationCreated => "federation_created",
             Self::FederationUpdated => "federation_updated",
             Self::FederationDeleted => "federation_deleted",
@@ -593,6 +604,7 @@ mod tests {
             AuditEventType::BillingUpgrade,
             AuditEventType::BillingDowngrade,
             AuditEventType::BillingCanceled,
+            AuditEventType::PaymentFailed,
             AuditEventType::ApiTokenCreated,
             AuditEventType::ApiTokenDeleted,
             AuditEventType::ApiTokenRotated,
@@ -619,6 +631,7 @@ mod tests {
             AuditEventType::TwoFactorEnabled,
             AuditEventType::TwoFactorDisabled,
             AuditEventType::DataExported,
+            AuditEventType::AiUsage,
             AuditEventType::FederationCreated,
             AuditEventType::FederationUpdated,
             AuditEventType::FederationDeleted,
@@ -656,5 +669,14 @@ mod tests {
         assert_eq!(AuditEventType::ApiTokenCreated.as_str(), "api_token_created");
         assert_eq!(AuditEventType::OrgUpdated.as_str(), "org_updated");
         assert_eq!(AuditEventType::MemberRoleChanged.as_str(), "member_role_changed");
+    }
+
+    #[test]
+    fn audit_event_type_new_variants_round_trip() {
+        // New in PR 2 (#866 / #873): AI usage + dedicated payment-failure event.
+        assert_eq!(AuditEventType::AiUsage.as_str(), "ai_usage");
+        assert_eq!(AuditEventType::from_str("ai_usage"), Some(AuditEventType::AiUsage));
+        assert_eq!(AuditEventType::PaymentFailed.as_str(), "payment_failed");
+        assert_eq!(AuditEventType::from_str("payment_failed"), Some(AuditEventType::PaymentFailed));
     }
 }

--- a/crates/mockforge-registry-server/migrations/20250101000081_ai_usage_audit_event.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000081_ai_usage_audit_event.sql
@@ -1,0 +1,23 @@
+-- New audit event types wired in PR 2 of the SOC2 audit-emit sprint.
+--
+-- The Rust mirror lives in
+-- `crates/mockforge-registry-core/src/models/audit_log.rs`
+-- (`AuditEventType::{AiUsage, PaymentFailed}`). The round-trip test in that
+-- file guarantees every snake_case literal below also exists on the Rust side.
+--
+-- ADD VALUE is safe inside this migration's transaction because none of these
+-- values are *used* (referenced as a literal cast to the enum) in the same
+-- migration — same pattern as `20250101000080_audit_log_integrity.sql`.
+
+-- AI usage (#866). Emitted from the shared metered LLM path
+-- (`handlers::ai_studio::run_completion_for_org`) and the test-generation
+-- worker after a successful `record_ai_usage`. Payload (in `metadata`)
+-- includes the handler/endpoint name, provider, and prompt/completion/total
+-- token counts for SOC2 cost-attribution and abuse forensics.
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'ai_usage';
+
+-- Payment failure (#873). The Stripe `invoice.payment_failed` webhook
+-- previously reused `billing_canceled`, conflating a past-due dunning state
+-- with a real cancellation. This dedicated value is emitted from
+-- `handlers::billing::handle_payment_failed`.
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'payment_failed';

--- a/crates/mockforge-registry-server/src/handlers/ai_studio.rs
+++ b/crates/mockforge-registry-server/src/handlers/ai_studio.rs
@@ -13,7 +13,7 @@
 //! See `docs/cloud/CLOUD_AI_STUDIO_DESIGN.md` for the full design.
 
 use axum::{extract::State, http::HeaderMap, Json};
-use mockforge_registry_core::models::{BYOKConfig, Plan};
+use mockforge_registry_core::models::{AuditEventType, BYOKConfig, Plan};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -496,6 +496,30 @@ pub(crate) async fn run_completion_for_org(
     let total_tokens = result.total_tokens();
     record_ai_usage(state, org.id, selection, total_tokens as i64).await?;
 
+    // 6b. Audit the AI usage (#866) for SOC2 cost-attribution / abuse
+    //     forensics. Best-effort: never fails the user's request. No user_id
+    //     here — `run_completion_for_org` is the org-scoped shared path used by
+    //     internal callers without a user session; the user-driven wrapper
+    //     `run_completion` records the same row at the org level.
+    state
+        .store
+        .record_audit_event(
+            org.id,
+            None,
+            AuditEventType::AiUsage,
+            format!("AI completion via {} provider", provider_label(selection)),
+            Some(serde_json::json!({
+                "handler": "ai_studio.run_completion_for_org",
+                "provider": provider_label(selection),
+                "prompt_tokens": result.prompt_tokens,
+                "completion_tokens": result.completion_tokens,
+                "total_tokens": total_tokens,
+            })),
+            None,
+            None,
+        )
+        .await;
+
     // 7. Build response metadata.
     let billed_now = if matches!(selection, ProviderSelection::Platform) {
         total_tokens as i64
@@ -515,6 +539,16 @@ pub(crate) async fn run_completion_for_org(
     };
 
     Ok((result.content, meta))
+}
+
+/// Stable wire label for a provider selection, shared by the response
+/// metadata and the `ai_usage` audit row so they never drift.
+fn provider_label(selection: ProviderSelection) -> &'static str {
+    match selection {
+        ProviderSelection::Byok => "byok",
+        ProviderSelection::Platform => "platform",
+        ProviderSelection::Disabled => "disabled",
+    }
 }
 
 /// Read the org's BYOK config, returning `None` if missing or disabled.

--- a/crates/mockforge-registry-server/src/handlers/billing.rs
+++ b/crates/mockforge-registry-server/src/handlers/billing.rs
@@ -755,7 +755,13 @@ async fn handle_subscription_event(
 
     tracing::info!("Subscription updated: org_id={}, plan={:?}", org_id, plan);
 
-    // Record audit log (webhook event, so no user_id or IP)
+    // Record audit log (webhook event, so no user_id or IP).
+    //
+    // #873 note: `OrgPlanChanged` is intentionally NOT emitted here. Every
+    // plan transition on this webhook path is already logged as the more
+    // specific `BillingUpgrade` / `BillingDowngrade` below, so adding
+    // `OrgPlanChanged` would double-log the same event. `OrgPlanChanged`
+    // remains available for non-billing plan mutations should any ever exist.
     if old_plan != plan {
         // Determine if this is an upgrade or downgrade based on plan ordering
         // Free < Pro < Team
@@ -960,12 +966,15 @@ async fn handle_payment_failed(pool: &sqlx::PgPool, invoice: &Invoice) -> Result
 
     tracing::info!("Payment failed: org_id={}", subscription.org_id);
 
-    // Record audit log (webhook event, so no user_id or IP)
+    // Record audit log (webhook event, so no user_id or IP).
+    // #873: use the dedicated PaymentFailed event instead of reusing
+    // BillingCanceled — a failed payment puts the sub in `past_due` dunning,
+    // which is distinct from an actual cancellation.
     crate::models::record_audit_event(
         pool,
         subscription.org_id,
-        None,                            // Webhook event, no user context
-        AuditEventType::BillingCanceled, // Using canceled as closest match
+        None, // Webhook event, no user context
+        AuditEventType::PaymentFailed,
         format!("Payment failed for subscription: {}", invoice.id),
         Some(serde_json::json!({
             "invoice_id": invoice.id.to_string(),

--- a/crates/mockforge-registry-server/src/handlers/oidc.rs
+++ b/crates/mockforge-registry-server/src/handlers/oidc.rs
@@ -522,7 +522,7 @@ pub async fn oidc_callback(
     let username_hint = claims.preferred_username.clone().or_else(|| claims.name.clone());
 
     // Domain-ownership gate + provisioning, identical to the SAML path (#833).
-    let user =
+    let super::sso::ProvisionedUser { user, jit_created } =
         super::sso::provision_sso_user(&state, &org, &email, username_hint.as_deref()).await?;
 
     // Mirror saml_acs: create an SSO session and mint a short-lived app token.
@@ -540,6 +540,27 @@ pub async fn oidc_callback(
 
     let token = crate::auth::create_token(&user.id.to_string(), &state.config.jwt_secret)
         .map_err(ApiError::Internal)?;
+
+    // Audit the successful SSO login (#871). The domain-ownership gate
+    // (`assert_email_in_verified_domain`, enforced inside `provision_sso_user`)
+    // has already passed for this user, identical to the SAML path.
+    state
+        .store
+        .record_audit_event(
+            org.id,
+            Some(user.id),
+            crate::models::AuditEventType::LoginSucceeded,
+            format!("SSO login via OIDC for {}", email),
+            Some(serde_json::json!({
+                "method": "oidc",
+                "jit_created": jit_created,
+                "email": email,
+            })),
+            None, // IdP redirect callback; no meaningful end-user IP/UA here.
+            None,
+        )
+        .await;
+
     let redirect_url =
         format!("{}/auth/sso/callback?token={}&org_slug={}", app_base_url(), token, org_slug);
 

--- a/crates/mockforge-registry-server/src/handlers/organizations.rs
+++ b/crates/mockforge-registry-server/src/handlers/organizations.rs
@@ -21,6 +21,7 @@ use crate::{
 pub async fn create_organization(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
+    headers: HeaderMap,
     Json(request): Json<CreateOrganizationRequest>,
 ) -> ApiResult<Json<OrganizationResponse>> {
     // Validate input
@@ -62,6 +63,30 @@ pub async fn create_organization(
         .store
         .create_organization(&request.name, &request.slug, user_id, Plan::Free)
         .await?;
+
+    // Record audit event (#873): OrgCreated existed but was never emitted.
+    let ip_address = headers
+        .get("x-forwarded-for")
+        .or_else(|| headers.get("x-real-ip"))
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
+    let user_agent = headers.get("user-agent").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+
+    state
+        .store
+        .record_audit_event(
+            org.id,
+            Some(user_id),
+            AuditEventType::OrgCreated,
+            format!("Created organization {} ({})", org.name, org.slug),
+            Some(serde_json::json!({
+                "slug": org.slug,
+                "plan": org.plan().to_string(),
+            })),
+            ip_address.as_deref(),
+            user_agent.as_deref(),
+        )
+        .await;
 
     Ok(Json(OrganizationResponse {
         id: org.id,
@@ -558,9 +583,7 @@ pub async fn update_organization(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
     Path(org_id): Path<Uuid>,
-    // `headers` is retained for the axum extractor signature only; the plan
-    // mutation that previously logged an audit event from here was removed (#733).
-    _headers: HeaderMap,
+    headers: HeaderMap,
     Json(request): Json<UpdateOrganizationRequest>,
 ) -> ApiResult<Json<OrganizationResponse>> {
     // Get organization
@@ -575,12 +598,16 @@ pub async fn update_organization(
         return Err(ApiError::PermissionDenied);
     }
 
+    // Track which fields changed so the audit row records them (#873).
+    let mut changed_fields: Vec<&str> = Vec::new();
+
     // Update name if provided
     if let Some(name) = &request.name {
         if name.is_empty() {
             return Err(ApiError::InvalidRequest("Organization name cannot be empty".to_string()));
         }
         state.store.update_organization_name(org_id, name).await?;
+        changed_fields.push("name");
     }
 
     // Update slug if provided
@@ -606,6 +633,7 @@ pub async fn update_organization(
         }
 
         state.store.update_organization_slug(org_id, slug).await?;
+        changed_fields.push("slug");
     }
 
     // The plan is server-authoritative (#733): it is managed exclusively by the
@@ -624,6 +652,35 @@ pub async fn update_organization(
         .find_organization_by_id(org_id)
         .await?
         .ok_or_else(|| ApiError::InvalidRequest("Organization not found".to_string()))?;
+
+    // Record audit event (#873): OrgUpdated existed but was never emitted.
+    // Only log when a field actually changed (a no-op PATCH shouldn't audit).
+    if !changed_fields.is_empty() {
+        let ip_address = headers
+            .get("x-forwarded-for")
+            .or_else(|| headers.get("x-real-ip"))
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s.to_string());
+        let user_agent =
+            headers.get("user-agent").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+
+        state
+            .store
+            .record_audit_event(
+                org_id,
+                Some(user_id),
+                AuditEventType::OrgUpdated,
+                format!("Updated organization fields: {}", changed_fields.join(", ")),
+                Some(serde_json::json!({
+                    "changed_fields": changed_fields,
+                    "name": updated_org.name,
+                    "slug": updated_org.slug,
+                })),
+                ip_address.as_deref(),
+                user_agent.as_deref(),
+            )
+            .await;
+    }
 
     Ok(Json(OrganizationResponse {
         id: updated_org.id,

--- a/crates/mockforge-registry-server/src/handlers/sso.rs
+++ b/crates/mockforge-registry-server/src/handlers/sso.rs
@@ -788,7 +788,8 @@ pub async fn saml_acs(
     }
 
     // Find or create user
-    let user = find_or_create_user_from_saml(&state, &user_info, &org).await?;
+    let ProvisionedUser { user, jit_created } =
+        find_or_create_user_from_saml(&state, &user_info, &org).await?;
 
     // Record assertion ID to prevent replay attacks
     if let Some(assertion_id) = &user_info.assertion_id {
@@ -840,6 +841,28 @@ pub async fn saml_acs(
     // with this token to get a proper token pair for ongoing sessions.
     let token = crate::auth::create_token(&user.id.to_string(), &state.config.jwt_secret)
         .map_err(ApiError::Internal)?;
+
+    // Audit the successful SSO login (#871). The domain-ownership gate
+    // (`assert_email_in_verified_domain`, enforced inside `provision_sso_user`)
+    // has already passed by the time we reach here, so every audited row
+    // corresponds to a provisioning decision that cleared the #746/#778 gate.
+    state
+        .store
+        .record_audit_event(
+            org.id,
+            Some(user.id),
+            AuditEventType::LoginSucceeded,
+            format!("SSO login via SAML for {}", user.email),
+            Some(serde_json::json!({
+                "method": "saml",
+                "jit_created": jit_created,
+                "name_id": user_info.name_id,
+                "email": user.email,
+            })),
+            None, // ACS is an IdP POST; no meaningful end-user IP/UA here.
+            None,
+        )
+        .await;
 
     // Redirect to app with token
     let app_base_url =
@@ -1356,7 +1379,7 @@ async fn find_or_create_user_from_saml(
     state: &AppState,
     user_info: &SAMLUserInfo,
     org: &Organization,
-) -> Result<User, ApiError> {
+) -> Result<ProvisionedUser, ApiError> {
     let email = user_info
         .email
         .as_deref()
@@ -1379,7 +1402,7 @@ pub(crate) async fn provision_sso_user(
     org: &Organization,
     email: &str,
     username_hint: Option<&str>,
-) -> Result<User, ApiError> {
+) -> Result<ProvisionedUser, ApiError> {
     use crate::models::organization::OrgRole;
 
     let verifier = crate::sso_domain::DnsDomainVerifier;
@@ -1392,7 +1415,10 @@ pub(crate) async fn provision_sso_user(
             crate::sso_domain::assert_email_in_verified_domain(&verifier, org.id, email).await?;
             state.store.create_org_member(org.id, user.id, OrgRole::Member).await?;
         }
-        return Ok(user);
+        return Ok(ProvisionedUser {
+            user,
+            jit_created: false,
+        });
     }
 
     // JIT-provision a new user; gated on domain ownership.
@@ -1406,7 +1432,20 @@ pub(crate) async fn provision_sso_user(
     let user = state.store.create_user(&username, email, &password_hash).await?;
     state.store.mark_user_verified(user.id).await?;
     state.store.create_org_member(org.id, user.id, OrgRole::Member).await?;
-    Ok(user)
+    Ok(ProvisionedUser {
+        user,
+        jit_created: true,
+    })
+}
+
+/// Result of [`provision_sso_user`]: the resolved/created user plus whether
+/// this call JIT-created the account (vs. logging in / attaching an existing
+/// one). The flag feeds the `login_succeeded` audit event's `jit_created`
+/// metadata (#871) so account-provisioning is distinguishable from re-login in
+/// the forensic trail.
+pub(crate) struct ProvisionedUser {
+    pub user: User,
+    pub jit_created: bool,
 }
 
 /// Validate SAML assertion timestamps (NotBefore/NotOnOrAfter)

--- a/crates/mockforge-registry-server/src/workers/test_generation_worker.rs
+++ b/crates/mockforge-registry-server/src/workers/test_generation_worker.rs
@@ -49,7 +49,8 @@ use crate::{
     AppState,
 };
 use mockforge_registry_core::models::{
-    organization::Plan, test_generation_job::TestGenerationJob, BYOKConfig, Organization,
+    organization::Plan, test_generation_job::TestGenerationJob, AuditEventType, BYOKConfig,
+    Organization,
 };
 
 /// Default poll cadence. Test-generation jobs are interactive (user
@@ -244,6 +245,29 @@ async fn process_job(state: &AppState, job: TestGenerationJob) -> Result<Value, 
             "test_generation_worker: usage metering failed",
         );
     }
+
+    // Audit the AI usage (#866), mirroring the ai_studio metered path.
+    // Best-effort: never fails the job. `created_by` is the user who queued
+    // the job (when present).
+    state
+        .store
+        .record_audit_event(
+            org.id,
+            job.created_by,
+            AuditEventType::AiUsage,
+            format!("AI test-generation completion via {} provider", provider_label),
+            Some(json!({
+                "handler": "test_generation_worker.process_job",
+                "job_id": job.id,
+                "provider": provider_label,
+                "prompt_tokens": llm_result.prompt_tokens,
+                "completion_tokens": llm_result.completion_tokens,
+                "total_tokens": llm_result.total_tokens(),
+            })),
+            None,
+            None,
+        )
+        .await;
 
     // 8. Parse + assemble the persisted result.
     let scenarios = parse_scenarios(&llm_result.content);

--- a/crates/mockforge-registry-server/tests/audit_integrity_e2e.rs
+++ b/crates/mockforge-registry-server/tests/audit_integrity_e2e.rs
@@ -117,3 +117,35 @@ async fn chain_verifies_and_is_tamper_evident_and_append_only() {
         "verify_chain must detect the tampered description"
     );
 }
+
+/// PR 2 (#866 / #873): the new `ai_usage` + `payment_failed` enum values must
+/// be present in the Postgres `audit_event_type` enum (added by migration
+/// 20250101000081). If migration ...081 were missing or the values mismatched
+/// the Rust `as_str()` literals, `AuditLog::create` would fail the enum bind
+/// here. This also confirms the rows extend the tamper-evident chain normally.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL Postgres"]
+async fn new_event_types_insert_and_extend_chain() {
+    let pool = pool().await;
+    let org_id = Uuid::new_v4();
+
+    for event_type in [AuditEventType::AiUsage, AuditEventType::PaymentFailed] {
+        AuditLog::create(
+            &pool,
+            org_id,
+            None,
+            event_type,
+            format!("pr2 event {}", event_type.as_str()),
+            Some(serde_json::json!({ "event": event_type.as_str() })),
+            None,
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("create {} failed: {e}", event_type.as_str()));
+    }
+
+    assert!(
+        AuditLog::verify_chain(&pool, org_id).await.expect("verify_chain"),
+        "chain with ai_usage + payment_failed rows must verify"
+    );
+}


### PR DESCRIPTION
## Summary
PR2 of the SOC2 audit-logging sprint. Builds on the hardening foundation from #883 (#871/#872 — auth events, tamper-evident hash chain, GDPR export) by wiring concrete **emit sites** into the registry handlers so the forensic trail actually captures the events those controls protect.

## Emit sites wired
- **SSO login** (`sso.rs` SAML ACS + `oidc.rs` OIDC callback): `LoginSucceeded` audit row emitted *after* the domain-ownership gate clears. The `assert_email_in_verified_domain` gate (#746/#778 cross-tenant guard) is fully preserved on both the attach-existing and JIT-create paths. `provision_sso_user` now returns `ProvisionedUser { user, jit_created }` so the audit metadata distinguishes provisioning from re-login.
- **AI usage** (`ai_studio.rs` + `test_generation_worker.rs`): new `AiUsage` audit event type (#866).
- **Org lifecycle** (`organizations.rs`): `OrgCreated` / `OrgUpdated`.
- **Billing** (`billing.rs`): `PaymentFailed`.

## New types + migration
- `AuditEventType::AiUsage` + `PaymentFailed` event types in `mockforge-registry-core`.
- Migration `20250101000081_ai_usage_audit_event.sql`.

## Verification
- `cargo clippy -p mockforge-registry-server --all-targets --all-features -- -D warnings`: clean (pre-commit gate).
- `cargo test -p mockforge-registry-core --lib`: 273 passed.
- `cargo test -p mockforge-registry-server --lib`: 519 passed.
- `cargo fmt --all --check`: clean.
- Audit-integrity e2e (`#[ignore]`, docker-PG) covered by #883's foundation.

Closes #866. Completes #873 (org/billing emit sites).