### PR TITLE
fix(bench): r51 — spec-valid self-test filler + Content-Length wire bytes + packet-level traffic doc (#79)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,4 +10,9 @@ ignore = [
     "RUSTSEC-2026-0047",
     "RUSTSEC-2026-0048",
     "RUSTSEC-2026-0049",
+    # quick-xml < 0.41.0 DoS (published 2026-07-02); direct SAML bump tracked
+    # in #919. Root audit.toml is the CI source of truth; kept here for local
+    # `cargo audit` runs.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.3.198] - 2026-07-02
+
+### Fixed
+
+- **[Contracts]** Self-test probes no longer trip spurious query/body violations that get attributed to the wrong check (#79 round 51 / Srikanth on 0.3.196: a `request-body:content-type-mismatch:multipart` probe reported `query_value_mismatch` on `alt`/`prettyPrint`, "incorrect and confusing"). Root cause: the baseline probe filled every query/path param with the literal `test-value` and every string body property with `test-string`, both invalid against enum/boolean/type constraints, so every probe tripped the same incidental violations regardless of what it was testing. The baseline filler is now spec-VALID: enum -> first member, boolean -> `true`, integer/number -> a valid number, string formats (email/uuid/date/...) -> a plausible value, and enum body properties -> a valid member. Negative probes still override the specific param/body they attack. Real-binary verified against `mockforge serve`: on the Apigee-style spec the by-probe violation count dropped from 32 to 12, every `request-body:*` probe now shows `query_viols=0`, and the `content-type-mismatch` probes are clean. (This also makes the SQLi/OWASP probes truthful: they now show the violation for the param they actually injected, not unrelated filler noise.)
+- **[Contracts]** Multipart `wire` byte count now matches a proxy's observed body length exactly (#79 round 51 / Srikanth on 0.3.196: the r50 reconstructed envelope was 264 bytes short of his proxy's 1955). The k6-side reconstruction from `res.request.body` can drift from the real socket bytes, so `wire` now prefers the request's `Content-Length` header (the exact wire body size k6 puts on the socket, which is what a proxy counts), falling back to the reconstructed envelope only when the header is absent. Fixed in both render paths (`generator.rs` + `spec_driven.rs`).
+
+### Added
+
+- **[AI][DevX]** New reference page "Agent / LLM / MCP Traffic (Packet-Level)" (#79 / Srikanth on 0.3.196 asked for a document explaining Agent<->LLM, Agent<->Agent, and MCP-Agent<->MCP-Server interactions at the HTTP-packet level with PCAP guidance). Documents the wire structure (methods, headers, request/response bodies, SSE streaming, JSON-RPC envelopes) for OpenAI, Anthropic, and MCP using real captures taken against `mockforge serve --llm-mock --mcp-mock`, plus copy-paste `tcpdump`/`tshark`/`mitmproxy`/`SSLKEYLOGFILE` recipes for recording true `.pcap` files.
+
 ## [0.3.197] - 2026-07-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.197"
+version = "0.3.198"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/audit.toml
+++ b/audit.toml
@@ -26,6 +26,14 @@ ignore = [
     # side, only emit them. Clears once printpdf bumps its lopdf pin.
     { id = "RUSTSEC-2026-0187", reason = "lopdf stack overflow on deeply nested PDFs — only on the mockforge-reporting PDF emit path; we don't parse untrusted PDFs" },
 
+    # quick-xml < 0.41.0 DoS advisories (published 2026-07-02, fixed in
+    # >=0.41.0). Four versions in the tree: one direct (registry-server SAML,
+    # 0.31, feature-gated) plus three transitive (0.37/0.38/0.39) that can't
+    # reach 0.41 without upstream releases. Tracked in #919; the direct SAML
+    # dep (the only untrusted-XML path) is the priority upgrade.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic runtime on duplicate attrs (DoS) — transitive versions have no 0.41 upstream yet; direct SAML bump tracked in #919" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace allocation (DoS) — transitive versions have no 0.41 upstream yet; direct SAML bump tracked in #919" },
+
     # wasmtime 36.x is pinned by mockforge-plugin-loader's current API
     # surface. Every one of these needs a major-version bump to resolve,
     # which is a tracked follow-up (see plugin-loader).

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -160,6 +160,7 @@
 - [Conformance Self-Test Probes](reference/conformance-self-test-probes.md)
 - [Bench Custom Checks (Uploads + Chains)](reference/bench-custom-checks.md)
 - [Bench Capacity Sizing](reference/bench-capacity-sizing.md)
+- [Agent / LLM / MCP Traffic (Packet-Level)](reference/agent-llm-mcp-traffic.md)
 - [Troubleshooting](reference/troubleshooting.md)
 - [Common Issues & Solutions](reference/common-issues.md)
 - [FAQ](reference/faq.md)

--- a/book/src/reference/agent-llm-mcp-traffic.md
+++ b/book/src/reference/agent-llm-mcp-traffic.md
@@ -1,0 +1,296 @@
+# Agent, LLM, and MCP Traffic (Packet-Level Reference)
+
+This page explains, at the HTTP-packet level, the three interaction patterns an
+AI agent (Cursor, Claude Code, ChatGPT-style clients, or a custom agent) uses:
+
+1. **Agent → LLM** — the agent calls a chat/completions API (OpenAI or Anthropic shaped).
+2. **MCP-Agent → MCP-Server** — the agent, acting as an MCP client, calls tools over JSON-RPC.
+3. **Agent → Agent** — one agent calls another agent that exposes an LLM-shaped or tool-shaped endpoint.
+
+Every capture below is **real traffic** taken against MockForge's built-in mock
+endpoints (`mockforge serve --llm-mock --mcp-mock`), so you can reproduce all of
+it locally with no API key and no external service. The last section shows how
+to record true `.pcap` files for Wireshark.
+
+> Set up the endpoints used throughout this page:
+>
+> ```bash
+> mockforge serve --spec examples/openapi-demo.json --http-port 3000 --llm-mock --mcp-mock
+> ```
+>
+> - LLM: `POST /v1/chat/completions`, `GET /v1/models`, `POST /v1/messages`
+> - MCP: `POST /mcp`
+
+---
+
+## 1. Agent → LLM
+
+### 1a. Use cases
+
+- Chat / code completion (Cursor, Claude Code, Copilot-style clients).
+- Tool-calling / function-calling loops (the model returns a `tool_calls` block; the agent executes and calls back).
+- Retrieval-augmented generation (the agent stuffs retrieved context into the `messages` array).
+- Streaming UIs (the model streams tokens back over Server-Sent Events).
+
+### 1b. OpenAI-shaped request (the wire bytes)
+
+`POST /v1/chat/completions`. The request is a single JSON object; the important
+headers are `Authorization: Bearer <key>`, `Content-Type: application/json`, and
+`Content-Length`.
+
+```
+=> Send header, 181 bytes
+POST /v1/chat/completions HTTP/1.1
+Host: 127.0.0.1:3000
+Authorization: Bearer sk-test
+Content-Type: application/json
+Content-Length: 62
+
+=> Send body, 62 bytes
+{"model":"gpt-4o","messages":[{"role":"user","content":"Hi"}]}
+```
+
+Key request fields: `model`, `messages[]` (each `{role, content}` where role is
+`system` | `user` | `assistant` | `tool`), and optionally `stream`,
+`max_tokens`, `temperature`, `tools`, `tool_choice`.
+
+### 1c. OpenAI-shaped response (non-streaming)
+
+```
+<= Recv header
+HTTP/1.1 200 OK
+content-type: application/json
+content-length: 323
+
+<= Recv body
+{
+  "id": "chatcmpl-a345353a3984267e",
+  "object": "chat.completion",
+  "created": 0,
+  "model": "gpt-4o",
+  "choices": [
+    { "index": 0,
+      "message": { "role": "assistant", "content": "..." },
+      "finish_reason": "stop" }
+  ],
+  "usage": { "prompt_tokens": 1, "completion_tokens": 12, "total_tokens": 13 }
+}
+```
+
+Token accounting lives in `usage`; the stop condition is `finish_reason`
+(`stop` | `length` | `tool_calls` | `content_filter`).
+
+### 1d. OpenAI streaming (Server-Sent Events)
+
+When the request sets `"stream": true`, the response is
+`Content-Type: text/event-stream` and the body is a sequence of `data:` frames,
+one per token delta, terminated by `data: [DONE]`:
+
+```
+data: {"choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}],"object":"chat.completion.chunk", ...}
+
+data: {"choices":[{"delta":{"content":"This"},"index":0,"finish_reason":null}],"object":"chat.completion.chunk", ...}
+
+data: {"choices":[{"delta":{"content":" is"},"index":0,"finish_reason":null}],"object":"chat.completion.chunk", ...}
+
+...
+
+data: {"choices":[{"delta":{},"index":0,"finish_reason":"stop"}],"object":"chat.completion.chunk", ...}
+
+data: [DONE]
+```
+
+Each event is separated by a blank line (`\n\n`). The first frame carries the
+`role`, subsequent frames carry `content` deltas, the penultimate frame carries
+`finish_reason`, and the stream closes with the literal `[DONE]` sentinel.
+
+### 1e. Anthropic-shaped request/response
+
+Anthropic uses a different path and header scheme: `POST /v1/messages`,
+`x-api-key: <key>`, and `anthropic-version: 2023-06-01`. `max_tokens` is
+**required**.
+
+Request:
+
+```
+POST /v1/messages HTTP/1.1
+x-api-key: sk-ant-test
+anthropic-version: 2023-06-01
+content-type: application/json
+
+{"model":"claude-3-5-sonnet","max_tokens":64,"messages":[{"role":"user","content":"Hi"}]}
+```
+
+Response:
+
+```
+HTTP/1.1 200 OK
+content-type: application/json
+content-length: 296
+
+{
+  "id": "msg_a345353a3984267e",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-3-5-sonnet",
+  "content": [ { "type": "text", "text": "..." } ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": { "input_tokens": 1, "output_tokens": 12 }
+}
+```
+
+Differences from OpenAI worth noting at the packet level: `content` is an array
+of typed blocks (not a bare string), usage is `input_tokens`/`output_tokens`,
+and the stop field is `stop_reason` (`end_turn` | `max_tokens` | `stop_sequence`
+| `tool_use`). Anthropic streaming uses named SSE events
+(`message_start`, `content_block_delta`, `message_stop`) rather than OpenAI's
+anonymous `data:` chunks.
+
+---
+
+## 2. MCP-Agent → MCP-Server
+
+### 2a. Use cases
+
+The Model Context Protocol lets an agent (the MCP **client**) discover and call
+tools/resources/prompts exposed by an MCP **server**. Cursor and Claude Code are
+MCP clients; the servers they talk to expose things like filesystem access, a
+database, or a web search. Transport is **JSON-RPC 2.0**, over stdio (local
+subprocess) or streamable HTTP (`POST /mcp`).
+
+### 2b. Handshake: `initialize`
+
+The client's first call negotiates protocol version and advertises its identity:
+
+```
+POST /mcp HTTP/1.1
+content-type: application/json
+
+{"jsonrpc":"2.0","id":1,"method":"initialize",
+ "params":{"protocolVersion":"2024-11-05","capabilities":{},
+           "clientInfo":{"name":"claude-code","version":"1.0"}}}
+```
+
+Response — the server returns its capabilities and identity:
+
+```
+{"jsonrpc":"2.0","id":1,"result":{
+  "protocolVersion":"2024-11-05",
+  "capabilities":{"tools":{"listChanged":false},
+                  "resources":{"listChanged":false},
+                  "prompts":{"listChanged":false}},
+  "serverInfo":{"name":"mockforge-mcp","version":"..."}}}
+```
+
+After `initialize` the client sends a `notifications/initialized`
+**notification** (a JSON-RPC message with a `method` but **no `id`**, so the
+server must not reply with a result — MockForge answers `202 Accepted` with an
+empty body).
+
+### 2c. Discovery and invocation
+
+- `tools/list` → `{ "tools": [ { "name", "description", "inputSchema" } ] }`
+- `tools/call` with `{ "name", "arguments" }`:
+
+```
+POST /mcp HTTP/1.1
+content-type: application/json
+
+{"jsonrpc":"2.0","id":2,"method":"tools/call",
+ "params":{"name":"echo","arguments":{"text":"hello"}}}
+```
+
+Response:
+
+```
+{"jsonrpc":"2.0","id":2,"result":{
+  "content":[{"type":"text","text":"hello"}],
+  "isError":false}}
+```
+
+`resources/list` and `prompts/list` follow the same request/response envelope.
+A failed tool call still returns HTTP 200 with `"isError": true` inside
+`result.content`; a malformed/unknown method returns a JSON-RPC `error` object
+(`{"code": -32601, "message": "method not found"}`).
+
+---
+
+## 3. Agent → Agent
+
+"Agent to agent" traffic is, at the packet level, one of the two patterns above:
+the callee agent exposes either an **LLM-shaped** endpoint (so the caller talks
+to it exactly like section 1) or an **MCP/tool** endpoint (section 2).
+Emerging A2A protocols layer a task/session envelope on top, but the transport
+is still HTTP + JSON (often JSON-RPC), so the capture technique is identical.
+
+To simulate a fan-out of many agents against one target, point MockForge's k6
+load generator at the mock endpoint:
+
+```bash
+mockforge bench --spec examples/openapi-demo.json --target http://localhost:3000 \
+  --scenario spike --vus 200
+```
+
+MockForge can also sit **in front of** a real model as a recording proxy so you
+can capture and replay real traffic deterministically — see
+`--llm-mock-mode record|replay|proxy`.
+
+---
+
+## 4. Capturing real PCAP files
+
+The traces above are the HTTP payloads. To get true `.pcap` files (with TCP/IP
+framing) for Wireshark:
+
+### Plaintext HTTP (MockForge on `http://`)
+
+```bash
+# 1. Start the mock endpoints on a plain HTTP port
+mockforge serve --spec examples/openapi-demo.json --http-port 3000 --llm-mock --mcp-mock
+
+# 2. Capture loopback traffic on that port to a file
+sudo tcpdump -i lo -w agent-llm.pcap 'tcp port 3000'
+# (or: tshark -i lo -f 'tcp port 3000' -w agent-llm.pcap)
+
+# 3. In another shell, drive the traffic
+curl -N -X POST http://localhost:3000/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}'
+
+curl -X POST http://localhost:3000/mcp -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}'
+
+# 4. Stop tcpdump (Ctrl-C) and open agent-llm.pcap in Wireshark.
+#    Wireshark's "Follow > HTTP Stream" reconstructs each request/response.
+```
+
+Because the port is plaintext HTTP, every byte (request line, headers, JSON
+body, and each SSE `data:` frame) is visible in the capture with no decryption.
+
+### Real providers over TLS (`https://`)
+
+Real OpenAI/Anthropic/MCP-over-HTTPS traffic is TLS-encrypted, so a raw pcap
+shows only ciphertext. Two ways to see the plaintext:
+
+- **`SSLKEYLOGFILE`** — set `export SSLKEYLOGFILE=/tmp/keys.log` before launching
+  the client, capture with tcpdump, then point Wireshark at the key log
+  (Preferences → Protocols → TLS → *(Pre)-Master-Secret log filename*) to
+  decrypt.
+- **`mitmproxy`** — run `mitmproxy` (or `mitmdump -w flows.mitm`) as an explicit
+  proxy and route the agent through it; it shows and records the decrypted
+  request/response for each call.
+
+To capture the exact bytes without a proxy at all, `curl --trace-ascii trace.txt`
+dumps every header and body byte sent and received — the same view used to
+produce the captures on this page.
+
+---
+
+## Quick reference
+
+| Interaction | Method + path | Auth header | Body envelope | Streaming |
+|---|---|---|---|---|
+| Agent → LLM (OpenAI) | `POST /v1/chat/completions` | `Authorization: Bearer` | `{model, messages[]}` | SSE `data:` chunks + `[DONE]` |
+| Agent → LLM (Anthropic) | `POST /v1/messages` | `x-api-key` + `anthropic-version` | `{model, max_tokens, messages[]}` | named SSE events |
+| MCP-Agent → MCP-Server | `POST /mcp` | (transport-defined) | JSON-RPC 2.0 `{jsonrpc, id, method, params}` | notifications have no `id` |

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,16 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.198] - 2026-07-02
+
+### Fixed
+
+- **[Contracts]** Self-test baseline probe filler is now spec-VALID (enum -> first member, boolean -> `true`, string body enums -> a valid member), so a `request-body:*` probe no longer trips spurious `query_value_mismatch` violations on `alt`/`prettyPrint` and body probes no longer show `test-string` enum noise (#79 round 51 / Srikanth on 0.3.196). Verified against `mockforge serve`: by-probe violations dropped 32 -> 12, `request-body:*` query violations now 0.
+- **[Contracts]** Multipart `wire` byte count now prefers k6's `Content-Length` (the exact wire body size a proxy sees) over the reconstructed envelope, closing the 264-byte gap Srikanth reported on 0.3.196 (#79 round 51).
+
+### Added
+
+- **[AI][DevX]** New "Agent / LLM / MCP Traffic (Packet-Level)" reference page documenting Agent<->LLM, Agent<->Agent, and MCP interactions at the HTTP-packet level with real captures and PCAP-recording recipes (#79 / Srikanth on 0.3.196).
+
 ## [0.3.197] - 2026-07-01
 
 ### Added

--- a/crates/mockforge-bench/src/conformance/generator.rs
+++ b/crates/mockforge-bench/src/conformance/generator.rs
@@ -364,7 +364,12 @@ impl ConformanceGenerator {
                  \x20\x20\x20\x20\x20\x20\x20\x20  // and it UNDERcounts. The envelope is only ~2KB for 9\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  // parts, so wire can never be less than total. Compute it\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  // from the disk-accurate payload plus the ASCII envelope.\n\
-                 \x20\x20\x20\x20\x20\x20\x20\x20  const wireBytes = __allKnown ? (partsTotal + envelopeBytes) : ((typeof raw === 'string' && raw.length) ? raw.length : totalBytes);\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // Round 51 #79 — Srikanth on 0.3.196: the reconstructed\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // envelope was 264 bytes short of his proxy's 1955. k6 sets\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // Content-Length to the EXACT wire body size (what the proxy\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // counts); prefer it, fall back to the reconstruction.\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  const __clHdr = parseInt((reqHeaders['Content-Length'] || reqHeaders['content-length'] || ''), 10);\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  const wireBytes = (!isNaN(__clHdr) && __clHdr > 0) ? __clHdr : (__allKnown ? (partsTotal + envelopeBytes) : ((typeof raw === 'string' && raw.length) ? raw.length : totalBytes));\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  const summary = parts.map(function (p) { return '\\'' + p.name + '\\':\\'' + p.filename + '\\' (' + p.contentType + ', ' + p.bytes + ' bytes)'; }).join(', ');\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  reqBody = '<multipart/form-data; boundary=' + boundary + '; ' + parts.length + ' part(s); total ' + totalBytes + ' bytes (wire ' + wireBytes + ' bytes w/ envelope): ' + summary + '>';\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20} catch (e) {\n\

--- a/crates/mockforge-bench/src/conformance/spec_driven.rs
+++ b/crates/mockforge-bench/src/conformance/spec_driven.rs
@@ -375,14 +375,15 @@ impl SpecDrivenConformanceGenerator {
         let is_integer = Self::param_schema_is_integer(data, spec);
         let is_array = Self::param_schema_is_array(data, spec);
 
-        // Generate sample value
-        let sample = if is_integer {
-            "42".to_string()
-        } else if is_array {
-            "a,b".to_string()
-        } else {
-            "test-value".to_string()
-        };
+        // Round 51 (#79) — generate a spec-VALID sample so the baseline probe
+        // doesn't trip spurious query/path violations on every probe (Srikanth
+        // on 0.3.196: a `request-body:content-type-mismatch:multipart` probe
+        // reported `query_value_mismatch` on `alt`/`prettyPrint` because every
+        // param was filled with the invalid literal "test-value"). Enum ->
+        // first member; boolean -> "true"; integer/number -> a valid number;
+        // array -> "a,b"; string formats -> a plausible valid value. Negative
+        // probes still override the specific param they attack.
+        let sample = Self::param_sample_value(data, spec);
 
         match location {
             "path" => {
@@ -441,6 +442,65 @@ impl SpecDrivenConformanceGenerator {
             }
         }
         false
+    }
+
+    /// Round 51 (#79) — a spec-VALID sample value for a parameter, used as the
+    /// baseline (positive) filler so a probe that isn't attacking a given
+    /// param doesn't trip a spurious violation on it. Falls back to the generic
+    /// "test-value" only when the schema doesn't constrain the value.
+    fn param_sample_value(data: &openapiv3::ParameterData, spec: &OpenAPI) -> String {
+        if let ParameterSchemaOrContent::Schema(schema_ref) = &data.format {
+            if let Some(schema) = ref_resolver::resolve_schema(schema_ref, spec) {
+                return Self::schema_sample_value(schema);
+            }
+        }
+        "test-value".to_string()
+    }
+
+    /// Produce a value that satisfies `schema`'s type / enum / format so the
+    /// server-side (and client-side) validator accepts it.
+    fn schema_sample_value(schema: &Schema) -> String {
+        match &schema.schema_kind {
+            SchemaKind::Type(Type::String(s)) => {
+                if let Some(first) = s.enumeration.iter().flatten().next() {
+                    return first.clone();
+                }
+                match &s.format {
+                    VariantOrUnknownOrEmpty::Item(StringFormat::Date) => "2024-01-01".to_string(),
+                    VariantOrUnknownOrEmpty::Item(StringFormat::DateTime) => {
+                        "2024-01-01T00:00:00Z".to_string()
+                    }
+                    VariantOrUnknownOrEmpty::Unknown(fmt) => match fmt.as_str() {
+                        "email" => "user@example.com".to_string(),
+                        "uuid" => "00000000-0000-0000-0000-000000000000".to_string(),
+                        "uri" | "url" => "https://example.com".to_string(),
+                        "ipv4" => "192.0.2.1".to_string(),
+                        "ipv6" => "2001:db8::1".to_string(),
+                        "hostname" => "example.com".to_string(),
+                        "byte" => "dGVzdA==".to_string(),
+                        _ => "test-value".to_string(),
+                    },
+                    _ => "test-value".to_string(),
+                }
+            }
+            SchemaKind::Type(Type::Integer(i)) => i
+                .enumeration
+                .iter()
+                .flatten()
+                .next()
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "42".to_string()),
+            SchemaKind::Type(Type::Number(n)) => n
+                .enumeration
+                .iter()
+                .flatten()
+                .next()
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "42".to_string()),
+            SchemaKind::Type(Type::Boolean(_)) => "true".to_string(),
+            SchemaKind::Type(Type::Array(_)) => "a,b".to_string(),
+            _ => "test-value".to_string(),
+        }
     }
 
     /// Annotate schema-level features (types, composition, formats, constraints)
@@ -859,7 +919,10 @@ impl SpecDrivenConformanceGenerator {
                  \x20\x20\x20\x20\x20\x20\x20\x20  // Round 49/50 #79 — total = disk-sum payload; wire = total +\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  // ASCII envelope. raw.length UNDERcounts binary bodies, so\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  // never use it for wire when part sizes are known.\n\
-                 \x20\x20\x20\x20\x20\x20\x20\x20  const wireBytes = __allKnown ? (partsTotal + envelopeBytes) : ((typeof raw === 'string' && raw.length) ? raw.length : totalBytes);\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // Round 51 #79 — prefer k6's Content-Length (exact wire body\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // size, matches the proxy) over the reconstructed envelope.\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  const __clHdr = parseInt((reqHeaders['Content-Length'] || reqHeaders['content-length'] || ''), 10);\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  const wireBytes = (!isNaN(__clHdr) && __clHdr > 0) ? __clHdr : (__allKnown ? (partsTotal + envelopeBytes) : ((typeof raw === 'string' && raw.length) ? raw.length : totalBytes));\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  const summary = parts.map(function (p) { return '\\'' + p.name + '\\':\\'' + p.filename + '\\' (' + p.contentType + ', ' + p.bytes + ' bytes)'; }).join(', ');\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  reqBody = '<multipart/form-data; boundary=' + boundary + '; ' + parts.length + ' part(s); total ' + totalBytes + ' bytes (wire ' + wireBytes + ' bytes w/ envelope): ' + summary + '>';\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20} catch (e) {\n\
@@ -1936,5 +1999,65 @@ mod tests {
         assert_eq!(effective[1], ("X-Other".to_string(), "keep-this".to_string()));
         // Cookie should be appended
         assert_eq!(effective[2], ("Cookie".to_string(), "session=abc".to_string()));
+    }
+
+    // Round 51 (#79) — baseline param filler must be spec-VALID so a probe that
+    // isn't attacking a given param doesn't trip a spurious violation on it.
+    #[test]
+    fn param_sample_value_respects_enum_boolean_and_type() {
+        use openapiv3::{BooleanType, IntegerType, NumberType, VariantOrUnknownOrEmpty};
+
+        // Enum string (like Apigee's `alt`: json|media|proto) -> first member.
+        let st = StringType {
+            enumeration: vec![Some("json".into()), Some("media".into())],
+            ..Default::default()
+        };
+        let enum_schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(st)),
+        };
+        assert_eq!(SpecDrivenConformanceGenerator::schema_sample_value(&enum_schema), "json");
+
+        // Boolean (like `prettyPrint`) -> "true", not "test-value".
+        let bool_schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Boolean(BooleanType::default())),
+        };
+        assert_eq!(SpecDrivenConformanceGenerator::schema_sample_value(&bool_schema), "true");
+
+        // Integer -> a number.
+        let int_schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Integer(IntegerType::default())),
+        };
+        assert_eq!(SpecDrivenConformanceGenerator::schema_sample_value(&int_schema), "42");
+
+        // Number -> a number.
+        let num_schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Number(NumberType::default())),
+        };
+        assert_eq!(SpecDrivenConformanceGenerator::schema_sample_value(&num_schema), "42");
+
+        // Plain string with no constraints -> the generic filler.
+        let plain = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(StringType::default())),
+        };
+        assert_eq!(SpecDrivenConformanceGenerator::schema_sample_value(&plain), "test-value");
+
+        // String with a known format -> a value valid for that format.
+        let email = StringType {
+            format: VariantOrUnknownOrEmpty::Unknown("email".into()),
+            ..Default::default()
+        };
+        let email_schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(email)),
+        };
+        assert_eq!(
+            SpecDrivenConformanceGenerator::schema_sample_value(&email_schema),
+            "user@example.com"
+        );
     }
 }

--- a/crates/mockforge-bench/src/request_gen.rs
+++ b/crates/mockforge-bench/src/request_gen.rs
@@ -243,8 +243,20 @@ impl RequestGenerator {
                 json!([])
             }
             SchemaKind::Type(Type::String(_)) => Self::generate_string_value(schema),
-            SchemaKind::Type(Type::Number(_)) => json!(42.0),
-            SchemaKind::Type(Type::Integer(_)) => json!(42),
+            SchemaKind::Type(Type::Number(n)) => n
+                .enumeration
+                .iter()
+                .flatten()
+                .next()
+                .map(|v| json!(v))
+                .unwrap_or_else(|| json!(42.0)),
+            SchemaKind::Type(Type::Integer(i)) => i
+                .enumeration
+                .iter()
+                .flatten()
+                .next()
+                .map(|v| json!(v))
+                .unwrap_or_else(|| json!(42)),
             SchemaKind::Type(Type::Boolean(_)) => json!(true),
             _ => json!(null),
         }
@@ -255,6 +267,15 @@ impl RequestGenerator {
         // Use example if available
         if let Some(example) = &schema.schema_data.example {
             return example.clone();
+        }
+        // Round 51 (#79) — respect an enum so the positive body is spec-VALID
+        // (Srikanth on 0.3.196: `billingType` was filled with the invalid
+        // literal "test-string", tripping a body enum violation on every
+        // probe). Negative body probes still override the value they attack.
+        if let SchemaKind::Type(Type::String(s)) = &schema.schema_kind {
+            if let Some(first) = s.enumeration.iter().flatten().next() {
+                return json!(first);
+            }
         }
 
         json!("test-string")
@@ -276,6 +297,29 @@ impl RequestGenerator {
 mod tests {
     use super::*;
     use openapiv3::Operation;
+
+    // Round 51 (#79) — a string property with an enum must generate a VALID
+    // member, not the invalid literal "test-string".
+    #[test]
+    fn generate_string_value_uses_enum_member() {
+        use openapiv3::{Schema, SchemaData, SchemaKind, StringType, Type};
+        let st = StringType {
+            enumeration: vec![Some("EVALUATION".into()), Some("PAYG".into())],
+            ..Default::default()
+        };
+        let schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(st)),
+        };
+        assert_eq!(RequestGenerator::generate_string_value(&schema), json!("EVALUATION"));
+
+        // No enum -> the generic filler is fine.
+        let plain = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(StringType::default())),
+        };
+        assert_eq!(RequestGenerator::generate_string_value(&plain), json!("test-string"));
+    }
 
     #[test]
     fn test_generate_path() {


### PR DESCRIPTION
Addresses Srikanth's 0.3.196 feedback on #79.

## Fixes (real-binary verified against `mockforge serve`)
1. **by-probe check_name vs violation mismatch** — a `request-body:content-type-mismatch:multipart` probe reported `query_value_mismatch` on `alt`/`prettyPrint`. Root cause: the baseline probe filled every query/path param with `test-value` and every string body property with `test-string`, both invalid against enum/boolean/type constraints, so **every** probe tripped the same incidental violations regardless of what it tested. The baseline filler is now spec-VALID (enum -> first member, boolean -> `true`, integer/number -> valid number, string formats -> valid value, body enums -> valid member); negative probes still override the param/body they attack. Verified: by-probe violations dropped **32 -> 12**, every `request-body:*` probe now shows **query_viols=0**, content-type-mismatch probes are clean. Also makes the SQLi/OWASP probes truthful (they show the violation for the param they actually injected).
2. **multipart `wire` bytes 264 short of his proxy** — the r50 reconstruction from k6's `res.request.body` drifts from the real socket bytes. `wire` now prefers the request's `Content-Length` (the exact wire body size the proxy counts), falling back to the reconstruction. Both render paths.

## Added
- New reference doc **Agent / LLM / MCP Traffic (Packet-Level)** (`book/src/reference/agent-llm-mcp-traffic.md`) answering his doc/PCAP request: HTTP wire structure for OpenAI / Anthropic / MCP with **real captures** taken against `mockforge serve --llm-mock --mcp-mock`, plus `tcpdump`/`tshark`/`mitmproxy`/`SSLKEYLOGFILE` recipes for true `.pcap` files.

New unit tests for both valid-filler generators; `mockforge-bench` clippy-clean in changed files; fmt clean.