### PR TITLE
chore(release): v0.3.202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3.202] - 2026-07-11
+
+### Fixed
+
+- **[Contracts]** Parameter violations now surface in the by-request / by-probe logs, not just OWASP and request-body ones (#79 round 54 / Srikanth on 0.3.200: `parameters` negatives were missed in the console but absent from the violation files). Two gaps: (1) a `parameters:bad-path-param` probe targets a custom-verb path like `/v1/{instance}:reportStatus`, whose templated segment `{instance}:reportStatus` never matched the path template, so the whole request was skipped before any parameter check ran; (2) parameter value validation only covered enum/integer/number/boolean, not string `pattern` / `minLength` / `maxLength`. A new segment matcher binds `{name}`, `{name}:verb`, and `prefix{name}` forms (used by both the path matcher and the path-param extractor), and string length/pattern constraints are now checked. Real-binary verified: a self-test against a spec with a custom-verb path and a `maxLength`-constrained param now writes `parameters:bad-path-param => path.instance: value "self-test-invalid-id" is longer than maxLength 8`. (Probes that drop an OPTIONAL query param or add an extra param stay spec-valid by construction and correctly produce no client-side violation; the full negative-probe record is in `conformance-self-test.json`.)
+- **[Reality]** `--source-ip` now takes effect with `--targets-file` (#79 round 54 / Srikanth on 0.3.200: source-ip was a silent no-op in multi-target mode). The per-target `BenchCommand` clone in `execute_multi_target` hardcoded `source_ips: Vec::new()`, and the `ParallelExecutor` built `K6Executor::new()` without `.with_local_ips`. The source IPs (and geo variants) now flow through the clone and `--local-ips` is passed to each target's k6. Real-binary verified: `bench --targets-file --source-ip 10.99.99.99` now makes k6 fail with `bind: cannot assign requested address` (proving the source IP is applied), where before it connected from the default address.
+
 ## [0.3.201] - 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7822,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8053,7 +8053,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8502,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8943,7 +8943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15428,7 +15428,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.201"
+version = "0.3.202"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.201"
+version = "0.3.202"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release v0.3.202: #79 round 54 (parameter violations surface via custom-verb path + string constraints; --source-ip works with --targets-file). Crates published from the local pipeline; this PR lands the bump + CHANGELOG.