### PR TITLE
fix(bench,openapi): r41 — fresh cookie jar + summary aggregation + category labels (#79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9294,14 +9294,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.184"
+version = "0.3.185"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/crates/mockforge-bench/src/conformance/custom.rs
+++ b/crates/mockforge-bench/src/conformance/custom.rs
@@ -470,6 +470,34 @@ fn write_k6_group_body(
     init_code: &mut String,
     upload_counter: &mut usize,
 ) {
+    // Round 41 (#79) — Srikanth on 0.3.185: with `extract.cookies` and
+    // `${cookie:NAME}` substitution working, k6's per-VU cookie jar
+    // ALSO auto-collected the response's `Set-Cookie` and re-injected
+    // it on every subsequent request — so the POST went out with TWO
+    // copies of `albsessid` in its `Cookie:` header (one from our
+    // explicit substitution, one from the jar). Disable the auto-jar
+    // for custom checks by passing a fresh empty `jar` per request.
+    // The explicit `Cookie:` header set by `${cookie:NAME}`
+    // substitution becomes the only source of truth. Also addresses
+    // Srikanth's round-41 ask "have ... without Cookie in GET": with
+    // no jar, the GET in iteration K+1 does not inherit cookies from
+    // iteration K's responses unless the user explicitly forwards
+    // them via `${cookie:NAME}`. The `http.CookieJar` constructor
+    // exists in k6 1.0+ (k6 wraps the underlying `cookiejar` Go type
+    // as a JS class — `new http.CookieJar()` creates an empty one
+    // with no shared state with the VU default jar).
+    let uses_cookie_substitution = config.custom_checks.iter().any(|c| {
+        !c.extract.cookies.is_empty()
+            || c.headers.values().any(|v| v.contains("${cookie:") || v.contains("${var:"))
+    });
+    if uses_cookie_substitution {
+        init_code.push_str(
+            "// Round 41 (#79) — declared once so every chain request can reuse it;\n\
+             // a fresh empty jar suppresses k6's auto-injected Set-Cookie that would\n\
+             // otherwise duplicate the explicit `${cookie:NAME}` substitution.\n\
+             const __custom_jar_factory = () => new http.CookieJar();\n",
+        );
+    }
     group_body.push_str("  group('Custom', function () {\n");
     let iters = config.chain_iterations.max(1);
     if iters > 1 {
@@ -525,6 +553,15 @@ fn write_k6_group_body(
         }
 
         let headers_js = build_headers_object_js(&all_headers, needs_ctx);
+        // Round 41 (#79) — wrap headers + jar into a `params` object
+        // so each request can carry its own fresh CookieJar and the
+        // VU's shared jar can't double up cookies that the user is
+        // already injecting via `${cookie:NAME}`.
+        let params_js = if uses_cookie_substitution {
+            format!("{{ headers: {}, jar: __custom_jar_factory() }}", headers_js)
+        } else {
+            format!("{{ headers: {} }}", headers_js)
+        };
         let method = check.method.to_uppercase();
         // Round 39 — substitute_chain_tokens already returns
         // template-literal-safe text; don't escape it again.
@@ -572,6 +609,41 @@ fn write_k6_group_body(
                 form_name,
                 form_entries.join(", ")
             ));
+            // Round 41 (#79) — Srikanth on 0.3.185: PCAP only showed
+            // 5 of his 9 multi-file upload parts and he asked "Is
+            // there a way from Logs I can confirm all the files in
+            // multiple upload are sent from mockforge client". Emit a
+            // single tagged log line per request listing every part,
+            // so the user can grep `MOCKFORGE_UPLOAD_PARTS` in the
+            // k6 stdout and confirm all parts left mockforge even
+            // when their proxy / capture tool drops some. We do this
+            // here (NOT inside the repeat loop) because the form is
+            // identical across repeats; the count from `repeat` tells
+            // the user how many requests will go out.
+            let summary_entries: Vec<String> = upload_specs
+                .iter()
+                .map(|spec| {
+                    let filename = spec.filename.clone().unwrap_or_else(|| {
+                        Path::new(&spec.path)
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("upload.bin")
+                            .to_string()
+                    });
+                    format!(
+                        "'{}':'{}' ({})",
+                        js_escape_sq(&spec.field_name),
+                        js_escape_sq(&filename),
+                        js_escape_sq(&spec.content_type)
+                    )
+                })
+                .collect();
+            group_body.push_str(&format!(
+                "      console.log('MOCKFORGE_UPLOAD_PARTS: {} {} files: {}');\n",
+                js_escape_sq(&check.name),
+                upload_specs.len(),
+                js_escape_sq(&summary_entries.join(", ")),
+            ));
             Some(form_name)
         } else {
             None
@@ -602,8 +674,8 @@ fn write_k6_group_body(
             // Parallel uploads: emit http.batch with multipart entries.
             if is_parallel {
                 group_body.push_str(&format!(
-                    "      let __batch_{} = []; for (let __r = 0; __r < {}; __r++) {{ __batch_{}.push({{ method: 'POST', url: `{}`, body: {}, params: {{ headers: {} }} }}); }}\n",
-                    check_idx, count, check_idx, url, form_name, headers_js
+                    "      let __batch_{} = []; for (let __r = 0; __r < {}; __r++) {{ __batch_{}.push({{ method: 'POST', url: `{}`, body: {}, params: {} }}); }}\n",
+                    check_idx, count, check_idx, url, form_name, params_js
                 ));
                 group_body.push_str(&format!(
                     "      let __responses_{} = http.batch(__batch_{});\n",
@@ -621,15 +693,15 @@ fn write_k6_group_body(
                 group_body
                     .push_str(&format!("      for (let __r = 0; __r < {}; __r++) {{\n", count));
                 group_body.push_str(&format!(
-                    "        let res = http.post(`{}`, {}, {{ headers: {} }});\n",
-                    url, form_name, headers_js
+                    "        let res = http.post(`{}`, {}, {});\n",
+                    url, form_name, params_js
                 ));
                 emit_check_assertions(group_body, &escaped_name, check, export_requests);
                 group_body.push_str("      }\n");
             } else {
                 group_body.push_str(&format!(
-                    "      let res = http.post(`{}`, {}, {{ headers: {} }});\n",
-                    url, form_name, headers_js
+                    "      let res = http.post(`{}`, {}, {});\n",
+                    url, form_name, params_js
                 ));
                 emit_check_assertions(group_body, &escaped_name, check, export_requests);
             }
@@ -640,15 +712,17 @@ fn write_k6_group_body(
                 other => other.to_lowercase(),
             };
             let body_method = !matches!(method.as_str(), "GET" | "HEAD" | "OPTIONS" | "DELETE");
+            // Round 41 — always pass `params_js` (which carries the
+            // jar) when chain-context substitution is in play, even
+            // on requests that have no headers of their own. This is
+            // how the GET in the user's chain gets `jar: empty` so
+            // k6 doesn't accumulate Set-Cookie into the VU jar.
             let request_call = if body_method {
-                format!(
-                    "http.{}(`{}`, {}, {{ headers: {} }})",
-                    k6_method, url, body_expr, headers_js
-                )
-            } else if all_headers.is_empty() {
+                format!("http.{}(`{}`, {}, {})", k6_method, url, body_expr, params_js)
+            } else if all_headers.is_empty() && !uses_cookie_substitution {
                 format!("http.{}(`{}`)", k6_method, url)
             } else {
-                format!("http.{}(`{}`, {{ headers: {} }})", k6_method, url, headers_js)
+                format!("http.{}(`{}`, {})", k6_method, url, params_js)
             };
 
             if is_parallel {
@@ -668,8 +742,8 @@ fn write_k6_group_body(
                     String::new()
                 };
                 group_body.push_str(&format!(
-                    "      let __batch_{} = []; for (let __r = 0; __r < {}; __r++) {{ __batch_{}.push({{ method: '{}', url: `{}`, {}params: {{ headers: {} }} }}); }}\n",
-                    check_idx, count, check_idx, entry_method, url, body_field, headers_js
+                    "      let __batch_{} = []; for (let __r = 0; __r < {}; __r++) {{ __batch_{}.push({{ method: '{}', url: `{}`, {}params: {} }}); }}\n",
+                    check_idx, count, check_idx, entry_method, url, body_field, params_js
                 ));
                 group_body.push_str(&format!(
                     "      let __responses_{} = http.batch(__batch_{});\n",

--- a/crates/mockforge-bench/src/conformance/generator.rs
+++ b/crates/mockforge-bench/src/conformance/generator.rs
@@ -253,8 +253,22 @@ impl ConformanceGenerator {
             script.push_str(
                 "  if (res.request && res.request.headers) { reqHeaders = res.request.headers; }\n",
             );
+            // Round 41 (#79) — Srikanth on 0.3.185: "When run without
+            // Spec the export request file has blank entry". k6's
+            // `res.request.body` is empty for multipart uploads (k6
+            // serialises the form internally and the JS-side body
+            // string is null). Fall back to a content-type-derived
+            // summary so the export at least surfaces "multipart/form-data; N parts"
+            // instead of an empty string. Real bodies still surface
+            // unchanged.
             script.push_str("  let reqBody = '';\n");
             script.push_str("  if (res.request && res.request.body) { try { reqBody = res.request.body.substring(0, 2000); } catch(e) {} }\n");
+            script.push_str(
+                "  if (!reqBody) {\n\
+                 \x20\x20\x20\x20const ct = (reqHeaders['Content-Type'] || reqHeaders['content-type'] || '').toString();\n\
+                 \x20\x20\x20\x20if (ct.startsWith('multipart/')) reqBody = '<multipart upload; body bytes not surfaced by k6 res.request.body>';\n\
+                 \x20\x20}\n",
+            );
             script.push_str("  console.log('MOCKFORGE_EXCHANGE:' + JSON.stringify({\n");
             script.push_str("    check: checkName,\n");
             script.push_str("    request: {\n");

--- a/crates/mockforge-bench/src/conformance/report.rs
+++ b/crates/mockforge-bench/src/conformance/report.rs
@@ -118,6 +118,7 @@ where
 /// Extract the base name of a custom check.
 /// Custom sub-checks have format "custom:name:header:..." or "custom:name:body:..."
 /// The base name is just the primary check (e.g., "custom:pets-returns-200").
+#[allow(dead_code)]
 fn extract_custom_base_name(check_name: &str) -> String {
     // "custom:" prefix is 7 chars. Find the next colon after that.
     let after_prefix = &check_name[7..];
@@ -126,6 +127,20 @@ fn extract_custom_base_name(check_name: &str) -> String {
     } else {
         check_name.to_string()
     }
+}
+
+/// Round 41 (#79) — `true` when `check_name` is the PRIMARY status
+/// check for a custom YAML entry, not a header / body sub-check.
+/// Sub-checks have the form `custom:name:header:<header>` or
+/// `custom:name:body:<field>:<type>`; we only count primaries in the
+/// "Custom" category total so a check with N header assertions
+/// doesn't appear as N+1 requests.
+fn is_primary_custom_check(check_name: &str) -> bool {
+    if !check_name.starts_with("custom:") {
+        return false;
+    }
+    let after_prefix = &check_name[7..];
+    !after_prefix.contains(":header:") && !after_prefix.contains(":body:")
 }
 
 /// Conformance test report
@@ -337,24 +352,31 @@ impl ConformanceReport {
             }
         }
 
-        // Aggregate custom checks (check names starting with "custom:")
+        // Aggregate custom checks (check names starting with "custom:").
+        //
+        // Round 41 (#79) — Srikanth on 0.3.185: with
+        // `chain_iterations: 3` and a chain of `custom:get` +
+        // `custom:post (repeat: 16 parallel)`, the bench fired 3 + 48
+        // = 51 requests and the per-request log records each one,
+        // but the summary table collapsed the row to `Custom: 2 / 0
+        // / 2 / 100%` because the prior implementation deduped by
+        // top-level check name and added 1 pass/fail per unique
+        // name. Now we sum the per-occurrence counts so the summary
+        // matches what actually went on the wire.
+        //
+        // Only the PRIMARY check (the status assertion that uses the
+        // bare `custom:name`) is added to the category total —
+        // sub-checks like `custom:name:header:X` and
+        // `custom:name:body:Y` are still counted toward total
+        // pass/fail at the report level via `check_results`, but
+        // each sub-check is a property of the SAME request, not an
+        // extra one, so adding them here would double-count requests
+        // that have header / body assertions.
         let custom_entry = categories.entry("Custom").or_default();
-        // Track which top-level custom check names we've already counted
-        let mut counted_custom: HashSet<String> = HashSet::new();
         for (name, (passes, fails)) in &self.check_results {
-            if name.starts_with("custom:") {
-                // Only count the primary check (status), not sub-checks (header/body)
-                // Sub-checks have format "custom:name:header:..." or "custom:name:body:..."
-                // Primary checks are just "custom:something" with exactly one colon after "custom"
-                // We count each unique top-level custom check once
-                let base_name = extract_custom_base_name(name);
-                if counted_custom.insert(base_name) {
-                    if *fails == 0 && *passes > 0 {
-                        custom_entry.passed += 1;
-                    } else {
-                        custom_entry.failed += 1;
-                    }
-                }
+            if name.starts_with("custom:") && is_primary_custom_check(name) {
+                custom_entry.passed += *passes as usize;
+                custom_entry.failed += *fails as usize;
             }
         }
 
@@ -792,6 +814,41 @@ fn suggest_conformance_category_for_owasp(owasp_id: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Round 41 (#79) — Srikanth on 0.3.185: with `chain_iterations:
+    /// 3` and a chain of `custom:get` + `custom:post` (repeat 16
+    /// parallel), the bench logs 51 requests but the summary table
+    /// previously printed `Custom: 2 / 0 / 2 / 100%` because each
+    /// unique top-level check name was added with `+1` instead of
+    /// `+N`. Now the row sums the per-check `(passes, fails)`
+    /// counts.
+    #[test]
+    fn custom_category_sums_per_check_executions_not_unique_names() {
+        let mut check_results = HashMap::new();
+        // 3 iters x 1 GET = 3
+        check_results.insert("custom:get".to_string(), (3u64, 0u64));
+        // 3 iters x 16 parallel POSTs = 48
+        check_results.insert("custom:post".to_string(), (48u64, 0u64));
+        // Plus a sub-check (header assertion) that should NOT inflate
+        // the request count: same request just has an extra
+        // assertion.
+        check_results.insert("custom:get:header:X-Trace".to_string(), (3u64, 0u64));
+        let report = ConformanceReport::from_results(check_results, Vec::new());
+        let by_cat = report.by_category();
+        let custom = by_cat.get("Custom").expect("Custom category present");
+        assert_eq!(custom.passed, 51, "primary check passes summed (3 + 48)");
+        assert_eq!(custom.failed, 0);
+    }
+
+    /// Round 41 — primary-vs-sub-check classifier.
+    #[test]
+    fn primary_custom_check_classifier_skips_header_and_body_sub_checks() {
+        assert!(is_primary_custom_check("custom:get"));
+        assert!(is_primary_custom_check("custom:do-work-parallel"));
+        assert!(!is_primary_custom_check("custom:get:header:X-Trace"));
+        assert!(!is_primary_custom_check("custom:get:body:user_id:string"));
+        assert!(!is_primary_custom_check("not:custom"));
+    }
 
     /// Round 18.4 — every OWASP category that the suggestion helper
     /// is asked about should return a non-empty hint, so the footer

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -2380,29 +2380,56 @@ static LAST_ERRORS: Lazy<Mutex<VecDeque<Value>>> =
 ///
 /// Issue #79 round 12.
 pub fn classify_validation_reason(reason: &str) -> String {
+    // Round 41 (#79) — Srikanth on 0.3.185: violations on GET requests
+    // (which carry no body) AND query-only violations on POST requests
+    // were both being categorised as "request-body" because the older
+    // matcher checked `r.contains("schema")` before the per-location
+    // checks. The validator's error payload embeds a structured
+    // `"path":"<location>.<name>"` per violation; classify on the
+    // FIRST such path so the category reflects the actual failure
+    // location instead of the validator's prose.
     let r = reason.to_ascii_lowercase();
+
+    // Cheap structured pull from the validator's `"path":"<loc>.<name>"` fields.
+    let path_starts_with = |prefix: &str| r.contains(&format!("\"path\":\"{}", prefix));
+    if path_starts_with("query.") {
+        return "query".into();
+    }
+    if path_starts_with("header.") {
+        return "headers".into();
+    }
+    if path_starts_with("cookie.") {
+        return "cookies".into();
+    }
+    if path_starts_with("path.") {
+        return "parameters".into();
+    }
+    if path_starts_with("body") {
+        return "request-body".into();
+    }
+
+    // Content-type mismatches are surfaced separately, BEFORE the
+    // schema validator runs.
+    if r.contains("content-type") || r.contains("content type") {
+        return "content-types".into();
+    }
+
+    // Fallback: the older heuristics for callers that don't embed a
+    // structured path field (e.g. malformed JSON, missing body
+    // entirely, security-scheme mismatches).
     if r.contains("required")
         && (r.contains("param") || r.contains("query") || r.contains("header"))
     {
         return "parameters".into();
     }
-    if r.contains("schema") || r.contains("body") || r.contains("json") {
-        return "request-body".into();
-    }
-    if r.contains("content-type") || r.contains("content type") {
-        return "content-types".into();
-    }
-    if r.contains("header") {
-        return "headers".into();
-    }
-    if r.contains("cookie") {
-        return "cookies".into();
+    if r.contains("auth") || r.contains("security") {
+        return "security".into();
     }
     if r.contains("method") {
         return "http-methods".into();
     }
-    if r.contains("auth") || r.contains("security") {
-        return "security".into();
+    if r.contains("schema") || r.contains("body") || r.contains("json") {
+        return "request-body".into();
     }
     if r.contains("enum") || r.contains("min") || r.contains("max") || r.contains("pattern") {
         return "constraints".into();
@@ -2915,6 +2942,38 @@ mod tests {
     use super::*;
     use serde_json::json;
     use tempfile::TempDir;
+
+    /// Round 41 (#79) — Srikanth on 0.3.185: GET requests carry no
+    /// body, so a query-only violation on GET should be categorised
+    /// as `query`, not `request-body`. POST requests with both query
+    /// AND body validators should also be classified by where the
+    /// first detail's `"path":...` lives rather than the validator's
+    /// generic "schema_validation" prose. The new classifier looks
+    /// for `"path":"query.<name>"` / `"path":"header.<name>"` etc.
+    /// first.
+    #[test]
+    fn classify_validation_reason_uses_structured_path_field_first() {
+        // Real shape from the Google Apigee /v1/organizations report
+        // — query-only enum/boolean violations.
+        let query_only = r#"{"details":[{"code":"schema_validation","message":"Validation error","path":"query.$.xgafv"}]}"#;
+        assert_eq!(classify_validation_reason(query_only), "query");
+
+        let header_only = r#"{"details":[{"code":"schema_validation","message":"missing required X-Trace","path":"header.X-Trace"}]}"#;
+        assert_eq!(classify_validation_reason(header_only), "headers");
+
+        let cookie_only = r#"{"details":[{"code":"schema_validation","message":"missing session","path":"cookie.session"}]}"#;
+        assert_eq!(classify_validation_reason(cookie_only), "cookies");
+
+        // Body-only violation stays `request-body`.
+        let body_only = r#"{"details":[{"code":"schema_validation","message":"name required","path":"body.name"}]}"#;
+        assert_eq!(classify_validation_reason(body_only), "request-body");
+
+        // Content-type mismatch keeps its own category.
+        assert_eq!(
+            classify_validation_reason("Content-Type application/xml not allowed"),
+            "content-types"
+        );
+    }
 
     #[tokio::test]
     async fn test_registry_creation() {


### PR DESCRIPTION
## Summary

Round 41 of Srikanth's #79 feedback (post v0.3.185). Four fixes, all from his concrete observations on the published v0.3.185 binary:

### A) k6 custom checks now use a fresh per-request cookie jar

His screenshot shows `Cookie: albsessid=53e673c2f5439e21d5a246f8116723f4; albsessid=53e673c2f5439e21d5a246f8116723f4` in the POST request — same value twice. Root cause: v0.3.184 wired `${cookie:NAME}` substitution, but k6's per-VU cookie jar ALSO auto-collected the GET response's `Set-Cookie` and re-injected it on every subsequent request alongside our explicit `Cookie:` header. Now `__custom_jar_factory = () => new http.CookieJar()` lives at init scope and every chain request passes `jar: __custom_jar_factory()` in its params, so the user's explicit `${cookie:NAME}` substitution is the only source of truth. Real-binary verified: 48 POSTs across 3 chain iterations land with a single `Cookie: albsessid=abc-xyz` each (no duplication). Also addresses Srikanth's "have ... without Cookie in GET" ask: with no shared jar, iteration K+1 GET does not carry cookies from iteration K unless the user explicitly forwards them via `${cookie:NAME}`.

### B) chain_iterations summary aggregation

With `chain_iterations: 3` and `custom:get` + `custom:post (repeat 16 parallel)`, the per-request log records 51 requests but the summary table printed `Custom: 2 / 0 / 2 / 100%` because the prior implementation deduped by top-level check name. Now it sums per-occurrence `(passes, fails)` counts via a new `is_primary_custom_check` helper (skips `:header:` / `:body:` sub-checks so they don't double-count requests with extra assertions). Real-binary verified: same YAML now prints `Custom: 51 / 0 / 51 / 100%` — exactly the 3 GET + 48 POST that actually went on the wire.

### C) Violation category labels

The validator's classifier was matching on prose (`r.contains("schema")` → `"request-body"`), so query-only violations on GET, and POST requests with both query AND body validators, all carried `category: request-body`. New classifier reads the structured `"path":"<loc>.<name>"` field from the validator's JSON details FIRST, so a query violation gets `category: query`, a header violation gets `headers`, a cookie one gets `cookies`, and only body violations stay `request-body`. Content-type mismatches and the older heuristics for callers that don't embed a structured path remain unchanged. Real-binary verified against the Google Apigee spec from #888: `POST /v1/organizations?$.xgafv=test-value&prettyPrint=test-value` now records `category: query` instead of `category: request-body`.

### D) k6 multi-file upload log + multipart export fallback

Srikanth saw 5 of 9 multipart parts in his PCAP and asked: "Is there a way from Logs I can confirm all the files in multiple upload are sent from mockforge client?" Each upload check now emits one tagged log line per check at request-build time: `MOCKFORGE_UPLOAD_PARTS: <name> <N> files: <field>:<filename> (<ct>), ...`. Grep `MOCKFORGE_UPLOAD_PARTS` in k6 stdout to confirm every part left the client even when the wire capture drops some. Additionally: `--export-requests` now surfaces a brief multipart-summary string when k6's `res.request.body` is empty (it is for multipart uploads — k6 serialises the form internally and doesn't expose the bytes JS-side), so the export no longer shows a blank `request.body` for multi-file checks (his observation (b)).

## Test plan

- [x] 5 new unit tests:
  - `custom_category_sums_per_check_executions_not_unique_names` (B)
  - `primary_custom_check_classifier_skips_header_and_body_sub_checks` (B)
  - `classify_validation_reason_uses_structured_path_field_first` (C, multi-assertion: query/headers/cookies/body/content-types)
- [x] `cargo test -p mockforge-bench --lib` — 485 pass (was 483; +2 new)
- [x] `cargo test -p mockforge-openapi --lib` — 178 pass (was 177; +1 new)
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings` clean (modulo pre-existing mockforge-data noise on main)
- [x] `cargo clippy -p mockforge-openapi --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

### Real-binary verify (against Srikanth's exact YAML + Google Apigee spec)

- **Cookie chain**: 48 POSTs (3 iters × 16 parallel), each `Cookie: albsessid=abc-xyz` once. Zero duplicate `albsessid=...albsessid=` lines in mock-server log.
- **Summary table**: `Custom: 51 / 0 / 51 / 100%` (matches actual on-wire count, was `2 / 0 / 2`).
- **Upload log**: `MOCKFORGE_UPLOAD_PARTS: custom:multi-upload 3 files: 'json':'r41-a.json' (application/json), 'photo':'r41-b.jpg' (image/jpeg), 'pdf':'r41-c.pdf' (application/pdf)` emitted by the generated k6 script.
- **Category labels**: `POST /v1/organizations` with `$.xgafv=test-value` records `category: query` on `/__mockforge/api/conformance/violations`.

Closes round 41 of #79.