### PR TITLE
chore(release): v0.3.200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [0.3.200] - 2026-07-10
+
+### Fixed
+
+- **[Contracts]** Emitted-request validation now reports `owasp:*` and parameter violations, not just request-body ones (#79 round 53 / Srikanth on 0.3.199: the by-request / by-probe logs showed only `request-body:*` rows even though the console reported 7602 missed owasp and 3248 missed parameter negatives). Two causes: (1) every OWASP probe injects into `$.xgafv`, which reaches the wire percent-encoded as `%24.xgafv`; the validator built its query map from the raw query string then looked each parameter up by the spec's DECODED name, so the lookup missed and all 7602 probes were skipped silently. Query keys/values and path segments are now percent-decoded (and `$ref` parameter schemas resolved). (2) A `parameters:missing-query` probe that drops a REQUIRED parameter now surfaces as `query.<name>: required parameter missing`; before, the loop only inspected parameters that were actually sent. Real-binary verified against `mockforge serve`: all seven OWASP checks now appear as e.g. `owasp:sqli => query.$.xgafv: value "' OR '1'='1" is not one of "1" or "2"`.
+- **[Reality]** PUT (and any) request bodies that are not JSON are no longer rejected as missing (#925: every `PUT` with an `application/octet-stream` / XML / urlencoded body returned `400 body: Request body is required but not provided`, while JSON POSTs passed). The handlers derived body presence from `serde_json::from_slice(&bytes).ok()`, so a non-JSON body collapsed to `None` and looked absent. Body presence is now tracked from the raw bytes, `requestBody.required` is honored, and the AI handler no longer uses `Option<Json<Value>>` (which axum yields as `None` for non-JSON). Real-binary verified: PUT octet-stream -> 200, empty body against `required: true` -> 400, JSON schema validation unchanged.
+- **[DevX]** A relative `openapi_spec` config value now resolves from the config file's directory when it does not resolve from the working directory (#928: in Docker, a relative path resolved from `/app` (CWD) instead of `/config` and silently failed to load). Absolute and CWD-resolvable paths are untouched. Verified from a foreign CWD.
+- **[DevX]** `serve` fails fast when a configured OpenAPI spec cannot be loaded, instead of starting "healthy" with zero routes (#929). Clear error names the path; set `MOCKFORGE_ALLOW_MISSING_SPEC=1` to start anyway. Verified against a config-driven bad path.
+- **[DevX]** `http.request_validation` is honored as a deprecated alias for `http.validation.mode`, and unknown `http:` config keys now log a warning instead of being dropped silently (#927).
+- **[DevX]** The Docker image now uses an entrypoint shim so the documented `command: serve --config ...` works (#930: the image only set CMD, so a user `command:` execed `serve` as a binary). The old `command: mockforge serve ...` workaround still works.
+- **[DevX]** The container user now has a real, owned home directory, so `~/.mockforge/scenarios` is writable and the startup "Failed to create scenarios directory: Permission denied" warning is gone (#931).
+- **[Cloud]** Bumped `crossbeam-epoch` to 0.9.20 (RUSTSEC-2026-0204, invalid pointer dereference) and `quinn-proto` to 0.11.15 (RUSTSEC-2026-0185/-0037); both were transitive. Merged the dependabot cargo patch/minor group (14 updates incl. `rustls` 0.23.41, `anyhow` 1.0.103, `tauri` 2.11.5) and the GitHub Actions bump group.
+
+### Note
+
+- **[Contracts]** #926 (stale Content-Type allowlist after a spec change) is addressed by the #928 / #929 fixes: MockForge reads the allowlist fresh from the loaded spec per request with no static cache, so the reported persistence was the relative-path failure silently loading a stale spec. Srikanth's QoS / L3-L4 traffic-generation request is tracked in #933.
+
 ## [0.3.199] - 2026-07-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7820,7 +7820,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7861,7 +7861,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7876,7 +7876,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7899,7 +7899,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7915,7 +7915,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7996,7 +7996,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8051,7 +8051,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8076,7 +8076,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8149,7 +8149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8216,7 +8216,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8239,7 +8239,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8263,7 +8263,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8290,7 +8290,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8372,7 +8372,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8453,7 +8453,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8471,7 +8471,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8500,7 +8500,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8535,7 +8535,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8557,7 +8557,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8584,7 +8584,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8609,7 +8609,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8632,7 +8632,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8674,7 +8674,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8704,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8723,7 +8723,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8753,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8782,7 +8782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8797,7 +8797,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8821,7 +8821,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8861,7 +8861,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8879,7 +8879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8898,7 +8898,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8923,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8975,7 +8975,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9091,7 +9091,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9111,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9124,7 +9124,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9146,7 +9146,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9183,7 +9183,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9211,7 +9211,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9241,7 +9241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9268,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9291,14 +9291,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9325,7 +9325,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9336,7 +9336,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9358,7 +9358,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9376,7 +9376,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9400,7 +9400,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9483,7 +9483,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9518,7 +9518,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9529,7 +9529,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9546,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15426,7 +15426,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.199"
+version = "0.3.200"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.199"
+version = "0.3.200"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -95,8 +95,8 @@ CRATES=(
   mockforge-performance
   mockforge-proxy
   mockforge-route-chaos
-  mockforge-runtime-daemon
   mockforge-scenarios
+  mockforge-runtime-daemon
   mockforge-smtp
   mockforge-tcp
   mockforge-workspace


### PR DESCRIPTION
Release v0.3.200: #79 round 53 (owasp/param violations now logged), #925 (PUT non-JSON bodies), #927/#928/#929 (config DX), #930/#931 (Docker), plus RUSTSEC dep bumps and the merged dependabot groups. Also fixes a publish-crates.sh dep-order bug (scenarios before runtime-daemon). Crates published from the local pipeline; this PR lands the version bump + CHANGELOG on main.