### PR TITLE
feat(cli,bench,book): r38 — admin-host bind + bench file-upload + cookie/CSRF chain (#79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9294,14 +9294,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.181"
+version = "0.3.182"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -158,6 +158,7 @@
 - [Request Chaining](reference/chaining.md)
 - [Fixtures and Smoke Testing](reference/fixtures.md)
 - [Conformance Self-Test Probes](reference/conformance-self-test-probes.md)
+- [Bench Custom Checks (Uploads + Chains)](reference/bench-custom-checks.md)
 - [Bench Capacity Sizing](reference/bench-capacity-sizing.md)
 - [Troubleshooting](reference/troubleshooting.md)
 - [Common Issues & Solutions](reference/common-issues.md)

--- a/book/src/getting-started/quick-start.md
+++ b/book/src/getting-started/quick-start.md
@@ -145,6 +145,33 @@ mockforge serve --spec examples/openapi-demo.json \
 
 Access the admin interface at: http://localhost:9080
 
+### Accessing the admin port from another machine
+
+By default the admin port binds to `127.0.0.1` so it is only reachable
+from the same host. When mockforge runs in a VM or remote box and you
+want to point a `mockforge-tui` (or the admin UI in a browser) at it
+from another machine, use `--admin-host 0.0.0.0` to bind on every
+interface:
+
+```bash
+mockforge serve --spec examples/openapi-demo.json \
+  --admin --admin-port 9080 --admin-host 0.0.0.0 \
+  --http-port 3000
+```
+
+Then on the other machine:
+
+```bash
+mockforge-tui --admin-url http://<vm-ip>:9080
+```
+
+Use `--admin-host ::` to dual-stack bind on IPv6 + IPv4-mapped-IPv6.
+
+**Security note**: `0.0.0.0` exposes the admin API on every interface in
+your network. The admin API is auth-less by default; pair the bind with
+`auth_required: true` in your config when the host has any untrusted
+network. Inside an air-gapped lab / docker network this is fine.
+
 ## Step 7: Using Configuration Files
 
 Instead of environment variables, you can use a configuration file:

--- a/book/src/reference/bench-custom-checks.md
+++ b/book/src/reference/bench-custom-checks.md
@@ -1,0 +1,235 @@
+# Bench Custom Checks: File Uploads + Cookie/CSRF Chains
+
+`mockforge bench --conformance --conformance-custom-checks-file <yaml>` runs
+a YAML-defined sequence of HTTP probes against a target. Round 38 of issue
+[#79](https://github.com/SaaSy-Solutions/mockforge/issues/79) extends the
+YAML with three pieces that map directly to common load-test scenarios:
+
+1. **File uploads** as multipart/form-data (single or multi-file).
+2. **Cookie + CSRF capture and reuse** across subsequent requests, with
+   support for parallel and sequential repetition.
+3. **Whole-chain iteration** so a login + work + logout sequence can be
+   exercised N times under load.
+
+This page is the reference for the YAML knobs. The bench tool ships
+single-shot custom checks since v0.3.55; the chain features below are
+purely additive (existing YAML files keep working).
+
+## File uploads (multipart/form-data)
+
+The simplest case: send a `.json` payload as a multipart form field.
+
+```yaml
+custom_checks:
+  - name: "custom:upload-json"
+    method: POST
+    path: /api/uploads
+    expected_status: 201
+    upload:
+      path: /path/to/payload.json
+      content_type: application/json
+      field_name: file
+```
+
+The bench reads `path` off disk at request time, builds a
+`multipart/form-data` body, and sets the part's `Content-Type` to the value
+you supplied. `field_name` is the form key the receiving server sees;
+`filename` defaults to the basename of `path` but can be overridden.
+
+### Multi-file uploads
+
+`uploads:` (plural) takes a list. Each file becomes its own part in the
+same multipart request.
+
+```yaml
+custom_checks:
+  - name: "custom:upload-evidence-bundle"
+    method: POST
+    path: /api/cases/{caseId}/evidence
+    expected_status: 201
+    uploads:
+      - path: /var/cases/photo.jpg
+        content_type: image/jpeg
+        field_name: photo
+      - path: /var/cases/report.docx
+        content_type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
+        field_name: report
+      - path: /var/cases/manifest.xml
+        content_type: application/xml
+        field_name: manifest
+      - path: /var/cases/binary.exe
+        content_type: application/octet-stream
+        field_name: artifact
+```
+
+Notes:
+
+- `body:` (the JSON-string body knob) wins over `upload` / `uploads` when
+  both are set. The bench warns on stderr so the mistake is visible.
+- A missing file is logged to stderr but does NOT abort the run; the
+  remaining parts still go out.
+- For very large uploads (hundreds of MiB), `--export-requests` will write
+  a brief summary like `<2 file(s): photo.jpg (image/jpeg, 1234 bytes),
+  report.docx (..., 56 bytes)>` instead of dumping bytes into the JSON
+  capture.
+
+## Cookie + CSRF capture and reuse
+
+The bench supports a chain context: capture values from one response,
+substitute them into the next request. Three substitution token shapes:
+
+| Token | Source | Set by `extract:` |
+|---|---|---|
+| `${var:NAME}` | a variable | `headers:` or `body_fields:` |
+| `${cookie:NAME}` | a `Set-Cookie` value | `cookies:` |
+| `${header:NAME}` | alias for `${var:NAME}` | `headers:` (reads better when the source was a header) |
+
+Unknown tokens are preserved verbatim (e.g. `${var:nope}` stays in the
+request), so a missing capture is visible in the request log rather than
+silently sending an empty string.
+
+### Srikanth's Sequence 1: login + 16 parallel writes
+
+```yaml
+chain_iterations: 1
+
+custom_checks:
+  - name: "custom:login"
+    method: POST
+    path: /api/login
+    expected_status: 200
+    body: '{"user":"alice","password":"hunter2"}'
+    extract:
+      cookies:
+        - session
+      headers:
+        csrf: X-CSRF-Token
+      body_fields:
+        user_id: data.id
+
+  - name: "custom:do-work"
+    method: POST
+    path: /api/items
+    expected_status: 201
+    headers:
+      Cookie: "session=${cookie:session}"
+      X-CSRF-Token: "${var:csrf}"
+    body: '{"action":"create","owner_id":"${var:user_id}"}'
+    repeat:
+      count: 16
+      mode: parallel
+```
+
+The login request captures `session` (cookie), `csrf` (header), and
+`user_id` (JSON body field at `data.id`). The follow-up `custom:do-work`
+fires 16 concurrent requests, all carrying the same captured values.
+
+### Srikanth's Sequence 2: login + sequential writes
+
+Same shape, but `mode: sequential` (the default) fires the repeats one
+after another:
+
+```yaml
+custom_checks:
+  - name: "custom:login"
+    method: POST
+    path: /api/login
+    expected_status: 200
+    body: '{"user":"alice","password":"hunter2"}'
+    extract:
+      cookies: [session]
+      headers:
+        csrf: X-CSRF-Token
+
+  - name: "custom:do-work"
+    method: POST
+    path: /api/items
+    expected_status: 201
+    headers:
+      Cookie: "session=${cookie:session}"
+      X-CSRF-Token: "${var:csrf}"
+    body: '{"action":"create"}'
+    repeat:
+      count: 8
+      mode: sequential
+```
+
+### Repeat both scenarios N times
+
+`chain_iterations: N` runs the whole `custom_checks` list N times. Each
+iteration starts with a **fresh** chain context, so a stale session from
+iteration K can't accidentally leak into K+1.
+
+```yaml
+chain_iterations: 50
+
+custom_checks:
+  - name: "custom:login"
+    ...
+  - name: "custom:do-work-parallel"
+    ...
+    repeat:
+      count: 16
+      mode: parallel
+  - name: "custom:do-work-sequential"
+    ...
+    repeat:
+      count: 8
+      mode: sequential
+  - name: "custom:logout"
+    method: POST
+    path: /api/logout
+    expected_status: 204
+    headers:
+      Cookie: "session=${cookie:session}"
+```
+
+That YAML defines the exact loop Srikanth asked for in round 38: log in,
+do 16 parallel writes, do 8 sequential writes, log out, repeat 50 times.
+
+### Substitution: where it applies
+
+- `path:` template (e.g. `/users/${var:user_id}`).
+- Every header value.
+- Raw / JSON / form-urlencoded bodies. JSON bodies are walked and only
+  string leaves are touched, so numbers / booleans / arrays are passed
+  through unchanged.
+- Multipart bodies are NOT substituted (binary uploads should stay
+  byte-identical across iterations).
+
+### Extraction sources
+
+- **Cookies**: `extract.cookies` is a list of cookie names. The bench
+  walks the response's `Set-Cookie` header (multi-cookie headers are
+  comma-split) and captures the matching `name=value` pair. Attributes
+  after the value (`; Path=/; HttpOnly`) are dropped.
+- **Headers**: `extract.headers` is a map of `var_name -> header_name`.
+  Header name lookup is case-insensitive on read.
+- **Body fields**: `extract.body_fields` is a map of
+  `var_name -> dotted_path`. The path is a simple object walk
+  (`data.token` traverses `{"data":{"token":"..."}}`); arrays and filter
+  expressions are NOT supported here (use the CRUD-flow extractor for
+  that). Non-string JSON values are stringified (`42` becomes `"42"`).
+
+### Race semantics
+
+Under `mode: parallel` with `count: N`, the chain context's **extract**
+runs against the **first** response (by input order, not completion
+order). Captures from the remaining N-1 racing requests are dropped.
+This keeps subsequent checks deterministic. If you genuinely want to
+forward a per-repeat value, run them `sequential`.
+
+## Running
+
+```bash
+mockforge bench \
+  --conformance \
+  --conformance-custom-checks-file scenarios/login-and-do-work.yaml \
+  --target https://api.example.com/ \
+  --output bench-results/
+```
+
+`--export-requests` dumps every request/response (substituted) to
+`conformance-requests.json` so you can grep for what actually went on the
+wire. Without it, the bench still produces the standard
+`conformance-self-test.json` aggregate.

--- a/crates/mockforge-bench/src/conformance/capture_html.rs
+++ b/crates/mockforge-bench/src/conformance/capture_html.rs
@@ -526,6 +526,8 @@ mod tests {
             expected_status_range: expected_range.to_string(),
             path_template: String::new(),
             spec_label: None,
+            mockforge_version: String::new(),
+            client_sent_at: String::new(),
         }
     }
 

--- a/crates/mockforge-bench/src/conformance/custom.rs
+++ b/crates/mockforge-bench/src/conformance/custom.rs
@@ -13,6 +13,18 @@ use std::path::Path;
 pub struct CustomConformanceConfig {
     /// List of custom checks to run
     pub custom_checks: Vec<CustomCheck>,
+    /// Round 38 (#79) — Srikanth on 0.3.182. Repeat the entire
+    /// `custom_checks` sequence N times so a "log in, do work,
+    /// log out" chain can be exercised under load. The
+    /// `${var:...}` / `${cookie:...}` substitution context is
+    /// reset at the start of each iteration; values captured in
+    /// iteration K are NOT visible to iteration K+1. Defaults to 1.
+    #[serde(default = "default_iterations")]
+    pub chain_iterations: u32,
+}
+
+fn default_iterations() -> u32 {
+    1
 }
 
 /// A single custom conformance check
@@ -38,6 +50,31 @@ pub struct CustomCheck {
     /// Optional request headers
     #[serde(default)]
     pub headers: std::collections::HashMap<String, String>,
+
+    /// Round 38 (#79) — file upload support. When set, the request
+    /// is sent as `multipart/form-data` with one part per file. Each
+    /// file's bytes come from a local path (so the YAML can name a
+    /// `.exe`, `.jpg`, `.json`, `.docx`, `.xml`, etc. without
+    /// embedding the bytes). `body` wins over `upload`/`uploads`.
+    #[serde(default)]
+    pub upload: Option<UploadFile>,
+    #[serde(default)]
+    pub uploads: Vec<UploadFile>,
+
+    /// Round 38 (#79) — capture values from the response into the
+    /// chain context so subsequent checks can reference them via
+    /// `${var:NAME}`, `${cookie:NAME}`, `${header:NAME}` in path /
+    /// headers / body.
+    #[serde(default)]
+    pub extract: ExtractRules,
+
+    /// Round 38 (#79) — repeat the check N times within an
+    /// iteration. `mode: parallel` fires N concurrent requests
+    /// (Srikanth's Sequence 1: "Use that cookie and csrf token in 16
+    /// subsequent requests that should be sent in parallel").
+    /// `mode: sequential` runs them one after another (Sequence 2).
+    #[serde(default)]
+    pub repeat: Repeat,
 }
 
 /// Expected field in the response body with type checking
@@ -48,6 +85,92 @@ pub struct ExpectedBodyField {
     /// Expected JSON type: "string", "integer", "number", "boolean", "array", "object"
     #[serde(rename = "type")]
     pub field_type: String,
+}
+
+/// Round 38 (#79) — a single file to upload as a multipart form part.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UploadFile {
+    /// Local path to the file; bytes are read at request time.
+    pub path: String,
+    /// `Content-Type` for this part. Common values:
+    /// `application/octet-stream`, `image/jpeg`, `application/json`,
+    /// `application/xml`.
+    #[serde(default = "default_upload_content_type")]
+    pub content_type: String,
+    /// Multipart form field name. Defaults to `"file"`.
+    #[serde(default = "default_upload_field_name")]
+    pub field_name: String,
+    /// Filename announced to the server. Defaults to the basename
+    /// of `path`.
+    #[serde(default)]
+    pub filename: Option<String>,
+}
+
+fn default_upload_content_type() -> String {
+    "application/octet-stream".to_string()
+}
+fn default_upload_field_name() -> String {
+    "file".to_string()
+}
+
+/// Round 38 (#79) — what to capture from a check's response.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ExtractRules {
+    /// Cookie names to capture from `Set-Cookie`. Stored under
+    /// `${cookie:NAME}`.
+    #[serde(default)]
+    pub cookies: Vec<String>,
+    /// Response headers to capture (var_name -> header_name). Header
+    /// name is case-insensitive. Stored under `${var:VAR_NAME}`.
+    #[serde(default)]
+    pub headers: std::collections::HashMap<String, String>,
+    /// JSON body fields by simple dotted path. Stored under
+    /// `${var:VAR_NAME}`.
+    #[serde(default)]
+    pub body_fields: std::collections::HashMap<String, String>,
+}
+
+impl ExtractRules {
+    pub fn is_empty(&self) -> bool {
+        self.cookies.is_empty() && self.headers.is_empty() && self.body_fields.is_empty()
+    }
+}
+
+/// Round 38 (#79) — repeat semantics for a single custom check.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Repeat {
+    #[serde(default = "default_repeat_count")]
+    pub count: u32,
+    #[serde(default)]
+    pub mode: RepeatMode,
+}
+
+impl Default for Repeat {
+    fn default() -> Self {
+        Self {
+            count: 1,
+            mode: RepeatMode::default(),
+        }
+    }
+}
+
+impl Repeat {
+    pub fn is_default(&self) -> bool {
+        self.count == 1 && matches!(self.mode, RepeatMode::Sequential)
+    }
+}
+
+fn default_repeat_count() -> u32 {
+    1
+}
+
+/// Round 38 (#79) — sequential vs parallel repeat.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RepeatMode {
+    #[default]
+    Sequential,
+    Parallel,
 }
 
 impl CustomConformanceConfig {
@@ -293,7 +416,12 @@ custom_checks:
                 expected_headers: std::collections::HashMap::new(),
                 expected_body_fields: vec![],
                 headers: std::collections::HashMap::new(),
+                upload: None,
+                uploads: vec![],
+                extract: ExtractRules::default(),
+                repeat: Repeat::default(),
             }],
+            chain_iterations: 1,
         };
 
         let script = config.generate_k6_group("BASE_URL", &[]);
@@ -317,7 +445,12 @@ custom_checks:
                     field_type: "integer".to_string(),
                 }],
                 headers: std::collections::HashMap::new(),
+                upload: None,
+                uploads: vec![],
+                extract: ExtractRules::default(),
+                repeat: Repeat::default(),
             }],
+            chain_iterations: 1,
         };
 
         let script = config.generate_k6_group("BASE_URL", &[]);
@@ -342,7 +475,12 @@ custom_checks:
                 expected_headers,
                 expected_body_fields: vec![],
                 headers: std::collections::HashMap::new(),
+                upload: None,
+                uploads: vec![],
+                extract: ExtractRules::default(),
+                repeat: Repeat::default(),
             }],
+            chain_iterations: 1,
         };
 
         let script = config.generate_k6_group("BASE_URL", &[]);
@@ -362,7 +500,12 @@ custom_checks:
                 expected_headers: std::collections::HashMap::new(),
                 expected_body_fields: vec![],
                 headers: std::collections::HashMap::new(),
+                upload: None,
+                uploads: vec![],
+                extract: ExtractRules::default(),
+                repeat: Repeat::default(),
             }],
+            chain_iterations: 1,
         };
 
         let custom_headers = vec![("Authorization".to_string(), "Bearer token123".to_string())];
@@ -389,7 +532,12 @@ custom_checks:
                     field_type: "integer".to_string(),
                 }],
                 headers: std::collections::HashMap::new(),
+                upload: None,
+                uploads: vec![],
+                extract: ExtractRules::default(),
+                repeat: Repeat::default(),
             }],
+            chain_iterations: 1,
         };
 
         let script = config.generate_k6_group("BASE_URL", &[]);
@@ -430,7 +578,12 @@ custom_checks:
                 expected_headers: std::collections::HashMap::new(),
                 expected_body_fields: vec![],
                 headers: std::collections::HashMap::new(),
+                upload: None,
+                uploads: vec![],
+                extract: ExtractRules::default(),
+                repeat: Repeat::default(),
             }],
+            chain_iterations: 1,
         };
 
         let script = config.generate_k6_group("BASE_URL", &[]);
@@ -482,7 +635,12 @@ custom_checks:
                     },
                 ],
                 headers: std::collections::HashMap::new(),
+                upload: None,
+                uploads: vec![],
+                extract: ExtractRules::default(),
+                repeat: Repeat::default(),
             }],
+            chain_iterations: 1,
         };
 
         let script = config.generate_k6_group("BASE_URL", &[]);

--- a/crates/mockforge-bench/src/conformance/executor.rs
+++ b/crates/mockforge-bench/src/conformance/executor.rs
@@ -57,6 +57,96 @@ pub enum CheckBody {
         content: String,
         content_type: String,
     },
+    /// Round 38 (#79) — multipart/form-data with file attachments.
+    /// Bytes are read from disk at request time so a YAML can name a
+    /// 50 MiB `.docx` without inflating the config. Use one entry per
+    /// part; the executor builds a single `reqwest::multipart::Form`
+    /// containing all of them so multi-file uploads land in one
+    /// request.
+    Multipart { parts: Vec<MultipartPart> },
+}
+
+/// Round 38 (#79) — one part of a multipart/form-data request body.
+#[derive(Debug, Clone)]
+pub struct MultipartPart {
+    /// Bytes that go on the wire as the part body.
+    pub bytes: Vec<u8>,
+    /// `Content-Type` for this part (e.g. `image/jpeg`,
+    /// `application/octet-stream`, `application/json`).
+    pub content_type: String,
+    /// Multipart form field name (the key on the receiving server).
+    pub field_name: String,
+    /// Filename announced in this part's `Content-Disposition` header.
+    pub filename: String,
+}
+
+/// Round 38 (#79) — chain metadata stored alongside a custom
+/// `ConformanceCheck`. Tells the executor how to substitute captured
+/// values into the request, how to capture values from the response,
+/// and how to repeat the check.
+#[derive(Debug, Clone, Default)]
+struct ChainMeta {
+    /// What to capture from the response on success. Empty when the
+    /// check declared no `extract` rules.
+    extract: super::custom::ExtractRules,
+    /// How many times to fire this check within one outer
+    /// `chain_iterations` pass, sequentially or in parallel.
+    repeat: super::custom::Repeat,
+}
+
+/// Round 38 (#79) — values captured during a chain run, keyed by the
+/// name the YAML asked for them under. `cookies` is kept separate so
+/// `${cookie:session}` and `${var:session}` substitute different
+/// things even if they happen to share a name.
+#[derive(Debug, Default, Clone)]
+struct ChainContext {
+    vars: std::collections::HashMap<String, String>,
+    cookies: std::collections::HashMap<String, String>,
+}
+
+impl ChainContext {
+    /// Substitute every `${var:NAME}`, `${cookie:NAME}`, and
+    /// `${header:NAME}` token in `text` with the corresponding
+    /// captured value. Unknown tokens are left in place verbatim so a
+    /// missing capture is obvious in the request log rather than
+    /// silently sending an empty string.
+    fn substitute(&self, text: &str) -> String {
+        let mut out = String::with_capacity(text.len());
+        let mut rest = text;
+        while let Some(start) = rest.find("${") {
+            out.push_str(&rest[..start]);
+            let after = &rest[start + 2..];
+            if let Some(end) = after.find('}') {
+                let token = &after[..end];
+                let replaced = if let Some(name) = token.strip_prefix("var:") {
+                    self.vars.get(name).cloned()
+                } else if let Some(name) = token.strip_prefix("cookie:") {
+                    self.cookies.get(name).cloned()
+                } else {
+                    // Round 38 — `${header:...}` aliases `${var:...}` for
+                    // captures recorded under the `headers` extraction
+                    // block. Same map, just a more readable token shape.
+                    token.strip_prefix("header:").and_then(|name| self.vars.get(name).cloned())
+                };
+                if let Some(value) = replaced {
+                    out.push_str(&value);
+                } else {
+                    // Preserve the original `${...}` so a missing
+                    // capture is visible in failure detail / logs.
+                    out.push_str("${");
+                    out.push_str(token);
+                    out.push('}');
+                }
+                rest = &after[end + 1..];
+            } else {
+                out.push_str("${");
+                rest = after;
+                break;
+            }
+        }
+        out.push_str(rest);
+        out
+    }
 }
 
 /// How to validate a conformance check response
@@ -130,6 +220,16 @@ pub struct NativeConformanceExecutor {
     config: ConformanceConfig,
     client: Client,
     checks: Vec<ConformanceCheck>,
+    /// Round 38 (#79) — per-check chain metadata. Keyed by the index
+    /// in `checks`. Entries are only present for custom checks that
+    /// declared a non-default `extract` block or `repeat` config in
+    /// the YAML.
+    chain_meta: std::collections::HashMap<usize, ChainMeta>,
+    /// Round 38 (#79) — how many times to repeat the entire chain
+    /// of custom checks. Built-in spec checks always run once. Reset
+    /// to a fresh `ChainContext` at the start of each iteration so
+    /// captures from iteration K do not leak into K+1.
+    chain_iterations: u32,
 }
 
 impl NativeConformanceExecutor {
@@ -151,6 +251,8 @@ impl NativeConformanceExecutor {
             config,
             client,
             checks: Vec::new(),
+            chain_meta: std::collections::HashMap::new(),
+            chain_iterations: 1,
         })
     }
 
@@ -560,6 +662,10 @@ impl NativeConformanceExecutor {
 
         let mut included = 0usize;
         let total = custom_config.custom_checks.len();
+        // Round 38 — propagate the chain-iteration count from the YAML
+        // into the executor. Saturates to `1` when the YAML omits the
+        // field, matching the existing single-pass behaviour.
+        self.chain_iterations = custom_config.chain_iterations.max(1);
         for check in &custom_config.custom_checks {
             if let Some(ref re) = filter_re {
                 if !re.is_match(&check.name) && !re.is_match(&check.path) {
@@ -584,14 +690,26 @@ impl NativeConformanceExecutor {
 
     /// Execute all checks and return a `ConformanceReport`
     pub async fn execute(&self) -> Result<ConformanceReport> {
-        let mut results = Vec::with_capacity(self.checks.len());
+        let chain_iters = self.chain_iterations.max(1);
+        let mut results = Vec::with_capacity(self.checks.len() * chain_iters as usize);
         let delay = self.config.request_delay_ms;
 
-        for (i, check) in self.checks.iter().enumerate() {
-            if delay > 0 && i > 0 {
-                tokio::time::sleep(Duration::from_millis(delay)).await;
+        for _iter in 0..chain_iters {
+            // Round 38 (#79) — every iteration starts with a fresh
+            // chain context so captures from iteration K do not leak
+            // into K+1. This is what Srikanth wants for repeated
+            // login + work + logout cycles.
+            let mut ctx = ChainContext::default();
+            for (i, check) in self.checks.iter().enumerate() {
+                if delay > 0 && i > 0 {
+                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                }
+                if let Some(meta) = self.chain_meta.get(&i).cloned() {
+                    results.extend(self.execute_chain_check(check, &meta, &mut ctx).await);
+                } else {
+                    results.push(self.execute_check(check).await);
+                }
             }
-            results.push(self.execute_check(check).await);
         }
 
         // Write request log if --export-requests was set
@@ -639,7 +757,8 @@ impl NativeConformanceExecutor {
         &self,
         tx: mpsc::Sender<ConformanceProgress>,
     ) -> Result<ConformanceReport> {
-        let total = self.checks.len();
+        let chain_iters = self.chain_iterations.max(1);
+        let total = self.checks.len() * chain_iters as usize;
         let delay = self.config.request_delay_ms;
         let _ = tx
             .send(ConformanceProgress::Started {
@@ -649,22 +768,30 @@ impl NativeConformanceExecutor {
 
         let mut results = Vec::with_capacity(total);
 
-        for (i, check) in self.checks.iter().enumerate() {
-            if delay > 0 && i > 0 {
-                tokio::time::sleep(Duration::from_millis(delay)).await;
+        for _iter in 0..chain_iters {
+            let mut ctx = ChainContext::default();
+            for (i, check) in self.checks.iter().enumerate() {
+                if delay > 0 && i > 0 {
+                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                }
+                let new_results = if let Some(meta) = self.chain_meta.get(&i).cloned() {
+                    self.execute_chain_check(check, &meta, &mut ctx).await
+                } else {
+                    vec![self.execute_check(check).await]
+                };
+                for result in new_results {
+                    let passed = result.passed;
+                    let name = result.name.clone();
+                    results.push(result);
+                    let _ = tx
+                        .send(ConformanceProgress::CheckCompleted {
+                            name,
+                            passed,
+                            checks_done: results.len(),
+                        })
+                        .await;
+                }
             }
-            let result = self.execute_check(check).await;
-            let passed = result.passed;
-            let name = result.name.clone();
-            results.push(result);
-
-            let _ = tx
-                .send(ConformanceProgress::CheckCompleted {
-                    name,
-                    passed,
-                    checks_done: i + 1,
-                })
-                .await;
         }
 
         let _ = tx.send(ConformanceProgress::Finished).await;
@@ -710,6 +837,28 @@ impl NativeConformanceExecutor {
                         request.header("Content-Type", content_type.as_str()).body(content.clone());
                 }
             }
+            // Round 38 (#79) — file-upload via multipart/form-data.
+            // One reqwest `Part` per declared upload, all merged into a
+            // single `Form`. `mime_str` rejects malformed Content-Types
+            // (e.g. "application / json" with spaces); fall back to
+            // octet-stream so the request still goes out and the
+            // server can decide what to do with the bytes.
+            Some(CheckBody::Multipart { parts }) => {
+                let mut form = reqwest::multipart::Form::new();
+                for part_spec in parts {
+                    let mut part = reqwest::multipart::Part::bytes(part_spec.bytes.clone())
+                        .file_name(part_spec.filename.clone());
+                    part = match part.mime_str(&part_spec.content_type) {
+                        Ok(p) => p,
+                        Err(_) => reqwest::multipart::Part::bytes(part_spec.bytes.clone())
+                            .file_name(part_spec.filename.clone())
+                            .mime_str("application/octet-stream")
+                            .expect("application/octet-stream is a valid MIME type"),
+                    };
+                    form = form.part(part_spec.field_name.clone(), part);
+                }
+                request = request.multipart(form);
+            }
             None => {}
         }
 
@@ -719,6 +868,21 @@ impl NativeConformanceExecutor {
                 f.iter().map(|(k, v)| format!("{}={}", k, v)).collect::<Vec<_>>().join("&")
             }
             Some(CheckBody::Raw { content, .. }) => content.clone(),
+            // Round 38 — for `--export-requests`, write a brief
+            // multipart summary (`<N files: a.jpg (image/jpeg, 1234
+            // bytes), b.json (application/json, 56 bytes)>`) instead
+            // of the raw multipart envelope (which would be megabytes
+            // for real file uploads and not useful in a JSON capture
+            // anyway).
+            Some(CheckBody::Multipart { parts }) => {
+                let summary: Vec<String> = parts
+                    .iter()
+                    .map(|p| {
+                        format!("{} ({}, {} bytes)", p.filename, p.content_type, p.bytes.len())
+                    })
+                    .collect();
+                format!("<{} file(s): {}>", parts.len(), summary.join(", "))
+            }
             None => String::new(),
         };
 
@@ -760,8 +924,14 @@ impl NativeConformanceExecutor {
         let (passed, schema_violations) =
             self.validate_response(&check.validation, status, &resp_headers, &resp_body);
 
-        // Always capture the exchange when export_requests is enabled
-        let captured = if self.config.export_requests {
+        // Capture the exchange when export_requests is on OR when any
+        // check in this run declared chain semantics (extract /
+        // repeat). The chain executor needs the response headers and
+        // body to extract captured values — without `captured` the
+        // chain context can't populate `${cookie:...}` /
+        // `${var:...}`. Round 38 (#79).
+        let need_capture = self.config.export_requests || !self.chain_meta.is_empty();
+        let captured = if need_capture {
             Some(CapturedExchange {
                 method: check.method.to_string(),
                 url: url.clone(),
@@ -794,6 +964,12 @@ impl NativeConformanceExecutor {
                             .collect::<Vec<_>>()
                             .join("&"),
                         Some(CheckBody::Raw { content, .. }) => content.clone(),
+                        // Round 38 — same brief summary used by the
+                        // export path; keeps failure detail readable
+                        // without dumping multi-MB upload bytes.
+                        Some(CheckBody::Multipart { parts }) => {
+                            format!("<{} multipart file(s)>", parts.len())
+                        }
                         None => String::new(),
                     },
                 },
@@ -819,6 +995,59 @@ impl NativeConformanceExecutor {
             failure_detail,
             captured,
         }
+    }
+
+    /// Round 38 (#79) — execute a custom check with chain semantics:
+    /// substitute captured values from `ctx` into the request, run
+    /// the configured repeat (sequential or parallel), and pour any
+    /// `extract`-matched response data back into `ctx` for the next
+    /// check to use. The first response's data is the one that
+    /// becomes visible to extract; under `parallel` repeat the
+    /// captures from the racing requests would be ambiguous so we
+    /// pull only from the first to finish.
+    ///
+    /// Returns a vector because a `repeat.count > 1` produces N
+    /// `CheckResult`s, all of which need to flow through the aggregate.
+    async fn execute_chain_check(
+        &self,
+        check: &ConformanceCheck,
+        meta: &ChainMeta,
+        ctx: &mut ChainContext,
+    ) -> Vec<CheckResult> {
+        let substituted = apply_chain_context(check, ctx);
+        let count = meta.repeat.count.max(1);
+        let results = match meta.repeat.mode {
+            super::custom::RepeatMode::Sequential => {
+                let mut out = Vec::with_capacity(count as usize);
+                for _ in 0..count {
+                    out.push(self.execute_check(&substituted).await);
+                }
+                out
+            }
+            super::custom::RepeatMode::Parallel => {
+                let futs = (0..count).map(|_| self.execute_check(&substituted));
+                futures::future::join_all(futs).await
+            }
+        };
+
+        // Extract from the first response. Under sequential repeat
+        // this is the first request fired; under parallel it's the
+        // first slot in the result array, which join_all preserves
+        // by input order (not completion order), so the extraction
+        // is at least deterministic.
+        if !meta.extract.is_empty() {
+            if let Some(first) = results.first() {
+                if let Some(captured) = &first.captured {
+                    extract_into_context(
+                        &meta.extract,
+                        &captured.response_headers,
+                        &captured.response_body,
+                        ctx,
+                    );
+                }
+            }
+        }
+        results
     }
 
     /// Validate a response against the check's validation rules.
@@ -1340,11 +1569,62 @@ impl NativeConformanceExecutor {
             headers.push(("Content-Type".to_string(), "application/json".to_string()));
         }
 
-        // Body
-        let body = check
-            .body
-            .as_ref()
-            .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok().map(CheckBody::Json));
+        // Body. Round 38 (#79) — `body` wins over `upload` /
+        // `uploads` when both are set; the YAML is a misconfiguration
+        // and we warn rather than silently picking one. When `body`
+        // is absent and `upload` / `uploads` is set, every file is
+        // read off disk at construction time and folded into a
+        // `CheckBody::Multipart`. The file read is *eager* (not at
+        // request time) so the executor's send path stays purely
+        // synchronous to the network and a missing file is surfaced
+        // here, not mid-run.
+        let upload_specs: Vec<&super::custom::UploadFile> =
+            check.upload.as_ref().into_iter().chain(check.uploads.iter()).collect();
+        let body = if check.body.is_some() {
+            if !upload_specs.is_empty() {
+                eprintln!(
+                    "warning: custom check '{}' has both `body` and `upload`/`uploads`; ignoring uploads",
+                    check.name
+                );
+            }
+            check.body.as_ref().and_then(|b| {
+                serde_json::from_str::<serde_json::Value>(b).ok().map(CheckBody::Json)
+            })
+        } else if !upload_specs.is_empty() {
+            let mut parts = Vec::with_capacity(upload_specs.len());
+            for spec in upload_specs {
+                match std::fs::read(&spec.path) {
+                    Ok(bytes) => {
+                        let filename = spec.filename.clone().unwrap_or_else(|| {
+                            std::path::Path::new(&spec.path)
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .unwrap_or("upload.bin")
+                                .to_string()
+                        });
+                        parts.push(MultipartPart {
+                            bytes,
+                            content_type: spec.content_type.clone(),
+                            field_name: spec.field_name.clone(),
+                            filename,
+                        });
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "warning: custom check '{}' could not read upload '{}': {}",
+                            check.name, spec.path, e
+                        );
+                    }
+                }
+            }
+            if parts.is_empty() {
+                None
+            } else {
+                Some(CheckBody::Multipart { parts })
+            }
+        } else {
+            None
+        };
 
         // Build expected headers for validation
         let expected_headers: Vec<(String, String)> =
@@ -1356,6 +1636,22 @@ impl NativeConformanceExecutor {
             .iter()
             .map(|f| (f.name.clone(), f.field_type.clone()))
             .collect();
+
+        // Round 38 (#79) — register chain metadata when the YAML
+        // asked for capture / replay. Only non-default extract or
+        // repeat blocks reach the chain map so the steady-state
+        // (single-shot custom check) still skips the chain path.
+        let needs_chain = !check.extract.is_empty() || !check.repeat.is_default();
+        let next_index = self.checks.len();
+        if needs_chain {
+            self.chain_meta.insert(
+                next_index,
+                ChainMeta {
+                    extract: check.extract.clone(),
+                    repeat: check.repeat.clone(),
+                },
+            );
+        }
 
         // Primary status check
         self.checks.push(ConformanceCheck {
@@ -1371,6 +1667,128 @@ impl NativeConformanceExecutor {
             },
         });
     }
+}
+
+/// Round 38 (#79) — return a clone of `check` with every
+/// `${var:...}` / `${cookie:...}` / `${header:...}` token in `path`,
+/// header values, and string bodies replaced by the corresponding
+/// captured value. Free function (not `&self`) so unit tests can
+/// drive it directly. JSON bodies are substituted by walking each
+/// string leaf; non-string JSON values are left untouched.
+fn apply_chain_context(check: &ConformanceCheck, ctx: &ChainContext) -> ConformanceCheck {
+    let path = ctx.substitute(&check.path);
+    let headers = check.headers.iter().map(|(k, v)| (k.clone(), ctx.substitute(v))).collect();
+    let body = check.body.as_ref().map(|b| match b {
+        CheckBody::Json(v) => CheckBody::Json(substitute_in_json(v, ctx)),
+        CheckBody::FormUrlencoded(fields) => CheckBody::FormUrlencoded(
+            fields.iter().map(|(k, v)| (k.clone(), ctx.substitute(v))).collect(),
+        ),
+        CheckBody::Raw {
+            content,
+            content_type,
+        } => CheckBody::Raw {
+            content: ctx.substitute(content),
+            content_type: content_type.clone(),
+        },
+        // Multipart bytes are not text and are not template-targets;
+        // pass-through unchanged so binary uploads are byte-identical
+        // across iterations.
+        CheckBody::Multipart { parts } => CheckBody::Multipart {
+            parts: parts.clone(),
+        },
+    });
+    ConformanceCheck {
+        name: check.name.clone(),
+        method: check.method.clone(),
+        path,
+        headers,
+        body,
+        validation: check.validation.clone(),
+    }
+}
+
+fn substitute_in_json(value: &serde_json::Value, ctx: &ChainContext) -> serde_json::Value {
+    use serde_json::Value;
+    match value {
+        Value::String(s) => Value::String(ctx.substitute(s)),
+        Value::Array(arr) => Value::Array(arr.iter().map(|v| substitute_in_json(v, ctx)).collect()),
+        Value::Object(obj) => Value::Object(
+            obj.iter().map(|(k, v)| (k.clone(), substitute_in_json(v, ctx))).collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// Round 38 (#79) — read captured cookies / headers / body fields off
+/// a response and store them in the chain context for subsequent
+/// requests to reference. Unknown extractions (e.g. a cookie name the
+/// server didn't set) are silently skipped so a partially-met
+/// extract block doesn't fail the whole chain.
+fn extract_into_context(
+    rules: &super::custom::ExtractRules,
+    response_headers: &HashMap<String, String>,
+    response_body: &str,
+    ctx: &mut ChainContext,
+) {
+    // Cookies: every Set-Cookie header is parsed for `name=value`
+    // (the cookie's own attributes after the value are dropped).
+    // Multi-Set-Cookie responses (different `Set-Cookie` values
+    // each with the same header name) are coalesced into one
+    // comma-separated string when reqwest collects the headers,
+    // so we split on commas and try each candidate.
+    for cookie_name in &rules.cookies {
+        if let Some(raw) = response_headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("set-cookie"))
+            .map(|(_, v)| v)
+        {
+            // Each Set-Cookie entry looks like `name=value; attr=...`.
+            // Multiple cookies in one header are comma-separated.
+            for entry in raw.split(',') {
+                let head = entry.split(';').next().unwrap_or(entry).trim();
+                if let Some((name, value)) = head.split_once('=') {
+                    if name.trim().eq_ignore_ascii_case(cookie_name) {
+                        ctx.cookies.insert(cookie_name.clone(), value.trim().to_string());
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    // Headers: case-insensitive lookup.
+    for (var_name, header_name) in &rules.headers {
+        if let Some((_, value)) =
+            response_headers.iter().find(|(k, _)| k.eq_ignore_ascii_case(header_name))
+        {
+            ctx.vars.insert(var_name.clone(), value.clone());
+        }
+    }
+    // Body fields via simple dotted lookup. Empty / non-JSON bodies
+    // simply contribute nothing rather than failing the chain.
+    if !rules.body_fields.is_empty() {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(response_body) {
+            for (var_name, field_path) in &rules.body_fields {
+                if let Some(value) = lookup_json_path(&json, field_path) {
+                    let stringified = match value {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    };
+                    ctx.vars.insert(var_name.clone(), stringified);
+                }
+            }
+        }
+    }
+}
+
+fn lookup_json_path<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = match current {
+            serde_json::Value::Object(obj) => obj.get(segment)?,
+            _ => return None,
+        };
+    }
+    Some(current)
 }
 
 /// Convert an `openapiv3::Schema` to a JSON Schema `serde_json::Value`
@@ -1435,6 +1853,94 @@ fn openapi_schema_to_json_schema(schema: &openapiv3::Schema) -> serde_json::Valu
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Round 38 (#79) — substitution replaces `${var:...}`,
+    /// `${cookie:...}`, and `${header:...}` tokens with the matching
+    /// captured value. Unknown tokens are preserved verbatim so a
+    /// missing capture is visible in the request log.
+    #[test]
+    fn chain_context_substitutes_all_token_kinds() {
+        let mut ctx = ChainContext::default();
+        ctx.vars.insert("csrf".to_string(), "abc123".to_string());
+        ctx.vars.insert("trace".to_string(), "xyz".to_string());
+        ctx.cookies.insert("session".to_string(), "deadbeef".to_string());
+        assert_eq!(ctx.substitute("plain"), "plain");
+        assert_eq!(ctx.substitute("X-CSRF: ${var:csrf}"), "X-CSRF: abc123");
+        assert_eq!(ctx.substitute("Cookie: session=${cookie:session}"), "Cookie: session=deadbeef");
+        // header: aliases var: so the same map is used.
+        assert_eq!(ctx.substitute("X-Trace: ${header:trace}"), "X-Trace: xyz");
+        // Unknown name preserved verbatim (no silent empty string).
+        assert_eq!(ctx.substitute("missing: ${var:nope}"), "missing: ${var:nope}");
+    }
+
+    /// Round 38 — extraction pulls cookies, headers, and body fields
+    /// off a response and stores them in the chain context under the
+    /// caller-named keys.
+    #[test]
+    fn extract_into_context_captures_cookies_headers_and_body_fields() {
+        let mut headers = HashMap::new();
+        headers.insert("Set-Cookie".to_string(), "session=abc123; Path=/; HttpOnly".to_string());
+        headers.insert("X-CSRF-Token".to_string(), "csrf-token-xyz".to_string());
+        let body = r#"{"data":{"token":"body-token-456"},"id":42}"#;
+        let mut rules = super::super::custom::ExtractRules::default();
+        rules.cookies.push("session".to_string());
+        rules.headers.insert("csrf".to_string(), "X-CSRF-Token".to_string());
+        rules.body_fields.insert("nested_token".to_string(), "data.token".to_string());
+        rules.body_fields.insert("user_id".to_string(), "id".to_string());
+        let mut ctx = ChainContext::default();
+        extract_into_context(&rules, &headers, body, &mut ctx);
+        assert_eq!(ctx.cookies.get("session").map(|s| s.as_str()), Some("abc123"));
+        assert_eq!(ctx.vars.get("csrf").map(|s| s.as_str()), Some("csrf-token-xyz"));
+        assert_eq!(ctx.vars.get("nested_token").map(|s| s.as_str()), Some("body-token-456"));
+        // Numeric body field stringifies to "42".
+        assert_eq!(ctx.vars.get("user_id").map(|s| s.as_str()), Some("42"));
+    }
+
+    /// Round 38 — a missing cookie name doesn't poison subsequent
+    /// extractions; the cookie pull silently no-ops and the header /
+    /// body extractions still happen.
+    #[test]
+    fn extract_into_context_skips_missing_captures_gracefully() {
+        let mut headers = HashMap::new();
+        headers.insert("X-CSRF-Token".to_string(), "csrf-value".to_string());
+        let body = r#"{"id":1}"#;
+        let mut rules = super::super::custom::ExtractRules::default();
+        rules.cookies.push("never-set".to_string());
+        rules.headers.insert("csrf".to_string(), "X-CSRF-Token".to_string());
+        let mut ctx = ChainContext::default();
+        extract_into_context(&rules, &headers, body, &mut ctx);
+        assert!(ctx.cookies.is_empty(), "missing cookie should not insert anything");
+        assert_eq!(ctx.vars.get("csrf").map(|s| s.as_str()), Some("csrf-value"));
+    }
+
+    /// Round 38 — substitution into a ConformanceCheck flows through
+    /// path, headers, raw bodies, JSON bodies, and form-urlencoded
+    /// fields. Multipart bodies are pass-through (binary uploads
+    /// shouldn't be touched by string templating).
+    #[test]
+    fn apply_chain_context_substitutes_path_headers_and_body() {
+        let mut ctx = ChainContext::default();
+        ctx.vars.insert("user".to_string(), "alice".to_string());
+        ctx.cookies.insert("sid".to_string(), "deadbeef".to_string());
+        let check = ConformanceCheck {
+            name: "custom:t".into(),
+            method: Method::POST,
+            path: "/users/${var:user}".into(),
+            headers: vec![("Cookie".into(), "sid=${cookie:sid}".into())],
+            body: Some(CheckBody::Json(serde_json::json!({"by": "${var:user}", "ts": 1}))),
+            validation: CheckValidation::ExactStatus(200),
+        };
+        let substituted = apply_chain_context(&check, &ctx);
+        assert_eq!(substituted.path, "/users/alice");
+        assert_eq!(substituted.headers[0].1, "sid=deadbeef");
+        match substituted.body {
+            Some(CheckBody::Json(v)) => {
+                assert_eq!(v["by"], "alice");
+                assert_eq!(v["ts"], 1);
+            }
+            _ => panic!("expected json body"),
+        }
+    }
 
     #[test]
     fn test_reference_check_count() {
@@ -1763,6 +2269,10 @@ custom_checks:
             expected_headers: HashMap::new(),
             expected_body_fields: vec![],
             headers: HashMap::new(),
+            upload: None,
+            uploads: vec![],
+            extract: crate::conformance::custom::ExtractRules::default(),
+            repeat: crate::conformance::custom::Repeat::default(),
         };
 
         executor.add_custom_check(&custom);

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -527,6 +527,21 @@ struct ServeCliArgs {
     #[arg(long, help_heading = "Admin & UI")]
     pub admin_port: Option<u16>,
 
+    /// Bind the admin UI on this host instead of the safe loopback default
+    /// (`127.0.0.1`). Pass `0.0.0.0` to expose the admin port on every
+    /// interface so the mockforge-tui on another machine can connect
+    /// (Issue #79 round 38 / Srikanth on 0.3.182: "admin ports are
+    /// opening only on 127.0.0.1 so I am able to open the mockforge tui
+    /// UI on the Server locally but when I access the server from some
+    /// other machine via mockforge TUI connections are getting refused").
+    /// Pass `::` to dual-stack bind on IPv6 + IPv4-mapped-IPv6.
+    ///
+    /// SECURITY NOTE: `0.0.0.0` exposes the admin API on every interface
+    /// in your network. Pair with `--admin-auth-required` when binding
+    /// publicly.
+    #[arg(long, help_heading = "Admin & UI")]
+    pub admin_host: Option<String>,
+
     /// Validate configuration and check port availability without starting servers
     #[arg(long, help_heading = "Validation")]
     pub dry_run: bool,
@@ -2579,6 +2594,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 tcp_port: args.ports.tcp_port,
                 admin: args.admin,
                 admin_port: args.admin_port,
+                admin_host: args.admin_host,
                 metrics: args.observability.metrics,
                 metrics_port: args.observability.metrics_port,
                 tracing: args.observability.tracing,

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -30,6 +30,10 @@ pub(crate) struct ServeArgs {
     pub(crate) tcp_port: Option<u16>,
     pub(crate) admin: bool,
     pub(crate) admin_port: Option<u16>,
+    /// Round 38 (#79) — bind host for the admin UI / API. `None` falls
+    /// back to the config-file value (loopback by default; `::` inside
+    /// containers per the AdminConfig::default heuristic).
+    pub(crate) admin_host: Option<String>,
     pub(crate) metrics: bool,
     pub(crate) metrics_port: Option<u16>,
     pub(crate) tracing: bool,
@@ -133,6 +137,7 @@ impl Default for ServeArgs {
             tcp_port: None,
             admin: false,
             admin_port: None,
+            admin_host: None,
             metrics: false,
             metrics_port: None,
             tracing: false,
@@ -348,6 +353,13 @@ pub(crate) async fn build_server_config_from_cli(serve_args: &ServeArgs) -> Serv
     }
     if let Some(admin_port) = serve_args.admin_port {
         config.admin.port = admin_port;
+    }
+    // Round 38 (#79) — Srikanth on 0.3.182: admin port was only
+    // listening on 127.0.0.1 when he ran mockforge in a VM, so a TUI
+    // on another machine could not connect. `--admin-host 0.0.0.0`
+    // (or `::` for dual-stack) overrides the loopback default.
+    if let Some(ref host) = serve_args.admin_host {
+        config.admin.host = host.clone();
     }
 
     // Prometheus metrics configuration


### PR DESCRIPTION
## Summary

Round 38 of Srikanth's #79 vCenter conformance feedback (post v0.3.182). Three pieces, all driven by what he asked for explicitly:

### A) `mockforge serve --admin-host <addr>`

Default stays loopback for safety. Pass `0.0.0.0` to expose admin on every interface so a `mockforge-tui` on another machine can connect. Srikanth on 0.3.182: *"admin ports are opening only on 127.0.0.1 so I am able to open the mockforge tui UI on the Server locally but when I access the server from some other machine via mockforge TUI connections are getting refused"*.

Real-binary verified: `--admin-host 0.0.0.0` binds the admin port on `0.0.0.0:N`, and `curl` from the host's eth0 IP returns 200 on `/__mockforge/api/conformance/violations`.

### B) Bench file uploads (multipart/form-data)

New YAML fields on `CustomCheck`:
- `upload: { path, content_type, field_name, filename? }` for a single file.
- `uploads: [{...}, {...}]` for multi-file requests.

Bytes are read off disk at construction time so a missing file is surfaced before the run starts, not mid-stream. New `CheckBody::Multipart` variant + `reqwest::multipart::Form` wiring in the executor's send path; `mime_str` failures fall back to `application/octet-stream` so a typo in `content_type` still sends bytes. Brief summary in `--export-requests` output (`<2 file(s): a.jpg (image/jpeg, 1234 bytes), b.json (application/json, 56 bytes)>`) instead of dumping raw multipart envelopes. `body` wins over `upload`/`uploads` when both are set (mistake gets a stderr warning).

### C) Cookie + CSRF capture and reuse across a chain of requests

Srikanth's exact ask: *"Get a cookie and csrf token on first request from the server, use that cookie and csrf token in 16 subsequent requests that should be sent in parallel"* (Sequence 1), and the same sequential variant (Sequence 2), iterable any number of times.

New YAML fields:
- `extract: { cookies: [...], headers: { var: header }, body_fields: { var: dotted.path } }` captures values from the response.
- `repeat: { count: N, mode: parallel | sequential }` fires the check N times. Parallel uses `tokio::join_all`; sequential runs one-after-another.
- Top-level `chain_iterations: N` repeats the whole `custom_checks` list N times, with a fresh chain context per iteration (no leakage between iterations).

Substitution tokens in path / headers / bodies: `${var:NAME}`, `${cookie:NAME}`, `${header:NAME}`. Unknown tokens preserved verbatim so a missing capture is visible in the request log rather than silently sending an empty string. JSON body walks only touch string leaves so numbers / arrays / booleans are unchanged. Multipart bodies pass through unchanged (binary uploads stay byte-identical across iterations).

## Test plan

- [x] `cargo test -p mockforge-bench --lib` — 483 pass, 4 new unit tests for substitution + extraction
- [x] `cargo clippy -p mockforge-bench --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy -p mockforge-cli --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Real-binary end-to-end verify:
  - 2-iteration chain (login + 4 parallel + 3 sequential): `conformance-requests.json` shows `login: 2, do-work-parallel: 8, do-work-sequential: 6, total: 110`. `${var:user_id}` was substituted to `42` from the login response's `data.id`; `${var:csrf}` left verbatim because the mock server does not synthesize `X-CSRF-Token` (correct behavior).
  - Single + multi-file uploads return 201 with the brief multipart summary in the export.
  - `--admin-host 0.0.0.0` opens the admin port on every interface; curl from the host eth0 IP succeeds.

## Docs

- New `book/src/reference/bench-custom-checks.md` page with the YAML reference and both Srikanth-shape examples (Sequence 1 / Sequence 2 + iteration).
- New "Accessing the admin port from another machine" subsection in `book/src/getting-started/quick-start.md`.

Closes round 38 of #79.