### PR TITLE
feat(http,cli): --llm-mock-mode proxy/record/replay (#915)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,10 @@
       "Bash(grep --line-buffered -E \"Published mockforge-cli|=== mockforge-cli ===|error: failed|No space left|publish failed$|all .* at 0.3.195|remain stale\")",
       "Read(//tmp/**)",
       "Bash(curl -sL \"https://crates.io/api/v1/crates/mockforge-cli\" -H 'User-Agent: mockforge-release \\(ray@saasysolutionsllc.com\\)')",
-      "Bash(python3 -c \"import sys,json; print\\(json.load\\(sys.stdin\\)['crate']['max_version']\\)\")"
+      "Bash(python3 -c \"import sys,json; print\\(json.load\\(sys.stdin\\)['crate']['max_version']\\)\")",
+      "Bash(curl -sL \"https://crates.io/api/v1/crates/mockforge-cli\" -H 'User-Agent: mf \\(ray@saasysolutionsllc.com\\)')",
+      "Bash(python3 -c \"import sys,json;print\\(json.load\\(sys.stdin\\)['crate']['max_version']\\)\")",
+      "Bash(/tmp/mf-install/bin/mockforge --version)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.197] - 2026-07-01
+
+### Added
+
+- **[AI]** Mock LLM endpoint gains real-model modes via `--llm-mock-mode` (#915, follow-up to #912). The default stays a pure offline `mock`, and three new opt-in modes let it work with a real OpenAI/Anthropic-compatible upstream: `proxy` forwards every request to `--llm-mock-upstream` and returns the real response (combine with `--latency`/`--failures` for chaos on live traffic); `record` forwards on a cassette miss and saves the response to `--llm-mock-cassette`, replaying from the cassette on a hit (real content, deterministic after warm-up); `replay` serves only from the cassette (fully offline), falling back to the canned reply on a miss. New flags: `--llm-mock-mode`, `--llm-mock-upstream`, `--llm-mock-api-key` (or `$OPENAI_API_KEY`/`$ANTHROPIC_API_KEY`), `--llm-mock-cassette`. Upstream/cassette failures degrade to the canned reply so the endpoint never hard-fails a caller. Reuses the existing reqwest client; upstream calls forward the model + messages verbatim (always non-streaming) and streaming clients get the resolved text re-chunked locally. Real-binary verified against `mockforge serve` by pointing one `--llm-mock` instance at another as the upstream (no API key needed): record captured to the cassette then replayed with the upstream stopped; pure `replay` served hits offline and fell back to canned on a miss; `proxy` live-forwarded both OpenAI and Anthropic dialects.
+
 ## [0.3.196] - 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9294,14 +9294,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.195"
+version = "0.3.196"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.196"
+version = "0.3.197"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.197] - 2026-07-01
+
+### Added
+
+- **[AI]** Mock LLM endpoint real-model modes via `--llm-mock-mode` (#915): `proxy` (forward to `--llm-mock-upstream`), `record` (forward on cassette miss + save, replay on hit), `replay` (cassette only, offline; canned fallback). Default stays pure offline `mock`. New flags `--llm-mock-upstream` / `--llm-mock-api-key` / `--llm-mock-cassette`. Verified against `mockforge serve` by pointing one `--llm-mock` instance at another (no API key).
+
 ## [0.3.196] - 2026-06-30
 
 ### Added

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -531,6 +531,27 @@ struct ServeCliArgs {
     #[arg(long, help_heading = "AI Features")]
     pub llm_mock: bool,
 
+    /// Mock LLM reply source (#915): `mock` (canned, default), `proxy` (forward
+    /// every request to `--llm-mock-upstream`), `record` (forward on cassette
+    /// miss and save, replay on hit), or `replay` (cassette only, offline).
+    #[arg(long, default_value = "mock", help_heading = "AI Features")]
+    pub llm_mock_mode: String,
+
+    /// Upstream OpenAI/Anthropic-compatible base URL for `proxy`/`record` modes,
+    /// e.g. `https://api.openai.com` or `http://localhost:11434` (#915).
+    #[arg(long, help_heading = "AI Features")]
+    pub llm_mock_upstream: Option<String>,
+
+    /// API key forwarded to the upstream (Bearer for OpenAI, `x-api-key` for
+    /// Anthropic). Falls back to `$OPENAI_API_KEY` / `$ANTHROPIC_API_KEY` (#915).
+    #[arg(long, help_heading = "AI Features")]
+    pub llm_mock_api_key: Option<String>,
+
+    /// Cassette file for `record`/`replay` modes (JSON). Created on first
+    /// record; loaded at startup for replay (#915).
+    #[arg(long, help_heading = "AI Features")]
+    pub llm_mock_cassette: Option<PathBuf>,
+
     /// Enable the mock MCP server: JSON-RPC 2.0 at `POST /mcp` answering
     /// `initialize` / `tools/list` / `tools/call` / `resources/list` /
     /// `prompts/list` with a configurable tool catalog, so an agent acting as
@@ -2664,6 +2685,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 admin_port: args.admin_port,
                 admin_host: args.admin_host,
                 llm_mock: args.llm_mock,
+                llm_mock_mode: args.llm_mock_mode,
+                llm_mock_upstream: args.llm_mock_upstream,
+                llm_mock_api_key: args.llm_mock_api_key,
+                llm_mock_cassette: args.llm_mock_cassette,
                 mcp_mock: args.mcp_mock,
                 metrics: args.observability.metrics,
                 metrics_port: args.observability.metrics_port,

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -116,6 +116,14 @@ pub(crate) struct ServeArgs {
     /// `--llm-mock` (#912): mount OpenAI/Anthropic-compatible mock LLM
     /// endpoints (`/v1/chat/completions`, `/v1/messages`, `/v1/models`).
     pub(crate) llm_mock: bool,
+    /// `--llm-mock-mode` (#915): `mock` | `proxy` | `record` | `replay`.
+    pub(crate) llm_mock_mode: String,
+    /// `--llm-mock-upstream` (#915): upstream base URL for proxy/record.
+    pub(crate) llm_mock_upstream: Option<String>,
+    /// `--llm-mock-api-key` (#915): key forwarded to the upstream.
+    pub(crate) llm_mock_api_key: Option<String>,
+    /// `--llm-mock-cassette` (#915): cassette file for record/replay.
+    pub(crate) llm_mock_cassette: Option<PathBuf>,
     /// `--mcp-mock` (#913): mount the mock MCP server (JSON-RPC over HTTP at
     /// `/mcp`).
     pub(crate) mcp_mock: bool,
@@ -211,6 +219,10 @@ impl Default for ServeArgs {
             bulkhead_max_queue: 10,
             bulkhead_queue_timeout_ms: 5000,
             llm_mock: false,
+            llm_mock_mode: "mock".to_string(),
+            llm_mock_upstream: None,
+            llm_mock_api_key: None,
+            llm_mock_cassette: None,
             mcp_mock: false,
             conformance_buffer_size: None,
             conformance_buffer_unique: false,
@@ -2001,12 +2013,34 @@ pub async fn handle_serve(
     // Mount the mock LLM endpoint (#912) so an agent can point its base URL
     // at MockForge and get OpenAI/Anthropic-shaped completions (with SSE
     // streaming) for scale / offline / failure testing. Opt-in via --llm-mock.
+    // #915 adds proxy/record/replay modes over a real upstream.
     if serve_args.llm_mock {
-        http_app = http_app.merge(mockforge_http::llm_mock::router(
-            mockforge_http::llm_mock::LlmMockConfig::default(),
-        ));
+        let mode = serve_args
+            .llm_mock_mode
+            .parse::<mockforge_http::llm_mock::LlmMockMode>()
+            .unwrap_or_else(|e| {
+                tracing::warn!(target: "mockforge::serve", "{e}; defaulting to mock");
+                mockforge_http::llm_mock::LlmMockMode::Mock
+            });
+        // API key: explicit flag wins, else fall back to the conventional env
+        // vars so `proxy`/`record` against a real provider needs no secret on
+        // the command line.
+        let api_key = serve_args.llm_mock_api_key.clone().or_else(|| {
+            std::env::var("OPENAI_API_KEY")
+                .ok()
+                .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
+        });
+        let llm_cfg = mockforge_http::llm_mock::LlmMockConfig {
+            mode,
+            upstream_base_url: serve_args.llm_mock_upstream.clone(),
+            upstream_api_key: api_key,
+            cassette_path: serve_args.llm_mock_cassette.clone(),
+            ..Default::default()
+        };
+        http_app = http_app.merge(mockforge_http::llm_mock::router(llm_cfg));
         println!(
-            "✅ Mock LLM endpoint available at POST /v1/chat/completions, POST /v1/messages, GET /v1/models (OpenAI + Anthropic shapes, SSE streaming)"
+            "✅ Mock LLM endpoint available at POST /v1/chat/completions, POST /v1/messages, GET /v1/models (OpenAI + Anthropic shapes, SSE streaming; mode={})",
+            mode
         );
     }
 

--- a/crates/mockforge-http/src/llm_mock.rs
+++ b/crates/mockforge-http/src/llm_mock.rs
@@ -1,13 +1,27 @@
-//! Mock LLM endpoint (#912, #79 round 50 follow-up).
+//! Mock LLM endpoint (#912, #915).
 //!
 //! Serves OpenAI-compatible (`POST /v1/chat/completions`, `GET /v1/models`)
 //! and Anthropic-compatible (`POST /v1/messages`) endpoints so an agent
 //! (Cursor, Claude Code, ChatGPT clients, custom agents) can point its base
-//! URL at MockForge and receive correctly-shaped, deterministic completions
-//! for scale / offline / failure testing. This is a MOCK: it never calls a
-//! real model, it returns canned/templated text with realistic envelopes
-//! (ids, `usage` token counts, `finish_reason` / `stop_reason`) and supports
+//! URL at MockForge and receive correctly-shaped completions with realistic
+//! envelopes (ids, `usage` token counts, `finish_reason` / `stop_reason`) and
 //! SSE streaming when the caller sets `stream: true`.
+//!
+//! Four modes ([`LlmMockMode`]), all opt-in via `--llm-mock-mode`; the default
+//! stays a pure offline mock:
+//! - `mock` (default): canned/templated text, never calls out. Deterministic.
+//! - `proxy`: forward every request to a configured OpenAI/Anthropic-compatible
+//!   upstream and return the real response (a man-in-the-middle for agent<->LLM
+//!   traffic; combine with `--latency`/`--failures` for chaos on real traffic).
+//! - `record`: on a cassette miss, forward to upstream and save the response;
+//!   on a hit, replay from the cassette. Real content, deterministic after
+//!   warm-up.
+//! - `replay`: serve only from the cassette (fully offline); a miss falls back
+//!   to the canned reply.
+//!
+//! Any request the caller sends is already in the upstream's wire shape, so
+//! upstream calls forward the model + messages verbatim (always non-streaming);
+//! streaming clients get the resolved text re-chunked locally.
 //!
 //! Mounted by `mockforge serve --llm-mock`.
 
@@ -22,8 +36,49 @@ use axum::{
 };
 use futures::stream::{self, Stream};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::convert::Infallible;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+/// How the mock LLM endpoint sources its reply text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum LlmMockMode {
+    /// Canned/templated text only; never calls out. Deterministic + offline.
+    #[default]
+    Mock,
+    /// Always forward to the configured upstream and return the real response.
+    Proxy,
+    /// Cassette miss forwards to upstream and records; hit replays from cassette.
+    Record,
+    /// Cassette only (offline); a miss falls back to the canned reply.
+    Replay,
+}
+
+impl std::str::FromStr for LlmMockMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "mock" | "canned" | "off" => Ok(Self::Mock),
+            "proxy" | "passthrough" => Ok(Self::Proxy),
+            "record" => Ok(Self::Record),
+            "replay" => Ok(Self::Replay),
+            _ => Err(format!("unknown --llm-mock-mode '{s}' (mock|proxy|record|replay)")),
+        }
+    }
+}
+
+impl std::fmt::Display for LlmMockMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Mock => "mock",
+            Self::Proxy => "proxy",
+            Self::Record => "record",
+            Self::Replay => "replay",
+        })
+    }
+}
 
 /// Runtime configuration for the mock LLM endpoint.
 #[derive(Clone, Debug)]
@@ -37,6 +92,18 @@ pub struct LlmMockConfig {
     pub echo_prompt: bool,
     /// Per-chunk delay for streaming responses (milliseconds). 0 = no delay.
     pub stream_chunk_delay_ms: u64,
+    /// Reply sourcing mode. Defaults to [`LlmMockMode::Mock`].
+    pub mode: LlmMockMode,
+    /// Base URL of the OpenAI/Anthropic-compatible upstream (no trailing path),
+    /// e.g. `https://api.openai.com` or `http://localhost:11434`. Required for
+    /// `proxy` and `record`.
+    pub upstream_base_url: Option<String>,
+    /// API key forwarded to the upstream (Bearer for OpenAI, `x-api-key` for
+    /// Anthropic). When None, no auth header is sent (fine for local upstreams).
+    pub upstream_api_key: Option<String>,
+    /// Cassette file for `record` / `replay`. Loaded at startup; `record`
+    /// rewrites it as new prompts are captured.
+    pub cassette_path: Option<PathBuf>,
 }
 
 impl Default for LlmMockConfig {
@@ -46,6 +113,65 @@ impl Default for LlmMockConfig {
             default_model: "mockforge-mock-1".to_string(),
             echo_prompt: true,
             stream_chunk_delay_ms: 0,
+            mode: LlmMockMode::Mock,
+            upstream_base_url: None,
+            upstream_api_key: None,
+            cassette_path: None,
+        }
+    }
+}
+
+/// One recorded completion, keyed by a hash of (endpoint, model, messages).
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct CassetteEntry {
+    text: String,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+}
+
+/// In-memory cassette backed by a JSON file on disk.
+#[derive(Default)]
+struct Cassette {
+    entries: HashMap<String, CassetteEntry>,
+    path: Option<PathBuf>,
+}
+
+impl Cassette {
+    fn load(path: Option<PathBuf>) -> Self {
+        let entries = path
+            .as_ref()
+            .and_then(|p| std::fs::read(p).ok())
+            .and_then(|b| serde_json::from_slice::<HashMap<String, CassetteEntry>>(&b).ok())
+            .unwrap_or_default();
+        Self { entries, path }
+    }
+
+    fn save(&self) {
+        if let Some(ref p) = self.path {
+            if let Ok(json) = serde_json::to_string_pretty(&self.entries) {
+                let _ = std::fs::write(p, json);
+            }
+        }
+    }
+}
+
+/// Router state: config plus the shared cassette and an HTTP client for
+/// upstream calls. Cheap to clone (Arc + reqwest::Client are handle types).
+#[derive(Clone)]
+pub struct LlmMockState {
+    config: LlmMockConfig,
+    cassette: Arc<Mutex<Cassette>>,
+    http: reqwest::Client,
+}
+
+impl LlmMockState {
+    /// Build state from config, loading any existing cassette from disk.
+    pub fn new(config: LlmMockConfig) -> Self {
+        let cassette = Cassette::load(config.cassette_path.clone());
+        Self {
+            config,
+            cassette: Arc::new(Mutex::new(cassette)),
+            http: reqwest::Client::new(),
         }
     }
 }
@@ -56,7 +182,21 @@ pub fn router(config: LlmMockConfig) -> Router {
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/models", get(list_models))
         .route("/v1/messages", post(anthropic_messages))
-        .with_state(config)
+        .with_state(LlmMockState::new(config))
+}
+
+/// Which upstream wire dialect a request/response uses.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Dialect {
+    OpenAi,
+    Anthropic,
+}
+
+/// The resolved reply text plus token counts, and where it came from.
+struct Resolved {
+    text: String,
+    prompt_tokens: u32,
+    completion_tokens: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -140,11 +280,11 @@ fn stream_chunks(reply: &str) -> Vec<String> {
 // OpenAI: GET /v1/models
 // ---------------------------------------------------------------------------
 
-async fn list_models(State(config): State<LlmMockConfig>) -> Json<Value> {
+async fn list_models(State(state): State<LlmMockState>) -> Json<Value> {
     Json(json!({
         "object": "list",
         "data": [{
-            "id": config.default_model,
+            "id": state.config.default_model,
             "object": "model",
             "created": 0,
             "owned_by": "mockforge",
@@ -156,31 +296,22 @@ async fn list_models(State(config): State<LlmMockConfig>) -> Json<Value> {
 // OpenAI: POST /v1/chat/completions
 // ---------------------------------------------------------------------------
 
-async fn chat_completions(
-    State(config): State<LlmMockConfig>,
-    Json(body): Json<Value>,
-) -> Response {
+async fn chat_completions(State(state): State<LlmMockState>, Json(body): Json<Value>) -> Response {
     let model = body
         .get("model")
         .and_then(|m| m.as_str())
-        .unwrap_or(&config.default_model)
+        .unwrap_or(&state.config.default_model)
         .to_string();
     let messages: Vec<Value> =
         body.get("messages").and_then(|m| m.as_array()).cloned().unwrap_or_default();
     let stream = body.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
 
-    let reply = build_reply(&config, &messages);
-    let prompt_text = messages
-        .iter()
-        .map(|m| content_to_text(m.get("content")))
-        .collect::<Vec<_>>()
-        .join(" ");
-    let prompt_tokens = approx_tokens(&prompt_text);
-    let completion_tokens = approx_tokens(&reply);
-    let id = stable_id("chatcmpl-", &reply);
+    let r = resolve_reply(&state, Dialect::OpenAi, &model, &messages).await;
+    let id = stable_id("chatcmpl-", &r.text);
 
     if stream {
-        return openai_stream(config, id, model, reply).into_response();
+        return openai_stream(state.config.stream_chunk_delay_ms, id, model, r.text)
+            .into_response();
     }
 
     Json(json!({
@@ -190,20 +321,20 @@ async fn chat_completions(
         "model": model,
         "choices": [{
             "index": 0,
-            "message": { "role": "assistant", "content": reply },
+            "message": { "role": "assistant", "content": r.text },
             "finish_reason": "stop",
         }],
         "usage": {
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": completion_tokens,
-            "total_tokens": prompt_tokens + completion_tokens,
+            "prompt_tokens": r.prompt_tokens,
+            "completion_tokens": r.completion_tokens,
+            "total_tokens": r.prompt_tokens + r.completion_tokens,
         },
     }))
     .into_response()
 }
 
 fn openai_stream(
-    config: LlmMockConfig,
+    delay_ms: u64,
     id: String,
     model: String,
     reply: String,
@@ -228,7 +359,7 @@ fn openai_stream(
     })));
     events.push(Event::default().data("[DONE]"));
 
-    sse_response(events, config.stream_chunk_delay_ms)
+    sse_response(events, delay_ms)
 }
 
 // ---------------------------------------------------------------------------
@@ -236,31 +367,31 @@ fn openai_stream(
 // ---------------------------------------------------------------------------
 
 async fn anthropic_messages(
-    State(config): State<LlmMockConfig>,
+    State(state): State<LlmMockState>,
     Json(body): Json<Value>,
 ) -> Response {
     let model = body
         .get("model")
         .and_then(|m| m.as_str())
-        .unwrap_or(&config.default_model)
+        .unwrap_or(&state.config.default_model)
         .to_string();
     let messages: Vec<Value> =
         body.get("messages").and_then(|m| m.as_array()).cloned().unwrap_or_default();
     let stream = body.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
 
-    let reply = build_reply(&config, &messages);
-    let prompt_text = messages
-        .iter()
-        .map(|m| content_to_text(m.get("content")))
-        .collect::<Vec<_>>()
-        .join(" ");
-    let input_tokens = approx_tokens(&prompt_text);
-    let output_tokens = approx_tokens(&reply);
-    let id = stable_id("msg_", &reply);
+    let r = resolve_reply(&state, Dialect::Anthropic, &model, &messages).await;
+    let id = stable_id("msg_", &r.text);
 
     if stream {
-        return anthropic_stream(config, id, model, reply, input_tokens, output_tokens)
-            .into_response();
+        return anthropic_stream(
+            state.config.stream_chunk_delay_ms,
+            id,
+            model,
+            r.text,
+            r.prompt_tokens,
+            r.completion_tokens,
+        )
+        .into_response();
     }
 
     Json(json!({
@@ -268,16 +399,16 @@ async fn anthropic_messages(
         "type": "message",
         "role": "assistant",
         "model": model,
-        "content": [{ "type": "text", "text": reply }],
+        "content": [{ "type": "text", "text": r.text }],
         "stop_reason": "end_turn",
         "stop_sequence": Value::Null,
-        "usage": { "input_tokens": input_tokens, "output_tokens": output_tokens },
+        "usage": { "input_tokens": r.prompt_tokens, "output_tokens": r.completion_tokens },
     }))
     .into_response()
 }
 
 fn anthropic_stream(
-    config: LlmMockConfig,
+    delay_ms: u64,
     id: String,
     model: String,
     reply: String,
@@ -316,7 +447,181 @@ fn anthropic_stream(
     ));
     events.push(sse_named("message_stop", &json!({ "type": "message_stop" })));
 
-    sse_response(events, config.stream_chunk_delay_ms)
+    sse_response(events, delay_ms)
+}
+
+// ---------------------------------------------------------------------------
+// Reply resolution: mock / proxy / record / replay
+// ---------------------------------------------------------------------------
+
+/// Stable cassette key for a request: FNV hash of dialect + model + canonical
+/// messages JSON. serde_json's default `Map` sorts keys, so the key is stable
+/// across runs for identical inputs.
+fn cassette_key(dialect: Dialect, model: &str, messages: &[Value]) -> String {
+    let d = match dialect {
+        Dialect::OpenAi => "openai",
+        Dialect::Anthropic => "anthropic",
+    };
+    let msgs = serde_json::to_string(messages).unwrap_or_default();
+    stable_id("", &format!("{d}\n{model}\n{msgs}"))
+}
+
+/// Build the canned reply + approximate token counts (the default path and the
+/// fallback for every mode when the upstream/cassette can't serve).
+fn canned_resolved(cfg: &LlmMockConfig, messages: &[Value]) -> Resolved {
+    let text = build_reply(cfg, messages);
+    let prompt_text = messages
+        .iter()
+        .map(|m| content_to_text(m.get("content")))
+        .collect::<Vec<_>>()
+        .join(" ");
+    Resolved {
+        prompt_tokens: approx_tokens(&prompt_text),
+        completion_tokens: approx_tokens(&text),
+        text,
+    }
+}
+
+fn cassette_lookup(state: &LlmMockState, key: &str) -> Option<Resolved> {
+    let e = state.cassette.lock().ok()?.entries.get(key).cloned()?;
+    Some(Resolved {
+        text: e.text,
+        prompt_tokens: e.prompt_tokens,
+        completion_tokens: e.completion_tokens,
+    })
+}
+
+/// Resolve the reply text + token counts per the configured mode. Upstream and
+/// cassette failures degrade to the canned reply so the mock never hard-fails a
+/// caller (it logs the reason instead).
+async fn resolve_reply(
+    state: &LlmMockState,
+    dialect: Dialect,
+    model: &str,
+    messages: &[Value],
+) -> Resolved {
+    let cfg = &state.config;
+    match cfg.mode {
+        LlmMockMode::Mock => canned_resolved(cfg, messages),
+        LlmMockMode::Replay => {
+            let key = cassette_key(dialect, model, messages);
+            cassette_lookup(state, &key).unwrap_or_else(|| {
+                tracing::warn!(target: "mockforge::llm_mock", "replay cassette miss (key {key}); serving canned reply");
+                canned_resolved(cfg, messages)
+            })
+        }
+        LlmMockMode::Record => {
+            let key = cassette_key(dialect, model, messages);
+            if let Some(hit) = cassette_lookup(state, &key) {
+                return hit;
+            }
+            match call_upstream(state, dialect, model, messages).await {
+                Ok(r) => {
+                    if let Ok(mut c) = state.cassette.lock() {
+                        c.entries.insert(
+                            key,
+                            CassetteEntry {
+                                text: r.text.clone(),
+                                prompt_tokens: r.prompt_tokens,
+                                completion_tokens: r.completion_tokens,
+                            },
+                        );
+                        c.save();
+                    }
+                    r
+                }
+                Err(e) => {
+                    tracing::error!(target: "mockforge::llm_mock", "record: upstream call failed ({e}); serving canned reply");
+                    canned_resolved(cfg, messages)
+                }
+            }
+        }
+        LlmMockMode::Proxy => match call_upstream(state, dialect, model, messages).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(target: "mockforge::llm_mock", "proxy: upstream call failed ({e}); serving canned reply");
+                canned_resolved(cfg, messages)
+            }
+        },
+    }
+}
+
+/// Forward a request to the configured OpenAI/Anthropic-compatible upstream
+/// (always non-streaming) and parse the reply text + token usage back out.
+async fn call_upstream(
+    state: &LlmMockState,
+    dialect: Dialect,
+    model: &str,
+    messages: &[Value],
+) -> Result<Resolved, String> {
+    let base = state
+        .config
+        .upstream_base_url
+        .as_deref()
+        .ok_or("no upstream configured (set --llm-mock-upstream)")?
+        .trim_end_matches('/');
+
+    let (url, body) = match dialect {
+        Dialect::OpenAi => (
+            format!("{base}/v1/chat/completions"),
+            json!({ "model": model, "messages": messages, "stream": false }),
+        ),
+        // Anthropic requires max_tokens on the request.
+        Dialect::Anthropic => (
+            format!("{base}/v1/messages"),
+            json!({ "model": model, "messages": messages, "max_tokens": 1024, "stream": false }),
+        ),
+    };
+
+    let mut req = state.http.post(&url).json(&body);
+    if let Some(ref k) = state.config.upstream_api_key {
+        req = match dialect {
+            Dialect::OpenAi => req.header("authorization", format!("Bearer {k}")),
+            Dialect::Anthropic => {
+                req.header("x-api-key", k).header("anthropic-version", "2023-06-01")
+            }
+        };
+    }
+
+    let resp = req.send().await.map_err(|e| e.to_string())?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("{url} returned HTTP {status}"));
+    }
+    let v: Value = resp.json().await.map_err(|e| e.to_string())?;
+
+    let (text, pt, ct) = match dialect {
+        Dialect::OpenAi => (
+            v.pointer("/choices/0/message/content")
+                .and_then(|x| x.as_str())
+                .unwrap_or_default(),
+            v.pointer("/usage/prompt_tokens").and_then(|x| x.as_u64()).unwrap_or(0) as u32,
+            v.pointer("/usage/completion_tokens").and_then(|x| x.as_u64()).unwrap_or(0) as u32,
+        ),
+        Dialect::Anthropic => (
+            v.pointer("/content/0/text").and_then(|x| x.as_str()).unwrap_or_default(),
+            v.pointer("/usage/input_tokens").and_then(|x| x.as_u64()).unwrap_or(0) as u32,
+            v.pointer("/usage/output_tokens").and_then(|x| x.as_u64()).unwrap_or(0) as u32,
+        ),
+    };
+    let text = text.to_string();
+    // Backfill token counts if the upstream omitted usage.
+    let prompt_tokens = if pt > 0 {
+        pt
+    } else {
+        let pj = messages
+            .iter()
+            .map(|m| content_to_text(m.get("content")))
+            .collect::<Vec<_>>()
+            .join(" ");
+        approx_tokens(&pj)
+    };
+    let completion_tokens = if ct > 0 { ct } else { approx_tokens(&text) };
+    Ok(Resolved {
+        text,
+        prompt_tokens,
+        completion_tokens,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -356,6 +661,15 @@ mod tests {
             echo_prompt: false,
             ..Default::default()
         }
+    }
+
+    /// Router state wrapping a config, for handler tests.
+    fn st() -> LlmMockState {
+        LlmMockState::new(cfg())
+    }
+
+    fn user(text: &str) -> Vec<Value> {
+        vec![json!({"role":"user","content":text})]
     }
 
     #[test]
@@ -407,7 +721,7 @@ mod tests {
     #[tokio::test]
     async fn chat_completions_non_stream_shape() {
         let body = json!({"model":"gpt-x","messages":[{"role":"user","content":"hi there"}]});
-        let resp = chat_completions(State(cfg()), Json(body)).await;
+        let resp = chat_completions(State(st()), Json(body)).await;
         let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["object"], "chat.completion");
@@ -420,7 +734,7 @@ mod tests {
     #[tokio::test]
     async fn anthropic_non_stream_shape() {
         let body = json!({"model":"claude-x","messages":[{"role":"user","content":"hi"}]});
-        let resp = anthropic_messages(State(cfg()), Json(body)).await;
+        let resp = anthropic_messages(State(st()), Json(body)).await;
         let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["type"], "message");
@@ -432,8 +746,106 @@ mod tests {
 
     #[tokio::test]
     async fn models_list_shape() {
-        let Json(v) = list_models(State(cfg())).await;
+        let Json(v) = list_models(State(st())).await;
         assert_eq!(v["object"], "list");
         assert_eq!(v["data"][0]["owned_by"], "mockforge");
+    }
+
+    // ---- #915: modes + cassette ----
+
+    #[test]
+    fn mode_parses_and_displays() {
+        for (s, m) in [
+            ("mock", LlmMockMode::Mock),
+            ("off", LlmMockMode::Mock),
+            ("proxy", LlmMockMode::Proxy),
+            ("record", LlmMockMode::Record),
+            ("replay", LlmMockMode::Replay),
+        ] {
+            assert_eq!(s.parse::<LlmMockMode>().unwrap(), m);
+        }
+        assert!("bogus".parse::<LlmMockMode>().is_err());
+        assert_eq!(LlmMockMode::Record.to_string(), "record");
+    }
+
+    #[test]
+    fn cassette_key_is_stable_and_input_sensitive() {
+        let m = user("hello");
+        let k1 = cassette_key(Dialect::OpenAi, "gpt-4o", &m);
+        let k2 = cassette_key(Dialect::OpenAi, "gpt-4o", &m);
+        assert_eq!(k1, k2, "same input -> same key");
+        assert_ne!(k1, cassette_key(Dialect::OpenAi, "gpt-4o", &user("world")));
+        assert_ne!(k1, cassette_key(Dialect::OpenAi, "gpt-5", &m), "model is part of the key");
+        assert_ne!(
+            k1,
+            cassette_key(Dialect::Anthropic, "gpt-4o", &m),
+            "dialect is part of the key"
+        );
+    }
+
+    #[test]
+    fn cassette_roundtrips_through_disk() {
+        let dir = std::env::temp_dir().join(format!("mf-cassette-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("c.json");
+        let mut c = Cassette::load(Some(path.clone()));
+        c.entries.insert(
+            "k".into(),
+            CassetteEntry {
+                text: "recorded".into(),
+                prompt_tokens: 3,
+                completion_tokens: 1,
+            },
+        );
+        c.save();
+        let reloaded = Cassette::load(Some(path.clone()));
+        assert_eq!(reloaded.entries.get("k").unwrap().text, "recorded");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn mock_mode_serves_canned_without_upstream() {
+        let state = LlmMockState::new(cfg()); // mode defaults to Mock, no upstream
+        let r = resolve_reply(&state, Dialect::OpenAi, "gpt-4o", &user("hi")).await;
+        assert!(r.text.contains("mock response"));
+    }
+
+    #[tokio::test]
+    async fn replay_hit_serves_cassette_miss_serves_canned() {
+        let state = LlmMockState::new(LlmMockConfig {
+            mode: LlmMockMode::Replay,
+            echo_prompt: false,
+            ..Default::default()
+        });
+        // Seed a cassette entry under the exact key the resolver will compute.
+        let msgs = user("what is 2+2");
+        let key = cassette_key(Dialect::OpenAi, "gpt-4o", &msgs);
+        state.cassette.lock().unwrap().entries.insert(
+            key,
+            CassetteEntry {
+                text: "four".into(),
+                prompt_tokens: 4,
+                completion_tokens: 1,
+            },
+        );
+        // Hit -> cassette content.
+        let hit = resolve_reply(&state, Dialect::OpenAi, "gpt-4o", &msgs).await;
+        assert_eq!(hit.text, "four");
+        assert_eq!(hit.completion_tokens, 1);
+        // Miss -> canned fallback (offline, no upstream).
+        let miss = resolve_reply(&state, Dialect::OpenAi, "gpt-4o", &user("unseen")).await;
+        assert!(miss.text.contains("mock response"));
+    }
+
+    #[tokio::test]
+    async fn proxy_without_upstream_degrades_to_canned() {
+        // Proxy mode but no upstream configured: must not hard-fail.
+        let state = LlmMockState::new(LlmMockConfig {
+            mode: LlmMockMode::Proxy,
+            echo_prompt: false,
+            ..Default::default()
+        });
+        let r = resolve_reply(&state, Dialect::OpenAi, "gpt-4o", &user("hi")).await;
+        assert!(r.text.contains("mock response"), "should fall back to canned, got: {}", r.text);
     }
 }


### PR DESCRIPTION
Follow-up to #912. The `--llm-mock` endpoint can now optionally work against a real OpenAI/Anthropic-compatible upstream, while the default stays a pure offline mock.

## Modes (`--llm-mock-mode`)
- `mock` (default): canned, offline, deterministic.
- `proxy`: forward every request to `--llm-mock-upstream`, return the real response (combine with `--latency`/`--failures` for chaos on live traffic).
- `record`: forward on a cassette miss and save to `--llm-mock-cassette`; replay from the cassette on a hit. Real content, deterministic after warm-up.
- `replay`: cassette only (offline); a miss falls back to the canned reply.

New flags: `--llm-mock-mode`, `--llm-mock-upstream`, `--llm-mock-api-key` (or `$OPENAI_API_KEY`/`$ANTHROPIC_API_KEY`), `--llm-mock-cassette`. Upstream/cassette failures degrade to canned so the endpoint never hard-fails.

## Verification
14 `llm_mock` unit tests (mode parsing, cassette key stability, cassette disk roundtrip, replay hit/miss, proxy-without-upstream fallback). **Real-binary verified against `mockforge serve` with zero API keys** by pointing one `--llm-mock` instance at another as the upstream: `record` captured to the cassette then replayed with the upstream stopped; pure `replay` served hits offline and fell back to canned on a miss; `proxy` live-forwarded both OpenAI and Anthropic dialects. Full `mockforge-http` suite: 594 passed. clippy-clean in changed files; fmt clean.

Closes #915.