### PR TITLE
fix(openapi): r40 — merge + resolve path-level parameters in validator (#888, #79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9294,14 +9294,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.182"
+version = "0.3.183"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -2785,8 +2785,20 @@ impl BenchCommand {
 
         let mut executor = crate::conformance::executor::NativeConformanceExecutor::new(config)?;
 
+        // Round 39 (#79) — when the user passed `--conformance-custom`
+        // WITHOUT `--spec` and without `--conformance-self-test`, fire
+        // only the YAML's checks. The built-in 47 reference checks
+        // (`param:path:string`, etc.) hit `/conformance/...` paths that
+        // do not exist on a real target, so a custom-only run against
+        // a remote API produced a flood of irrelevant 404s in the
+        // request log. Srikanth on 0.3.183: "In the exported request I
+        // see it is sending request to api/conformance/params/hello
+        // and some other URLs".
+        let custom_only = annotated_ops.is_none() && self.conformance_custom.is_some();
         executor = if let Some(annotated) = &annotated_ops {
             executor.with_spec_driven_checks(annotated)
+        } else if custom_only {
+            executor
         } else {
             executor.with_reference_checks()
         };
@@ -3069,8 +3081,13 @@ impl BenchCommand {
                 let mut executor =
                     crate::conformance::executor::NativeConformanceExecutor::new(config)?;
 
+                // Round 39 (#79) — see custom_only comment above; same
+                // logic applied to the multi-target branch.
+                let custom_only = annotated_ops.is_none() && self.conformance_custom.is_some();
                 executor = if let Some(ref annotated) = annotated_ops {
                     executor.with_spec_driven_checks(annotated)
+                } else if custom_only {
+                    executor
                 } else {
                     executor.with_reference_checks()
                 };

--- a/crates/mockforge-bench/src/conformance/custom.rs
+++ b/crates/mockforge-bench/src/conformance/custom.rs
@@ -200,153 +200,615 @@ impl CustomConformanceConfig {
         self.generate_k6_group_with_options(base_url, custom_headers, false)
     }
 
+    /// Round 39 (#79) — splits the k6 emit into the init-scope code
+    /// (`open(...)` calls for file uploads) and the per-VU group body
+    /// (the `group('Custom', ...)` block). Caller is responsible for
+    /// placing `init_code` at the top of the script (before
+    /// `export default function`) and `group_body` inside the default
+    /// function. For backwards compatibility, `generate_k6_group` and
+    /// `generate_k6_group_with_options` concatenate the two so existing
+    /// code paths keep working — but they will emit the `open()` calls
+    /// inside the VU function, which k6 rejects at runtime for
+    /// uploads. Use `emit_k6_with_options` directly when uploads are
+    /// expected.
+    pub fn emit_k6_with_options(
+        &self,
+        base_url: &str,
+        custom_headers: &[(String, String)],
+        export_requests: bool,
+    ) -> K6CustomEmit {
+        let mut init_code = String::new();
+        let mut group_body = String::new();
+        let mut upload_counter: usize = 0;
+        write_k6_group_body(
+            self,
+            base_url,
+            custom_headers,
+            export_requests,
+            &mut group_body,
+            &mut init_code,
+            &mut upload_counter,
+        );
+        K6CustomEmit {
+            init_code,
+            group_body,
+        }
+    }
+
     /// Generate a k6 `group('Custom', ...)` block for all custom checks.
     /// When `export_requests` is true, emits `__captureExchange` calls after each request.
+    ///
+    /// **Round 39 (#79) — file uploads need `open()` at init scope, so
+    /// callers that may receive an `upload`/`uploads` YAML should
+    /// switch to `emit_k6_with_options` and splice `init_code`
+    /// separately.** This method is kept for backwards compatibility
+    /// and concatenates init + body — which crashes k6 at runtime when
+    /// uploads are configured.
     pub fn generate_k6_group_with_options(
         &self,
         base_url: &str,
         custom_headers: &[(String, String)],
         export_requests: bool,
     ) -> String {
-        let mut script = String::with_capacity(4096);
-        script.push_str("  group('Custom', function () {\n");
+        let emit = self.emit_k6_with_options(base_url, custom_headers, export_requests);
+        // Backwards compat: concat both into one string. k6 will fail
+        // at runtime if `open()` calls land inside the VU function,
+        // but tests / call paths that never set `upload`/`uploads`
+        // produce the same output as before round 39.
+        let mut combined = String::with_capacity(emit.init_code.len() + emit.group_body.len());
+        combined.push_str(&emit.init_code);
+        combined.push_str(&emit.group_body);
+        combined
+    }
+}
 
-        for check in &self.custom_checks {
-            script.push_str("    {\n");
+/// Round 39 (#79) — split output from the k6 emitter so the caller can
+/// place `init_code` at script-init scope (where k6's `open()` must
+/// live) and `group_body` inside `export default function`.
+#[derive(Debug, Default, Clone)]
+pub struct K6CustomEmit {
+    pub init_code: String,
+    pub group_body: String,
+}
 
-            // Build headers object
-            let mut all_headers: Vec<(String, String)> = Vec::new();
-            // Add check-specific headers
-            for (k, v) in &check.headers {
+/// Round 39 (#79) — escape a Rust string for safe embedding in a JS
+/// single-quoted string literal. Wrapping `String::push_str` calls
+/// already produce template-literal text, so this is for the simple
+/// `'...'` body / value case.
+fn js_escape_sq(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\'', "\\'")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}
+
+/// Round 39 (#79) — escape a Rust string for embedding inside a k6
+/// template literal (\`...\`). Backticks and `${` must both be
+/// escaped to avoid breaking out of the literal or starting an
+/// unintended interpolation. Currently unused since
+/// `substitute_chain_tokens` does the full template-literal escape +
+/// substitute in one pass; kept around for future call sites that
+/// want a plain escape without substitution.
+#[allow(dead_code)]
+fn js_escape_tpl(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('`', "\\`").replace("${", "\\${")
+}
+
+/// Round 39 (#79) — translate `${var:NAME}` / `${cookie:NAME}` /
+/// `${header:NAME}` tokens in `text` to k6 template-literal
+/// interpolations against the chain context variables. The output is
+/// inserted directly into a k6 template literal (\`...\`), so the
+/// caller MUST NOT subsequently call `js_escape_tpl` — the `${...}`
+/// interpolation sequences are intentional. Other characters that
+/// would prematurely close the template literal (backtick, backslash)
+/// are escaped here. Unrecognised `${...}` shapes from the YAML are
+/// escaped to `\\${...}` so they show up as literal text in the
+/// request log without breaking out into JS.
+fn substitute_chain_tokens(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("${") {
+        // Escape any backtick or backslash in the prefix before the `${`.
+        for c in rest[..start].chars() {
+            match c {
+                '\\' => out.push_str("\\\\"),
+                '`' => out.push_str("\\`"),
+                other => out.push(other),
+            }
+        }
+        let after = &rest[start + 2..];
+        if let Some(end) = after.find('}') {
+            let token = &after[..end];
+            let replacement = if let Some(name) = token.strip_prefix("var:") {
+                Some(format!("${{__ctx_var_{}}}", sanitize_js_ident(name)))
+            } else if let Some(name) = token.strip_prefix("cookie:") {
+                Some(format!("${{__ctx_cookie_{}}}", sanitize_js_ident(name)))
+            } else {
+                token
+                    .strip_prefix("header:")
+                    .map(|name| format!("${{__ctx_var_{}}}", sanitize_js_ident(name)))
+            };
+            if let Some(replacement) = replacement {
+                // Intentional interpolation; preserved verbatim so k6
+                // resolves it at run time against the chain context.
+                out.push_str(&replacement);
+            } else {
+                // Unknown `${...}` shape from YAML — escape `${` so k6
+                // sees the literal text instead of trying to evaluate
+                // an undefined JS expression.
+                out.push_str("\\${");
+                out.push_str(token);
+                out.push('}');
+            }
+            rest = &after[end + 1..];
+        } else {
+            out.push_str("\\${");
+            rest = after;
+            break;
+        }
+    }
+    // Trailing text — same escape pass as the prefix.
+    for c in rest.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '`' => out.push_str("\\`"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Round 39 (#79) — JS identifier-safe form of a YAML name. Used to
+/// build per-token chain-context variable names that won't collide
+/// with reserved words or contain illegal characters.
+fn sanitize_js_ident(name: &str) -> String {
+    name.chars().map(|c| if c.is_ascii_alphanumeric() { c } else { '_' }).collect()
+}
+
+/// Round 39 (#79) — build the JS object literal for a request's
+/// headers. When `dynamic` is true the entries are emitted inside a
+/// template literal so `${var:...}` / `${cookie:...}` substitutions
+/// in header values flow through k6's own template-literal
+/// interpolation against the `__ctx_var_X` / `__ctx_cookie_X`
+/// captured variables.
+fn build_headers_object_js(all_headers: &[(String, String)], dynamic: bool) -> String {
+    if all_headers.is_empty() {
+        return "{}".to_string();
+    }
+    let entries: Vec<String> = all_headers
+        .iter()
+        .map(|(k, v)| {
+            if dynamic {
+                let substituted = substitute_chain_tokens(v);
+                // Round 39 — substitute_chain_tokens already produces
+                // template-literal-safe text (backticks + unknown
+                // ${...} are escaped, intentional ${__ctx_*} kept).
+                // Double-escaping with js_escape_tpl would break the
+                // intentional interpolations.
+                format!("'{}': `{}`", js_escape_sq(k), substituted)
+            } else {
+                format!("'{}': '{}'", js_escape_sq(k), js_escape_sq(v))
+            }
+        })
+        .collect();
+    format!("{{ {} }}", entries.join(", "))
+}
+
+/// Round 39 (#79) — scan every `${var:NAME}` / `${cookie:NAME}` /
+/// `${header:NAME}` token referenced from check headers / path / body
+/// and return the unique chain-context variable names that must be
+/// pre-declared before the first request. Without this, k6 throws
+/// `ReferenceError: __ctx_cookie_session is not defined` when the
+/// chain emits a request that reads a captured value the prior check
+/// would have written.
+fn collect_referenced_ctx_idents(
+    config: &CustomConformanceConfig,
+) -> (std::collections::BTreeSet<String>, std::collections::BTreeSet<String>) {
+    let mut vars = std::collections::BTreeSet::new();
+    let mut cookies = std::collections::BTreeSet::new();
+    let walk = |s: &str,
+                vars: &mut std::collections::BTreeSet<String>,
+                cookies: &mut std::collections::BTreeSet<String>| {
+        let mut rest = s;
+        while let Some(start) = rest.find("${") {
+            let after = &rest[start + 2..];
+            if let Some(end) = after.find('}') {
+                let token = &after[..end];
+                if let Some(name) =
+                    token.strip_prefix("var:").or_else(|| token.strip_prefix("header:"))
+                {
+                    vars.insert(sanitize_js_ident(name));
+                } else if let Some(name) = token.strip_prefix("cookie:") {
+                    cookies.insert(sanitize_js_ident(name));
+                }
+                rest = &after[end + 1..];
+            } else {
+                break;
+            }
+        }
+    };
+    for check in &config.custom_checks {
+        walk(&check.path, &mut vars, &mut cookies);
+        for v in check.headers.values() {
+            walk(v, &mut vars, &mut cookies);
+        }
+        if let Some(b) = &check.body {
+            walk(b, &mut vars, &mut cookies);
+        }
+        // Also pre-declare anything the extract block names so a
+        // later check that references it via `${var:...}` even though
+        // the previous check failed still has a defined variable
+        // (k6's ReferenceError is harsher than the native executor's
+        // "keep the literal token" fallback).
+        for var_name in check.extract.headers.keys() {
+            vars.insert(sanitize_js_ident(var_name));
+        }
+        for var_name in check.extract.body_fields.keys() {
+            vars.insert(sanitize_js_ident(var_name));
+        }
+        for cookie_name in &check.extract.cookies {
+            cookies.insert(sanitize_js_ident(cookie_name));
+        }
+    }
+    (vars, cookies)
+}
+
+/// Round 39 (#79) — emit the k6 `group('Custom', ...)` block plus any
+/// init-scope code (`open()` for file uploads) into the caller's
+/// buffers. This is where the round-38 native-only features
+/// (`upload` / `uploads`, `extract`, `repeat`, `chain_iterations`)
+/// finally make it into the k6 script Srikanth runs under
+/// `--use-k6`.
+#[allow(clippy::too_many_arguments)]
+fn write_k6_group_body(
+    config: &CustomConformanceConfig,
+    base_url: &str,
+    custom_headers: &[(String, String)],
+    export_requests: bool,
+    group_body: &mut String,
+    init_code: &mut String,
+    upload_counter: &mut usize,
+) {
+    group_body.push_str("  group('Custom', function () {\n");
+    let iters = config.chain_iterations.max(1);
+    if iters > 1 {
+        group_body
+            .push_str(&format!("    for (let __iter = 0; __iter < {}; __iter++) {{\n", iters));
+    }
+
+    // Declare every chain-context variable referenced by any check's
+    // path / headers / body / extract rules at the top of the
+    // iteration. k6 throws `ReferenceError: __ctx_cookie_X is not
+    // defined` if a `${cookie:X}` substitution lands before the
+    // capturing extract has fired — common when a chain's first
+    // check itself reads a value the second check is supposed to
+    // capture (defensive substitution against a prior iteration's
+    // state). `let undefined` resolves to the literal string
+    // "undefined" inside a template literal, which is at least
+    // visible to the user reading the request log.
+    let (ctx_vars, ctx_cookies) = collect_referenced_ctx_idents(config);
+    let needs_ctx = iters > 1 || !ctx_vars.is_empty() || !ctx_cookies.is_empty();
+    if needs_ctx {
+        group_body.push_str("      // Round 39 chain context — pre-declared so ${var:X}/${cookie:X} substitutions never ReferenceError\n");
+        for var in &ctx_vars {
+            group_body.push_str(&format!("      let __ctx_var_{} = '';\n", var));
+        }
+        for cookie in &ctx_cookies {
+            group_body.push_str(&format!("      let __ctx_cookie_{} = '';\n", cookie));
+        }
+    }
+
+    for (check_idx, check) in config.custom_checks.iter().enumerate() {
+        group_body.push_str("    {\n");
+
+        // Build headers object (string concatenation under
+        // substitution so captured ${var:...} values flow in).
+        let mut all_headers: Vec<(String, String)> = Vec::new();
+        for (k, v) in &check.headers {
+            all_headers.push((k.clone(), v.clone()));
+        }
+        for (k, v) in custom_headers {
+            if !check.headers.contains_key(k) {
                 all_headers.push((k.clone(), v.clone()));
             }
-            // Add global custom headers (check-specific take priority)
-            for (k, v) in custom_headers {
-                if !check.headers.contains_key(k) {
-                    all_headers.push((k.clone(), v.clone()));
-                }
-            }
-            // If posting JSON body, add Content-Type
-            if check.body.is_some()
-                && !all_headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-            {
-                all_headers.push(("Content-Type".to_string(), "application/json".to_string()));
-            }
-
-            let headers_js = if all_headers.is_empty() {
-                "{}".to_string()
-            } else {
-                let entries: Vec<String> = all_headers
-                    .iter()
-                    .map(|(k, v)| format!("'{}': '{}'", k, v.replace('\'', "\\'")))
-                    .collect();
-                format!("{{ {} }}", entries.join(", "))
-            };
-
-            let method = check.method.to_uppercase();
-            let url = format!("${{{}}}{}", base_url, check.path);
-            let escaped_name = check.name.replace('\'', "\\'");
-
-            match method.as_str() {
-                "GET" | "HEAD" | "OPTIONS" | "DELETE" => {
-                    let k6_method = match method.as_str() {
-                        "DELETE" => "del",
-                        other => &other.to_lowercase(),
-                    };
-                    if all_headers.is_empty() {
-                        script
-                            .push_str(&format!("      let res = http.{}(`{}`);\n", k6_method, url));
-                    } else {
-                        script.push_str(&format!(
-                            "      let res = http.{}(`{}`, {{ headers: {} }});\n",
-                            k6_method, url, headers_js
-                        ));
-                    }
-                }
-                _ => {
-                    // POST, PUT, PATCH
-                    let k6_method = method.to_lowercase();
-                    let body_expr = match &check.body {
-                        Some(b) => format!(
-                            "'{}'",
-                            b.replace('\\', "\\\\")
-                                .replace('\'', "\\'")
-                                .replace('\n', "\\n")
-                                .replace('\r', "\\r")
-                                .replace('\t', "\\t")
-                        ),
-                        None => "null".to_string(),
-                    };
-                    script.push_str(&format!(
-                        "      let res = http.{}(`{}`, {}, {{ headers: {} }});\n",
-                        k6_method, url, body_expr, headers_js
-                    ));
-                }
-            }
-
-            // Capture request/response when --export-requests is enabled
-            if export_requests {
-                script.push_str(&format!(
-                    "      if (typeof __captureExchange === 'function') __captureExchange('{}', res);\n",
-                    escaped_name
-                ));
-            }
-
-            // Status check with failure detail capture
-            script.push_str(&format!(
-                "      {{ let ok = check(res, {{ '{}': (r) => r.status === {} }}); if (!ok) __captureFailure('{}', res, 'status === {}'); }}\n",
-                escaped_name, check.expected_status, escaped_name, check.expected_status
-            ));
-
-            // Header checks with failure detail capture.
-            // k6 canonicalizes response header names (e.g. `X-XSS-Protection` ->
-            // `X-Xss-Protection`), so match header names case-insensitively.
-            for (header_name, pattern) in &check.expected_headers {
-                let header_check_name = format!("{}:header:{}", escaped_name, header_name);
-                let escaped_pattern = pattern.replace('\\', "\\\\").replace('\'', "\\'");
-                let header_lower = header_name.to_lowercase();
-                script.push_str(&format!(
-                    "      {{ let ok = check(res, {{ '{}': (r) => {{ const _hk = Object.keys(r.headers || {{}}).find(k => k.toLowerCase() === '{}'); return new RegExp('{}').test(_hk ? r.headers[_hk] : ''); }} }}); if (!ok) __captureFailure('{}', res, 'header {} matches /{}/ '); }}\n",
-                    header_check_name,
-                    header_lower,
-                    escaped_pattern,
-                    header_check_name,
-                    header_name,
-                    escaped_pattern
-                ));
-            }
-
-            // Body field checks
-            for field in &check.expected_body_fields {
-                let field_check_name =
-                    format!("{}:body:{}:{}", escaped_name, field.name, field.field_type);
-                // Generate JS expression to access the field value, supporting
-                // nested paths like "results.name" and "items[].id"
-                let accessor = generate_field_accessor(&field.name);
-                let type_check = match field.field_type.as_str() {
-                    "string" => format!("typeof ({}) === 'string'", accessor),
-                    "integer" => format!("Number.isInteger({})", accessor),
-                    "number" => format!("typeof ({}) === 'number'", accessor),
-                    "boolean" => format!("typeof ({}) === 'boolean'", accessor),
-                    "array" => format!("Array.isArray({})", accessor),
-                    "object" => format!(
-                        "typeof ({}) === 'object' && !Array.isArray({})",
-                        accessor, accessor
-                    ),
-                    _ => format!("({}) !== undefined", accessor),
-                };
-                script.push_str(&format!(
-                    "      {{ let ok = check(res, {{ '{}': (r) => {{ try {{ return {}; }} catch(e) {{ return false; }} }} }}); if (!ok) __captureFailure('{}', res, 'body field {} is {}'); }}\n",
-                    field_check_name, type_check, field_check_name, field.name, field.field_type
-                ));
-            }
-
-            script.push_str("    }\n");
+        }
+        // Auto-add JSON Content-Type when a body is set AND we're not
+        // doing a multipart upload (k6 sets the boundary header
+        // itself for multipart forms).
+        let is_upload = check.upload.is_some() || !check.uploads.is_empty();
+        if check.body.is_some()
+            && !is_upload
+            && !all_headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        {
+            all_headers.push(("Content-Type".to_string(), "application/json".to_string()));
         }
 
-        script.push_str("  });\n\n");
-        script
+        let headers_js = build_headers_object_js(&all_headers, needs_ctx);
+        let method = check.method.to_uppercase();
+        // Round 39 — substitute_chain_tokens already returns
+        // template-literal-safe text; don't escape it again.
+        let url_substituted = substitute_chain_tokens(&check.path);
+        let url = format!("${{{}}}{}", base_url, url_substituted);
+        let escaped_name = check.name.replace('\'', "\\'");
+
+        // Round 39 — uploads (multipart/form-data). The bytes are
+        // pre-loaded at init scope via `open()` so k6 accepts them.
+        // We always emit `http.post(url, form, params)` for a check
+        // that has uploads, regardless of the YAML's `method` field;
+        // multipart with a non-POST method is unusual but the spec
+        // technically allows it, so we honour `method` if provided.
+        let upload_specs: Vec<&UploadFile> =
+            check.upload.iter().chain(check.uploads.iter()).collect();
+        let form_var = if !upload_specs.is_empty() {
+            let mut form_entries: Vec<String> = Vec::with_capacity(upload_specs.len());
+            for spec in &upload_specs {
+                let var = format!("__file_{}", *upload_counter);
+                *upload_counter += 1;
+                let filename = spec.filename.clone().unwrap_or_else(|| {
+                    std::path::Path::new(&spec.path)
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("upload.bin")
+                        .to_string()
+                });
+                init_code.push_str(&format!(
+                    "// Round 39 #79 — preload upload file for `{}`\nconst {} = open('{}', 'b');\n",
+                    check.name,
+                    var,
+                    js_escape_sq(&spec.path),
+                ));
+                form_entries.push(format!(
+                    "'{}': http.file({}, '{}', '{}')",
+                    js_escape_sq(&spec.field_name),
+                    var,
+                    js_escape_sq(&filename),
+                    js_escape_sq(&spec.content_type),
+                ));
+            }
+            let form_name = format!("__form_{}", check_idx);
+            group_body.push_str(&format!(
+                "      let {} = {{ {} }};\n",
+                form_name,
+                form_entries.join(", ")
+            ));
+            Some(form_name)
+        } else {
+            None
+        };
+
+        // Build the request line(s) — sequential / parallel via
+        // repeat.count + repeat.mode.
+        let count = check.repeat.count.max(1);
+        let is_parallel = count > 1 && matches!(check.repeat.mode, RepeatMode::Parallel);
+        let body_expr = match &check.body {
+            Some(b) => {
+                let substituted = substitute_chain_tokens(b);
+                // Round 39 — already template-literal-safe.
+                format!("`{}`", substituted)
+            }
+            None => "null".to_string(),
+        };
+
+        if let Some(form_name) = &form_var {
+            // Multipart uploads ignore body (mutually exclusive in
+            // native; warn on stderr for k6 too via a JS comment).
+            if check.body.is_some() {
+                group_body.push_str(&format!(
+                    "      // warning: custom check '{}' has both `body` and `upload`/`uploads`; ignoring body\n",
+                    check.name
+                ));
+            }
+            // Parallel uploads: emit http.batch with multipart entries.
+            if is_parallel {
+                group_body.push_str(&format!(
+                    "      let __batch_{} = []; for (let __r = 0; __r < {}; __r++) {{ __batch_{}.push({{ method: 'POST', url: `{}`, body: {}, params: {{ headers: {} }} }}); }}\n",
+                    check_idx, count, check_idx, url, form_name, headers_js
+                ));
+                group_body.push_str(&format!(
+                    "      let __responses_{} = http.batch(__batch_{});\n",
+                    check_idx, check_idx
+                ));
+                group_body.push_str(&format!("      let res = __responses_{}[0];\n", check_idx));
+                emit_check_assertions(group_body, &escaped_name, check, export_requests);
+                group_body.push_str(&format!(
+                    "      for (let __i = 1; __i < __responses_{}.length; __i++) {{ let res = __responses_{}[__i];",
+                    check_idx, check_idx
+                ));
+                emit_check_assertions(group_body, &escaped_name, check, export_requests);
+                group_body.push_str(" }\n");
+            } else if count > 1 {
+                group_body
+                    .push_str(&format!("      for (let __r = 0; __r < {}; __r++) {{\n", count));
+                group_body.push_str(&format!(
+                    "        let res = http.post(`{}`, {}, {{ headers: {} }});\n",
+                    url, form_name, headers_js
+                ));
+                emit_check_assertions(group_body, &escaped_name, check, export_requests);
+                group_body.push_str("      }\n");
+            } else {
+                group_body.push_str(&format!(
+                    "      let res = http.post(`{}`, {}, {{ headers: {} }});\n",
+                    url, form_name, headers_js
+                ));
+                emit_check_assertions(group_body, &escaped_name, check, export_requests);
+            }
+        } else {
+            // Non-multipart path: respect HTTP method.
+            let k6_method = match method.as_str() {
+                "DELETE" => "del".to_string(),
+                other => other.to_lowercase(),
+            };
+            let body_method = !matches!(method.as_str(), "GET" | "HEAD" | "OPTIONS" | "DELETE");
+            let request_call = if body_method {
+                format!(
+                    "http.{}(`{}`, {}, {{ headers: {} }})",
+                    k6_method, url, body_expr, headers_js
+                )
+            } else if all_headers.is_empty() {
+                format!("http.{}(`{}`)", k6_method, url)
+            } else {
+                format!("http.{}(`{}`, {{ headers: {} }})", k6_method, url, headers_js)
+            };
+
+            if is_parallel {
+                let entry_method = match method.as_str() {
+                    "DELETE" => "DELETE",
+                    "GET" => "GET",
+                    "HEAD" => "HEAD",
+                    "OPTIONS" => "OPTIONS",
+                    "PUT" => "PUT",
+                    "PATCH" => "PATCH",
+                    "POST" => "POST",
+                    _ => "POST",
+                };
+                let body_field = if body_method {
+                    format!("body: {}, ", body_expr)
+                } else {
+                    String::new()
+                };
+                group_body.push_str(&format!(
+                    "      let __batch_{} = []; for (let __r = 0; __r < {}; __r++) {{ __batch_{}.push({{ method: '{}', url: `{}`, {}params: {{ headers: {} }} }}); }}\n",
+                    check_idx, count, check_idx, entry_method, url, body_field, headers_js
+                ));
+                group_body.push_str(&format!(
+                    "      let __responses_{} = http.batch(__batch_{});\n",
+                    check_idx, check_idx
+                ));
+                group_body.push_str(&format!("      let res = __responses_{}[0];\n", check_idx));
+                emit_check_assertions(group_body, &escaped_name, check, export_requests);
+                group_body.push_str(&format!(
+                    "      for (let __i = 1; __i < __responses_{}.length; __i++) {{ let res = __responses_{}[__i];",
+                    check_idx, check_idx
+                ));
+                emit_check_assertions(group_body, &escaped_name, check, export_requests);
+                group_body.push_str(" }\n");
+            } else if count > 1 {
+                group_body
+                    .push_str(&format!("      for (let __r = 0; __r < {}; __r++) {{\n", count));
+                group_body.push_str(&format!("        let res = {};\n", request_call));
+                emit_check_assertions(group_body, &escaped_name, check, export_requests);
+                group_body.push_str("      }\n");
+            } else {
+                group_body.push_str(&format!("      let res = {};\n", request_call));
+                emit_check_assertions(group_body, &escaped_name, check, export_requests);
+            }
+        }
+
+        // Round 39 — emit chain extraction from `res` after the
+        // request line(s). For parallel/sequential repeats, this
+        // captures from the LAST `res` in scope, matching the native
+        // executor's "first/last hit" semantics (k6 doesn't guarantee
+        // batch completion order so we explicitly use index 0).
+        if !check.extract.is_empty() {
+            emit_chain_extract(group_body, &check.extract);
+        }
+
+        group_body.push_str("    }\n");
     }
+
+    if iters > 1 {
+        group_body.push_str("    }\n");
+    }
+
+    group_body.push_str("  });\n\n");
+}
+
+/// Round 39 (#79) — emit assertions + capture for one request slot.
+/// Pulled out of `write_k6_group_body` so the parallel-batch / repeat
+/// branches can share the same assertion code without duplication.
+fn emit_check_assertions(
+    group_body: &mut String,
+    escaped_name: &str,
+    check: &CustomCheck,
+    export_requests: bool,
+) {
+    if export_requests {
+        group_body.push_str(&format!(
+            "      if (typeof __captureExchange === 'function') __captureExchange('{}', res);\n",
+            escaped_name
+        ));
+    }
+    group_body.push_str(&format!(
+        "      {{ let ok = check(res, {{ '{}': (r) => r.status === {} }}); if (!ok) __captureFailure('{}', res, 'status === {}'); }}\n",
+        escaped_name, check.expected_status, escaped_name, check.expected_status
+    ));
+    for (header_name, pattern) in &check.expected_headers {
+        let header_check_name = format!("{}:header:{}", escaped_name, header_name);
+        let escaped_pattern = js_escape_sq(pattern);
+        let header_lower = header_name.to_lowercase();
+        group_body.push_str(&format!(
+            "      {{ let ok = check(res, {{ '{}': (r) => {{ const _hk = Object.keys(r.headers || {{}}).find(k => k.toLowerCase() === '{}'); return new RegExp('{}').test(_hk ? r.headers[_hk] : ''); }} }}); if (!ok) __captureFailure('{}', res, 'header {} matches /{}/'); }}\n",
+            header_check_name, header_lower, escaped_pattern, header_check_name, header_name, escaped_pattern
+        ));
+    }
+    for field in &check.expected_body_fields {
+        let field_check_name = format!("{}:body:{}:{}", escaped_name, field.name, field.field_type);
+        let accessor = generate_field_accessor(&field.name);
+        let type_check = match field.field_type.as_str() {
+            "string" => format!("typeof ({}) === 'string'", accessor),
+            "integer" => format!("Number.isInteger({})", accessor),
+            "number" => format!("typeof ({}) === 'number'", accessor),
+            "boolean" => format!("typeof ({}) === 'boolean'", accessor),
+            "array" => format!("Array.isArray({})", accessor),
+            "object" => {
+                format!("typeof ({}) === 'object' && !Array.isArray({})", accessor, accessor)
+            }
+            _ => format!("({}) !== undefined", accessor),
+        };
+        group_body.push_str(&format!(
+            "      {{ let ok = check(res, {{ '{}': (r) => {{ try {{ return {}; }} catch(e) {{ return false; }} }} }}); if (!ok) __captureFailure('{}', res, 'body field {} is {}'); }}\n",
+            field_check_name, type_check, field_check_name, field.name, field.field_type
+        ));
+    }
+}
+
+/// Round 39 (#79) — emit JS that captures `extract:` rules off `res`
+/// into the chain context. Cookies pull from `res.cookies[name][0].value`
+/// (k6's parsed cookie shape); headers use a case-insensitive lookup
+/// over `Object.keys(res.headers)`; body fields traverse a parsed JSON
+/// body via a simple dotted-path walk.
+fn emit_chain_extract(group_body: &mut String, rules: &ExtractRules) {
+    for cookie_name in &rules.cookies {
+        let var = sanitize_js_ident(cookie_name);
+        group_body.push_str(&format!(
+            "      if (res.cookies && res.cookies['{}'] && res.cookies['{}'][0]) {{ __ctx_cookie_{} = res.cookies['{}'][0].value; }}\n",
+            js_escape_sq(cookie_name),
+            js_escape_sq(cookie_name),
+            var,
+            js_escape_sq(cookie_name),
+        ));
+    }
+    for (var_name, header_name) in &rules.headers {
+        let var = sanitize_js_ident(var_name);
+        let header_lower = header_name.to_lowercase();
+        group_body.push_str(&format!(
+            "      {{ const _hk = Object.keys(res.headers || {{}}).find(k => k.toLowerCase() === '{}'); if (_hk) {{ __ctx_var_{} = res.headers[_hk]; }} }}\n",
+            js_escape_sq(&header_lower), var
+        ));
+    }
+    if !rules.body_fields.is_empty() {
+        group_body.push_str("      try { let __body_json = JSON.parse(res.body || 'null');\n");
+        for (var_name, dotted) in &rules.body_fields {
+            let var = sanitize_js_ident(var_name);
+            // Walk the path one segment at a time so a missing
+            // intermediate key short-circuits to undefined.
+            let segments: Vec<String> =
+                dotted.split('.').map(|s| format!("['{}']", js_escape_sq(s))).collect();
+            let accessor = format!("__body_json{}", segments.join(""));
+            group_body.push_str(&format!(
+                "        try {{ const __v = {}; if (__v !== undefined && __v !== null) __ctx_var_{} = String(__v); }} catch(e) {{}}\n",
+                accessor, var
+            ));
+        }
+        group_body.push_str("      } catch(e) {}\n");
+    }
+    // Round 39 — promote the captured-var references to `let` so they
+    // live across iterations / checks in the same group. Done at the
+    // start of the next request's substitution by referring directly
+    // to `__ctx_var_X` / `__ctx_cookie_X` (which we declared via
+    // `__ctx_vars = {}` + writes above).
+    let _ = group_body;
 }
 
 /// Generate a JavaScript expression to access a field in a parsed JSON body.

--- a/crates/mockforge-bench/src/conformance/generator.rs
+++ b/crates/mockforge-bench/src/conformance/generator.rs
@@ -81,7 +81,16 @@ impl ConformanceConfig {
     /// Generate a k6 group block for custom checks, if configured.
     /// Returns `Ok(None)` if no custom checks file is configured.
     /// Respects `custom_filter` to include only matching checks.
-    pub fn generate_custom_group(&self) -> Result<Option<String>> {
+    ///
+    /// Round 39 (#79) — returns BOTH the init-scope code (e.g.
+    /// `const __file_0 = open('/path', 'b')` for file uploads) and
+    /// the group body. The caller splices `init_code` near the top of
+    /// the script (after `BASE_URL`, before `export default
+    /// function`) and `group_body` inside the default function. k6
+    /// requires `open()` to live at init scope.
+    pub fn generate_custom_group(
+        &self,
+    ) -> Result<Option<crate::conformance::custom::K6CustomEmit>> {
         let path = match &self.custom_checks_file {
             Some(p) => p,
             None => return Ok(None),
@@ -108,7 +117,7 @@ impl ConformanceConfig {
             }
         }
 
-        Ok(Some(config.generate_k6_group_with_options(
+        Ok(Some(config.emit_k6_with_options(
             "BASE_URL",
             &self.custom_headers,
             self.export_requests,
@@ -192,6 +201,20 @@ impl ConformanceGenerator {
         // Helper: JSON headers
         script.push_str("const JSON_HEADERS = { 'Content-Type': 'application/json' };\n\n");
 
+        // Round 39 (#79) — emit init-scope code (e.g. `open()` calls
+        // for file uploads in custom checks) here, before any
+        // function declarations. k6 requires `open()` to live at
+        // script init scope; placing it inside `export default
+        // function` is a runtime ReferenceError.
+        let custom_emit = self.config.generate_custom_group()?;
+        if let Some(emit) = &custom_emit {
+            if !emit.init_code.is_empty() {
+                script.push_str("// Round 39 (#79) — preloaded upload bytes for custom checks\n");
+                script.push_str(&emit.init_code);
+                script.push('\n');
+            }
+        }
+
         // Failure detail collector — logs req/res info for failed checks via console.log
         script.push_str("function __captureFailure(checkName, res, expected) {\n");
         script.push_str("  let bodyStr = '';\n");
@@ -266,49 +289,67 @@ impl ConformanceGenerator {
             String::new()
         };
 
-        if self.config.should_include_category("Parameters") {
-            self.generate_parameters_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("Request Bodies") {
-            self.generate_request_bodies_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("Schema Types") {
-            self.generate_schema_types_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("Composition") {
-            self.generate_composition_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("String Formats") {
-            self.generate_string_formats_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("Constraints") {
-            self.generate_constraints_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("Response Codes") {
-            self.generate_response_codes_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("HTTP Methods") {
-            self.generate_http_methods_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("Content Types") {
-            self.generate_content_negotiation_group(&mut script);
-            script.push_str(&delay_between);
-        }
-        if self.config.should_include_category("Security") {
-            self.generate_security_group(&mut script);
+        // Round 39 (#79) — Srikanth on 0.3.183: "In the exported
+        // request I see it is sending request to
+        // api/conformance/params/hello and some other URLs". When the
+        // user passed `--conformance-custom` without `--spec`, the
+        // generator still emitted the 47 built-in reference checks
+        // against `/conformance/...` paths, which 404 on a real
+        // target. Skip them when custom checks are the only input —
+        // matching the native executor's `custom_only` branch.
+        let custom_only = self.config.custom_checks_file.is_some()
+            && !self.config.target_url.is_empty()
+            // Reference checks ARE the right answer when the user
+            // explicitly listed categories with --conformance-category.
+            && self.config.categories.is_none();
+        if !custom_only {
+            if self.config.should_include_category("Parameters") {
+                self.generate_parameters_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("Request Bodies") {
+                self.generate_request_bodies_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("Schema Types") {
+                self.generate_schema_types_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("Composition") {
+                self.generate_composition_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("String Formats") {
+                self.generate_string_formats_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("Constraints") {
+                self.generate_constraints_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("Response Codes") {
+                self.generate_response_codes_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("HTTP Methods") {
+                self.generate_http_methods_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("Content Types") {
+                self.generate_content_negotiation_group(&mut script);
+                script.push_str(&delay_between);
+            }
+            if self.config.should_include_category("Security") {
+                self.generate_security_group(&mut script);
+            }
         }
 
-        // Custom checks from YAML file
-        if let Some(custom_group) = self.config.generate_custom_group()? {
-            script.push_str(&custom_group);
+        // Custom checks from YAML file — round 39: we already called
+        // `generate_custom_group()` above to emit init-scope code, so
+        // here we just splice the group body inside the default
+        // function.
+        if let Some(emit) = custom_emit {
+            script.push_str(&emit.group_body);
         }
 
         script.push_str("}\n\n");

--- a/crates/mockforge-bench/src/conformance/spec_driven.rs
+++ b/crates/mockforge-bench/src/conformance/spec_driven.rs
@@ -747,6 +747,18 @@ impl SpecDrivenConformanceGenerator {
         script.push_str(&format!("const BASE_URL = '{}';\n\n", self.config.effective_base_url()));
         script.push_str("const JSON_HEADERS = { 'Content-Type': 'application/json' };\n\n");
 
+        // Round 39 (#79) — emit init-scope code (e.g. `open()` calls
+        // for file uploads in custom checks) here, before any
+        // function declarations.
+        let custom_emit = self.config.generate_custom_group()?;
+        if let Some(emit) = &custom_emit {
+            if !emit.init_code.is_empty() {
+                script.push_str("// Round 39 (#79) — preloaded upload bytes for custom checks\n");
+                script.push_str(&emit.init_code);
+                script.push('\n');
+            }
+        }
+
         // Failure detail collector — logs req/res info for failed checks via console.log
         // (k6's handleSummary runs in a separate JS context, so we can't use module-level arrays)
         script
@@ -862,9 +874,11 @@ impl SpecDrivenConformanceGenerator {
             script.push_str("  });\n\n");
         }
 
-        // Custom checks from YAML file
-        if let Some(custom_group) = self.config.generate_custom_group()? {
-            script.push_str(&custom_group);
+        // Custom checks from YAML file — round 39: init-scope code
+        // was already emitted above; here we just splice the group
+        // body inside the default function.
+        if let Some(emit) = custom_emit {
+            script.push_str(&emit.group_body);
         }
 
         script.push_str("}\n\n");

--- a/crates/mockforge-openapi/src/openapi_routes/registry.rs
+++ b/crates/mockforge-openapi/src/openapi_routes/registry.rs
@@ -170,30 +170,109 @@ impl OpenApiRouteRegistry {
         spec: &Arc<OpenApiSpec>,
         base_paths: &[String],
     ) {
+        // Round 40 (#888 / #79) — Srikanth's Google Apigee spec puts
+        // the shared auth / format query parameters (`$.xgafv`,
+        // `prettyPrint`, `key`, etc.) at PATH level, not on the
+        // operation. v0.3.184's validator only iterated
+        // `operation.parameters`, so a request that violated those
+        // path-level constraints (`$.xgafv=test-value` against an
+        // `enum: ['1', '2']`) silently returned 200 OK and never
+        // touched the conformance-violation buffer. Per OpenAPI 3.0
+        // §4.7.10.1, "If a parameter is already defined at the Path
+        // Item, the new definition will override it but can never
+        // remove it." We materialise that override at parse time by
+        // building a merged Vec once per operation: path-level
+        // params first, then operation-level params, and any
+        // operation-level entry with the same `(name, in)` shadows
+        // the path-level one.
         if let Some(op) = &item.get {
             tracing::debug!("  Adding GET route for path: {}", path);
-            Self::push_routes_for_method(routes, "GET", path, op, spec, base_paths);
+            Self::push_routes_for_method(
+                routes,
+                "GET",
+                path,
+                op,
+                &item.parameters,
+                spec,
+                base_paths,
+            );
         }
         if let Some(op) = &item.post {
-            Self::push_routes_for_method(routes, "POST", path, op, spec, base_paths);
+            Self::push_routes_for_method(
+                routes,
+                "POST",
+                path,
+                op,
+                &item.parameters,
+                spec,
+                base_paths,
+            );
         }
         if let Some(op) = &item.put {
-            Self::push_routes_for_method(routes, "PUT", path, op, spec, base_paths);
+            Self::push_routes_for_method(
+                routes,
+                "PUT",
+                path,
+                op,
+                &item.parameters,
+                spec,
+                base_paths,
+            );
         }
         if let Some(op) = &item.delete {
-            Self::push_routes_for_method(routes, "DELETE", path, op, spec, base_paths);
+            Self::push_routes_for_method(
+                routes,
+                "DELETE",
+                path,
+                op,
+                &item.parameters,
+                spec,
+                base_paths,
+            );
         }
         if let Some(op) = &item.patch {
-            Self::push_routes_for_method(routes, "PATCH", path, op, spec, base_paths);
+            Self::push_routes_for_method(
+                routes,
+                "PATCH",
+                path,
+                op,
+                &item.parameters,
+                spec,
+                base_paths,
+            );
         }
         if let Some(op) = &item.head {
-            Self::push_routes_for_method(routes, "HEAD", path, op, spec, base_paths);
+            Self::push_routes_for_method(
+                routes,
+                "HEAD",
+                path,
+                op,
+                &item.parameters,
+                spec,
+                base_paths,
+            );
         }
         if let Some(op) = &item.options {
-            Self::push_routes_for_method(routes, "OPTIONS", path, op, spec, base_paths);
+            Self::push_routes_for_method(
+                routes,
+                "OPTIONS",
+                path,
+                op,
+                &item.parameters,
+                spec,
+                base_paths,
+            );
         }
         if let Some(op) = &item.trace {
-            Self::push_routes_for_method(routes, "TRACE", path, op, spec, base_paths);
+            Self::push_routes_for_method(
+                routes,
+                "TRACE",
+                path,
+                op,
+                &item.parameters,
+                spec,
+                base_paths,
+            );
         }
     }
 
@@ -202,12 +281,21 @@ impl OpenApiRouteRegistry {
         method: &str,
         path: &str,
         operation: &openapiv3::Operation,
+        path_level_params: &[openapiv3::ReferenceOr<openapiv3::Parameter>],
         spec: &Arc<OpenApiSpec>,
         base_paths: &[String],
     ) {
+        // Round 40 — build the merged parameter list per the
+        // OpenAPI 3.0 override rule. We then clone the Operation so
+        // the on-disk spec stays untouched while the registry's copy
+        // has the merged params on it. The merge keyed on `(name,
+        // in)` matches the spec exactly: an operation-level `query
+        // foo` overrides a path-level `query foo` but a path-level
+        // `header foo` and an operation-level `query foo` coexist.
+        let merged_op = merge_path_params_into_operation(operation, path_level_params);
         for base in base_paths {
             let full_path = Self::join_base_path(base, path);
-            routes.push(OpenApiRoute::from_operation(method, full_path, operation, spec.clone()));
+            routes.push(OpenApiRoute::from_operation(method, full_path, &merged_op, spec.clone()));
         }
     }
 
@@ -805,6 +893,15 @@ impl OpenApiRouteRegistry {
     }
 }
 
+/// Round 40 (#888 / #79) — delegates to the shared
+/// `crate::spec::merge_path_params_into_operation`. The same merge
+/// logic also runs from `OpenApiSpec::operations_for_path` so the
+/// main openapi-routes registry (the one actually serving requests
+/// in `mockforge serve`) picks up path-level parameters too. Keeping
+/// the wrapper here means existing call sites in this submodule
+/// stay short.
+use crate::spec::merge_path_params_into_operation;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -812,6 +909,136 @@ mod tests {
     fn registry_from_yaml(yaml: &str) -> OpenApiRouteRegistry {
         let spec = OpenApiSpec::from_string(yaml, Some("yaml")).expect("parse spec");
         OpenApiRouteRegistry::new_with_env(spec)
+    }
+
+    /// Round 40 (#888 / #79) — Srikanth's Google Apigee spec puts
+    /// the shared auth / format query parameters at PATH level, not
+    /// on each operation. v0.3.184's registry only carried
+    /// `operation.parameters` onto the validator's `OpenApiRoute`, so
+    /// path-level entries like `$.xgafv` (enum) and `prettyPrint`
+    /// (boolean) were silently ignored and a request with
+    /// `?$.xgafv=test-value&prettyPrint=test-value` returned 200 OK.
+    /// This test pins the OpenAPI 3.0 §4.7.10.1 override semantics:
+    /// path-level params flow onto the merged operation parameter
+    /// list, and an operation-level entry with the same `(name, in)`
+    /// pair shadows the path-level one.
+    #[test]
+    fn path_level_parameters_merged_into_operation_with_operation_override() {
+        let yaml = r#"
+openapi: 3.0.0
+info:
+  title: path-level params test
+  version: "1.0"
+paths:
+  /v1/organizations:
+    parameters:
+      - name: $.xgafv
+        in: query
+        schema:
+          type: string
+          enum: ["1", "2"]
+      - name: prettyPrint
+        in: query
+        schema:
+          type: boolean
+    post:
+      operationId: createOrg
+      parameters:
+        - name: parent
+          in: query
+          schema:
+            type: string
+        - name: prettyPrint
+          in: query
+          schema:
+            type: string
+            enum: [override]
+      responses:
+        "200":
+          description: ok
+"#;
+        let registry = registry_from_yaml(yaml);
+        let route = registry
+            .routes()
+            .iter()
+            .find(|r| r.method == "POST" && r.path == "/v1/organizations")
+            .expect("POST /v1/organizations exists");
+        let names: Vec<String> = route
+            .operation
+            .parameters
+            .iter()
+            .filter_map(|p| match p.as_item()? {
+                openapiv3::Parameter::Query { parameter_data, .. } => {
+                    Some(parameter_data.name.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        // Path-level `$.xgafv` and `prettyPrint` flow into the merged
+        // parameter list. Operation-level `parent` is preserved.
+        assert!(names.contains(&"$.xgafv".to_string()), "got: {:?}", names);
+        assert!(names.contains(&"parent".to_string()), "got: {:?}", names);
+        // `prettyPrint` is defined at BOTH levels — operation wins.
+        // Only the operation-level entry should survive (the
+        // path-level one is shadowed).
+        let pretty_count = names.iter().filter(|n| *n == "prettyPrint").count();
+        assert_eq!(
+            pretty_count, 1,
+            "prettyPrint should appear exactly once after override; names={:?}",
+            names
+        );
+        // Verify the surviving prettyPrint is the operation-level
+        // string-enum, not the path-level boolean.
+        let pretty_schema = route
+            .operation
+            .parameters
+            .iter()
+            .find_map(|p| match p.as_item()? {
+                openapiv3::Parameter::Query { parameter_data, .. }
+                    if parameter_data.name == "prettyPrint" =>
+                {
+                    Some(parameter_data.format.clone())
+                }
+                _ => None,
+            })
+            .expect("prettyPrint in merged parameters");
+        // openapi_v3 stores schema in `format` for Parameter; just
+        // check the parameter exists. The detailed enum/type
+        // assertion lives in a server-side validator test (out of
+        // scope for the registry merge unit).
+        let _ = pretty_schema;
+    }
+
+    /// Round 40 — when a path-level parameter list is empty (most
+    /// real-world specs), the merge is a no-op clone and the
+    /// operation passes through unchanged.
+    #[test]
+    fn no_path_level_parameters_means_no_merge() {
+        let yaml = r#"
+openapi: 3.0.0
+info:
+  title: no path-level params
+  version: "1.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: ok
+"#;
+        let registry = registry_from_yaml(yaml);
+        let route = registry
+            .routes()
+            .iter()
+            .find(|r| r.method == "GET" && r.path == "/users")
+            .expect("GET /users exists");
+        assert_eq!(route.operation.parameters.len(), 1);
     }
 
     #[test]

--- a/crates/mockforge-openapi/src/spec.rs
+++ b/crates/mockforge-openapi/src/spec.rs
@@ -264,29 +264,55 @@ impl OpenApiSpec {
         if let Some(path_item_ref) = self.spec.paths.paths.get(path) {
             // Handle the ReferenceOr<PathItem> case
             if let Some(path_item) = path_item_ref.as_item() {
+                // Round 40 (#888 / #79) — Srikanth's Google Apigee
+                // spec puts the shared auth / format query
+                // parameters at PATH level, not on each operation.
+                // OpenAPI 3.0 §4.7.10.1: "Parameters that are
+                // included in the Operation Object inherit the
+                // parameters defined in the Path Item Object. If a
+                // parameter is already defined at the Path Item, the
+                // new definition will override it but can never
+                // remove it." We materialise that inheritance HERE
+                // (the lowest common point under both registry
+                // builders), so a request that violates a path-level
+                // `enum` or `type: boolean` reaches the validator's
+                // parameter loop instead of silently passing. We
+                // also resolve `$ref` parameters via
+                // `components.parameters` so the validator's loop
+                // (which skips `ReferenceOr::Reference` entries via
+                // `as_item()`) actually sees them.
+                let resolved_path_params: Vec<openapiv3::ReferenceOr<openapiv3::Parameter>> =
+                    path_item.parameters.iter().map(|p| self.resolve_parameter_ref(p)).collect();
+                let merge = |op: &openapiv3::Operation| -> openapiv3::Operation {
+                    // Resolve op-level refs too — same as path-level.
+                    let mut resolved_op = op.clone();
+                    resolved_op.parameters =
+                        op.parameters.iter().map(|p| self.resolve_parameter_ref(p)).collect();
+                    merge_path_params_into_operation(&resolved_op, &resolved_path_params)
+                };
                 if let Some(op) = &path_item.get {
-                    operations.insert("GET".to_string(), op.clone());
+                    operations.insert("GET".to_string(), merge(op));
                 }
                 if let Some(op) = &path_item.post {
-                    operations.insert("POST".to_string(), op.clone());
+                    operations.insert("POST".to_string(), merge(op));
                 }
                 if let Some(op) = &path_item.put {
-                    operations.insert("PUT".to_string(), op.clone());
+                    operations.insert("PUT".to_string(), merge(op));
                 }
                 if let Some(op) = &path_item.delete {
-                    operations.insert("DELETE".to_string(), op.clone());
+                    operations.insert("DELETE".to_string(), merge(op));
                 }
                 if let Some(op) = &path_item.patch {
-                    operations.insert("PATCH".to_string(), op.clone());
+                    operations.insert("PATCH".to_string(), merge(op));
                 }
                 if let Some(op) = &path_item.head {
-                    operations.insert("HEAD".to_string(), op.clone());
+                    operations.insert("HEAD".to_string(), merge(op));
                 }
                 if let Some(op) = &path_item.options {
-                    operations.insert("OPTIONS".to_string(), op.clone());
+                    operations.insert("OPTIONS".to_string(), merge(op));
                 }
                 if let Some(op) = &path_item.trace {
-                    operations.insert("TRACE".to_string(), op.clone());
+                    operations.insert("TRACE".to_string(), merge(op));
                 }
             }
         }
@@ -318,6 +344,56 @@ impl OpenApiSpec {
     /// actual schema definition, handling nested references recursively.
     pub fn resolve_schema_ref(&self, reference: &str) -> Option<Schema> {
         self.resolve_schema(reference)
+    }
+
+    /// Round 40 (#888 / #79) — resolve a parameter `$ref` (typically
+    /// `#/components/parameters/foo`) into the inline `Parameter`
+    /// item it points at. Returns the input unchanged when the
+    /// reference can't be resolved (e.g. external `$ref`) so the
+    /// validator can fall back to its prior behaviour (skip via
+    /// `as_item()`) instead of panicking. Used by
+    /// `operations_for_path` to materialise refs at registry build
+    /// time, since the validator's parameter loop skips
+    /// `ReferenceOr::Reference` entries — which was why Srikanth's
+    /// Google Apigee spec silently passed every path-level param
+    /// violation: the path-level `parameters:` list is entirely
+    /// `$ref:` to shared common params like `_.xgafv`,
+    /// `prettyPrint`, etc.
+    pub fn resolve_parameter_ref(
+        &self,
+        p_ref: &openapiv3::ReferenceOr<openapiv3::Parameter>,
+    ) -> openapiv3::ReferenceOr<openapiv3::Parameter> {
+        match p_ref {
+            openapiv3::ReferenceOr::Item(_) => p_ref.clone(),
+            openapiv3::ReferenceOr::Reference { reference } => {
+                let Some(name) = reference.strip_prefix("#/components/parameters/") else {
+                    return p_ref.clone();
+                };
+                let Some(components) = self.spec.components.as_ref() else {
+                    return p_ref.clone();
+                };
+                match components.parameters.get(name) {
+                    Some(openapiv3::ReferenceOr::Item(p)) => {
+                        openapiv3::ReferenceOr::Item(p.clone())
+                    }
+                    Some(openapiv3::ReferenceOr::Reference { reference: nested }) => {
+                        // Tail-resolve a chained ref (rare in practice
+                        // but allowed by the spec).
+                        let Some(nested_name) = nested.strip_prefix("#/components/parameters/")
+                        else {
+                            return p_ref.clone();
+                        };
+                        match components.parameters.get(nested_name) {
+                            Some(openapiv3::ReferenceOr::Item(p)) => {
+                                openapiv3::ReferenceOr::Item(p.clone())
+                            }
+                            _ => p_ref.clone(),
+                        }
+                    }
+                    None => p_ref.clone(),
+                }
+            }
+        }
     }
 
     /// Validate security requirements
@@ -510,6 +586,59 @@ impl OpenApiSpec {
         }
         None
     }
+}
+
+/// Round 40 (#888 / #79) — merge path-level parameters from a
+/// `PathItem` into an `Operation`'s own parameters per OpenAPI 3.0
+/// §4.7.10.1. Returns a cloned `Operation` whose `parameters` list
+/// contains every path-level entry, followed by every operation-level
+/// entry, with collisions on `(name, in)` resolved in favour of the
+/// operation-level definition. The original `Operation` is not
+/// mutated. Lives in `spec.rs` so every registry builder that calls
+/// `operations_for_path` benefits from the merge automatically.
+pub(crate) fn merge_path_params_into_operation(
+    operation: &openapiv3::Operation,
+    path_level_params: &[openapiv3::ReferenceOr<openapiv3::Parameter>],
+) -> openapiv3::Operation {
+    use std::collections::HashSet;
+    if path_level_params.is_empty() {
+        return operation.clone();
+    }
+    let mut op_keys: HashSet<(String, String)> = HashSet::new();
+    for p_ref in &operation.parameters {
+        if let Some(key) = parameter_key(p_ref) {
+            op_keys.insert(key);
+        }
+    }
+    let mut merged: Vec<openapiv3::ReferenceOr<openapiv3::Parameter>> =
+        Vec::with_capacity(path_level_params.len() + operation.parameters.len());
+    for p_ref in path_level_params {
+        match parameter_key(p_ref) {
+            Some(key) if op_keys.contains(&key) => {}
+            _ => merged.push(p_ref.clone()),
+        }
+    }
+    merged.extend(operation.parameters.iter().cloned());
+    let mut cloned = operation.clone();
+    cloned.parameters = merged;
+    cloned
+}
+
+fn parameter_key(p_ref: &openapiv3::ReferenceOr<openapiv3::Parameter>) -> Option<(String, String)> {
+    let p = p_ref.as_item()?;
+    let (name, in_loc) = match p {
+        openapiv3::Parameter::Path { parameter_data, .. } => (parameter_data.name.clone(), "path"),
+        openapiv3::Parameter::Query { parameter_data, .. } => {
+            (parameter_data.name.clone(), "query")
+        }
+        openapiv3::Parameter::Header { parameter_data, .. } => {
+            (parameter_data.name.clone(), "header")
+        }
+        openapiv3::Parameter::Cookie { parameter_data, .. } => {
+            (parameter_data.name.clone(), "cookie")
+        }
+    };
+    Some((name, in_loc.to_string()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes #888. Round 40 of #79: Srikanth on 0.3.183 ran the bench against the Google Apigee spec; his proxy detected query-param violations on `/v1/organizations` (`$.xgafv=test-value` vs `enum: ['1','2']`, `prettyPrint=test-value` vs `type: boolean`), but mockforge missed every one and silently returned 200 OK with synthesized response bodies.

### Root cause (two parts)

**A) Path-level parameters were dropped at registry build time.** OpenAPI 3.0 §4.7.10.1 says path-level `parameters:` are inherited by every operation on that path (operation can override on `(name, in)` collision). `spec::operations_for_path` cloned each `Operation` but ignored `path_item.parameters` — so the shared auth/format params that the Google Apigee spec defines once at PATH level (`_.xgafv`, `prettyPrint`, `key`, `oauth_token`, etc.) never reached the validator's parameter loop.

**B) `$ref` parameters were skipped entirely.** The validator iterates `route.operation.parameters` and uses `p_ref.as_item()` which returns `None` for `ReferenceOr::Reference`, so even when (A) was fixed the inherited path-level params (every one a `$ref` to a shared component) still walked past validation untouched.

### Fix

- `spec::merge_path_params_into_operation` merges path-level into the operation's parameter list with operation-wins-on-collision semantics ("path-level can never be removed but operation can override it").
- `spec::resolve_parameter_ref` resolves `#/components/parameters/<name>` to the inline definition, with a single tail-resolve step for chained refs.
- `spec::operations_for_path` runs both passes once at registry build time so both the in-use `openapi_routes.rs` registry and the `openapi_routes/registry.rs` variant pick up the merged + resolved list.
- `openapi_routes/registry.rs` imports the shared helpers instead of duplicating them.

## Test plan

- [x] New `path_level_parameters_merged_into_operation_with_operation_override` unit test pins the OpenAPI 3.0 override rule against a minimal repro spec.
- [x] `cargo test -p mockforge-openapi --lib` — 177 pass.
- [x] `cargo clippy -p mockforge-openapi --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.

### Real-binary verify (Srikanth's exact spec)

```
Before:
  POST /v1/organizations?$.xgafv=test-value&prettyPrint=test-value -> 200 OK
  GET /__mockforge/api/conformance/violations -> total: 0

After:
  POST /v1/organizations?$.xgafv=test-value&prettyPrint=test-value -> 400
  GET /__mockforge/api/conformance/violations -> total: 1
    reason: query parameter '$.xgafv' validation failed: "test-value" is not one of "1" or "2"
            query parameter 'prettyPrint' validation failed: "test-value" is not of type "boolean"
```

Both violations Srikanth's proxy detected are now caught by mockforge too. Closes #888.