### PR TITLE
feat(http,cli): mock LLM endpoint + mock MCP server (#912, #913)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,14 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(grep --line-buffered -E \"Published mockforge-cli|=== mockforge-cli ===|error: failed|No space left|publish failed$|all .* at 0.3.195|remain stale\")",
+      "Read(//tmp/**)",
+      "Bash(curl -sL \"https://crates.io/api/v1/crates/mockforge-cli\" -H 'User-Agent: mockforge-release \\(ray@saasysolutionsllc.com\\)')",
+      "Bash(python3 -c \"import sys,json; print\\(json.load\\(sys.stdin\\)['crate']['max_version']\\)\")"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "playwright"
-  ],
-  "enableAllProjectMcpServers": true
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3.196] - 2026-06-30
+
+### Added
+
+- **[AI]** Mock LLM endpoint for agent testing (#912 / #79 Srikanth: "Agent Traffic to LLM ... LLM Simulation using MockForge Server"). `mockforge serve --llm-mock` mounts OpenAI-compatible `POST /v1/chat/completions` + `GET /v1/models` and Anthropic-compatible `POST /v1/messages`, so an agent (Cursor, Claude Code, ChatGPT clients, custom agents) can point its base URL at MockForge and receive correctly-shaped, deterministic completions. Responses carry realistic envelopes (ids, `usage`/token counts, `finish_reason`/`stop_reason`) and **SSE streaming** when the caller sets `stream: true` (OpenAI `chat.completion.chunk` deltas + `[DONE]`; Anthropic `message_start`/`content_block_delta`/`message_stop` events). Pure mock (no external model call); echoes the prompt by default so wiring is easy to confirm. Real-binary verified against `mockforge serve`: non-streaming + streaming OpenAI, Anthropic messages, and model list all return spec-shaped payloads.
+- **[AI]** Mock MCP (Model Context Protocol) server for agent-as-MCP-client testing (#913 / #79 Srikanth: "Agent (Acting as MCP Client) Traffic to MCP Servers"). `mockforge serve --mcp-mock` mounts a JSON-RPC 2.0 endpoint at `POST /mcp` answering `initialize`, `tools/list`, `tools/call`, `resources/list`, `prompts/list`, and the `notifications/initialized` notification, with a configurable tool catalog returning canned (or, via an error tool, failing) results. Real-binary verified against `mockforge serve`: `initialize` returns `serverInfo` + capabilities, `tools/list` returns the catalog, and `tools/call echo` reflects its argument.
+
 ## [0.3.195] - 2026-06-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.195"
+version = "0.3.196"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,12 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.196] - 2026-06-30
+
+### Added
+
+- **[AI]** Mock LLM endpoint: `mockforge serve --llm-mock` mounts OpenAI-compatible `POST /v1/chat/completions` + `GET /v1/models` and Anthropic-compatible `POST /v1/messages` with SSE streaming, so an agent can point its base URL at MockForge for scale/offline/failure testing (#912 / #79 Srikanth).
+- **[AI]** Mock MCP server: `mockforge serve --mcp-mock` mounts a JSON-RPC 2.0 endpoint at `POST /mcp` answering `initialize` / `tools/list` / `tools/call` / `resources/list` / `prompts/list`, so an agent acting as an MCP client can talk to MockForge (#913 / #79 Srikanth).
+
 ## [0.3.195] - 2026-06-30
 
 ### Fixed

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -523,6 +523,21 @@ struct ServeCliArgs {
     #[arg(long, help_heading = "Admin & UI")]
     pub admin: bool,
 
+    /// Enable the mock LLM endpoint: OpenAI-compatible
+    /// `POST /v1/chat/completions` + `GET /v1/models` and Anthropic-compatible
+    /// `POST /v1/messages` (with SSE streaming when `stream:true`), so an agent
+    /// can point its base URL at MockForge. Returns deterministic canned
+    /// completions with realistic envelopes (#912).
+    #[arg(long, help_heading = "AI Features")]
+    pub llm_mock: bool,
+
+    /// Enable the mock MCP server: JSON-RPC 2.0 at `POST /mcp` answering
+    /// `initialize` / `tools/list` / `tools/call` / `resources/list` /
+    /// `prompts/list` with a configurable tool catalog, so an agent acting as
+    /// an MCP client can talk to MockForge (#913).
+    #[arg(long, help_heading = "AI Features")]
+    pub mcp_mock: bool,
+
     /// Admin UI port (defaults to config or 9080)
     #[arg(long, help_heading = "Admin & UI")]
     pub admin_port: Option<u16>,
@@ -2648,6 +2663,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 admin: args.admin,
                 admin_port: args.admin_port,
                 admin_host: args.admin_host,
+                llm_mock: args.llm_mock,
+                mcp_mock: args.mcp_mock,
                 metrics: args.observability.metrics,
                 metrics_port: args.observability.metrics_port,
                 tracing: args.observability.tracing,

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -113,6 +113,12 @@ pub(crate) struct ServeArgs {
     pub(crate) bulkhead_max_concurrent: u32,
     pub(crate) bulkhead_max_queue: u32,
     pub(crate) bulkhead_queue_timeout_ms: u64,
+    /// `--llm-mock` (#912): mount OpenAI/Anthropic-compatible mock LLM
+    /// endpoints (`/v1/chat/completions`, `/v1/messages`, `/v1/models`).
+    pub(crate) llm_mock: bool,
+    /// `--mcp-mock` (#913): mount the mock MCP server (JSON-RPC over HTTP at
+    /// `/mcp`).
+    pub(crate) mcp_mock: bool,
     /// `--conformance-buffer-size` (round 31). Mirrors
     /// `MOCKFORGE_CONFORMANCE_BUFFER_SIZE`. None = honour env or default 256.
     pub(crate) conformance_buffer_size: Option<usize>,
@@ -204,6 +210,8 @@ impl Default for ServeArgs {
             bulkhead_max_concurrent: 100,
             bulkhead_max_queue: 10,
             bulkhead_queue_timeout_ms: 5000,
+            llm_mock: false,
+            mcp_mock: false,
             conformance_buffer_size: None,
             conformance_buffer_unique: false,
             inject_response_violations: false,
@@ -1988,6 +1996,29 @@ pub async fn handle_serve(
                 tracing::warn!("Failed to build GraphQL router; skipping: {}", e);
             }
         }
+    }
+
+    // Mount the mock LLM endpoint (#912) so an agent can point its base URL
+    // at MockForge and get OpenAI/Anthropic-shaped completions (with SSE
+    // streaming) for scale / offline / failure testing. Opt-in via --llm-mock.
+    if serve_args.llm_mock {
+        http_app = http_app.merge(mockforge_http::llm_mock::router(
+            mockforge_http::llm_mock::LlmMockConfig::default(),
+        ));
+        println!(
+            "✅ Mock LLM endpoint available at POST /v1/chat/completions, POST /v1/messages, GET /v1/models (OpenAI + Anthropic shapes, SSE streaming)"
+        );
+    }
+
+    // Mount the mock MCP server (#913) so an agent acting as an MCP client can
+    // talk to MockForge over JSON-RPC. Opt-in via --mcp-mock.
+    if serve_args.mcp_mock {
+        http_app = http_app.merge(mockforge_http::mcp_mock::router(
+            mockforge_http::mcp_mock::McpMockConfig::default(),
+        ));
+        println!(
+            "✅ Mock MCP server available at POST /mcp (JSON-RPC: initialize, tools/list, tools/call, resources/list, prompts/list)"
+        );
     }
 
     // Mount the recorder API on the public HTTP app so callers can list,

--- a/crates/mockforge-http/src/lib.rs
+++ b/crates/mockforge-http/src/lib.rs
@@ -230,10 +230,16 @@ pub mod health;
 pub mod http_tracing_middleware;
 /// Latency profile configuration for HTTP request simulation
 pub mod latency_profiles;
+
+/// Mock LLM endpoint (OpenAI/Anthropic-compatible) for agent testing (#912).
+pub mod llm_mock;
+
 /// Management API for server control and monitoring
 pub mod management;
 /// WebSocket-based management API for real-time updates
 pub mod management_ws;
+/// Mock MCP (Model Context Protocol) server for agent-as-MCP-client testing (#913).
+pub mod mcp_mock;
 pub mod metrics_middleware;
 pub mod middleware;
 /// Standalone MockAI HTTP API

--- a/crates/mockforge-http/src/llm_mock.rs
+++ b/crates/mockforge-http/src/llm_mock.rs
@@ -1,0 +1,439 @@
+//! Mock LLM endpoint (#912, #79 round 50 follow-up).
+//!
+//! Serves OpenAI-compatible (`POST /v1/chat/completions`, `GET /v1/models`)
+//! and Anthropic-compatible (`POST /v1/messages`) endpoints so an agent
+//! (Cursor, Claude Code, ChatGPT clients, custom agents) can point its base
+//! URL at MockForge and receive correctly-shaped, deterministic completions
+//! for scale / offline / failure testing. This is a MOCK: it never calls a
+//! real model, it returns canned/templated text with realistic envelopes
+//! (ids, `usage` token counts, `finish_reason` / `stop_reason`) and supports
+//! SSE streaming when the caller sets `stream: true`.
+//!
+//! Mounted by `mockforge serve --llm-mock`.
+
+use axum::{
+    extract::State,
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse, Response,
+    },
+    routing::{get, post},
+    Json, Router,
+};
+use futures::stream::{self, Stream};
+use serde_json::{json, Value};
+use std::convert::Infallible;
+use std::time::Duration;
+
+/// Runtime configuration for the mock LLM endpoint.
+#[derive(Clone, Debug)]
+pub struct LlmMockConfig {
+    /// Canned assistant reply used when no per-request override applies.
+    pub canned_reply: String,
+    /// Model id echoed back in responses when the request omits one.
+    pub default_model: String,
+    /// When true, prepend a short echo of the user's last message to the
+    /// reply so callers can confirm round-trip wiring.
+    pub echo_prompt: bool,
+    /// Per-chunk delay for streaming responses (milliseconds). 0 = no delay.
+    pub stream_chunk_delay_ms: u64,
+}
+
+impl Default for LlmMockConfig {
+    fn default() -> Self {
+        Self {
+            canned_reply: "This is a mock response from MockForge's LLM endpoint.".to_string(),
+            default_model: "mockforge-mock-1".to_string(),
+            echo_prompt: true,
+            stream_chunk_delay_ms: 0,
+        }
+    }
+}
+
+/// Build the axum router exposing the mock LLM endpoints.
+pub fn router(config: LlmMockConfig) -> Router {
+    Router::new()
+        .route("/v1/chat/completions", post(chat_completions))
+        .route("/v1/models", get(list_models))
+        .route("/v1/messages", post(anthropic_messages))
+        .with_state(config)
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Approximate token count: whitespace-delimited words. Good enough for a
+/// mock; real tokenizers differ but callers testing wiring only need a
+/// plausible, monotonic-with-length number.
+fn approx_tokens(text: &str) -> u32 {
+    text.split_whitespace().count().max(1) as u32
+}
+
+/// Extract the last user message text from a list of OpenAI/Anthropic-shaped
+/// messages. `content` may be a plain string or an array of content blocks
+/// (`[{"type":"text","text":"..."}]`); both are handled.
+fn last_user_text(messages: &[Value]) -> String {
+    for m in messages.iter().rev() {
+        if m.get("role").and_then(|r| r.as_str()) == Some("user") {
+            return content_to_text(m.get("content"));
+        }
+    }
+    // Fall back to the last message of any role.
+    messages.last().map(|m| content_to_text(m.get("content"))).unwrap_or_default()
+}
+
+fn content_to_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(parts)) => parts
+            .iter()
+            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => String::new(),
+    }
+}
+
+/// Produce the deterministic reply text for a request.
+fn build_reply(config: &LlmMockConfig, messages: &[Value]) -> String {
+    if config.echo_prompt {
+        let prompt = last_user_text(messages);
+        if !prompt.is_empty() {
+            let trimmed: String = prompt.chars().take(120).collect();
+            return format!("{} (you said: \"{}\")", config.canned_reply, trimmed);
+        }
+    }
+    config.canned_reply.clone()
+}
+
+/// Deterministic id derived from the reply + a prefix, so repeated identical
+/// requests yield stable ids (useful for snapshot tests) without pulling in a
+/// random/uuid dependency.
+fn stable_id(prefix: &str, seed: &str) -> String {
+    let mut hash: u64 = 1469598103934665603; // FNV-1a offset
+    for b in seed.bytes() {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(1099511628211);
+    }
+    format!("{prefix}{hash:016x}")
+}
+
+/// Split a reply into streaming "tokens" (words, keeping trailing spaces) for
+/// chunked SSE delivery.
+fn stream_chunks(reply: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for (i, word) in reply.split_whitespace().enumerate() {
+        if i == 0 {
+            out.push(word.to_string());
+        } else {
+            out.push(format!(" {word}"));
+        }
+    }
+    if out.is_empty() {
+        out.push(reply.to_string());
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI: GET /v1/models
+// ---------------------------------------------------------------------------
+
+async fn list_models(State(config): State<LlmMockConfig>) -> Json<Value> {
+    Json(json!({
+        "object": "list",
+        "data": [{
+            "id": config.default_model,
+            "object": "model",
+            "created": 0,
+            "owned_by": "mockforge",
+        }],
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI: POST /v1/chat/completions
+// ---------------------------------------------------------------------------
+
+async fn chat_completions(
+    State(config): State<LlmMockConfig>,
+    Json(body): Json<Value>,
+) -> Response {
+    let model = body
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or(&config.default_model)
+        .to_string();
+    let messages: Vec<Value> =
+        body.get("messages").and_then(|m| m.as_array()).cloned().unwrap_or_default();
+    let stream = body.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+
+    let reply = build_reply(&config, &messages);
+    let prompt_text = messages
+        .iter()
+        .map(|m| content_to_text(m.get("content")))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let prompt_tokens = approx_tokens(&prompt_text);
+    let completion_tokens = approx_tokens(&reply);
+    let id = stable_id("chatcmpl-", &reply);
+
+    if stream {
+        return openai_stream(config, id, model, reply).into_response();
+    }
+
+    Json(json!({
+        "id": id,
+        "object": "chat.completion",
+        "created": 0,
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": reply },
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }))
+    .into_response()
+}
+
+fn openai_stream(
+    config: LlmMockConfig,
+    id: String,
+    model: String,
+    reply: String,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let mut events: Vec<Event> = Vec::new();
+    // Initial role delta.
+    events.push(sse_json(&json!({
+        "id": id, "object": "chat.completion.chunk", "created": 0, "model": model,
+        "choices": [{ "index": 0, "delta": { "role": "assistant" }, "finish_reason": Value::Null }],
+    })));
+    // One content delta per token.
+    for chunk in stream_chunks(&reply) {
+        events.push(sse_json(&json!({
+            "id": id, "object": "chat.completion.chunk", "created": 0, "model": model,
+            "choices": [{ "index": 0, "delta": { "content": chunk }, "finish_reason": Value::Null }],
+        })));
+    }
+    // Terminal chunk + [DONE].
+    events.push(sse_json(&json!({
+        "id": id, "object": "chat.completion.chunk", "created": 0, "model": model,
+        "choices": [{ "index": 0, "delta": {}, "finish_reason": "stop" }],
+    })));
+    events.push(Event::default().data("[DONE]"));
+
+    sse_response(events, config.stream_chunk_delay_ms)
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic: POST /v1/messages
+// ---------------------------------------------------------------------------
+
+async fn anthropic_messages(
+    State(config): State<LlmMockConfig>,
+    Json(body): Json<Value>,
+) -> Response {
+    let model = body
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or(&config.default_model)
+        .to_string();
+    let messages: Vec<Value> =
+        body.get("messages").and_then(|m| m.as_array()).cloned().unwrap_or_default();
+    let stream = body.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+
+    let reply = build_reply(&config, &messages);
+    let prompt_text = messages
+        .iter()
+        .map(|m| content_to_text(m.get("content")))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let input_tokens = approx_tokens(&prompt_text);
+    let output_tokens = approx_tokens(&reply);
+    let id = stable_id("msg_", &reply);
+
+    if stream {
+        return anthropic_stream(config, id, model, reply, input_tokens, output_tokens)
+            .into_response();
+    }
+
+    Json(json!({
+        "id": id,
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{ "type": "text", "text": reply }],
+        "stop_reason": "end_turn",
+        "stop_sequence": Value::Null,
+        "usage": { "input_tokens": input_tokens, "output_tokens": output_tokens },
+    }))
+    .into_response()
+}
+
+fn anthropic_stream(
+    config: LlmMockConfig,
+    id: String,
+    model: String,
+    reply: String,
+    input_tokens: u32,
+    output_tokens: u32,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let mut events: Vec<Event> = Vec::new();
+    events.push(sse_named(
+        "message_start",
+        &json!({
+            "type": "message_start",
+            "message": {
+                "id": id, "type": "message", "role": "assistant", "model": model,
+                "content": [], "stop_reason": Value::Null, "stop_sequence": Value::Null,
+                "usage": { "input_tokens": input_tokens, "output_tokens": 0 },
+            },
+        }),
+    ));
+    events.push(sse_named(
+        "content_block_start",
+        &json!({ "type": "content_block_start", "index": 0, "content_block": { "type": "text", "text": "" } }),
+    ));
+    for chunk in stream_chunks(&reply) {
+        events.push(sse_named(
+            "content_block_delta",
+            &json!({ "type": "content_block_delta", "index": 0, "delta": { "type": "text_delta", "text": chunk } }),
+        ));
+    }
+    events.push(sse_named(
+        "content_block_stop",
+        &json!({ "type": "content_block_stop", "index": 0 }),
+    ));
+    events.push(sse_named(
+        "message_delta",
+        &json!({ "type": "message_delta", "delta": { "stop_reason": "end_turn", "stop_sequence": Value::Null }, "usage": { "output_tokens": output_tokens } }),
+    ));
+    events.push(sse_named("message_stop", &json!({ "type": "message_stop" })));
+
+    sse_response(events, config.stream_chunk_delay_ms)
+}
+
+// ---------------------------------------------------------------------------
+// SSE plumbing
+// ---------------------------------------------------------------------------
+
+fn sse_json(value: &Value) -> Event {
+    Event::default().data(value.to_string())
+}
+
+fn sse_named(name: &str, value: &Value) -> Event {
+    Event::default().event(name).data(value.to_string())
+}
+
+/// Turn a precomputed list of events into an SSE stream, optionally spacing
+/// them out by `delay_ms` so callers can observe incremental delivery.
+fn sse_response(
+    events: Vec<Event>,
+    delay_ms: u64,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let s = stream::unfold(events.into_iter(), move |mut it| async move {
+        let next = it.next()?;
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        }
+        Some((Ok::<Event, Infallible>(next), it))
+    });
+    Sse::new(s).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> LlmMockConfig {
+        LlmMockConfig {
+            echo_prompt: false,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn approx_tokens_counts_words() {
+        assert_eq!(approx_tokens("one two three"), 3);
+        assert_eq!(approx_tokens(""), 1); // min 1
+    }
+
+    #[test]
+    fn last_user_text_handles_string_and_array_content() {
+        let msgs = vec![
+            json!({"role":"system","content":"be brief"}),
+            json!({"role":"user","content":"hello world"}),
+        ];
+        assert_eq!(last_user_text(&msgs), "hello world");
+        let arr = vec![
+            json!({"role":"user","content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}),
+        ];
+        assert_eq!(last_user_text(&arr), "a b");
+    }
+
+    #[test]
+    fn echo_prompt_reflects_user_message() {
+        let c = LlmMockConfig {
+            echo_prompt: true,
+            ..Default::default()
+        };
+        let msgs = vec![json!({"role":"user","content":"ping"})];
+        let reply = build_reply(&c, &msgs);
+        assert!(reply.contains("ping"), "reply should echo the prompt: {reply}");
+    }
+
+    #[test]
+    fn stable_id_is_deterministic_and_prefixed() {
+        let a = stable_id("chatcmpl-", "same");
+        let b = stable_id("chatcmpl-", "same");
+        assert_eq!(a, b);
+        assert!(a.starts_with("chatcmpl-"));
+        assert_ne!(stable_id("chatcmpl-", "x"), stable_id("chatcmpl-", "y"));
+    }
+
+    #[test]
+    fn stream_chunks_preserve_leading_space_after_first() {
+        let chunks = stream_chunks("alpha beta gamma");
+        assert_eq!(chunks, vec!["alpha", " beta", " gamma"]);
+        assert_eq!(chunks.concat(), "alpha beta gamma");
+    }
+
+    #[tokio::test]
+    async fn chat_completions_non_stream_shape() {
+        let body = json!({"model":"gpt-x","messages":[{"role":"user","content":"hi there"}]});
+        let resp = chat_completions(State(cfg()), Json(body)).await;
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["object"], "chat.completion");
+        assert_eq!(v["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(v["choices"][0]["finish_reason"], "stop");
+        assert!(v["usage"]["total_tokens"].as_u64().unwrap() >= 2);
+        assert!(v["id"].as_str().unwrap().starts_with("chatcmpl-"));
+    }
+
+    #[tokio::test]
+    async fn anthropic_non_stream_shape() {
+        let body = json!({"model":"claude-x","messages":[{"role":"user","content":"hi"}]});
+        let resp = anthropic_messages(State(cfg()), Json(body)).await;
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["content"][0]["type"], "text");
+        assert_eq!(v["stop_reason"], "end_turn");
+        assert!(v["usage"]["output_tokens"].as_u64().unwrap() >= 1);
+        assert!(v["id"].as_str().unwrap().starts_with("msg_"));
+    }
+
+    #[tokio::test]
+    async fn models_list_shape() {
+        let Json(v) = list_models(State(cfg())).await;
+        assert_eq!(v["object"], "list");
+        assert_eq!(v["data"][0]["owned_by"], "mockforge");
+    }
+}

--- a/crates/mockforge-http/src/mcp_mock.rs
+++ b/crates/mockforge-http/src/mcp_mock.rs
@@ -1,0 +1,249 @@
+//! Mock MCP (Model Context Protocol) server (#913, #79 round 50 follow-up).
+//!
+//! Serves a JSON-RPC 2.0 endpoint at `POST /mcp` so an agent acting as an MCP
+//! client (the role Cursor / Claude Code / custom agents play when they call
+//! out to tool servers) can talk to MockForge as a fake MCP server. Answers
+//! the core MCP methods with a configurable tool catalog and canned results:
+//! `initialize`, `tools/list`, `tools/call`, `resources/list`, `prompts/list`,
+//! plus the `notifications/initialized` notification.
+//!
+//! This is a MOCK: no real tools run. `tools/call` returns deterministic
+//! canned content so agents can be exercised against a predictable (or, with
+//! a configured error tool, hostile) MCP server.
+//!
+//! Mounted by `mockforge serve --mcp-mock`.
+
+use axum::{
+    extract::State, http::StatusCode, response::IntoResponse, response::Response, routing::post,
+    Json, Router,
+};
+use serde_json::{json, Value};
+
+/// Protocol version this mock advertises. Matches the MCP spec revision the
+/// reference clients negotiate; clients that send a different version still
+/// work because we echo a fixed supported version.
+const PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// A single mock tool in the catalog.
+#[derive(Clone, Debug)]
+pub struct McpTool {
+    /// Tool name as advertised in `tools/list` and matched by `tools/call`.
+    pub name: String,
+    /// Human-readable description shown to the agent.
+    pub description: String,
+    /// JSON Schema for the tool's input (returned verbatim in `tools/list`).
+    pub input_schema: Value,
+    /// Canned text returned by `tools/call`. When `is_error` is true the call
+    /// result is flagged `isError: true` so agents can be tested against a
+    /// failing tool.
+    pub canned_result: String,
+    /// Whether `tools/call` should flag the result as an error (`isError`).
+    pub is_error: bool,
+}
+
+/// Runtime configuration for the mock MCP server.
+#[derive(Clone, Debug)]
+pub struct McpMockConfig {
+    /// Server name returned in `initialize` -> `serverInfo.name`.
+    pub server_name: String,
+    /// Server version returned in `initialize` -> `serverInfo.version`.
+    pub server_version: String,
+    /// Tool catalog returned by `tools/list` and dispatched by `tools/call`.
+    pub tools: Vec<McpTool>,
+}
+
+impl Default for McpMockConfig {
+    fn default() -> Self {
+        Self {
+            server_name: "mockforge-mcp".to_string(),
+            server_version: env!("CARGO_PKG_VERSION").to_string(),
+            tools: vec![
+                McpTool {
+                    name: "echo".to_string(),
+                    description: "Echo back the provided text.".to_string(),
+                    input_schema: json!({
+                        "type": "object",
+                        "properties": { "text": { "type": "string" } },
+                        "required": ["text"],
+                    }),
+                    canned_result: "echo".to_string(),
+                    is_error: false,
+                },
+                McpTool {
+                    name: "get_status".to_string(),
+                    description: "Return a canned status payload.".to_string(),
+                    input_schema: json!({ "type": "object", "properties": {} }),
+                    canned_result: "{\"status\":\"ok\",\"source\":\"mockforge-mcp\"}".to_string(),
+                    is_error: false,
+                },
+            ],
+        }
+    }
+}
+
+/// Build the axum router exposing the mock MCP JSON-RPC endpoint.
+pub fn router(config: McpMockConfig) -> Router {
+    Router::new().route("/mcp", post(handle_rpc)).with_state(config)
+}
+
+/// JSON-RPC error codes (subset of the spec) we may return.
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_REQUEST: i64 = -32600;
+
+async fn handle_rpc(State(config): State<McpMockConfig>, Json(req): Json<Value>) -> Response {
+    // Notifications have no `id`; per JSON-RPC the server must not reply with a
+    // result. MCP sends `notifications/initialized` after `initialize`.
+    let id = req.get("id").cloned();
+    let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    let params = req.get("params").cloned().unwrap_or(Value::Null);
+
+    if id.is_none() {
+        // Notification: acknowledge with 202 and no body.
+        return StatusCode::ACCEPTED.into_response();
+    }
+    let id = id.unwrap();
+
+    if req.get("jsonrpc").and_then(|v| v.as_str()) != Some("2.0") {
+        return Json(error_response(id, INVALID_REQUEST, "jsonrpc must be \"2.0\""))
+            .into_response();
+    }
+
+    let result = match method {
+        "initialize" => Some(json!({
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": { "listChanged": false },
+                "resources": { "listChanged": false },
+                "prompts": { "listChanged": false },
+            },
+            "serverInfo": { "name": config.server_name, "version": config.server_version },
+        })),
+        "tools/list" => Some(json!({
+            "tools": config.tools.iter().map(|t| json!({
+                "name": t.name,
+                "description": t.description,
+                "inputSchema": t.input_schema,
+            })).collect::<Vec<_>>(),
+        })),
+        "tools/call" => Some(tools_call(&config, &params)),
+        "resources/list" => Some(json!({ "resources": [] })),
+        "prompts/list" => Some(json!({ "prompts": [] })),
+        "ping" => Some(json!({})),
+        _ => None,
+    };
+
+    match result {
+        Some(r) => Json(result_response(id, r)).into_response(),
+        None => Json(error_response(id, METHOD_NOT_FOUND, &format!("method not found: {method}")))
+            .into_response(),
+    }
+}
+
+fn tools_call(config: &McpMockConfig, params: &Value) -> Value {
+    let name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+    let args = params.get("arguments").cloned().unwrap_or(Value::Null);
+
+    let Some(tool) = config.tools.iter().find(|t| t.name == name) else {
+        return json!({
+            "content": [{ "type": "text", "text": format!("unknown tool: {name}") }],
+            "isError": true,
+        });
+    };
+
+    // The `echo` tool reflects its `text` argument so agents can verify the
+    // round-trip; everything else returns its canned result verbatim.
+    let text = if tool.name == "echo" {
+        args.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string()
+    } else {
+        tool.canned_result.clone()
+    };
+
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": tool.is_error,
+    })
+}
+
+fn result_response(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn error_response(id: Value, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn call(body: Value) -> Value {
+        let resp = handle_rpc(State(McpMockConfig::default()), Json(body)).await;
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap()
+        }
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_server_info_and_capabilities() {
+        let v = call(json!({"jsonrpc":"2.0","id":1,"method":"initialize"})).await;
+        assert_eq!(v["jsonrpc"], "2.0");
+        assert_eq!(v["id"], 1);
+        assert_eq!(v["result"]["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(v["result"]["serverInfo"]["name"], "mockforge-mcp");
+        assert!(v["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[tokio::test]
+    async fn tools_list_returns_catalog() {
+        let v = call(json!({"jsonrpc":"2.0","id":2,"method":"tools/list"})).await;
+        let tools = v["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        assert!(tools.iter().any(|t| t["name"] == "echo"));
+        assert!(tools[0]["inputSchema"].is_object());
+    }
+
+    #[tokio::test]
+    async fn tools_call_echo_reflects_argument() {
+        let v = call(json!({
+            "jsonrpc":"2.0","id":3,"method":"tools/call",
+            "params": { "name": "echo", "arguments": { "text": "hello mcp" } }
+        }))
+        .await;
+        assert_eq!(v["result"]["content"][0]["text"], "hello mcp");
+        assert_eq!(v["result"]["isError"], false);
+    }
+
+    #[tokio::test]
+    async fn tools_call_unknown_tool_is_error() {
+        let v = call(json!({
+            "jsonrpc":"2.0","id":4,"method":"tools/call",
+            "params": { "name": "nope", "arguments": {} }
+        }))
+        .await;
+        assert_eq!(v["result"]["isError"], true);
+    }
+
+    #[tokio::test]
+    async fn unknown_method_returns_jsonrpc_error() {
+        let v = call(json!({"jsonrpc":"2.0","id":5,"method":"does/not/exist"})).await;
+        assert_eq!(v["error"]["code"], METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn notification_without_id_returns_no_body() {
+        // notifications/initialized has no `id`; must not produce a JSON-RPC reply.
+        let v = call(json!({"jsonrpc":"2.0","method":"notifications/initialized"})).await;
+        assert_eq!(v, Value::Null);
+    }
+
+    #[tokio::test]
+    async fn resources_and_prompts_list_are_empty() {
+        let r = call(json!({"jsonrpc":"2.0","id":6,"method":"resources/list"})).await;
+        assert!(r["result"]["resources"].as_array().unwrap().is_empty());
+        let p = call(json!({"jsonrpc":"2.0","id":7,"method":"prompts/list"})).await;
+        assert!(p["result"]["prompts"].as_array().unwrap().is_empty());
+    }
+}


### PR DESCRIPTION
Builds the two agent-simulation features Srikanth asked about on #79 that were previously only filed as issues (#912, #913).

## `mockforge serve --llm-mock` (#912)
OpenAI-compatible `POST /v1/chat/completions` + `GET /v1/models` and Anthropic-compatible `POST /v1/messages`, with **SSE streaming** when `stream:true`. Deterministic canned completions with realistic envelopes (ids, `usage` token counts, `finish_reason`/`stop_reason`). An agent (Cursor, Claude Code, custom) can point its base URL at MockForge for scale/offline/failure testing. Pure mock, no external model call.

## `mockforge serve --mcp-mock` (#913)
JSON-RPC 2.0 mock MCP server at `POST /mcp` answering `initialize` / `tools/list` / `tools/call` / `resources/list` / `prompts/list` (+ `notifications/initialized`), with a configurable tool catalog. An agent acting as an MCP client can talk to it.

## Implementation
Both are modules in `mockforge-http` (`llm_mock`, `mcp_mock`) exposing `router()` builders, merged in `serve.rs` behind the new flags (same pattern as the graphql/chaos routers). No new crates.

## Verification
15 new unit tests; **real-binary verified against `mockforge serve`**: OpenAI non-stream + SSE stream, Anthropic messages, model list, and the MCP initialize/tools.list/tools.call echo roundtrip. clippy-clean in changed files; fmt clean.

Closes #912, closes #913.