### PR TITLE
fix(openapi): remove redundant openapiv3::ReferenceOr qualifications (Rust 1.96)

### DIFF
--- a/crates/mockforge-openapi/src/openapi_routes/registry.rs
+++ b/crates/mockforge-openapi/src/openapi_routes/registry.rs
@@ -281,7 +281,7 @@ impl OpenApiRouteRegistry {
         method: &str,
         path: &str,
         operation: &openapiv3::Operation,
-        path_level_params: &[openapiv3::ReferenceOr<openapiv3::Parameter>],
+        path_level_params: &[ReferenceOr<openapiv3::Parameter>],
         spec: &Arc<OpenApiSpec>,
         base_paths: &[String],
     ) {

--- a/crates/mockforge-openapi/src/spec.rs
+++ b/crates/mockforge-openapi/src/spec.rs
@@ -281,7 +281,7 @@ impl OpenApiSpec {
                 // `components.parameters` so the validator's loop
                 // (which skips `ReferenceOr::Reference` entries via
                 // `as_item()`) actually sees them.
-                let resolved_path_params: Vec<openapiv3::ReferenceOr<openapiv3::Parameter>> =
+                let resolved_path_params: Vec<ReferenceOr<openapiv3::Parameter>> =
                     path_item.parameters.iter().map(|p| self.resolve_parameter_ref(p)).collect();
                 let merge = |op: &openapiv3::Operation| -> openapiv3::Operation {
                     // Resolve op-level refs too — same as path-level.
@@ -361,11 +361,11 @@ impl OpenApiSpec {
     /// `prettyPrint`, etc.
     pub fn resolve_parameter_ref(
         &self,
-        p_ref: &openapiv3::ReferenceOr<openapiv3::Parameter>,
-    ) -> openapiv3::ReferenceOr<openapiv3::Parameter> {
+        p_ref: &ReferenceOr<openapiv3::Parameter>,
+    ) -> ReferenceOr<openapiv3::Parameter> {
         match p_ref {
-            openapiv3::ReferenceOr::Item(_) => p_ref.clone(),
-            openapiv3::ReferenceOr::Reference { reference } => {
+            ReferenceOr::Item(_) => p_ref.clone(),
+            ReferenceOr::Reference { reference } => {
                 let Some(name) = reference.strip_prefix("#/components/parameters/") else {
                     return p_ref.clone();
                 };
@@ -373,10 +373,8 @@ impl OpenApiSpec {
                     return p_ref.clone();
                 };
                 match components.parameters.get(name) {
-                    Some(openapiv3::ReferenceOr::Item(p)) => {
-                        openapiv3::ReferenceOr::Item(p.clone())
-                    }
-                    Some(openapiv3::ReferenceOr::Reference { reference: nested }) => {
+                    Some(ReferenceOr::Item(p)) => ReferenceOr::Item(p.clone()),
+                    Some(ReferenceOr::Reference { reference: nested }) => {
                         // Tail-resolve a chained ref (rare in practice
                         // but allowed by the spec).
                         let Some(nested_name) = nested.strip_prefix("#/components/parameters/")
@@ -384,9 +382,7 @@ impl OpenApiSpec {
                             return p_ref.clone();
                         };
                         match components.parameters.get(nested_name) {
-                            Some(openapiv3::ReferenceOr::Item(p)) => {
-                                openapiv3::ReferenceOr::Item(p.clone())
-                            }
+                            Some(ReferenceOr::Item(p)) => ReferenceOr::Item(p.clone()),
                             _ => p_ref.clone(),
                         }
                     }
@@ -598,7 +594,7 @@ impl OpenApiSpec {
 /// `operations_for_path` benefits from the merge automatically.
 pub(crate) fn merge_path_params_into_operation(
     operation: &openapiv3::Operation,
-    path_level_params: &[openapiv3::ReferenceOr<openapiv3::Parameter>],
+    path_level_params: &[ReferenceOr<openapiv3::Parameter>],
 ) -> openapiv3::Operation {
     use std::collections::HashSet;
     if path_level_params.is_empty() {
@@ -610,7 +606,7 @@ pub(crate) fn merge_path_params_into_operation(
             op_keys.insert(key);
         }
     }
-    let mut merged: Vec<openapiv3::ReferenceOr<openapiv3::Parameter>> =
+    let mut merged: Vec<ReferenceOr<openapiv3::Parameter>> =
         Vec::with_capacity(path_level_params.len() + operation.parameters.len());
     for p_ref in path_level_params {
         match parameter_key(p_ref) {
@@ -624,7 +620,7 @@ pub(crate) fn merge_path_params_into_operation(
     cloned
 }
 
-fn parameter_key(p_ref: &openapiv3::ReferenceOr<openapiv3::Parameter>) -> Option<(String, String)> {
+fn parameter_key(p_ref: &ReferenceOr<openapiv3::Parameter>) -> Option<(String, String)> {
     let p = p_ref.as_item()?;
     let (name, in_loc) = match p {
         openapiv3::Parameter::Path { parameter_data, .. } => (parameter_data.name.clone(), "path"),


### PR DESCRIPTION
## Why main's `Test (1.96.0)` is red again
The r40 path-level-parameter work (#888/#892) added code to `mockforge-openapi` that writes the already-imported `ReferenceOr` type as `openapiv3::ReferenceOr`. Rust 1.96's `unused_qualifications` lint rejects that, and CI's clippy step denies it (`-D unused_qualifications`).

It landed on `main` because the **Test/clippy job is non-required** — only Security Audit + Registry E2E gate merges — so #892 merged with a red Test and reintroduced the lint in a crate my earlier sweep (#890) didn't touch.

## Fix
14 occurrences → `openapiv3::ReferenceOr` becomes `ReferenceOr` (inner `openapiv3::Parameter` stays — it isn't imported):
- `crates/mockforge-openapi/src/spec.rs` (13)
- `crates/mockforge-openapi/src/openapi_routes/registry.rs` (1)

## Verification
- `cargo clippy -p mockforge-openapi --lib --bins --all-features -- -D clippy::correctness -D unused_qualifications` → exit 0.
- `rustfmt --check` clean.

## Systemic note
This is the third time `unused_qualifications` has reached `main` (it's now pinned against *toolchain* drift via #891/#893, but new code can still introduce violations). Because `Test`/clippy is **non-required**, such violations merge freely and only show up after the fact. The durable fix is to make the clippy gate a **required** status check — flagged for a maintainer decision (trade-off: it would block merges while the self-hosted runners are backed up).