### PR TITLE
fix(bench): r55 --base-path / no longer voids all validation (#79)

### DIFF
--- a/crates/mockforge-bench/src/conformance/request_validator.rs
+++ b/crates/mockforge-bench/src/conformance/request_validator.rs
@@ -244,6 +244,26 @@ fn match_path_segment<'a>(
     }
 }
 
+/// Collapse runs of `/` into a single `/` (preserving a leading slash).
+/// `//v1//x` -> `/v1/x`. Round 55 (#79) — guards path matching against the
+/// `--base-path /` double-slash regression.
+fn collapse_slashes(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    let mut prev_slash = false;
+    for ch in path.chars() {
+        if ch == '/' {
+            if !prev_slash {
+                out.push(ch);
+            }
+            prev_slash = true;
+        } else {
+            out.push(ch);
+            prev_slash = false;
+        }
+    }
+    out
+}
+
 /// Check if a concrete path matches a path template with {param} segments
 fn path_matches_template(concrete: &str, template: &str) -> bool {
     let concrete_parts: Vec<&str> = concrete.split('/').collect();
@@ -708,6 +728,14 @@ pub async fn validate_emitted_requests_with_base_path(
         } else {
             path_only
         };
+
+        // Round 55 (#79) — collapse accidental double slashes so a request
+        // that reached the wire as `//v1/organizations` (e.g. an older
+        // `--base-path /` that prefixed a `/` onto an already-rooted path)
+        // still matches the spec's `/v1/organizations`. Belt-and-suspenders:
+        // the generator no longer produces the `//`, but stale captures /
+        // hand-built URLs might.
+        let path_only = collapse_slashes(&path_only);
 
         // Round 45 — strip base_path BEFORE matching so an Apigee-style
         // `/api/v1/organizations` on the wire matches `/v1/organizations`
@@ -1666,6 +1694,78 @@ mod emitted_body_tests {
             !rows.iter().any(|r| r["check_name"] == "positive"),
             "positive probe must not be flagged: {rows:?}"
         );
+    }
+
+    /// Round 55 (#79) — double slashes collapse so a `//v1/x` request (from a
+    /// stray `--base-path /`) still matches the spec's `/v1/x`.
+    #[test]
+    fn collapse_slashes_normalises_double_slashes() {
+        use super::collapse_slashes;
+        assert_eq!(collapse_slashes("//v1/organizations"), "/v1/organizations");
+        assert_eq!(collapse_slashes("/v1//x///y"), "/v1/x/y");
+        assert_eq!(collapse_slashes("/v1/organizations"), "/v1/organizations");
+        assert_eq!(collapse_slashes("/"), "/");
+    }
+
+    /// Round 55 (#79) — Srikanth on 0.3.202: `--base-path /` produced
+    /// `//v1/organizations` emitted URLs, which never matched the spec's
+    /// `/v1/organizations`, so EVERY owasp/param/body violation vanished.
+    /// The validator now collapses the double slash and still flags the
+    /// body probe.
+    #[tokio::test]
+    async fn double_slashed_url_still_validates() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let spec_json = serde_json::json!({
+            "openapi": "3.0.0",
+            "info": { "title": "apigee-min", "version": "1.0.0" },
+            "paths": {
+                "/v1/organizations": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": { "analyticsRegion": { "type": "string" } }
+                                    }
+                                }
+                            }
+                        },
+                        "responses": { "200": { "description": "ok" } }
+                    }
+                }
+            }
+        });
+        let spec_path = dir.path().join("apigee-min.json");
+        std::fs::write(&spec_path, serde_json::to_vec_pretty(&spec_json).unwrap()).unwrap();
+
+        let jsonl_path = dir.path().join("conformance-self-test-requests.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            serde_json::to_string(&serde_json::json!({
+                "label": "request-body:type-mismatch:analyticsRegion",
+                "method": "POST",
+                // Note the DOUBLE slash after the host — the `--base-path /` bug.
+                "url": "https://172.22.232.2:443//v1/organizations",
+                "request_body": "{\"analyticsRegion\":12345}"
+            }))
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+
+        let n = validate_emitted_requests_with_base_path(
+            std::slice::from_ref(&spec_path),
+            dir.path(),
+            // The exact combination Srikanth used: base_path = "/".
+            Some("/"),
+        )
+        .await
+        .expect("validation runs");
+        assert!(n >= 1, "double-slashed URL must still match and flag the body, got {n}");
+        let flat = std::fs::read_to_string(dir.path().join("conformance-request-violations.json"))
+            .unwrap();
+        assert!(flat.contains("analyticsRegion"), "body probe must be reported: {flat}");
     }
 
     /// Round 54 (#79) — the segment matcher must bind custom-verb path params

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -554,17 +554,9 @@ async fn test_operation(
     // leading `/` auto-added, trailing `/` stripped, empty
     // base_path → no prefix at all.
     let path_template = {
-        let prefix = match config.base_path.as_deref() {
-            Some(bp) if !bp.is_empty() => {
-                let trimmed = bp.trim_end_matches('/');
-                if trimmed.starts_with('/') {
-                    trimmed.to_string()
-                } else {
-                    format!("/{}", trimmed)
-                }
-            }
-            _ => String::new(),
-        };
+        // Round 55 — shared with build_url_with_base so `--base-path /`
+        // resolves to no prefix instead of a `//path` double slash.
+        let prefix = base_path_prefix(config.base_path.as_deref());
         let path = if op.path.starts_with('/') {
             op.path.clone()
         } else {
@@ -1893,11 +1885,38 @@ fn build_url(target: &str, path_template: &str, path_params: &[(String, String)]
     build_url_with_base(target, None, path_template, path_params)
 }
 
+/// Round 55 (#79) — normalise a `--base-path` into a URL path prefix.
+///
+/// `Some("/api")` / `Some("api")` / `Some("/api/")` all become `/api`;
+/// `Some("/")`, `Some("")`, and `None` all become `""` (root, no prefix).
+///
+/// Srikanth on 0.3.202 ran with `--base-path /` and got ZERO violations even
+/// though the console reported thousands of misses. The old logic did
+/// `"/".trim_end_matches('/')` = `""`, decided `"".starts_with('/')` was
+/// false, and produced the prefix `"/"`. Combined with the leading `/` on the
+/// spec path that yielded `<target>//v1/organizations` (double slash), which
+/// never matched the spec's `/v1/organizations`, so every emitted request was
+/// skipped by the validator and no violations were logged. Trimming slashes
+/// from BOTH ends and treating the empty result as "no prefix" fixes it.
+fn base_path_prefix(base_path: Option<&str>) -> String {
+    match base_path {
+        Some(bp) => {
+            let trimmed = bp.trim_matches('/');
+            if trimmed.is_empty() {
+                String::new()
+            } else {
+                format!("/{trimmed}")
+            }
+        }
+        None => String::new(),
+    }
+}
+
 /// Round 18.1 — variant of `build_url` that takes a `base_path`
 /// (e.g. `Some("/api")`). When set, prepends it to the spec path so a
 /// spec declaring `/users` against a target served behind `/api`
-/// resolves to `<target>/api/users`. `base_path` is normalised: leading
-/// `/` is auto-added, trailing `/` is stripped.
+/// resolves to `<target>/api/users`. `base_path` is normalised via
+/// [`base_path_prefix`] (both ends trimmed; `/` means root/no prefix).
 fn build_url_with_base(
     target: &str,
     base_path: Option<&str>,
@@ -1912,17 +1931,7 @@ fn build_url_with_base(
         }
     }
     let target = target.trim_end_matches('/');
-    let prefix = match base_path {
-        Some(bp) if !bp.is_empty() => {
-            let trimmed = bp.trim_end_matches('/');
-            if trimmed.starts_with('/') {
-                trimmed.to_string()
-            } else {
-                format!("/{}", trimmed)
-            }
-        }
-        _ => String::new(),
-    };
+    let prefix = base_path_prefix(base_path);
     let path = if url.starts_with('/') {
         url
     } else {
@@ -2102,6 +2111,25 @@ mod tests {
         assert_eq!(empty, "https://t/x");
         let none = build_url_with_base("https://t", None, "/x", &[]);
         assert_eq!(none, "https://t/x");
+    }
+
+    /// Round 55 (#79) — Srikanth on 0.3.202 passed `--base-path /` and got a
+    /// `//v1/organizations` double slash, which broke all validation. `/`
+    /// (and `//`) must be treated as root, i.e. no prefix.
+    #[test]
+    fn base_path_slash_is_root_no_double_slash() {
+        assert_eq!(base_path_prefix(Some("/")), "");
+        assert_eq!(base_path_prefix(Some("//")), "");
+        assert_eq!(base_path_prefix(Some("")), "");
+        assert_eq!(base_path_prefix(None), "");
+        assert_eq!(base_path_prefix(Some("/api")), "/api");
+        assert_eq!(base_path_prefix(Some("api/")), "/api");
+        assert_eq!(base_path_prefix(Some("/api/v1")), "/api/v1");
+        // The end-to-end URL no longer double-slashes.
+        assert_eq!(
+            build_url_with_base("https://t", Some("/"), "/v1/organizations", &[]),
+            "https://t/v1/organizations"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Srikanth on 0.3.202: a self-test with `--base-path /` wrote an empty violation file even though the console reported thousands of owasp/parameter/request-body misses.

## Root cause
`build_url_with_base` computed the prefix as `"/".trim_end_matches('/')` = `""`, decided `"".starts_with('/')` was false, and produced the prefix `"/"`. Prepended to the already-rooted spec path that yielded `<target>//v1/organizations` (double slash), whose template `//v1/organizations` never matched the spec's `/v1/organizations`. So the validator skipped **every** emitted request and logged nothing — which is why even OWASP and request-body, which worked in r53/r54, disappeared this run. The trigger was the `--base-path /` added to this command.

## Fix
- A shared `base_path_prefix()` trims slashes from **both** ends and treats the empty result (`/`, `//`, ``) as no prefix (root). Used by both prefix sites in `self_test.rs`.
- The validator also collapses stray double slashes before matching (belt-and-suspenders for old captures).

## Verified (real binary, Srikanth's exact command)
`bench --conformance-self-test ... --base-path / --validate-requests --targets-file ...`: the emitted URL is now `http://host/v1/organizations` (single slash), and the logs populate again with 13 rows (7 OWASP query violations + 6 request-body), where 0.3.202 wrote `[]`.

New unit + e2e tests (`base_path_prefix`, `collapse_slashes`, double-slashed-URL still validates). `mockforge-bench` 512 tests pass; `cargo fmt` clean; clippy clean on changed files.

source-ip he confirmed working on IPv4 + IPv6.