### PR TITLE
fix(openapi): r43 synthesize spec-declared response headers (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.188] - 2026-06-21
+
+### Fixed
+
+- **[Contracts]** `mockforge serve` now emits response headers declared in `responses.<code>.headers` instead of silently dropping them (#79 round 43, surfaced during the round-42 bench-vs-serve sweep). A spec like `responses.200.headers.Set-Cookie: { schema: { type: string } }` would return `200 OK` from `mockforge serve` with the cookie missing — the validator's `validate_response_headers` already understood the shape but the synthesiser was never wired up, so any contract test or k6 chain that relied on the server issuing a `Set-Cookie` would skip the cookie-based path entirely. New `OpenApiRoute::mock_response_headers_for_status` walks the matched response's `headers` map and produces schema-aware placeholder values: cookie-shaped (`mockforge_session=mockforge-synthetic; Path=/`) for `Set-Cookie`, the nil UUID for `format: uuid` strings, RFC-3339 epoch for `format: date-time`, `0` / `true` for integer / boolean, generic placeholder for plain strings, and `mockforge-mock-value` for any unresolved `$ref`. Both router builders (`build_router_with_context` and `build_router_with_mockai`) merge the synthesised list into the response via `inject_spec_response_headers`, preserving axum's existing `content-type` / `vary` / `x-rate-limit-*` headers (never overwrites). Three new unit tests pin the contract: cookie shape, UUID format, and the unmatched-status no-op. Real-binary verified: `GET /login` with the test spec returns `set-cookie: mockforge_session=mockforge-synthetic; Path=/` and `x-request-id: 00000000-0000-0000-0000-000000000000`; `POST /auth/login` (MockAI router path) likewise emits `set-cookie`.
+
 ## [0.3.187] - 2026-06-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9294,14 +9294,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.187"
+version = "0.3.188"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.187"
+version = "0.3.188"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -999,6 +999,7 @@ impl OpenApiRouteRegistry {
                     response.extensions_mut().insert(trace);
                     *response.status_mut() = axum::http::StatusCode::from_u16(selected_status)
                         .unwrap_or(axum::http::StatusCode::OK);
+                    inject_spec_response_headers(&mut response, &route_clone, selected_status);
                     return response;
                 }
 
@@ -1006,6 +1007,7 @@ impl OpenApiRouteRegistry {
                 let mut response = Json(final_response).into_response();
                 *response.status_mut() = axum::http::StatusCode::from_u16(selected_status)
                     .unwrap_or(axum::http::StatusCode::OK);
+                inject_spec_response_headers(&mut response, &route_clone, selected_status);
                 response
             };
 
@@ -1927,7 +1929,8 @@ impl OpenApiRouteRegistry {
                                     "error": "content_type_not_allowed",
                                     "message": ct_err,
                                 })),
-                            );
+                            )
+                                .into_response();
                         }
                     }
 
@@ -2006,7 +2009,7 @@ impl OpenApiRouteRegistry {
                     ) {
                         let status = axum::http::StatusCode::from_u16(status_code)
                             .unwrap_or(axum::http::StatusCode::BAD_REQUEST);
-                        return (status, Json(payload));
+                        return (status, Json(payload)).into_response();
                     }
 
                     tracing::info!(
@@ -2118,7 +2121,7 @@ impl OpenApiRouteRegistry {
                                         .unwrap_or(axum::http::StatusCode::OK);
 
                                 // Return as tuple (StatusCode, Json) to match handler signature
-                                return (status, Json(json_value));
+                                return (status, Json(json_value)).into_response();
                             } else {
                                 tracing::warn!(
                                     "[FIXTURE DEBUG] ❌ No fixture match found for {} {} (fingerprint.path='{}', normalized='{}')",
@@ -2205,11 +2208,16 @@ impl OpenApiRouteRegistry {
                                             spec_status,
                                             mockai_response.status_code
                                         );
-                                        return (
-                                            axum::http::StatusCode::from_u16(spec_status)
-                                                .unwrap_or(axum::http::StatusCode::OK),
-                                            Json(mockai_response.body),
+                                        let status = axum::http::StatusCode::from_u16(spec_status)
+                                            .unwrap_or(axum::http::StatusCode::OK);
+                                        let mut resp =
+                                            (status, Json(mockai_response.body)).into_response();
+                                        inject_spec_response_headers(
+                                            &mut resp,
+                                            &route,
+                                            spec_status,
                                         );
+                                        return resp;
                                     }
                                 }
                                 Err(e) => {
@@ -2250,11 +2258,11 @@ impl OpenApiRouteRegistry {
                             scenario.as_deref(),
                             status_override,
                         );
-                    (
-                        axum::http::StatusCode::from_u16(status)
-                            .unwrap_or(axum::http::StatusCode::OK),
-                        Json(response),
-                    )
+                    let status_code = axum::http::StatusCode::from_u16(status)
+                        .unwrap_or(axum::http::StatusCode::OK);
+                    let mut resp = (status_code, Json(response)).into_response();
+                    inject_spec_response_headers(&mut resp, &route, status);
+                    resp
                 }
             };
 
@@ -2264,6 +2272,42 @@ impl OpenApiRouteRegistry {
         // Issue #79 — see `build_router_with_context`; same body-limit raise
         // for the MockAI router.
         router.layer(DefaultBodyLimit::max(openapi_body_limit_bytes()))
+    }
+}
+
+/// Inject response headers declared in `responses.<code>.headers` from
+/// the spec into an axum response, after the body and status have been
+/// set. No-op when the route's operation has no headers for that status.
+///
+/// Round 43 (#79) — the validator already knew about declared response
+/// headers (`validation::validate_response_headers`) but the synthesiser
+/// never emitted them, so `mockforge serve` returned 200 with no
+/// `Set-Cookie` even when the spec promised one. Existing headers stay
+/// (so axum's content-type / vary / rate-limit headers aren't clobbered)
+/// — we only insert if absent. Invalid HeaderName / HeaderValue bytes
+/// are silently skipped so a typo in the spec doesn't take the response
+/// down.
+fn inject_spec_response_headers(
+    response: &mut axum::response::Response,
+    route: &crate::route::OpenApiRoute,
+    status_code: u16,
+) {
+    let synthesized = route.mock_response_headers_for_status(status_code);
+    if synthesized.is_empty() {
+        return;
+    }
+    let response_headers = response.headers_mut();
+    for (name, value) in synthesized {
+        let Ok(header_name) = axum::http::HeaderName::from_bytes(name.as_bytes()) else {
+            continue;
+        };
+        if response_headers.contains_key(&header_name) {
+            continue;
+        }
+        let Ok(header_value) = axum::http::HeaderValue::from_str(&value) else {
+            continue;
+        };
+        response_headers.insert(header_name, header_value);
     }
 }
 

--- a/crates/mockforge-openapi/src/route.rs
+++ b/crates/mockforge-openapi/src/route.rs
@@ -618,6 +618,93 @@ impl OpenApiRoute {
         }
         lowest_other.unwrap_or(200)
     }
+
+    /// Synthesize response headers declared in `responses.<code>.headers`.
+    ///
+    /// Round 43 (#79) — round 41's cookie chain work surfaced that a spec
+    /// that declares `responses.200.headers.Set-Cookie` returns 200 OK from
+    /// `mockforge serve` with no `Set-Cookie` header on the wire. The
+    /// validator's `validate_response_headers` even knows the shape, but
+    /// the synthesiser was never wired up. Returns a list of
+    /// `(header_name, value)` pairs for the given status code, suitable
+    /// for injecting straight into the axum response. The value is
+    /// schema-aware where the lift is cheap:
+    /// - `Set-Cookie`: a cookie-shaped placeholder (`<sanitized-name>=mockforge-session; Path=/`)
+    /// - `string`, `format: uuid`: a stable nil UUID so downstream parsing succeeds
+    /// - `string`, `format: date-time`: an RFC-3339 zero timestamp
+    /// - `integer` / `number` / `boolean`: minimal valid literals
+    /// - everything else (plain string, no schema, ref): the literal `mockforge-mock-value`
+    ///
+    /// `default` response headers are NOT included; only the explicitly
+    /// matched status's headers are emitted. The caller is expected to
+    /// merge these into the response after status + body.
+    pub fn mock_response_headers_for_status(&self, status_code: u16) -> Vec<(String, String)> {
+        use openapiv3::{
+            ParameterSchemaOrContent, ReferenceOr, SchemaKind, StatusCode, Type,
+            VariantOrUnknownOrEmpty,
+        };
+
+        let response_ref =
+            self.operation.responses.responses.iter().find_map(|(code, r)| match code {
+                StatusCode::Code(c) if *c == status_code => Some(r),
+                _ => None,
+            });
+        let Some(response_ref) = response_ref else {
+            return Vec::new();
+        };
+        let Some(response_item) = response_ref.as_item() else {
+            return Vec::new();
+        };
+
+        let mut out = Vec::new();
+        for (name, header_ref) in &response_item.headers {
+            let Some(header) = header_ref.as_item() else {
+                out.push((name.clone(), "mockforge-mock-value".to_string()));
+                continue;
+            };
+
+            let value = match &header.format {
+                ParameterSchemaOrContent::Schema(ReferenceOr::Item(schema)) => {
+                    match &schema.schema_kind {
+                        SchemaKind::Type(Type::Integer(_)) => "0".to_string(),
+                        SchemaKind::Type(Type::Number(_)) => "0".to_string(),
+                        SchemaKind::Type(Type::Boolean(_)) => "true".to_string(),
+                        SchemaKind::Type(Type::String(s)) => match &s.format {
+                            VariantOrUnknownOrEmpty::Item(openapiv3::StringFormat::DateTime) => {
+                                "1970-01-01T00:00:00Z".to_string()
+                            }
+                            VariantOrUnknownOrEmpty::Item(openapiv3::StringFormat::Date) => {
+                                "1970-01-01".to_string()
+                            }
+                            VariantOrUnknownOrEmpty::Unknown(fmt) if fmt == "uuid" => {
+                                "00000000-0000-0000-0000-000000000000".to_string()
+                            }
+                            _ => synthesize_string_header_value(name),
+                        },
+                        _ => synthesize_string_header_value(name),
+                    }
+                }
+                _ => synthesize_string_header_value(name),
+            };
+            out.push((name.clone(), value));
+        }
+        out
+    }
+}
+
+/// Pick a placeholder value for a generic string header, with a
+/// cookie-shaped fallback for `Set-Cookie`. Lives at module scope so it
+/// can be shared between `mock_response_headers_for_status` paths and
+/// any future overrides; keeping it free of schema state keeps it cheap.
+fn synthesize_string_header_value(header_name: &str) -> String {
+    if header_name.eq_ignore_ascii_case("set-cookie") {
+        // Use a fixed cookie name + value so downstream chains (the
+        // round-41 `${cookie:NAME}` substitution) can grep for it
+        // deterministically. The `Path=/` keeps it valid across paths.
+        "mockforge_session=mockforge-synthetic; Path=/".to_string()
+    } else {
+        "mockforge-mock-value".to_string()
+    }
 }
 
 /// OpenAPI operation wrapper with path context
@@ -804,5 +891,61 @@ mod status_code_selection_tests {
             "404": {"description": "err"},
         }));
         assert_eq!(r.find_first_available_status_code(), 404);
+    }
+
+    #[test]
+    fn synthesises_set_cookie_when_declared_in_spec() {
+        // Round 43 (#79) — spec declares `responses.200.headers.Set-Cookie`;
+        // synthesiser must surface a cookie-shaped value instead of skipping
+        // the header. The exact value is opaque from the caller's view; we
+        // only assert it's a `name=value` cookie line so future changes to
+        // the placeholder text don't break the test.
+        let r = route_from_responses(json!({
+            "200": {
+                "description": "ok",
+                "headers": {
+                    "Set-Cookie": {"schema": {"type": "string"}}
+                }
+            }
+        }));
+        let headers = r.mock_response_headers_for_status(200);
+        let (_, value) = headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("Set-Cookie"))
+            .expect("Set-Cookie header should be synthesised");
+        assert!(
+            value.contains('=') && value.contains("Path="),
+            "expected cookie shape `name=value; Path=...`, got: {value:?}"
+        );
+    }
+
+    #[test]
+    fn synthesises_uuid_format_value_for_string_header() {
+        let r = route_from_responses(json!({
+            "200": {
+                "description": "ok",
+                "headers": {
+                    "X-Request-Id": {"schema": {"type": "string", "format": "uuid"}}
+                }
+            }
+        }));
+        let headers = r.mock_response_headers_for_status(200);
+        let (_, value) = headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("X-Request-Id"))
+            .expect("X-Request-Id header should be synthesised");
+        assert_eq!(value, "00000000-0000-0000-0000-000000000000");
+    }
+
+    #[test]
+    fn omits_headers_for_unmatched_status() {
+        // Spec declares headers on 200 only; asking for a 404 should produce nothing.
+        let r = route_from_responses(json!({
+            "200": {
+                "description": "ok",
+                "headers": {"Set-Cookie": {"schema": {"type": "string"}}}
+            }
+        }));
+        assert!(r.mock_response_headers_for_status(404).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- **r43 fix**: `mockforge serve` was silently dropping response headers declared in `responses.<code>.headers`. A spec like `responses.200.headers.Set-Cookie: { schema: { type: string } }` would return `200 OK` with the cookie missing. Validator knew the shape (`validate_response_headers`) but the synthesiser was never wired up. New `OpenApiRoute::mock_response_headers_for_status` produces schema-aware placeholder values (cookie shape for `Set-Cookie`, nil UUID for `format: uuid`, RFC-3339 epoch for `format: date-time`, etc); both router builders inject them into the response without clobbering axum's own headers.
- **3 new unit tests** pin cookie shape, UUID format, unmatched-status no-op.
- **Real-binary verified** against `mockforge serve --spec <spec> --http-port N` on both GET (build_router_with_context path) and POST (build_router_with_mockai path).
- **Version bump**: 0.3.187 → 0.3.188.
- **Surfaced** during the round-42 bench-vs-serve sweep when verifying round-41 cookie-chain fixes against `mockforge serve` directly.

## Test plan

- [x] `cargo clippy -p mockforge-openapi --all-targets -- -D warnings` clean
- [x] `cargo test -p mockforge-openapi --lib` (178 + 3 new = 181 passed)
- [x] `cargo fmt --all --check` clean
- [x] Real-binary verify: `GET /login` returns `set-cookie:` + `x-request-id:` from a spec that declares them
- [x] Real-binary verify: `POST /auth/login` (MockAI router) returns `set-cookie:` from the spec
- [ ] CI run on PR
- [ ] Cut 0.3.188 release after merge