### PR TITLE
fix(bench,http): r52 — $ref request-body violations + multipart full-request bytes + richer MCP mock (#79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9294,14 +9294,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.196"
+version = "0.3.198"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/crates/mockforge-bench/src/conformance/generator.rs
+++ b/crates/mockforge-bench/src/conformance/generator.rs
@@ -370,8 +370,28 @@ impl ConformanceGenerator {
                  \x20\x20\x20\x20\x20\x20\x20\x20  // counts); prefer it, fall back to the reconstruction.\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  const __clHdr = parseInt((reqHeaders['Content-Length'] || reqHeaders['content-length'] || ''), 10);\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  const wireBytes = (!isNaN(__clHdr) && __clHdr > 0) ? __clHdr : (__allKnown ? (partsTotal + envelopeBytes) : ((typeof raw === 'string' && raw.length) ? raw.length : totalBytes));\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // Round 52 #79 — Srikanth on 0.3.198 still saw a fixed 264-byte gap\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // (proxy 57998271 vs our 57998007). Those 264 bytes are the top-level\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // HTTP request preface (request-line + Host + the script-visible\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // headers + the transport-managed Content-Length + the blank line):\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // his proxy meters the whole request, we reported only the multipart\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // entity body (Content-Length). Reconstruct the header block so\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // `request` reconciles with a full-request byte counter.\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  let __hdrBytes = 0;\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  try {\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    const __method = (res.request && res.request.method) ? res.request.method : 'POST';\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    const __url = (res.request && res.request.url) ? res.request.url : '';\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    let __rest = __url; const __sch = __rest.indexOf('://'); if (__sch !== -1) __rest = __rest.substring(__sch + 3);\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    const __slash = __rest.indexOf('/'); const __host = __slash === -1 ? __rest : __rest.substring(0, __slash); const __pathq = __slash === -1 ? '/' : __rest.substring(__slash);\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    __hdrBytes += (__method + ' ' + __pathq + ' HTTP/1.1').length + 2;\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    if (__host) __hdrBytes += ('Host: ' + __host).length + 2;\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    for (const __hn in reqHeaders) { let __hv = reqHeaders[__hn]; if (Array.isArray(__hv)) __hv = __hv.join(', '); __hdrBytes += (__hn + ': ' + String(__hv)).length + 2; }\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    if (!('Content-Length' in reqHeaders) && !('content-length' in reqHeaders)) { __hdrBytes += ('Content-Length: ' + wireBytes).length + 2; }\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    __hdrBytes += 2;\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  } catch (e) { __hdrBytes = 0; }\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  const requestBytes = wireBytes + __hdrBytes;\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  const summary = parts.map(function (p) { return '\\'' + p.name + '\\':\\'' + p.filename + '\\' (' + p.contentType + ', ' + p.bytes + ' bytes)'; }).join(', ');\n\
-                 \x20\x20\x20\x20\x20\x20\x20\x20  reqBody = '<multipart/form-data; boundary=' + boundary + '; ' + parts.length + ' part(s); total ' + totalBytes + ' bytes (wire ' + wireBytes + ' bytes w/ envelope): ' + summary + '>';\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  reqBody = '<multipart/form-data; boundary=' + boundary + '; ' + parts.length + ' part(s); total ' + totalBytes + ' bytes (wire ' + wireBytes + ' bytes w/ envelope' + (__hdrBytes > 0 ? ('; request ' + requestBytes + ' bytes incl ' + __hdrBytes + '-byte header block') : '') + '): ' + summary + '>';\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20} catch (e) {\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  reqBody = '<multipart upload; summary failed: ' + (e && e.message ? e.message : 'unknown') + '>';\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20}\n\

--- a/crates/mockforge-bench/src/conformance/request_validator.rs
+++ b/crates/mockforge-bench/src/conformance/request_validator.rs
@@ -762,35 +762,35 @@ pub async fn validate_emitted_requests_with_base_path(
 
         // Round 45 — request-body cross-check. Only kicks in when the
         // sent body parses as JSON and the operation declares a JSON
-        // requestBody schema. Shallow: missing required top-level
-        // fields + enum/type mismatches on direct properties. Deeper
-        // schema walks (nested objects, oneOf/anyOf) are the server-
-        // side validator's job; we just want to surface the obvious
-        // wire-level breaks the bench actually fired.
+        // requestBody schema.
+        //
+        // Round 52 (#79) — Srikanth on 0.3.198: a self-test +
+        // `--targets-file` run reported "2700 request-body caught" but
+        // the by-request / by-probe violation files came out EMPTY. The
+        // old shallow check here only fired when the requestBody media
+        // schema was an inline `ReferenceOr::Item`; the Apigee spec (and
+        // most real specs) declares
+        // `schema.$ref = #/components/schemas/GoogleCloudApigeeV1Organization`,
+        // so `schema_ref.as_item()` returned `None` and every body probe
+        // was silently skipped. It also only type-checked STRING values,
+        // so a `{"analyticsRegion":12345}` (number-where-string) probe
+        // never surfaced even when the schema resolved. We now resolve
+        // the requestBody + schema `$ref`s and reuse the same full JSON
+        // Schema validator `validate_custom_checks` uses (round 18.3's
+        // `build_validator`), so nested `$ref`s, root-type mismatches,
+        // and non-string type mismatches are all caught.
         let body_str = req.get("body").and_then(|v| v.as_str()).unwrap_or("");
         if !body_str.is_empty() {
             if let Ok(body_json) = serde_json::from_str::<serde_json::Value>(body_str) {
-                if let Some(req_body) = operation.request_body.as_ref().and_then(|r| r.as_item()) {
-                    for (ct, media) in &req_body.content {
-                        if !ct.contains("json") {
-                            continue;
-                        }
-                        let Some(schema_ref) = &media.schema else {
-                            continue;
-                        };
-                        let Some(schema) = schema_ref.as_item() else {
-                            continue;
-                        };
-                        check_body_against_schema(
-                            &check,
-                            &method,
-                            &url,
-                            &body_json,
-                            schema,
-                            &mut emitted_violations,
-                        );
-                    }
-                }
+                validate_emitted_body(
+                    &check,
+                    &method,
+                    &url,
+                    &body_json,
+                    operation,
+                    spec,
+                    &mut emitted_violations,
+                );
             }
         }
     }
@@ -1046,60 +1046,84 @@ fn group_violations_by_request(flat: &[serde_json::Value]) -> serde_json::Value 
     Value::Array(rows)
 }
 
-/// Round 45 (#79) — shallow body-vs-schema check for the retroactive
-/// emitted-request validator. Pushes a [`RequestViolation`] for each
-/// missing top-level `required` field and for each direct property
-/// that fails an `enum` / type check. Intentionally does NOT recurse
-/// into nested objects or follow `$ref` — the server-side validator is
-/// authoritative there; this client-side pass only mirrors the obvious
-/// wire-level breaks the bench actually fired.
-fn check_body_against_schema(
+/// Round 52 (#79) — validate an emitted request body against the
+/// operation's requestBody schema, resolving `$ref` at both the
+/// requestBody and schema level and delegating to the same full JSON
+/// Schema validator (`build_validator`) the custom-checks path uses.
+///
+/// This replaced a shallow, `$ref`-unaware check that only fired for
+/// inline schemas and only type-checked string values — which is why a
+/// self-test run against the Apigee spec (whose request bodies are all
+/// `$ref`s to component schemas) produced empty violation logs even
+/// though the summary reported thousands of caught request-body
+/// negatives. We cap at 5 errors per body so a deeply-broken probe
+/// can't flood the log; the by-probe file still gets one row per probe.
+fn validate_emitted_body(
     check: &str,
     method: &str,
     url: &str,
     body: &serde_json::Value,
-    schema: &openapiv3::Schema,
+    operation: &openapiv3::Operation,
+    spec: &OpenAPI,
     violations: &mut Vec<RequestViolation>,
 ) {
-    use openapiv3::{SchemaKind, Type};
-
-    let SchemaKind::Type(Type::Object(obj_type)) = &schema.schema_kind else {
+    // Resolve the requestBody (may itself be a $ref into components).
+    let Some(request_body_ref) = &operation.request_body else {
         return;
     };
-    let Some(body_obj) = body.as_object() else {
-        return;
-    };
-
-    for required in &obj_type.required {
-        if !body_obj.contains_key(required) {
-            violations.push(RequestViolation {
-                check_name: check.to_string(),
-                method: method.to_string(),
-                path: url.to_string(),
-                violation_type: "body_missing_required".to_string(),
-                message: format!("body.{}: required field missing", required),
-            });
-        }
-    }
-
-    for (prop_name, prop_ref) in &obj_type.properties {
-        let Some(value) = body_obj.get(prop_name) else {
-            continue;
-        };
-        let Some(prop_schema) = prop_ref.as_item() else {
-            continue;
-        };
-        if let Some(value_str) = value.as_str() {
-            if let Some(msg) = check_value_against_schema(value_str, prop_schema) {
-                violations.push(RequestViolation {
-                    check_name: check.to_string(),
-                    method: method.to_string(),
-                    path: url.to_string(),
-                    violation_type: "body_value_mismatch".to_string(),
-                    message: format!("body.{}: {}", prop_name, msg),
-                });
+    let request_body = match request_body_ref {
+        ReferenceOr::Item(rb) => rb,
+        ReferenceOr::Reference { reference } => {
+            let name = reference.strip_prefix("#/components/requestBodies/").unwrap_or(reference);
+            match spec.components.as_ref().and_then(|c| c.request_bodies.get(name)) {
+                Some(ReferenceOr::Item(rb)) => rb,
+                _ => return,
             }
         }
+    };
+
+    // Only cross-check JSON bodies — other media types (multipart,
+    // urlencoded) are handled elsewhere / by the server validator.
+    let json_media = request_body
+        .content
+        .get("application/json")
+        .or_else(|| request_body.content.iter().find(|(k, _)| k.contains("json")).map(|(_, v)| v));
+    let Some(media) = json_media else {
+        return;
+    };
+    let Some(schema_ref) = &media.schema else {
+        return;
+    };
+
+    // Resolve the immediate schema $ref (one level) to the root schema,
+    // then hand it to the resolver so nested $refs resolve against the
+    // full document (round 18.3's fix for vCenter's nested components).
+    let root_schema = match schema_ref {
+        ReferenceOr::Item(s) => s.clone(),
+        ReferenceOr::Reference { reference } => {
+            let name = reference.strip_prefix("#/components/schemas/").unwrap_or(reference);
+            match spec.components.as_ref().and_then(|c| c.schemas.get(name)) {
+                Some(ReferenceOr::Item(s)) => s.clone(),
+                _ => return,
+            }
+        }
+    };
+
+    let Ok(validator) = mockforge_openapi::schema_ref_resolver::build_validator(&root_schema, spec)
+    else {
+        // Schema itself is unbuildable — skip rather than false-positive.
+        return;
+    };
+    for err in validator.iter_errors(body).take(5) {
+        let loc = err.instance_path.to_string();
+        let loc = if loc.is_empty() { "$".to_string() } else { loc };
+        violations.push(RequestViolation {
+            check_name: check.to_string(),
+            method: method.to_string(),
+            path: url.to_string(),
+            violation_type: "body_schema_violation".to_string(),
+            message: format!("body{}: {}", loc, err),
+        });
     }
 }
 
@@ -1274,5 +1298,129 @@ mod grouping_tests {
         ];
         let out = group_violations_by_request(&flat);
         assert_eq!(out.as_array().unwrap().len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod emitted_body_tests {
+    use super::validate_emitted_requests_with_base_path;
+    use std::io::Write;
+
+    /// Round 52 (#79) — Srikanth on 0.3.198: a `--conformance-self-test
+    /// --targets-file` run reported "2700 request-body caught" in the
+    /// summary but wrote EMPTY `conformance-request-violations-by-request.json`
+    /// and `-by-probe.json`. Root cause: the emitted-request validator's
+    /// body check (`check_body_against_schema`) only fired when the
+    /// requestBody media schema was an inline `ReferenceOr::Item`. The
+    /// Apigee spec (like most real specs) declares
+    /// `requestBody.content.application/json.schema.$ref =
+    /// #/components/schemas/GoogleCloudApigeeV1Organization`, so
+    /// `schema_ref.as_item()` returned `None` and every body probe was
+    /// skipped. It also only type-checked STRING property values, so a
+    /// `{"analyticsRegion":12345}` (number where string expected) probe
+    /// produced no violation even when the schema resolved.
+    ///
+    /// This reproduces the multi-target self-test shape: a JSONL of
+    /// captured probes, a spec whose requestBody is a `$ref`, and the
+    /// exact negative labels the self-test generator emits.
+    #[tokio::test]
+    async fn emitted_requests_validate_ref_bodied_negatives() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        // Spec: /v1/organizations POST, requestBody is a $ref to a
+        // component schema (the real-world shape). No `required` fields
+        // so the positive `{}` probe stays clean (no false positive).
+        let spec_json = serde_json::json!({
+            "openapi": "3.0.0",
+            "info": { "title": "apigee-min", "version": "1.0.0" },
+            "paths": {
+                "/v1/organizations": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/Organization" }
+                                }
+                            }
+                        },
+                        "responses": { "200": { "description": "ok" } }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "Organization": {
+                        "type": "object",
+                        "properties": {
+                            "analyticsRegion": { "type": "string" },
+                            "displayName": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        });
+        let spec_path = dir.path().join("apigee-min.json");
+        std::fs::write(&spec_path, serde_json::to_vec_pretty(&spec_json).unwrap()).unwrap();
+
+        // JSONL of captured probes, mirroring the self-test capture shape
+        // (label / method / url / request_body). One positive, two
+        // negatives (a type-mismatch on a $ref'd property, and a
+        // wrong-root-type body).
+        let jsonl_path = dir.path().join("conformance-self-test-requests.jsonl");
+        let mut f = std::fs::File::create(&jsonl_path).unwrap();
+        let base = "https://172.22.232.2:443/v1/organizations?alt=json";
+        for line in [
+            serde_json::json!({
+                "label": "positive", "method": "POST", "url": base, "request_body": "{}"
+            }),
+            serde_json::json!({
+                "label": "request-body:type-mismatch:analyticsRegion",
+                "method": "POST", "url": base,
+                "request_body": "{\"analyticsRegion\":12345}"
+            }),
+            serde_json::json!({
+                "label": "request-body:wrong-type",
+                "method": "POST", "url": base, "request_body": "[]"
+            }),
+        ] {
+            writeln!(f, "{}", serde_json::to_string(&line).unwrap()).unwrap();
+        }
+        drop(f);
+
+        let n = validate_emitted_requests_with_base_path(
+            std::slice::from_ref(&spec_path),
+            dir.path(),
+            None,
+        )
+        .await
+        .expect("validation runs");
+
+        assert!(n >= 2, "expected the two request-body negatives to be flagged, got {n}");
+
+        // The grouped files the user actually reads must be non-empty.
+        let by_request = std::fs::read_to_string(
+            dir.path().join("conformance-request-violations-by-request.json"),
+        )
+        .unwrap();
+        let by_request: serde_json::Value = serde_json::from_str(&by_request).unwrap();
+        assert!(
+            !by_request.as_array().unwrap().is_empty(),
+            "by-request file must not be empty for a spec with $ref request bodies"
+        );
+
+        let by_probe = std::fs::read_to_string(
+            dir.path().join("conformance-request-violations-by-probe.json"),
+        )
+        .unwrap();
+        let by_probe: serde_json::Value = serde_json::from_str(&by_probe).unwrap();
+        assert!(!by_probe.as_array().unwrap().is_empty(), "by-probe file must not be empty");
+
+        // The type-mismatch probe must surface as a violation naming the field.
+        let flat = std::fs::read_to_string(dir.path().join("conformance-request-violations.json"))
+            .unwrap();
+        assert!(
+            flat.contains("analyticsRegion"),
+            "the number-where-string probe must be reported: {flat}"
+        );
     }
 }

--- a/crates/mockforge-bench/src/conformance/spec_driven.rs
+++ b/crates/mockforge-bench/src/conformance/spec_driven.rs
@@ -923,8 +923,28 @@ impl SpecDrivenConformanceGenerator {
                  \x20\x20\x20\x20\x20\x20\x20\x20  // size, matches the proxy) over the reconstructed envelope.\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  const __clHdr = parseInt((reqHeaders['Content-Length'] || reqHeaders['content-length'] || ''), 10);\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  const wireBytes = (!isNaN(__clHdr) && __clHdr > 0) ? __clHdr : (__allKnown ? (partsTotal + envelopeBytes) : ((typeof raw === 'string' && raw.length) ? raw.length : totalBytes));\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // Round 52 #79 — Srikanth on 0.3.198 still saw a fixed 264-byte gap\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // (proxy 57998271 vs our 57998007). Those 264 bytes are the top-level\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // HTTP request preface (request-line + Host + the script-visible\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // headers + the transport-managed Content-Length + the blank line):\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // his proxy meters the whole request, we reported only the multipart\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // entity body (Content-Length). Reconstruct the header block so\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  // `request` reconciles with a full-request byte counter.\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  let __hdrBytes = 0;\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  try {\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    const __method = (res.request && res.request.method) ? res.request.method : 'POST';\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    const __url = (res.request && res.request.url) ? res.request.url : '';\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    let __rest = __url; const __sch = __rest.indexOf('://'); if (__sch !== -1) __rest = __rest.substring(__sch + 3);\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    const __slash = __rest.indexOf('/'); const __host = __slash === -1 ? __rest : __rest.substring(0, __slash); const __pathq = __slash === -1 ? '/' : __rest.substring(__slash);\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    __hdrBytes += (__method + ' ' + __pathq + ' HTTP/1.1').length + 2;\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    if (__host) __hdrBytes += ('Host: ' + __host).length + 2;\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    for (const __hn in reqHeaders) { let __hv = reqHeaders[__hn]; if (Array.isArray(__hv)) __hv = __hv.join(', '); __hdrBytes += (__hn + ': ' + String(__hv)).length + 2; }\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    if (!('Content-Length' in reqHeaders) && !('content-length' in reqHeaders)) { __hdrBytes += ('Content-Length: ' + wireBytes).length + 2; }\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20    __hdrBytes += 2;\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  } catch (e) { __hdrBytes = 0; }\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  const requestBytes = wireBytes + __hdrBytes;\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  const summary = parts.map(function (p) { return '\\'' + p.name + '\\':\\'' + p.filename + '\\' (' + p.contentType + ', ' + p.bytes + ' bytes)'; }).join(', ');\n\
-                 \x20\x20\x20\x20\x20\x20\x20\x20  reqBody = '<multipart/form-data; boundary=' + boundary + '; ' + parts.length + ' part(s); total ' + totalBytes + ' bytes (wire ' + wireBytes + ' bytes w/ envelope): ' + summary + '>';\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20  reqBody = '<multipart/form-data; boundary=' + boundary + '; ' + parts.length + ' part(s); total ' + totalBytes + ' bytes (wire ' + wireBytes + ' bytes w/ envelope' + (__hdrBytes > 0 ? ('; request ' + requestBytes + ' bytes incl ' + __hdrBytes + '-byte header block') : '') + '): ' + summary + '>';\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20} catch (e) {\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20  reqBody = '<multipart upload; summary failed: ' + (e && e.message ? e.message : 'unknown') + '>';\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20}\n\

--- a/crates/mockforge-http/src/mcp_mock.rs
+++ b/crates/mockforge-http/src/mcp_mock.rs
@@ -3,13 +3,21 @@
 //! Serves a JSON-RPC 2.0 endpoint at `POST /mcp` so an agent acting as an MCP
 //! client (the role Cursor / Claude Code / custom agents play when they call
 //! out to tool servers) can talk to MockForge as a fake MCP server. Answers
-//! the core MCP methods with a configurable tool catalog and canned results:
-//! `initialize`, `tools/list`, `tools/call`, `resources/list`, `prompts/list`,
-//! plus the `notifications/initialized` notification.
+//! the core MCP methods with a configurable catalog and canned results:
+//! `initialize`, `tools/list`, `tools/call`, `resources/list`,
+//! `resources/read`, `resources/templates/list`, `prompts/list`,
+//! `prompts/get`, `ping`, plus the `notifications/initialized` notification.
 //!
 //! This is a MOCK: no real tools run. `tools/call` returns deterministic
 //! canned content so agents can be exercised against a predictable (or, with
 //! a configured error tool, hostile) MCP server.
+//!
+//! Round 52 (#79) — Srikanth on 0.3.198 asked whether the mock can "respond
+//! with more tools, resources, prompts so that applications are chatty (sees
+//! more client-server traffic)". The default catalog now ships a fuller set
+//! of tools plus non-empty resources and prompts, and `resources/read` /
+//! `prompts/get` are implemented, so a client that lists then reads/gets/calls
+//! generates substantially more request/response traffic to capture.
 //!
 //! Mounted by `mockforge serve --mcp-mock`.
 
@@ -41,6 +49,46 @@ pub struct McpTool {
     pub is_error: bool,
 }
 
+/// A single mock resource in the catalog.
+#[derive(Clone, Debug)]
+pub struct McpResource {
+    /// Resource URI advertised in `resources/list` and matched by
+    /// `resources/read`.
+    pub uri: String,
+    /// Human-readable resource name.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// MIME type advertised for the resource contents.
+    pub mime_type: String,
+    /// Canned text returned by `resources/read`.
+    pub text: String,
+}
+
+/// A single argument declared by a mock prompt.
+#[derive(Clone, Debug)]
+pub struct McpPromptArg {
+    /// Argument name.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Whether the client must supply this argument.
+    pub required: bool,
+}
+
+/// A single mock prompt in the catalog.
+#[derive(Clone, Debug)]
+pub struct McpPrompt {
+    /// Prompt name advertised in `prompts/list` and matched by `prompts/get`.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Declared arguments (surfaced in `prompts/list`).
+    pub arguments: Vec<McpPromptArg>,
+    /// Canned user-message text returned by `prompts/get`.
+    pub text: String,
+}
+
 /// Runtime configuration for the mock MCP server.
 #[derive(Clone, Debug)]
 pub struct McpMockConfig {
@@ -50,6 +98,11 @@ pub struct McpMockConfig {
     pub server_version: String,
     /// Tool catalog returned by `tools/list` and dispatched by `tools/call`.
     pub tools: Vec<McpTool>,
+    /// Resource catalog returned by `resources/list` and read by
+    /// `resources/read`.
+    pub resources: Vec<McpResource>,
+    /// Prompt catalog returned by `prompts/list` and fetched by `prompts/get`.
+    pub prompts: Vec<McpPrompt>,
 }
 
 impl Default for McpMockConfig {
@@ -57,28 +110,183 @@ impl Default for McpMockConfig {
         Self {
             server_name: "mockforge-mcp".to_string(),
             server_version: env!("CARGO_PKG_VERSION").to_string(),
-            tools: vec![
-                McpTool {
-                    name: "echo".to_string(),
-                    description: "Echo back the provided text.".to_string(),
-                    input_schema: json!({
-                        "type": "object",
-                        "properties": { "text": { "type": "string" } },
-                        "required": ["text"],
-                    }),
-                    canned_result: "echo".to_string(),
-                    is_error: false,
-                },
-                McpTool {
-                    name: "get_status".to_string(),
-                    description: "Return a canned status payload.".to_string(),
-                    input_schema: json!({ "type": "object", "properties": {} }),
-                    canned_result: "{\"status\":\"ok\",\"source\":\"mockforge-mcp\"}".to_string(),
-                    is_error: false,
-                },
-            ],
+            tools: default_tools(),
+            resources: default_resources(),
+            prompts: default_prompts(),
         }
     }
+}
+
+/// Default tool catalog. Deliberately broad (round 52 #79) so `tools/list`
+/// and subsequent `tools/call`s produce meaningful client-server traffic.
+fn default_tools() -> Vec<McpTool> {
+    let obj = |props: Value, required: Value| {
+        json!({
+            "type": "object", "properties": props, "required": required,
+        })
+    };
+    vec![
+        McpTool {
+            name: "echo".to_string(),
+            description: "Echo back the provided text.".to_string(),
+            input_schema: obj(json!({ "text": { "type": "string" } }), json!(["text"])),
+            canned_result: "echo".to_string(),
+            is_error: false,
+        },
+        McpTool {
+            name: "get_status".to_string(),
+            description: "Return a canned service status payload.".to_string(),
+            input_schema: json!({ "type": "object", "properties": {} }),
+            canned_result: "{\"status\":\"ok\",\"source\":\"mockforge-mcp\"}".to_string(),
+            is_error: false,
+        },
+        McpTool {
+            name: "get_time".to_string(),
+            description: "Return a canned current timestamp (UTC, ISO-8601).".to_string(),
+            input_schema: json!({ "type": "object", "properties": {} }),
+            canned_result: "{\"now\":\"2026-01-01T00:00:00Z\",\"tz\":\"UTC\"}".to_string(),
+            is_error: false,
+        },
+        McpTool {
+            name: "add".to_string(),
+            description: "Add two numbers and return their sum.".to_string(),
+            input_schema: obj(
+                json!({ "a": { "type": "number" }, "b": { "type": "number" } }),
+                json!(["a", "b"]),
+            ),
+            canned_result: "{\"sum\":42}".to_string(),
+            is_error: false,
+        },
+        McpTool {
+            name: "search_documents".to_string(),
+            description: "Search a canned document index and return matching hits.".to_string(),
+            input_schema: obj(
+                json!({
+                    "query": { "type": "string" },
+                    "limit": { "type": "integer", "minimum": 1, "maximum": 50 },
+                }),
+                json!(["query"]),
+            ),
+            canned_result: "{\"hits\":[{\"id\":\"doc-1\",\"title\":\"Getting Started\",\"score\":0.98},{\"id\":\"doc-2\",\"title\":\"API Reference\",\"score\":0.71}]}".to_string(),
+            is_error: false,
+        },
+        McpTool {
+            name: "get_weather".to_string(),
+            description: "Return a canned weather report for a location.".to_string(),
+            input_schema: obj(
+                json!({ "location": { "type": "string" } }),
+                json!(["location"]),
+            ),
+            canned_result: "{\"location\":\"Sample City\",\"tempC\":21,\"conditions\":\"Partly cloudy\"}".to_string(),
+            is_error: false,
+        },
+        McpTool {
+            name: "create_ticket".to_string(),
+            description: "Create a canned support ticket and return its id.".to_string(),
+            input_schema: obj(
+                json!({
+                    "title": { "type": "string" },
+                    "priority": { "type": "string", "enum": ["low", "medium", "high"] },
+                }),
+                json!(["title"]),
+            ),
+            canned_result: "{\"ticketId\":\"TKT-1001\",\"state\":\"open\"}".to_string(),
+            is_error: false,
+        },
+        McpTool {
+            name: "fail_tool".to_string(),
+            description: "Always returns an error result (for testing hostile tools).".to_string(),
+            input_schema: json!({ "type": "object", "properties": {} }),
+            canned_result: "simulated tool failure".to_string(),
+            is_error: true,
+        },
+    ]
+}
+
+/// Default resource catalog (round 52 #79). Non-empty so `resources/list`
+/// and `resources/read` exercise the resource half of the protocol.
+fn default_resources() -> Vec<McpResource> {
+    vec![
+        McpResource {
+            uri: "file:///readme.md".to_string(),
+            name: "README".to_string(),
+            description: "Project readme served by the mock.".to_string(),
+            mime_type: "text/markdown".to_string(),
+            text: "# MockForge MCP Mock\n\nCanned readme resource.\n".to_string(),
+        },
+        McpResource {
+            uri: "config://app/settings.json".to_string(),
+            name: "App settings".to_string(),
+            description: "Canned application settings document.".to_string(),
+            mime_type: "application/json".to_string(),
+            text: "{\"featureFlags\":{\"beta\":true},\"maxItems\":100}".to_string(),
+        },
+        McpResource {
+            uri: "db://users/schema".to_string(),
+            name: "Users schema".to_string(),
+            description: "Canned users table schema.".to_string(),
+            mime_type: "application/json".to_string(),
+            text: "{\"table\":\"users\",\"columns\":[\"id\",\"email\",\"created_at\"]}".to_string(),
+        },
+        McpResource {
+            uri: "log://app/latest".to_string(),
+            name: "Latest app log".to_string(),
+            description: "Canned tail of the application log.".to_string(),
+            mime_type: "text/plain".to_string(),
+            text: "2026-01-01T00:00:00Z INFO booted\n2026-01-01T00:00:01Z INFO ready\n".to_string(),
+        },
+    ]
+}
+
+/// Default prompt catalog (round 52 #79). Non-empty so `prompts/list` and
+/// `prompts/get` exercise the prompt half of the protocol.
+fn default_prompts() -> Vec<McpPrompt> {
+    vec![
+        McpPrompt {
+            name: "summarize".to_string(),
+            description: "Summarize the provided text.".to_string(),
+            arguments: vec![McpPromptArg {
+                name: "text".to_string(),
+                description: "The text to summarize.".to_string(),
+                required: true,
+            }],
+            text: "Please summarize the following text in three sentences.".to_string(),
+        },
+        McpPrompt {
+            name: "code_review".to_string(),
+            description: "Review a code snippet for bugs and style.".to_string(),
+            arguments: vec![
+                McpPromptArg {
+                    name: "language".to_string(),
+                    description: "Programming language of the snippet.".to_string(),
+                    required: false,
+                },
+                McpPromptArg {
+                    name: "code".to_string(),
+                    description: "The code to review.".to_string(),
+                    required: true,
+                },
+            ],
+            text: "Review the following code and list bugs, risks, and style issues.".to_string(),
+        },
+        McpPrompt {
+            name: "translate".to_string(),
+            description: "Translate text into a target language.".to_string(),
+            arguments: vec![
+                McpPromptArg {
+                    name: "target_language".to_string(),
+                    description: "Language to translate into.".to_string(),
+                    required: true,
+                },
+                McpPromptArg {
+                    name: "text".to_string(),
+                    description: "The text to translate.".to_string(),
+                    required: true,
+                },
+            ],
+            text: "Translate the following text into the requested target language.".to_string(),
+        },
+    ]
 }
 
 /// Build the axum router exposing the mock MCP JSON-RPC endpoint.
@@ -108,6 +316,27 @@ async fn handle_rpc(State(config): State<McpMockConfig>, Json(req): Json<Value>)
             .into_response();
     }
 
+    // Fallible lookups: an unknown uri / prompt name is INVALID_PARAMS, not a
+    // successful empty result, so a client can tell "no such resource" apart
+    // from "resource has no contents".
+    match method {
+        "resources/read" => {
+            return Json(match resources_read(&config, &params) {
+                Ok(r) => result_response(id, r),
+                Err((code, msg)) => error_response(id, code, &msg),
+            })
+            .into_response();
+        }
+        "prompts/get" => {
+            return Json(match prompts_get(&config, &params) {
+                Ok(r) => result_response(id, r),
+                Err((code, msg)) => error_response(id, code, &msg),
+            })
+            .into_response();
+        }
+        _ => {}
+    }
+
     let result = match method {
         "initialize" => Some(json!({
             "protocolVersion": PROTOCOL_VERSION,
@@ -126,8 +355,26 @@ async fn handle_rpc(State(config): State<McpMockConfig>, Json(req): Json<Value>)
             })).collect::<Vec<_>>(),
         })),
         "tools/call" => Some(tools_call(&config, &params)),
-        "resources/list" => Some(json!({ "resources": [] })),
-        "prompts/list" => Some(json!({ "prompts": [] })),
+        "resources/list" => Some(json!({
+            "resources": config.resources.iter().map(|r| json!({
+                "uri": r.uri,
+                "name": r.name,
+                "description": r.description,
+                "mimeType": r.mime_type,
+            })).collect::<Vec<_>>(),
+        })),
+        "resources/templates/list" => Some(json!({ "resourceTemplates": [] })),
+        "prompts/list" => Some(json!({
+            "prompts": config.prompts.iter().map(|p| json!({
+                "name": p.name,
+                "description": p.description,
+                "arguments": p.arguments.iter().map(|a| json!({
+                    "name": a.name,
+                    "description": a.description,
+                    "required": a.required,
+                })).collect::<Vec<_>>(),
+            })).collect::<Vec<_>>(),
+        })),
         "ping" => Some(json!({})),
         _ => None,
     };
@@ -162,6 +409,43 @@ fn tools_call(config: &McpMockConfig, params: &Value) -> Value {
         "content": [{ "type": "text", "text": text }],
         "isError": tool.is_error,
     })
+}
+
+/// JSON-RPC invalid-params error code, returned for an unknown resource uri
+/// or prompt name.
+const INVALID_PARAMS: i64 = -32602;
+
+/// Handle `resources/read`: look the requested `uri` up in the catalog and
+/// return its canned contents, or an INVALID_PARAMS error if unknown.
+fn resources_read(config: &McpMockConfig, params: &Value) -> Result<Value, (i64, String)> {
+    let uri = params.get("uri").and_then(|u| u.as_str()).unwrap_or("");
+    let Some(resource) = config.resources.iter().find(|r| r.uri == uri) else {
+        return Err((INVALID_PARAMS, format!("unknown resource: {uri}")));
+    };
+    Ok(json!({
+        "contents": [{
+            "uri": resource.uri,
+            "mimeType": resource.mime_type,
+            "text": resource.text,
+        }],
+    }))
+}
+
+/// Handle `prompts/get`: look the requested prompt `name` up in the catalog
+/// and return a canned single-message conversation, or an INVALID_PARAMS
+/// error if unknown.
+fn prompts_get(config: &McpMockConfig, params: &Value) -> Result<Value, (i64, String)> {
+    let name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+    let Some(prompt) = config.prompts.iter().find(|p| p.name == name) else {
+        return Err((INVALID_PARAMS, format!("unknown prompt: {name}")));
+    };
+    Ok(json!({
+        "description": prompt.description,
+        "messages": [{
+            "role": "user",
+            "content": { "type": "text", "text": prompt.text },
+        }],
+    }))
 }
 
 fn result_response(id: Value, result: Value) -> Value {
@@ -200,8 +484,11 @@ mod tests {
     async fn tools_list_returns_catalog() {
         let v = call(json!({"jsonrpc":"2.0","id":2,"method":"tools/list"})).await;
         let tools = v["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 2);
+        // Round 52 (#79) — the default catalog is deliberately broad so the
+        // list response is chatty; keep echo/get_status and add several more.
+        assert!(tools.len() >= 6, "expected a rich default tool catalog");
         assert!(tools.iter().any(|t| t["name"] == "echo"));
+        assert!(tools.iter().any(|t| t["name"] == "search_documents"));
         assert!(tools[0]["inputSchema"].is_object());
     }
 
@@ -240,10 +527,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resources_and_prompts_list_are_empty() {
+    async fn resources_and_prompts_list_are_populated() {
+        // Round 52 (#79) — the mock now ships non-empty resource and prompt
+        // catalogs so the resource/prompt halves of the protocol produce
+        // real client-server traffic.
         let r = call(json!({"jsonrpc":"2.0","id":6,"method":"resources/list"})).await;
-        assert!(r["result"]["resources"].as_array().unwrap().is_empty());
+        let resources = r["result"]["resources"].as_array().unwrap();
+        assert!(!resources.is_empty());
+        assert!(resources.iter().all(|x| x["uri"].is_string() && x["mimeType"].is_string()));
+
         let p = call(json!({"jsonrpc":"2.0","id":7,"method":"prompts/list"})).await;
-        assert!(p["result"]["prompts"].as_array().unwrap().is_empty());
+        let prompts = p["result"]["prompts"].as_array().unwrap();
+        assert!(!prompts.is_empty());
+        assert!(prompts.iter().any(|x| x["name"] == "summarize"));
+    }
+
+    #[tokio::test]
+    async fn resources_read_returns_canned_contents() {
+        let v = call(json!({
+            "jsonrpc":"2.0","id":8,"method":"resources/read",
+            "params": { "uri": "file:///readme.md" }
+        }))
+        .await;
+        let contents = v["result"]["contents"].as_array().unwrap();
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0]["uri"], "file:///readme.md");
+        assert!(contents[0]["text"].as_str().unwrap().contains("MockForge"));
+    }
+
+    #[tokio::test]
+    async fn resources_read_unknown_uri_is_invalid_params() {
+        let v = call(json!({
+            "jsonrpc":"2.0","id":9,"method":"resources/read",
+            "params": { "uri": "file:///nope" }
+        }))
+        .await;
+        assert_eq!(v["error"]["code"], INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn prompts_get_returns_message() {
+        let v = call(json!({
+            "jsonrpc":"2.0","id":10,"method":"prompts/get",
+            "params": { "name": "summarize" }
+        }))
+        .await;
+        let messages = v["result"]["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[0]["content"]["type"], "text");
+    }
+
+    #[tokio::test]
+    async fn prompts_get_unknown_name_is_invalid_params() {
+        let v = call(json!({
+            "jsonrpc":"2.0","id":11,"method":"prompts/get",
+            "params": { "name": "nope" }
+        }))
+        .await;
+        assert_eq!(v["error"]["code"], INVALID_PARAMS);
     }
 }


### PR DESCRIPTION
Round 52 of #79 (Srikanth's 0.3.198 follow-up). Three items, each verified with the real binary.

## 1. Empty violation logs on `--conformance-self-test --targets-file`
The emitted-request validator's body check only fired for **inline** requestBody schemas. The Apigee spec (like most real specs) declares `schema.$ref = #/components/schemas/...`, so `schema_ref.as_item()` returned `None` and every body probe was silently skipped. It also only type-checked string values, so `{"analyticsRegion":12345}` produced nothing.

Fix: resolve the requestBody + schema `$ref`s and reuse the same full JSON Schema validator the custom-checks path uses (`build_validator`). Root-type, enum, and non-string type mismatches now populate the by-request / by-probe files.

**Verified end-to-end** — a self-test against a `$ref`-bodied spec now writes 16 flat / 8 by-request / 15 by-probe violations (previously empty `[]`), e.g. `body/analyticsRegion: 12345 is not of type "string"`, `body$: [] is not of type "object"`.

## 2. The residual 264-byte multipart gap
mockforge's `wire` figure is the exact RFC 7578 Content-Length (verified byte-for-byte against Srikanth's 9-part payload). The 264-byte delta he sees vs his proxy is the **top-level HTTP request preface** (request-line + `Host` + script-visible headers + the transport-managed `Content-Length` + blank line) — his proxy meters the whole request; we only reported the entity body.

Fix: the k6 captureExchange now reconstructs the header block and reports `request N bytes incl H-byte header block` alongside `wire`.

**Verified against a live raw-socket capture** — in the same k6 run, mockforge's reported `wire`/`request`/header-block (4838 / 5053 / 215) equalled the bytes k6 actually put on the socket, exactly. For Srikanth's own capture the header block is 264, which is his gap.

## 3. Richer MCP mock (question c)
The mock advertised only 2 tools and empty resources/prompts. The default catalog now ships 8 tools plus non-empty resources and prompts, and `resources/read` / `prompts/get` / `resources/templates/list` are implemented, so a client that lists then reads/gets/calls generates far more capturable traffic.

**Verified against the live server** — `tools/list` returns 8, `resources/list` 4, `prompts/list` 3; `resources/read` and `prompts/get` return canned content and INVALID_PARAMS on unknown ids.

## Tests / checks
- New unit tests: `$ref` body validation, enriched MCP catalog, resources/read + prompts/get error paths.
- `cargo test -p mockforge-bench` 500 passed; `-p mockforge-http` 598 passed.
- Both k6 captureExchange sites (`generator.rs` + `spec_driven.rs`) updated in lockstep.
- `cargo fmt --all --check` clean; clippy clean on changed files (pre-existing `mockforge-core` `sort_by` lints are unrelated).