### PR TITLE
fix: remove redundant path qualifications (unused_qualifications under Rust 1.96)

### DIFF
--- a/crates/mockforge-bench/src/conformance/custom.rs
+++ b/crates/mockforge-bench/src/conformance/custom.rs
@@ -546,7 +546,7 @@ fn write_k6_group_body(
                 let var = format!("__file_{}", *upload_counter);
                 *upload_counter += 1;
                 let filename = spec.filename.clone().unwrap_or_else(|| {
-                    std::path::Path::new(&spec.path)
+                    Path::new(&spec.path)
                         .file_name()
                         .and_then(|n| n.to_str())
                         .unwrap_or("upload.bin")

--- a/crates/mockforge-bench/src/conformance/executor.rs
+++ b/crates/mockforge-bench/src/conformance/executor.rs
@@ -100,8 +100,8 @@ struct ChainMeta {
 /// things even if they happen to share a name.
 #[derive(Debug, Default, Clone)]
 struct ChainContext {
-    vars: std::collections::HashMap<String, String>,
-    cookies: std::collections::HashMap<String, String>,
+    vars: HashMap<String, String>,
+    cookies: HashMap<String, String>,
 }
 
 impl ChainContext {
@@ -224,7 +224,7 @@ pub struct NativeConformanceExecutor {
     /// in `checks`. Entries are only present for custom checks that
     /// declared a non-default `extract` block or `repeat` config in
     /// the YAML.
-    chain_meta: std::collections::HashMap<usize, ChainMeta>,
+    chain_meta: HashMap<usize, ChainMeta>,
     /// Round 38 (#79) — how many times to repeat the entire chain
     /// of custom checks. Built-in spec checks always run once. Reset
     /// to a fresh `ChainContext` at the start of each iteration so
@@ -251,7 +251,7 @@ impl NativeConformanceExecutor {
             config,
             client,
             checks: Vec::new(),
-            chain_meta: std::collections::HashMap::new(),
+            chain_meta: HashMap::new(),
             chain_iterations: 1,
         })
     }

--- a/crates/mockforge-chaos-orchestration/src/alerts.rs
+++ b/crates/mockforge-chaos-orchestration/src/alerts.rs
@@ -281,7 +281,7 @@ impl AlertRule {
                 window_minutes,
             } => {
                 // Filter metrics within the window
-                let cutoff = chrono::Utc::now() - chrono::Duration::minutes(*window_minutes);
+                let cutoff = Utc::now() - chrono::Duration::minutes(*window_minutes);
                 let windowed: Vec<_> = metrics.iter().filter(|m| m.timestamp >= cutoff).collect();
 
                 if windowed.is_empty() {

--- a/crates/mockforge-registry-server/src/handlers/auth.rs
+++ b/crates/mockforge-registry-server/src/handlers/auth.rs
@@ -350,7 +350,7 @@ pub async fn refresh_token(
     }
 
     // Parse user ID from claims
-    let user_id = uuid::Uuid::parse_str(&claims.sub)
+    let user_id = Uuid::parse_str(&claims.sub)
         .map_err(|_| ApiError::InvalidRequest("Invalid user ID".to_string()))?;
 
     // Find user to ensure they still exist and are active

--- a/crates/mockforge-registry-server/src/handlers/oidc.rs
+++ b/crates/mockforge-registry-server/src/handlers/oidc.rs
@@ -308,13 +308,9 @@ fn encode_flow(secret: &str, flow: &FlowState) -> Result<String, ApiError> {
 fn decode_flow(secret: &str, token: &str) -> Result<FlowState, ApiError> {
     let mut validation = Validation::new(Algorithm::HS256);
     validation.validate_exp = true;
-    jsonwebtoken::decode::<FlowState>(
-        token,
-        &DecodingKey::from_secret(secret.as_bytes()),
-        &validation,
-    )
-    .map(|d| d.claims)
-    .map_err(|_| ApiError::InvalidRequest("OIDC login session expired or invalid".into()))
+    decode::<FlowState>(token, &DecodingKey::from_secret(secret.as_bytes()), &validation)
+        .map(|d| d.claims)
+        .map_err(|_| ApiError::InvalidRequest("OIDC login session expired or invalid".into()))
 }
 
 fn set_flow_cookie(token: &str) -> String {


### PR DESCRIPTION
## Problem
`main`'s **Test (stable)** CI went red. The clippy step in `ci.yml` runs:
```
cargo clippy --workspace --exclude mockforge-desktop --lib --bins --all-features -- -D clippy::correctness -D unused_qualifications
```
After the self-hosted runner's stable toolchain advanced to **1.96.0**, the `unused_qualifications` lint started flagging path qualifications whose final segment is already in scope. With `-D unused_qualifications` these became hard errors, failing the build (first in `mockforge-bench` and `mockforge-chaos-orchestration`, then — once those compiled — in `mockforge-registry-server`).

## Fix
Eight mechanical "remove the unnecessary path segment" changes across 5 files:

| Crate | Change |
|-------|--------|
| mockforge-bench | `std::path::Path` → `Path`; `std::collections::HashMap` → `HashMap` (×4) |
| mockforge-chaos-orchestration | `chrono::Utc` → `Utc` (`chrono::Duration` kept — not imported) |
| mockforge-registry-server | `uuid::Uuid` → `Uuid`; `jsonwebtoken::decode` → `decode` |

`oidc.rs::decode_flow` was reflowed by rustfmt because the shortened qualifier brought the call under the line-width threshold.

## Verification
Reproduced and verified under **stable 1.96.0** (matching the runner):
```
cargo clippy --workspace --exclude mockforge-desktop --lib --bins --all-features -- -D clippy::correctness -D unused_qualifications   # exit 0
rustfmt --check <all changed files>                                                                                                 # exit 0
```

## Scope note
The pre-existing `unnecessary_sort_by` / `collapsible_match` warnings the 1.96 toolchain also surfaces are **not** in CI's deny list (CI denies only `clippy::correctness` + `unused_qualifications`), so they don't block CI and are intentionally left out of this focused unblock. A follow-up could pin the toolchain (`rust-toolchain.toml`) to avoid future silent lint drift.