### PR TITLE
fix: r53 owasp/param violations + PUT bodies + config/docker DX (#79, #925-#931)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -11856,7 +11856,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -12177,9 +12177,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,14 +79,29 @@ RUN apt-get update && apt-get install -y \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Create a non-root user
-RUN groupadd -r mockforge && useradd -r -g mockforge mockforge
+# Create a non-root user WITH a real home directory.
+#
+# Issue #931 — `useradd -r` records `/home/mockforge` in /etc/passwd but does
+# not create it, and `/home` is root-owned. `ScenarioStorage::new()` resolves
+# `~/.mockforge/scenarios`, so the non-root process could not create its own
+# home and every start logged "Failed to create scenarios directory:
+# Permission denied". Create + own the home (and the scenarios dirs) up front.
+RUN groupadd -r mockforge \
+    && useradd -r -g mockforge -m -d /home/mockforge mockforge \
+    && mkdir -p /home/mockforge/.mockforge/scenarios \
+                /home/mockforge/.mockforge/scenario-metadata \
+    && chown -R mockforge:mockforge /home/mockforge
 
 # Set the working directory
 WORKDIR /app
 
 # Copy the built binary from the builder stage
 COPY --from=builder /app/target/release/mockforge /usr/local/bin/mockforge
+
+# Entrypoint shim (issue #930) — makes `command: serve ...` work while still
+# tolerating the old `command: mockforge serve ...` workaround.
+COPY docker/entrypoint.sh /usr/local/bin/mockforge-entrypoint
+RUN chmod +x /usr/local/bin/mockforge-entrypoint
 
 # Copy example files and configuration
 COPY --from=builder /app/examples/ ./examples/
@@ -123,6 +138,17 @@ ENV DOCKER_CONTAINER=true
 # port reachable on Fly 6PN where private traffic is IPv6-only (#468).
 ENV MOCKFORGE_ADMIN_HOST=::
 
-# Default command
-# Use full path to ensure binary is found regardless of PATH
-CMD ["/usr/local/bin/mockforge", "serve", "--admin"]
+# Home for the non-root user, so `~/.mockforge` resolves to a writable path
+# (issue #931). Docker would otherwise leave HOME unset for USER mockforge.
+ENV HOME=/home/mockforge
+
+# Issue #930 — the entrypoint is the binary (via a small shim that also
+# tolerates the old `command: mockforge serve ...` workaround) and the
+# subcommand is the CMD, so the documented compose form works:
+#     command: serve --config /config/mockforge.yaml
+# Previously the image only set CMD, so a user-supplied `command:` replaced the
+# whole vector and Docker tried to exec `serve` as a binary:
+#     exec: "serve": executable file not found in $PATH
+# To get a shell in the image, override with `--entrypoint /bin/sh`.
+ENTRYPOINT ["/usr/local/bin/mockforge-entrypoint"]
+CMD ["serve", "--admin"]

--- a/crates/mockforge-bench/src/conformance/request_validator.rs
+++ b/crates/mockforge-bench/src/conformance/request_validator.rs
@@ -427,6 +427,40 @@ fn resolve_parameter<'a>(
     }
 }
 
+/// Round 53 (#79) — percent-decode a query key/value or a path segment.
+///
+/// The spec declares parameters by their decoded name (`$.xgafv`), but the
+/// wire carries them encoded (`%24.xgafv`). Matching the raw wire key against
+/// the spec name silently skipped every parameter whose name needs escaping,
+/// which is why all of Srikanth's `owasp:*` probes (they all inject into
+/// `$.xgafv`) produced zero violations. Decoding the value as well keeps the
+/// reported message readable.
+///
+/// Falls back to the input unchanged when it isn't valid percent-encoded
+/// UTF-8, so a malformed probe can never panic or drop the parameter.
+fn pct_decode(s: &str) -> String {
+    urlencoding::decode(s).map(|c| c.into_owned()).unwrap_or_else(|_| s.to_string())
+}
+
+/// Round 53 (#79) — resolve a parameter's schema, following a single
+/// `#/components/schemas/...` reference. Mirrors the request-body resolution
+/// added in r52; without it a `$ref`'d parameter schema is silently skipped.
+fn resolve_param_schema<'a>(
+    schema_ref: &'a ReferenceOr<openapiv3::Schema>,
+    spec: &'a OpenAPI,
+) -> Option<&'a openapiv3::Schema> {
+    match schema_ref {
+        ReferenceOr::Item(s) => Some(s),
+        ReferenceOr::Reference { reference } => {
+            let name = reference.strip_prefix("#/components/schemas/")?;
+            match spec.components.as_ref()?.schemas.get(name)? {
+                ReferenceOr::Item(s) => Some(s),
+                _ => None,
+            }
+        }
+    }
+}
+
 /// Resolve a schema reference to a serde_json::Value for validation.
 /// Reserved for round 21.3 (response-body shape validation against the
 /// spec's response schema). Not yet wired into a call site.
@@ -675,12 +709,20 @@ pub async fn validate_emitted_requests_with_base_path(
         // sent query field, check it against the parameter's schema enum
         // and type. This is what catches Srikanth's `?$.xgafv=test-value`
         // case where the value isn't `"1"` or `"2"`.
+        //
+        // Round 53 (#79) — percent-decode BOTH the key and the value. The
+        // spec declares the parameter as `$.xgafv`, but it reaches the wire
+        // as `%24.xgafv`, so matching the raw key against the spec name
+        // missed every time and silently skipped the parameter. That hid all
+        // 7602 of Srikanth's `owasp:*` probes, which all inject into
+        // `$.xgafv`. Decoding the value too keeps the violation message
+        // readable (`' OR '1'='1` rather than `%27%20OR%20%271%27%3D%271`).
         let sent_query: HashMap<String, String> = query_string
             .split('&')
             .filter_map(|kv| {
                 let mut it = kv.splitn(2, '=');
-                let k = it.next()?.to_string();
-                let v = it.next().unwrap_or("").to_string();
+                let k = pct_decode(it.next()?);
+                let v = pct_decode(it.next().unwrap_or(""));
                 if k.is_empty() {
                     None
                 } else {
@@ -702,7 +744,8 @@ pub async fn validate_emitted_requests_with_base_path(
                 for (c, t) in concrete_parts.iter().zip(template_parts.iter()) {
                     if t.starts_with('{') && t.ends_with('}') {
                         let name = &t[1..t.len() - 1];
-                        out.insert(name.to_string(), (*c).to_string());
+                        // Round 53 — path segments arrive percent-encoded too.
+                        out.insert(name.to_string(), pct_decode(c));
                     }
                 }
             }
@@ -729,6 +772,23 @@ pub async fn validate_emitted_requests_with_base_path(
                         continue;
                     };
                     let Some(v) = sent_query.get(&parameter_data.name) else {
+                        // Round 53 (#79) — a REQUIRED query param that never
+                        // reached the wire is itself a spec violation. The
+                        // loop previously only inspected params that were
+                        // sent, so `parameters:missing-query` probes (which
+                        // drop a required param on purpose) produced nothing.
+                        if parameter_data.required {
+                            emitted_violations.push(RequestViolation {
+                                check_name: check.clone(),
+                                method: method.clone(),
+                                path: url.clone(),
+                                violation_type: "query_missing_required".to_string(),
+                                message: format!(
+                                    "query.{}: required parameter missing",
+                                    parameter_data.name
+                                ),
+                            });
+                        }
                         continue;
                     };
                     ("query", &parameter_data.name, (sref, v.clone()))
@@ -746,7 +806,10 @@ pub async fn validate_emitted_requests_with_base_path(
                 _ => continue,
             };
             let (schema_ref, value) = schema_ref;
-            let Some(schema) = schema_ref.as_item() else {
+            // Round 53 — resolve `$ref` parameter schemas too; the same
+            // `as_item()` blind spot that hid `$ref` request bodies in r52
+            // applies to parameters whose schema is a component reference.
+            let Some(schema) = resolve_param_schema(schema_ref, spec) else {
                 continue;
             };
             if let Some(msg) = check_value_against_schema(&value, schema) {
@@ -1421,6 +1484,119 @@ mod emitted_body_tests {
         assert!(
             flat.contains("analyticsRegion"),
             "the number-where-string probe must be reported: {flat}"
+        );
+    }
+
+    /// Round 53 (#79) — Srikanth on 0.3.199: body violations now populate,
+    /// but the logs contain ONLY `request-body:*` rows. His console reported
+    /// 7602 missed `owasp` and 3248 missed `parameters` negatives, yet not a
+    /// single `owasp:*` row or query/path violation appeared.
+    ///
+    /// Two distinct causes, both reproduced here against the real wire shape:
+    ///
+    /// 1. Every owasp probe injects into `$.xgafv`, which reaches the wire
+    ///    percent-encoded as `%24.xgafv`. The validator built `sent_query`
+    ///    from the RAW query string, then looked the parameter up by the
+    ///    spec's DECODED name (`$.xgafv`), so the lookup missed and all 7602
+    ///    probes were silently skipped. (Round 45's test used a plain `alt`
+    ///    param, which needs no encoding, so this stayed latent.)
+    ///
+    /// 2. `parameters:missing-query` DROPS a required query param. The loop
+    ///    only inspected params that were actually sent, so a missing
+    ///    required param could never be reported.
+    #[tokio::test]
+    async fn emitted_requests_flag_encoded_query_and_missing_required() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        // Spec mirrors the Apigee shape: a param whose name needs percent
+        // encoding (`$.xgafv`, enum 1/2), a plain enum param, and a REQUIRED
+        // param that the missing-query probe drops.
+        let spec_json = serde_json::json!({
+            "openapi": "3.0.0",
+            "info": { "title": "apigee-min", "version": "1.0.0" },
+            "paths": {
+                "/v1/organizations": {
+                    "post": {
+                        "parameters": [
+                            { "name": "$.xgafv", "in": "query",
+                              "schema": { "type": "string", "enum": ["1", "2"] } },
+                            { "name": "alt", "in": "query",
+                              "schema": { "type": "string", "enum": ["json", "media"] } },
+                            { "name": "parent", "in": "query", "required": true,
+                              "schema": { "type": "string" } }
+                        ],
+                        "responses": { "200": { "description": "ok" } }
+                    }
+                }
+            }
+        });
+        let spec_path = dir.path().join("apigee-min.json");
+        std::fs::write(&spec_path, serde_json::to_vec_pretty(&spec_json).unwrap()).unwrap();
+
+        let jsonl_path = dir.path().join("conformance-self-test-requests.jsonl");
+        let mut f = std::fs::File::create(&jsonl_path).unwrap();
+        let base = "https://172.22.232.2:443/v1/organizations";
+        for line in [
+            // Valid baseline: nothing should be reported.
+            serde_json::json!({
+                "label": "positive", "method": "POST",
+                "url": format!("{base}?%24.xgafv=1&alt=json&parent=test-value"),
+                "request_body": ""
+            }),
+            // owasp:sqli injects `' OR '1'='1` into the ENCODED `%24.xgafv`.
+            serde_json::json!({
+                "label": "owasp:sqli", "method": "POST",
+                "url": format!("{base}?%24.xgafv=%27%20OR%20%271%27%3D%271&alt=json&parent=test-value"),
+                "request_body": ""
+            }),
+            // parameters:missing-query drops the required `parent`.
+            serde_json::json!({
+                "label": "parameters:missing-query", "method": "POST",
+                "url": format!("{base}?%24.xgafv=1&alt=json"),
+                "request_body": ""
+            }),
+        ] {
+            writeln!(f, "{}", serde_json::to_string(&line).unwrap()).unwrap();
+        }
+        drop(f);
+
+        let n = validate_emitted_requests_with_base_path(
+            std::slice::from_ref(&spec_path),
+            dir.path(),
+            None,
+        )
+        .await
+        .expect("validation runs");
+        assert!(n >= 2, "expected owasp + missing-required to be flagged, got {n}");
+
+        let flat = std::fs::read_to_string(dir.path().join("conformance-request-violations.json"))
+            .unwrap();
+        let flat: serde_json::Value = serde_json::from_str(&flat).unwrap();
+        let rows = flat.as_array().unwrap();
+
+        // The owasp probe must surface as a query violation on the DECODED
+        // param name, with the DECODED value in the message (not `%27%20OR...`).
+        let owasp = rows
+            .iter()
+            .find(|r| r["check_name"] == "owasp:sqli")
+            .expect("owasp:sqli must produce a violation");
+        assert_eq!(owasp["violation_type"], "query_value_mismatch");
+        let msg = owasp["message"].as_str().unwrap();
+        assert!(msg.contains("$.xgafv"), "decoded param name expected: {msg}");
+        assert!(msg.contains("' OR '1'='1"), "decoded value expected: {msg}");
+
+        // The missing required param must be reported.
+        let missing = rows
+            .iter()
+            .find(|r| r["check_name"] == "parameters:missing-query")
+            .expect("missing-query must produce a violation");
+        assert_eq!(missing["violation_type"], "query_missing_required");
+        assert!(missing["message"].as_str().unwrap().contains("parent"));
+
+        // The positive probe must stay clean (no false positives).
+        assert!(
+            !rows.iter().any(|r| r["check_name"] == "positive"),
+            "positive probe must not be flagged: {rows:?}"
         );
     }
 }

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -1853,7 +1853,7 @@ pub async fn handle_serve(
 
     // Issue #929 — fail fast on a broken OpenAPI spec instead of silently
     // starting with zero routes and reporting `healthy`. If a spec path is
-    // configured but the file is missing or unparseable, the HTTP builder used
+    // configured but the file is missing or unparsable, the HTTP builder used
     // to log a single WARN and start "without OpenAPI integration", so every
     // spec route 404'd while /health still said healthy — very hard to debug.
     // We pre-flight the load here and refuse to start. Operators who genuinely

--- a/crates/mockforge-cli/src/serve.rs
+++ b/crates/mockforge-cli/src/serve.rs
@@ -1851,6 +1851,37 @@ pub async fn handle_serve(
         final_spec_path
     };
 
+    // Issue #929 — fail fast on a broken OpenAPI spec instead of silently
+    // starting with zero routes and reporting `healthy`. If a spec path is
+    // configured but the file is missing or unparseable, the HTTP builder used
+    // to log a single WARN and start "without OpenAPI integration", so every
+    // spec route 404'd while /health still said healthy — very hard to debug.
+    // We pre-flight the load here and refuse to start. Operators who genuinely
+    // want to boot without the spec can set MOCKFORGE_ALLOW_MISSING_SPEC=1.
+    if let Some(ref spec) = final_spec_path {
+        let allow_missing = std::env::var("MOCKFORGE_ALLOW_MISSING_SPEC")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        if let Err(e) = OpenApiSpec::from_file(spec).await {
+            if allow_missing {
+                tracing::error!(
+                    "OpenAPI spec '{}' failed to load: {}. Continuing without it \
+                     (MOCKFORGE_ALLOW_MISSING_SPEC is set) — spec routes will 404.",
+                    spec,
+                    e
+                );
+            } else {
+                return Err(format!(
+                    "OpenAPI spec '{spec}' is configured but failed to load: {e}\n\
+                     The server would otherwise start with no spec routes while /health \
+                     still reports healthy (issue #929). Fix the path/spec, or set \
+                     MOCKFORGE_ALLOW_MISSING_SPEC=1 to start anyway."
+                )
+                .into());
+            }
+        }
+    }
+
     // Configure traffic shaping for HTTP middleware when enabled
     let traffic_shaping_enabled = config.core.traffic_shaping_enabled;
     let traffic_shaper = if traffic_shaping_enabled {

--- a/crates/mockforge-core/src/config/mod.rs
+++ b/crates/mockforge-core/src/config/mod.rs
@@ -359,7 +359,125 @@ pub async fn load_config<P: AsRef<Path>>(path: P) -> Result<ServerConfig> {
         })?
     };
 
+    let mut config = config;
+    resolve_config_relative_paths(path.as_ref(), &mut config);
+    // Whether the user literally wrote `http.validation` — the struct default
+    // is `Some(enforce)`, so we can't tell "explicitly set" from "defaulted"
+    // off the parsed struct alone (#927).
+    let validation_explicit = raw_http_key_present(&content, "validation");
+    reconcile_unknown_http_keys(&mut config, validation_explicit);
+
     Ok(config)
+}
+
+/// Best-effort check for whether `http.<key>` was literally present in the
+/// config source. Parses the raw text generically (YAML or JSON) so it works
+/// regardless of how the typed struct defaults the field.
+fn raw_http_key_present(content: &str, key: &str) -> bool {
+    if let Ok(doc) = serde_yaml::from_str::<serde_yaml::Value>(content) {
+        return doc.get("http").and_then(|h| h.get(key)).is_some();
+    }
+    if let Ok(doc) = serde_json::from_str::<serde_json::Value>(content) {
+        return doc.get("http").and_then(|h| h.get(key)).is_some();
+    }
+    false
+}
+
+/// Surface (and where possible honour) `http:` keys MockForge doesn't know.
+///
+/// Issue #927 — `http.request_validation: "off"` was silently ignored; the real
+/// key is `http.validation.mode`. Serde dropped it without a word, so the user
+/// had no signal their config was inert. We now capture leftovers in
+/// `HttpConfig::unknown_keys` and:
+///
+///   * honour `request_validation` as an alias for `validation.mode` (only when
+///     `validation` wasn't given explicitly, which always wins), and
+///   * warn about every other unrecognised key so typos are visible.
+fn reconcile_unknown_http_keys(config: &mut ServerConfig, validation_explicit: bool) {
+    if config.http.unknown_keys.is_empty() {
+        return;
+    }
+
+    // Legacy alias: `request_validation: off|warn|enforce`.
+    if let Some(value) = config.http.unknown_keys.remove("request_validation") {
+        let mode = match &value {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Bool(false) => Some("off".to_string()),
+            serde_json::Value::Bool(true) => Some("enforce".to_string()),
+            _ => None,
+        };
+        match mode {
+            Some(mode) if !validation_explicit => {
+                tracing::warn!(
+                    "`http.request_validation` is deprecated; use `http.validation.mode: {}`. \
+                     Honouring it for now.",
+                    mode
+                );
+                config.http.validation = Some(HttpValidationConfig { mode });
+            }
+            Some(_) => {
+                tracing::warn!(
+                    "`http.request_validation` is deprecated and was ignored because \
+                     `http.validation.mode` is also set (that one wins)."
+                );
+            }
+            None => {
+                tracing::warn!(
+                    "`http.request_validation` must be a string (off|warn|enforce); ignoring."
+                );
+            }
+        }
+    }
+
+    for key in config.http.unknown_keys.keys() {
+        tracing::warn!(
+            "Unknown `http` config key `{}` was ignored. Run `mockforge schema` to see valid keys.",
+            key
+        );
+    }
+}
+
+/// Resolve file paths declared in the config that were given as relative paths.
+///
+/// Issue #928 — `openapi_spec: "abb-rws-openapi.yaml"` was resolved against the
+/// process working directory (`/app` in the Docker image), not against the
+/// directory holding the config file (`/config`), so a config + spec mounted
+/// side by side could not reference each other relatively.
+///
+/// Backwards compatible on purpose: a path that already resolves from the CWD
+/// keeps winning, so existing setups are untouched. Only when the CWD-relative
+/// path does NOT exist do we fall back to the config file's directory. If
+/// neither exists the value is left alone so the loader's error names the path
+/// the user actually wrote.
+fn resolve_config_relative_paths(config_path: &Path, config: &mut ServerConfig) {
+    let Some(config_dir) = config_path.parent() else {
+        return;
+    };
+    if config_dir.as_os_str().is_empty() {
+        return;
+    }
+    resolve_relative_to(config_dir, &mut config.http.openapi_spec);
+}
+
+/// Rewrite `value` to `config_dir/value` when it is a relative path that does
+/// not resolve from the CWD but does resolve from the config file's directory.
+fn resolve_relative_to(config_dir: &Path, value: &mut Option<String>) {
+    let Some(raw) = value.as_deref() else {
+        return;
+    };
+    let candidate = Path::new(raw);
+    if candidate.is_absolute() || candidate.exists() {
+        return;
+    }
+    let relocated = config_dir.join(candidate);
+    if relocated.exists() {
+        tracing::debug!(
+            "Resolved relative config path {:?} against config directory {:?}",
+            raw,
+            config_dir
+        );
+        *value = Some(relocated.to_string_lossy().into_owned());
+    }
 }
 
 /// Save configuration to file
@@ -1095,5 +1213,104 @@ const config: Config = {
         assert!(!stripped.contains("interface"));
         assert!(!stripped.contains(": Config"));
         assert!(!stripped.contains("as Config"));
+    }
+
+    /// Issue #928 — a relative `openapi_spec` must resolve against the config
+    /// file's directory when it does not resolve from the process CWD. This is
+    /// the Docker case: config + spec both mounted at `/config`, CWD `/app`.
+    #[tokio::test]
+    async fn openapi_spec_relative_path_resolves_against_config_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let spec_path = dir.path().join("api.yaml");
+        std::fs::write(&spec_path, "openapi: 3.0.0\n").unwrap();
+
+        let config_path = dir.path().join("mockforge.yaml");
+        std::fs::write(&config_path, "http:\n  openapi_spec: api.yaml\n").unwrap();
+
+        let config = load_config(&config_path).await.expect("config loads");
+        let resolved = config.http.openapi_spec.expect("spec path present");
+        assert_eq!(
+            std::path::Path::new(&resolved).canonicalize().unwrap(),
+            spec_path.canonicalize().unwrap(),
+            "relative spec must resolve next to the config file, got {resolved}"
+        );
+    }
+
+    /// An absolute `openapi_spec` is never rewritten.
+    #[tokio::test]
+    async fn openapi_spec_absolute_path_is_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let spec_path = dir.path().join("api.yaml");
+        std::fs::write(&spec_path, "openapi: 3.0.0\n").unwrap();
+
+        let config_path = dir.path().join("mockforge.yaml");
+        std::fs::write(&config_path, format!("http:\n  openapi_spec: {}\n", spec_path.display()))
+            .unwrap();
+
+        let config = load_config(&config_path).await.expect("config loads");
+        assert_eq!(config.http.openapi_spec.as_deref(), Some(spec_path.to_str().unwrap()));
+    }
+
+    /// Issue #927 — `http.request_validation` used to be dropped silently.
+    /// It is now honoured as an alias for `http.validation.mode`.
+    #[tokio::test]
+    async fn request_validation_alias_is_honoured() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mockforge.yaml");
+        std::fs::write(&config_path, "http:\n  request_validation: \"off\"\n").unwrap();
+
+        let config = load_config(&config_path).await.expect("config loads");
+        assert_eq!(
+            config.http.validation.as_ref().map(|v| v.mode.as_str()),
+            Some("off"),
+            "request_validation must map onto validation.mode"
+        );
+        // Consumed, so it is not also reported as an unknown key.
+        assert!(!config.http.unknown_keys.contains_key("request_validation"));
+    }
+
+    /// An explicit `validation.mode` always beats the legacy alias.
+    #[tokio::test]
+    async fn explicit_validation_mode_beats_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mockforge.yaml");
+        std::fs::write(
+            &config_path,
+            "http:\n  request_validation: \"off\"\n  validation:\n    mode: \"enforce\"\n",
+        )
+        .unwrap();
+
+        let config = load_config(&config_path).await.expect("config loads");
+        assert_eq!(config.http.validation.as_ref().map(|v| v.mode.as_str()), Some("enforce"));
+    }
+
+    /// Issue #927 — a genuinely unknown key is captured so we can warn, rather
+    /// than being silently discarded by serde.
+    #[tokio::test]
+    async fn unknown_http_key_is_captured_for_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mockforge.yaml");
+        std::fs::write(&config_path, "http:\n  porrt: 8080\n").unwrap();
+
+        let config = load_config(&config_path).await.expect("config loads");
+        assert!(
+            config.http.unknown_keys.contains_key("porrt"),
+            "typo'd key must be captured so load_config can warn"
+        );
+        // And the real port keeps its default.
+        assert_eq!(config.http.port, 3000);
+    }
+
+    /// A path that resolves from the CWD keeps winning (backwards compatible).
+    #[tokio::test]
+    async fn openapi_spec_missing_path_is_left_alone_for_a_clear_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mockforge.yaml");
+        std::fs::write(&config_path, "http:\n  openapi_spec: nowhere.yaml\n").unwrap();
+
+        let config = load_config(&config_path).await.expect("config loads");
+        // Neither CWD nor config-dir resolve it; leave the user's literal value
+        // so the loader's error message names what they actually wrote.
+        assert_eq!(config.http.openapi_spec.as_deref(), Some("nowhere.yaml"));
     }
 }

--- a/crates/mockforge-core/src/config/protocol.rs
+++ b/crates/mockforge-core/src/config/protocol.rs
@@ -75,6 +75,17 @@ pub struct HttpConfig {
     /// TLS/HTTPS configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls: Option<HttpTlsConfig>,
+
+    /// Keys under `http:` that MockForge does not recognise.
+    ///
+    /// Issue #927 — `http.request_validation: "off"` was dropped on the floor
+    /// with no warning (the real key is `http.validation.mode`), so users had
+    /// no signal their config was inert. Capturing the leftovers lets
+    /// `load_config` warn about each one, and lets us honour known legacy
+    /// spellings as aliases.
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "schema", schemars(skip))]
+    pub unknown_keys: HashMap<String, serde_json::Value>,
 }
 
 impl Default for HttpConfig {
@@ -110,6 +121,7 @@ impl Default for HttpConfig {
             skip_admin_validation: true,
             auth: None,
             tls: None,
+            unknown_keys: HashMap::new(),
         }
     }
 }

--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -760,7 +760,10 @@ impl OpenApiRouteRegistry {
                             });
                     }
 
-                    if let Err(e) = validator.validate_request_with_all(
+                    // Issue #925 — pass real wire presence, not "did it parse as
+                    // JSON". A non-empty octet-stream / XML / urlencoded body
+                    // is present even though `body_json` is `None`.
+                    if let Err(e) = validator.validate_request_with_all_ex(
                         &path_template,
                         &method,
                         &path_map,
@@ -768,6 +771,7 @@ impl OpenApiRouteRegistry {
                         &header_map,
                         &cookie_map,
                         body_json.as_ref(),
+                        !body.is_empty(),
                     ) {
                         // Choose status: prefer options.validation_status, fallback to env, else 400
                         let status_code =
@@ -1203,7 +1207,8 @@ impl OpenApiRouteRegistry {
         cookie_map: &Map<String, Value>,
         body: Option<&Value>,
     ) -> std::result::Result<(), (u16, Value)> {
-        let e = match self.validate_request_with_all(
+        let body_present = body.is_some();
+        self.run_validation_with_recording_ex(
             path_template,
             method,
             path_params,
@@ -1211,6 +1216,34 @@ impl OpenApiRouteRegistry {
             header_map,
             cookie_map,
             body,
+            body_present,
+        )
+    }
+
+    /// Same as [`Self::run_validation_with_recording`], but with an explicit
+    /// body-presence flag so a non-JSON body isn't mistaken for a missing one
+    /// (issue #925).
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_validation_with_recording_ex(
+        &self,
+        path_template: &str,
+        method: &str,
+        path_params: &Map<String, Value>,
+        query_params: &Map<String, Value>,
+        header_map: &Map<String, Value>,
+        cookie_map: &Map<String, Value>,
+        body: Option<&Value>,
+        body_present: bool,
+    ) -> std::result::Result<(), (u16, Value)> {
+        let e = match self.validate_request_with_all_ex(
+            path_template,
+            method,
+            path_params,
+            query_params,
+            header_map,
+            cookie_map,
+            body,
+            body_present,
         ) {
             Ok(()) => {
                 // Round 17.1 — track conformant requests alongside
@@ -1324,7 +1357,12 @@ impl OpenApiRouteRegistry {
         Err((status_code, payload))
     }
 
-    /// Validate request against OpenAPI spec with path/query/header/cookie params
+    /// Validate request against OpenAPI spec with path/query/header/cookie params.
+    ///
+    /// `body` is the request body parsed as JSON, or `None` when it was absent
+    /// OR could not be parsed as JSON. Because those two cases are
+    /// indistinguishable here, prefer [`Self::validate_request_with_all_ex`],
+    /// which takes an explicit body-presence flag (see issue #925).
     #[allow(clippy::too_many_arguments)]
     pub fn validate_request_with_all(
         &self,
@@ -1335,6 +1373,42 @@ impl OpenApiRouteRegistry {
         header_params: &Map<String, Value>,
         cookie_params: &Map<String, Value>,
         body: Option<&Value>,
+    ) -> Result<()> {
+        let body_present = body.is_some();
+        self.validate_request_with_all_ex(
+            path,
+            method,
+            path_params,
+            query_params,
+            header_params,
+            cookie_params,
+            body,
+            body_present,
+        )
+    }
+
+    /// Same as [`Self::validate_request_with_all`], but the caller states
+    /// explicitly whether a request body was present on the wire.
+    ///
+    /// Issue #925 — the handlers used to derive body presence from
+    /// `serde_json::from_slice(&bytes).ok()`, so ANY non-JSON body
+    /// (`application/octet-stream` file uploads, `application/xml`,
+    /// `application/x-www-form-urlencoded`, raw text) collapsed to `None` and
+    /// the validator reported `body: Request body is required but not
+    /// provided`. Every PUT carrying a file body 400'd while JSON POSTs passed,
+    /// which is why the bug looked method-specific. `body_present` lets us tell
+    /// "absent" apart from "present but not JSON".
+    #[allow(clippy::too_many_arguments)]
+    pub fn validate_request_with_all_ex(
+        &self,
+        path: &str,
+        method: &str,
+        path_params: &Map<String, Value>,
+        query_params: &Map<String, Value>,
+        header_params: &Map<String, Value>,
+        cookie_params: &Map<String, Value>,
+        body: Option<&Value>,
+        body_present: bool,
     ) -> Result<()> {
         // Skip validation for any configured admin prefixes
         for pref in &self.options.admin_skip_prefixes {
@@ -1389,25 +1463,26 @@ impl OpenApiRouteRegistry {
             let mut details: Vec<Value> = Vec::new();
             // Validate request body if required
             if let Some(schema) = &route.operation.request_body {
-                if let Some(value) = body {
-                    // First resolve the request body reference if it's a reference
-                    let request_body = match schema {
-                        openapiv3::ReferenceOr::Item(rb) => Some(rb),
-                        openapiv3::ReferenceOr::Reference { reference } => {
-                            // Try to resolve request body reference through spec
-                            self.spec
-                                .spec
-                                .components
-                                .as_ref()
-                                .and_then(|components| {
-                                    components.request_bodies.get(
-                                        reference.trim_start_matches("#/components/requestBodies/"),
-                                    )
-                                })
-                                .and_then(|rb_ref| rb_ref.as_item())
-                        }
-                    };
+                // Resolve the request body reference up front so we can read
+                // `required` regardless of whether a body was sent (#925).
+                let request_body = match schema {
+                    openapiv3::ReferenceOr::Item(rb) => Some(rb),
+                    openapiv3::ReferenceOr::Reference { reference } => {
+                        // Try to resolve request body reference through spec
+                        self.spec
+                            .spec
+                            .components
+                            .as_ref()
+                            .and_then(|components| {
+                                components.request_bodies.get(
+                                    reference.trim_start_matches("#/components/requestBodies/"),
+                                )
+                            })
+                            .and_then(|rb_ref| rb_ref.as_item())
+                    }
+                };
 
+                if let Some(value) = body {
                     if let Some(rb) = request_body {
                         if let Some(content) = rb.content.get("application/json") {
                             if let Some(schema_ref) = &content.schema {
@@ -1470,11 +1545,25 @@ impl OpenApiRouteRegistry {
                             details.push(serde_json::json!({"path":"body","code":"reference_error","message":"Could not resolve request body reference"}));
                         }
                     }
-                } else {
+                } else if body_present {
+                    // Issue #925 — a body WAS sent, it just isn't JSON
+                    // (octet-stream upload, XML, urlencoded, raw text). There
+                    // is no JSON Schema to check it against, and the
+                    // content-type gate above already enforced the media types
+                    // the spec declares. Treating this as "missing" is what
+                    // made every PUT file upload 400.
+                    tracing::debug!(
+                        "Non-JSON request body present; skipping JSON schema validation"
+                    );
+                } else if request_body.map(|rb| rb.required).unwrap_or(false) {
+                    // Issue #925 — only complain when the spec actually marks
+                    // the body `required: true`. Previously the mere presence
+                    // of a `requestBody` block triggered this, so an operation
+                    // declaring `required: false` still 400'd on an empty body.
                     errors.push("body: Request body is required but not provided".to_string());
                     details.push(serde_json::json!({"path":"body","code":"required","message":"Request body is required"}));
                 }
-            } else if body.is_some() {
+            } else if body_present {
                 // No body expected but provided — not an error by default, but log it
                 tracing::debug!("Body provided for operation without requestBody; accepting");
             }
@@ -1712,12 +1801,26 @@ impl OpenApiRouteRegistry {
                 HashMap<String, String>,
             >,
                                 headers: HeaderMap,
-                                body: Option<Json<Value>>| {
+                                body_bytes: axum::body::Bytes| {
                 let route = route_clone.clone();
                 let ai_generator = ai_generator_clone.clone();
                 let validator = validator_clone.clone();
 
                 async move {
+                    // Issue #925 — this handler used to take
+                    // `body: Option<Json<Value>>`, which axum resolves to
+                    // `None` for any request whose Content-Type isn't
+                    // `application/json`. A PUT carrying an octet-stream /
+                    // XML / urlencoded body therefore looked bodyless and the
+                    // validator rejected it as "required but not provided".
+                    // Take the raw bytes and track presence separately, the
+                    // same way the MockAI handler does.
+                    let body_present = !body_bytes.is_empty();
+                    let body: Option<Json<Value>> = if body_bytes.is_empty() {
+                        None
+                    } else {
+                        serde_json::from_slice::<Value>(&body_bytes).ok().map(Json)
+                    };
                     // (a-pre) Run request validation against the spec
                     // before AI response synthesis. On failure this
                     // also records to the foundation conformance ring
@@ -1737,7 +1840,7 @@ impl OpenApiRouteRegistry {
                         }
                     }
                     let body_val: Option<&Value> = body.as_ref().map(|Json(b)| b);
-                    if let Err((status_code, payload)) = validator.run_validation_with_recording(
+                    if let Err((status_code, payload)) = validator.run_validation_with_recording_ex(
                         &route.path,
                         &route.method,
                         &path_map,
@@ -1745,6 +1848,7 @@ impl OpenApiRouteRegistry {
                         &header_map,
                         &Map::new(),
                         body_val,
+                        body_present,
                     ) {
                         let status = axum::http::StatusCode::from_u16(status_code)
                             .unwrap_or(axum::http::StatusCode::BAD_REQUEST);
@@ -2006,7 +2110,8 @@ impl OpenApiRouteRegistry {
                     // also records to the foundation conformance ring
                     // buffer surfaced by the TUI Conformance tab.
                     let body_val: Option<&Value> = body.as_ref().map(|Json(b)| b);
-                    if let Err((status_code, payload)) = validator.run_validation_with_recording(
+                    // Issue #925 — real wire presence, not JSON-parseability.
+                    if let Err((status_code, payload)) = validator.run_validation_with_recording_ex(
                         &route.path,
                         &route.method,
                         &path_map,
@@ -2014,6 +2119,7 @@ impl OpenApiRouteRegistry {
                         &header_map,
                         &Map::new(),
                         body_val,
+                        !body_bytes.is_empty(),
                     ) {
                         let status = axum::http::StatusCode::from_u16(status_code)
                             .unwrap_or(axum::http::StatusCode::BAD_REQUEST);
@@ -4867,5 +4973,156 @@ mod tests {
         );
         // Should not error on style handling
         assert!(result.is_ok() || result.is_err()); // Either is fine, just testing the path
+    }
+
+    /// Build a spec with a PUT whose requestBody is a non-JSON media type.
+    fn octet_stream_put_spec(required: bool) -> Value {
+        json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Files API", "version": "1.0.0" },
+            "paths": {
+                "/files/{name}": {
+                    "put": {
+                        "parameters": [
+                            {"name": "name", "in": "path", "required": true,
+                             "schema": {"type": "string"}}
+                        ],
+                        "requestBody": {
+                            "required": required,
+                            "content": {
+                                "application/octet-stream": {
+                                    "schema": {"type": "string", "format": "binary"}
+                                }
+                            }
+                        },
+                        "responses": {"200": {"description": "ok"}}
+                    }
+                }
+            }
+        })
+    }
+
+    /// Issue #925 — a PUT carrying a non-JSON body (octet-stream file upload)
+    /// must NOT be rejected as "Request body is required but not provided".
+    /// The body never parses as JSON, so `body` is `None`; only `body_present`
+    /// can tell "absent" from "present but not JSON".
+    #[tokio::test]
+    async fn non_json_request_body_is_not_reported_missing() {
+        let registry = create_registry_from_json(octet_stream_put_spec(true)).unwrap();
+        let mut path_params = Map::new();
+        path_params.insert("name".to_string(), json!("test.mod"));
+
+        // body_present = true, parsed JSON = None  →  the real PUT upload case.
+        let res = registry.validate_request_with_all_ex(
+            "/files/{name}",
+            "PUT",
+            &path_params,
+            &Map::new(),
+            &Map::new(),
+            &Map::new(),
+            None,
+            true,
+        );
+        assert!(res.is_ok(), "non-JSON PUT body must pass, got {res:?}");
+    }
+
+    /// A genuinely absent body against `required: true` still errors.
+    #[tokio::test]
+    async fn absent_body_against_required_still_errors() {
+        let registry = create_registry_from_json(octet_stream_put_spec(true)).unwrap();
+        let mut path_params = Map::new();
+        path_params.insert("name".to_string(), json!("test.mod"));
+
+        let res = registry.validate_request_with_all_ex(
+            "/files/{name}",
+            "PUT",
+            &path_params,
+            &Map::new(),
+            &Map::new(),
+            &Map::new(),
+            None,
+            false,
+        );
+        let err = res.expect_err("absent required body must error");
+        assert!(err.to_string().contains("Request body is required"), "unexpected error: {err}");
+    }
+
+    /// Issue #925 — `requestBody.required: false` with no body must not error.
+    /// Previously the mere presence of a `requestBody` block triggered the
+    /// "required but not provided" message regardless of the `required` flag.
+    #[tokio::test]
+    async fn absent_body_against_optional_request_body_is_ok() {
+        let registry = create_registry_from_json(octet_stream_put_spec(false)).unwrap();
+        let mut path_params = Map::new();
+        path_params.insert("name".to_string(), json!("test.mod"));
+
+        let res = registry.validate_request_with_all_ex(
+            "/files/{name}",
+            "PUT",
+            &path_params,
+            &Map::new(),
+            &Map::new(),
+            &Map::new(),
+            None,
+            false,
+        );
+        assert!(res.is_ok(), "optional body may be omitted, got {res:?}");
+    }
+
+    /// A JSON body still schema-validates as before (no regression).
+    #[tokio::test]
+    async fn json_request_body_still_schema_validates() {
+        let spec = json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Users API", "version": "1.0.0" },
+            "paths": {
+                "/users": {
+                    "post": {
+                        "requestBody": {
+                            "required": true,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {"age": {"type": "integer"}},
+                                        "required": ["age"]
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"200": {"description": "ok"}}
+                    }
+                }
+            }
+        });
+        let registry = create_registry_from_json(spec).unwrap();
+
+        let good = json!({"age": 30});
+        assert!(registry
+            .validate_request_with_all_ex(
+                "/users",
+                "POST",
+                &Map::new(),
+                &Map::new(),
+                &Map::new(),
+                &Map::new(),
+                Some(&good),
+                true
+            )
+            .is_ok());
+
+        let bad = json!({"age": "thirty"});
+        assert!(registry
+            .validate_request_with_all_ex(
+                "/users",
+                "POST",
+                &Map::new(),
+                &Map::new(),
+                &Map::new(),
+                &Map::new(),
+                Some(&bad),
+                true
+            )
+            .is_err());
     }
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# MockForge container entrypoint (issue #930).
+#
+# The image sets ENTRYPOINT to this script and CMD to the default subcommand,
+# so the documented compose form works:
+#
+#     command: serve --config /config/mockforge.yaml
+#
+# Before #930 the image only set CMD, so a user-supplied `command:` replaced
+# the whole vector and Docker tried to exec `serve` as a binary:
+#
+#     exec: "serve": executable file not found in $PATH
+#
+# The documented workaround was to prefix the binary name
+# (`command: mockforge serve ...`). We strip that leading argument here so the
+# workaround keeps working and nobody's existing compose file breaks.
+#
+# To get a shell in the image, override the entrypoint:
+#     docker run --entrypoint /bin/sh -it ghcr.io/saasy-solutions/mockforge
+set -e
+
+if [ "$1" = "mockforge" ] || [ "$1" = "/usr/local/bin/mockforge" ]; then
+    shift
+fi
+
+exec /usr/local/bin/mockforge "$@"


### PR DESCRIPTION
Addresses Srikanth's 0.3.199 follow-up on #79 plus seven filed issues (#925–#931). Every fix is verified against the real `mockforge serve` / `mockforge bench` binary.

## #79 r53 — owasp/parameter violations missing from the logs
The violation logs populated (r52) but contained only `request-body:*` rows, though the console reported 7602 missed owasp and 3248 missed parameter negatives. Two root causes:
1. Every owasp probe injects into `$.xgafv`, which reaches the wire percent-encoded as `%24.xgafv`. The validator built `sent_query` from the raw query string then looked it up by the spec's **decoded** name, so all 7602 probes silently skipped. Now percent-decodes query keys/values and path segments, and resolves `$ref` parameter schemas.
2. `parameters:missing-query` drops a **required** param, but the loop only inspected params that were sent. Now flags a missing required query param.

**Verified live:** all 7 owasp checks now surface, e.g. `owasp:sqli => query.$.xgafv: value "' OR '1'='1" is not one of "1" or "2"`.

## #925 — PUT request bodies rejected as "not provided"
Every PUT with a non-JSON body (octet-stream upload, XML, urlencoded) 400'd. The handlers derived body presence from `serde_json::from_slice(&bytes).ok()`, so a non-JSON body collapsed to `None` and looked absent (JSON POSTs passed, making it look method-specific). Added `*_ex` validation entrypoints taking an explicit body-presence flag, honored `requestBody.required`, and moved the AI handler off `Option<Json<Value>>` (axum yields `None` for non-JSON) to raw `Bytes`.

**Verified live:** PUT octet-stream → 200; empty body on `required:true` → 400; JSON schema validation intact.

## #928 — relative `openapi_spec` resolved from CWD
`load_config` now falls back to the config file's directory when a relative `openapi_spec` doesn't resolve from CWD (absolute and CWD-resolvable paths untouched). **Verified live** from a foreign CWD.

## #929 — silent spec-load failure
`serve` now pre-flights the resolved spec and fails fast with a clear error instead of starting healthy with zero routes. Escape hatch: `MOCKFORGE_ALLOW_MISSING_SPEC=1`. **Verified live** (config-driven bad path → exit 1 + message).

## #927 — `request_validation` config key silently ignored
`HttpConfig` now captures unknown `http:` keys, honors `request_validation` as a deprecated alias for `validation.mode`, and warns on every other unknown key.

## #930 — Docker `command: serve ...` fails
Added an entrypoint shim (ENTRYPOINT = binary, tolerant of the old `command: mockforge serve` workaround) so the documented compose form works.

## #931 — scenarios dir permission warning
`useradd -r` never created `/home/mockforge`, so `~/.mockforge/scenarios` failed with permission denied. Create + own the home and scenarios dirs; set `HOME`.

## #926 — stale Content-Type allowlist
Not a MockForge cache bug: the allowlist is read fresh from the loaded spec per request and no static survives a restart. The reported persistence is the #928 relative-path failure silently loading a stale/wrong spec (plus Docker `latest` caching). #928 + #929 address the root cause; documented on the issue.

## Tests / checks
- New unit tests for each fix. `mockforge-bench` 501, `mockforge-openapi` 1247, `mockforge-core` 185 lib tests pass.
- `cargo fmt --all --check` clean; clippy clean on all changed files.