### PR TITLE
ci: pin remaining direct dtolnay/rust-toolchain@stable usages to 1.96.0

### DIFF
--- a/.github/workflows/chaos-testing.yml
+++ b/.github/workflows/chaos-testing.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install protoc
         run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,7 +36,7 @@ jobs:
         mdbook-version: '0.4.40'
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Build book
       run: |

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -32,7 +32,7 @@ jobs:
           mdbook-version: '0.4.40'
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache mdBook plugins
         uses: actions/cache@v5

--- a/.github/workflows/jcs-fuzz.yml
+++ b/.github/workflows/jcs-fuzz.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install k6
         run: 'command -v k6 > /dev/null 2>&1 || { echo "::error::k6 missing on self-hosted runner. Install: see https://k6.io/docs/getting-started/installation/"; exit 1; }'
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install k6
         run: 'command -v k6 > /dev/null 2>&1 || { echo "::error::k6 missing on self-hosted runner. Install: see https://k6.io/docs/getting-started/installation/"; exit 1; }'
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install protoc
         run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'

--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 
@@ -162,7 +162,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 
@@ -216,7 +216,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev
@@ -138,7 +138,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Why
Completes the toolchain-drift fix started in #891. That PR pinned everything routed through the composite action (`.github/actions/rust-toolchain` default) plus `ci.yml` and `registry-e2e.yml`. But **8 workflows call `dtolnay/rust-toolchain@stable` directly**, bypassing the composite action, so they were still tracking floating stable:

`release.yml` (×2), `plugin-publish.yml` (×3), `deploy-docs.yml`, `docs-check.yml`, `chaos-testing.yml`, `jcs-fuzz.yml`, `mutation-testing.yml`, `load-testing.yml` (×3)

## Change
`dtolnay/rust-toolchain@stable` → `@1.96.0` in all of them. dtolnay maintains a `1.96.0` branch (verified via the GitHub API before changing the ref). `fuzz.yml` is intentionally left on `@nightly` — fuzzing requires nightly, that's not drift.

This pins to the version the runner already uses, so there's **no behavior change today** — it just stops silent breakage on the next stable bump. Now consistent with `rust-toolchain.toml` and the composite-action default.

## Verification
- All 8 edited workflow files parse cleanly (`yaml.safe_load`).
- No `uses: dtolnay/rust-toolchain@stable` remain anywhere; only `fuzz.yml@nightly` is left by design.