### PR TITLE
fix(bench): r54 parameter violations + source-ip in multi-target (#79)

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -1032,9 +1032,13 @@ impl BenchCommand {
                 conformance_self_test_iterations: 1,
                 conformance_self_test_duration: None,
                 validate_response_schemas: false,
-                source_ips: Vec::new(),
-                geo_source_ips: Vec::new(),
-                geo_source_headers: Vec::new(),
+                // Issue #79 r54 (Srikanth on 0.3.200): these were hardcoded to
+                // empty, so `--source-ip` / `--geo-source-ip` were silently
+                // dropped in multi-target (`--targets-file`) mode. Carry them
+                // through to the ParallelExecutor so k6 gets `--local-ips`.
+                source_ips: self.source_ips.clone(),
+                geo_source_ips: self.geo_source_ips.clone(),
+                geo_source_headers: self.geo_source_headers.clone(),
                 report_missed_cap: None,
             },
             targets,

--- a/crates/mockforge-bench/src/conformance/request_validator.rs
+++ b/crates/mockforge-bench/src/conformance/request_validator.rs
@@ -201,6 +201,49 @@ fn find_matching_spec_path(
     None
 }
 
+/// Match a single templated path segment against a concrete one and, on
+/// success, return the bound `(param_name, value)` when the segment carries a
+/// `{param}` placeholder.
+///
+/// Handles a plain `{name}`, a literal segment (`v1`), AND — Round 54 (#79) —
+/// a single `{name}` wrapped in literals, i.e. Google's custom-verb form
+/// `{instance}:reportStatus` (also `prefix-{name}`). Multi-placeholder
+/// segments (`{a}-{b}`) fall back to plain equality. Returns:
+///   - `Some(None)` when the segment matches with no bound param (literal),
+///   - `Some(Some((name, value)))` when it matches and binds a param,
+///   - `None` when it does not match.
+fn match_path_segment<'a>(
+    template_seg: &'a str,
+    concrete_seg: &str,
+) -> Option<Option<(&'a str, String)>> {
+    let open = template_seg.find('{');
+    let close = template_seg.find('}');
+    match (open, close) {
+        (Some(o), Some(c)) if c > o && !template_seg[c + 1..].contains('{') => {
+            let prefix = &template_seg[..o];
+            let name = &template_seg[o + 1..c];
+            let suffix = &template_seg[c + 1..];
+            if concrete_seg.starts_with(prefix)
+                && concrete_seg.ends_with(suffix)
+                && concrete_seg.len() >= prefix.len() + suffix.len()
+            {
+                let value = &concrete_seg[prefix.len()..concrete_seg.len() - suffix.len()];
+                Some(Some((name, value.to_string())))
+            } else {
+                None
+            }
+        }
+        // No single clean placeholder — require literal equality.
+        _ => {
+            if template_seg == concrete_seg {
+                Some(None)
+            } else {
+                None
+            }
+        }
+    }
+}
+
 /// Check if a concrete path matches a path template with {param} segments
 fn path_matches_template(concrete: &str, template: &str) -> bool {
     let concrete_parts: Vec<&str> = concrete.split('/').collect();
@@ -213,7 +256,7 @@ fn path_matches_template(concrete: &str, template: &str) -> bool {
     concrete_parts
         .iter()
         .zip(template_parts.iter())
-        .all(|(c, t)| t.starts_with('{') && t.ends_with('}') || c == t)
+        .all(|(c, t)| match_path_segment(t, c).is_some())
 }
 
 /// Validate request body against the spec's requestBody schema
@@ -742,10 +785,11 @@ pub async fn validate_emitted_requests_with_base_path(
             let template_parts: Vec<&str> = spec_path.split('/').collect();
             if concrete_parts.len() == template_parts.len() {
                 for (c, t) in concrete_parts.iter().zip(template_parts.iter()) {
-                    if t.starts_with('{') && t.ends_with('}') {
-                        let name = &t[1..t.len() - 1];
-                        // Round 53 — path segments arrive percent-encoded too.
-                        out.insert(name.to_string(), pct_decode(c));
+                    // Round 54 — reuse the segment matcher so custom-verb path
+                    // params (`{instance}:reportStatus`) bind too, not just bare
+                    // `{name}` segments. Round 53 — path values arrive encoded.
+                    if let Some(Some((name, value))) = match_path_segment(t, c) {
+                        out.insert(name.to_string(), pct_decode(&value));
                     }
                 }
             }
@@ -1216,6 +1260,30 @@ fn check_value_against_schema(value: &str, schema: &openapiv3::Schema) -> Option
                     ));
                 }
             }
+            // Round 54 (#79) — string length + pattern constraints. Without
+            // these a `bad-path-param` / bad-query probe against a param that
+            // declares `pattern` / `minLength` / `maxLength` produced no
+            // violation even though the value clearly breaks the contract.
+            let len = value.chars().count();
+            if let Some(min) = s.min_length {
+                if len < min {
+                    return Some(format!("value \"{value}\" is shorter than minLength {min}"));
+                }
+            }
+            if let Some(max) = s.max_length {
+                if len > max {
+                    return Some(format!("value \"{value}\" is longer than maxLength {max}"));
+                }
+            }
+            if let Some(pat) = &s.pattern {
+                // Best-effort: an uncompilable pattern is skipped rather than
+                // reported as a false positive.
+                if let Ok(re) = regex::Regex::new(pat) {
+                    if !re.is_match(value) {
+                        return Some(format!("value \"{value}\" does not match pattern /{pat}/"));
+                    }
+                }
+            }
             None
         }
         Type::Integer(_) => {
@@ -1598,5 +1666,91 @@ mod emitted_body_tests {
             !rows.iter().any(|r| r["check_name"] == "positive"),
             "positive probe must not be flagged: {rows:?}"
         );
+    }
+
+    /// Round 54 (#79) — the segment matcher must bind custom-verb path params
+    /// (`{instance}:reportStatus`), not just bare `{name}` segments.
+    #[test]
+    fn segment_matcher_handles_custom_verbs() {
+        use super::match_path_segment;
+        // Bare placeholder.
+        assert_eq!(match_path_segment("{name}", "abc"), Some(Some(("name", "abc".to_string()))));
+        // Custom verb suffix — Google style.
+        assert_eq!(
+            match_path_segment("{instance}:reportStatus", "self-test-invalid-id:reportStatus"),
+            Some(Some(("instance", "self-test-invalid-id".to_string())))
+        );
+        // Wrong verb -> no match.
+        assert_eq!(match_path_segment("{instance}:reportStatus", "x:other"), None);
+        // Literal segment matches only itself.
+        assert_eq!(match_path_segment("v1", "v1"), Some(None));
+        assert_eq!(match_path_segment("v1", "v2"), None);
+    }
+
+    /// Round 54 (#79) — Srikanth on 0.3.200: OWASP violations now appear but
+    /// parameter probes didn't. A `parameters:bad-path-param` probe hits a
+    /// custom-verb path (`/v1/{instance}:reportStatus`); the path never matched
+    /// the template (so validation was skipped entirely), and even when it did
+    /// only enum/type were checked, not `pattern`/`maxLength`. This reproduces
+    /// the probe against a constrained path param and asserts the violation.
+    #[tokio::test]
+    async fn emitted_requests_flag_bad_custom_verb_path_param() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let spec_json = serde_json::json!({
+            "openapi": "3.0.0",
+            "info": { "title": "apigee-min", "version": "1.0.0" },
+            "paths": {
+                "/v1/{instance}:reportStatus": {
+                    "post": {
+                        "parameters": [
+                            { "name": "instance", "in": "path", "required": true,
+                              "schema": { "type": "string", "maxLength": 8 } }
+                        ],
+                        "responses": { "200": { "description": "ok" } }
+                    }
+                }
+            }
+        });
+        let spec_path = dir.path().join("apigee-min.json");
+        std::fs::write(&spec_path, serde_json::to_vec_pretty(&spec_json).unwrap()).unwrap();
+
+        let jsonl_path = dir.path().join("conformance-self-test-requests.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            serde_json::to_string(&serde_json::json!({
+                "label": "parameters:bad-path-param",
+                "method": "POST",
+                // 20-char instance value > maxLength 8, on the custom-verb path.
+                "url": "https://172.22.232.2:443/v1/self-test-invalid-id:reportStatus",
+                "request_body": ""
+            }))
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+
+        let n = validate_emitted_requests_with_base_path(
+            std::slice::from_ref(&spec_path),
+            dir.path(),
+            None,
+        )
+        .await
+        .expect("validation runs");
+        assert!(n >= 1, "the bad custom-verb path param must be flagged, got {n}");
+
+        let flat: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("conformance-request-violations.json"))
+                .unwrap(),
+        )
+        .unwrap();
+        let row = flat
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["check_name"] == "parameters:bad-path-param")
+            .expect("bad-path-param violation present");
+        assert_eq!(row["violation_type"], "path_value_mismatch");
+        let msg = row["message"].as_str().unwrap();
+        assert!(msg.contains("instance") && msg.contains("maxLength"), "unexpected: {msg}");
     }
 }

--- a/crates/mockforge-bench/src/parallel_executor.rs
+++ b/crates/mockforge-bench/src/parallel_executor.rs
@@ -386,6 +386,15 @@ impl ParallelExecutor {
             let chunked_request_bodies = self.base_command.chunked_request_bodies;
             let target_rps = self.base_command.target_rps;
             let no_keep_alive = self.base_command.no_keep_alive;
+            // Issue #79 r54 (Srikanth on 0.3.200): `--source-ip` was silently
+            // dropped in multi-target (`--targets-file`) mode because this
+            // executor built `K6Executor::new()` without `.with_local_ips` and
+            // the per-target BenchCommand clone zeroed `source_ips`. Thread the
+            // source IPs (as the k6 `--local-ips` list) and geo config through
+            // to each target's run.
+            let local_ips = self.base_command.source_ips.join(",");
+            let geo_source_ips = self.base_command.geo_source_ips.clone();
+            let geo_source_headers = self.base_command.geo_source_headers.clone();
 
             // Select per-target templates/base_path if this target has a custom spec
             let (templates, base_path) = if let Some(spec_path) = &target.spec {
@@ -442,6 +451,9 @@ impl ParallelExecutor {
                     target_rps,
                     no_keep_alive,
                     &enhancement_code,
+                    &local_ips,
+                    &geo_source_ips,
+                    &geo_source_headers,
                 )
                 .await;
 
@@ -546,6 +558,9 @@ impl ParallelExecutor {
         target_rps: Option<u32>,
         no_keep_alive: bool,
         enhancement_code: &str,
+        local_ips: &str,
+        geo_source_ips: &[String],
+        geo_source_headers: &[String],
     ) -> Result<TargetResult> {
         // Merge target-specific headers with base headers
         let mut custom_headers = base_headers.clone();
@@ -573,8 +588,8 @@ impl ParallelExecutor {
             chunked_request_bodies,
             target_rps,
             no_keep_alive,
-            geo_source_ips: Vec::new(),
-            geo_source_headers: Vec::new(),
+            geo_source_ips: geo_source_ips.to_vec(),
+            geo_source_headers: geo_source_headers.to_vec(),
         };
 
         // Generate k6 script
@@ -609,7 +624,10 @@ impl ParallelExecutor {
         // Execute k6 with a unique API server port per target to avoid port conflicts.
         // k6 defaults to localhost:6565 for its REST API; parallel instances collide.
         let api_port = 6565 + (target_index as u16) + 1; // 6566, 6567, ...
-        let executor = K6Executor::new()?;
+                                                         // Issue #79 r54 — forward `--source-ip` (as k6 `--local-ips`) so each
+                                                         // target's VUs rotate through the configured source IP pool. Without
+                                                         // this, `--source-ip` was a silent no-op in multi-target mode.
+        let executor = K6Executor::new()?.with_local_ips(local_ips.to_string());
         let results = executor
             .execute_with_port(&script_path, Some(&output_dir), verbose, Some(api_port))
             .await;


### PR DESCRIPTION
Srikanth's 0.3.200 follow-up on #79. Both fixes verified against the real binary.

## Parameter violations now surface (owasp landed in r53)
Two gaps left parameter probes out of the by-request / by-probe logs:
1. `parameters:bad-path-param` targets a **custom-verb** path like `/v1/{instance}:reportStatus`. The templated segment `{instance}:reportStatus` never matched the path template, so the whole request was skipped before any parameter check ran. Added a segment matcher that binds `{name}`, `{name}:verb`, and `prefix{name}` forms, used by both the path matcher and the path-param extractor.
2. Param value validation only checked enum/integer/number/boolean, not string `pattern` / `minLength` / `maxLength`. Added those.

**Verified:** a self-test against a spec with a custom-verb path and a `maxLength`'d `instance` param now writes `parameters:bad-path-param => path.instance: value "self-test-invalid-id" is longer than maxLength 8`.

Note: probes that drop an **optional** query param (his `$.xgafv` case) or add an extra param are spec-valid by construction, so they correctly produce no client-side violation. Only genuinely-constrained params surface; the full negative-probe record stays in `conformance-self-test.json`.

## `--source-ip` now works with `--targets-file`
It was silently dropped in multi-target mode: the per-target `BenchCommand` clone hardcoded `source_ips: Vec::new()`, and the `ParallelExecutor` built `K6Executor::new()` without `.with_local_ips`. Now the source/geo IPs flow through the clone and `--local-ips` is passed to each target's k6.

**Verified:** `bench --targets-file --source-ip 10.99.99.99` now makes k6 fail with `bind: cannot assign requested address` (proving the source IP is applied); before, it connected from the default IP.

## Checks
- New unit + end-to-end tests (custom-verb matcher, bad-path-param violation). `mockforge-bench` 509 tests pass; `cargo fmt` clean; clippy clean on changed files.

His HTTP request-pipelining ask (large JSON/XML/urlencoded/multipart at KB-GB) is a sizeable standalone feature, filed as #937.