### PR TITLE
feat(bench): r57 — --discard-response-bodies flag + caught/missed legend (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.205] - 2026-07-14
+
+### Added
+
+- **[DevX]** New `mockforge bench --discard-response-bodies` flag exposes `K6_DISCARD_RESPONSE_BODIES=true` as a first-class option (#79 round 57 / Srikanth on 0.3.204 asked for a flag instead of setting the env var for scale/stress runs). Plain load runs only check status codes but k6 buffers every response body by default, which OOM-kills k6 on long, high-VU runs. The flag opts a single-target load run into discarding bodies (multi-target load already discards by default since 0.3.204); it is a no-op on conformance / self-test / CRUD-extraction runs, which need the body. Verified with the real binary: passing the flag makes the launched k6 child carry `K6_DISCARD_RESPONSE_BODIES=true` and keeps `data_received` at header-only levels, while omitting it leaves the env unset.
+
+### Changed
+
+- **[DevX]** The self-test console summary now prints a one-line legend under the `Negatives [...]` lines explaining that "caught" means the target rejected a deliberately-bad request with a 4xx and "missed" means the target accepted it, and that a high "missed" is not automatically a bug because many probes are spec-valid by construction (#79 round 57 / Srikanth on 0.3.204 asked how to read caught vs missed). The self-test-probes reference page gains the same spec-valid nuance (a `string` field accepts any string so an `owasp:sqli` payload is a valid string; an optional query param can be dropped; an unconstrained `{id}` accepts any value), and the capacity-sizing page documents the new flag.
+
 ## [0.3.204] - 2026-07-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7822,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8053,7 +8053,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8502,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8943,7 +8943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15428,7 +15428,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.204"
+version = "0.3.205"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.204"
+version = "0.3.205"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/bench-capacity-sizing.md
+++ b/book/src/reference/bench-capacity-sizing.md
@@ -101,6 +101,28 @@ number to ~32 on a single client.
 **Symptoms of over-provisioning:** none worth worrying about. Extra
 CPU/RAM costs are tiny compared to the cost of a failed run.
 
+## `--discard-response-bodies` for long load runs
+
+Plain load runs only check status codes and latency, but k6 still buffers
+every response body in memory by default. On a long, high-VU or many-target
+run this accumulates until the kernel OOM-killer sends k6 `signal: 9
+(SIGKILL)`. Pass `--discard-response-bodies` so k6 runs with
+`K6_DISCARD_RESPONSE_BODIES=true` and drops the bodies it never inspects:
+
+```bash
+mockforge bench --spec api.yaml --target https://api.example.com \
+  --duration 1h --vus 50 --discard-response-bodies
+```
+
+Notes:
+
+- Multi-target load (`--targets-file`) already discards bodies by default;
+  the flag additionally covers single-target load runs.
+- It has no effect on conformance / self-test / CRUD-extraction runs, which
+  need the response body to validate or extract fields.
+- If OOM persists on a very large fan-out, also lower `--max-concurrency`
+  (each target is a separate k6 process) and shorten `--duration` / `--vus`.
+
 ## Sharding past 50 targets
 
 For 50+ targets at 100+ RPS, split the work across N clients:

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,15 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.205] - 2026-07-14
+
+### Added
+
+- **[DevX]** New `mockforge bench --discard-response-bodies` flag exposes `K6_DISCARD_RESPONSE_BODIES=true` as a first-class option (#79 round 57 / Srikanth on 0.3.204 asked for a flag instead of the env var for scale/stress runs). Opts a single-target load run into discarding response bodies (multi-target load already discards by default); no-op on conformance / self-test / extraction runs, which need the body. Real-binary verified: the launched k6 child carries the env var and `data_received` stays at header-only levels.
+
+### Changed
+
+- **[DevX]** The self-test console summary prints a one-line legend under the `Negatives [...]` lines explaining "caught" (target rejected a deliberately-bad request with a 4xx) vs "missed" (target accepted it), and that a high "missed" is not automatically a bug because many probes are spec-valid by construction (#79 round 57 / Srikanth on 0.3.204 asked how to read caught vs missed). The self-test-probes and capacity-sizing reference pages gain the same nuance and document the new flag.
+
 ## [0.3.204] - 2026-07-13
 
 ### Fixed

--- a/book/src/reference/conformance-self-test-probes.md
+++ b/book/src/reference/conformance-self-test-probes.md
@@ -205,15 +205,42 @@ intentionally separate knobs from request-body conformance.
 Negatives [security]: 739 caught / 1812 missed  ⚠
 ```
 
-- **caught** = the server correctly rejected with a 4xx.
-- **missed** = the server accepted (`2xx-3xx`) or crashed (`5xx`)
-  when it shouldn't have.
+A **negative** is a deliberately-bad request that *should* draw a `4xx`
+from the **target** (the service you are benching), not from MockForge.
+The two buckets are about the target's behaviour:
 
-A category that's all-missed is the spec telling you that whole
+- **caught** = the target rejected it with a `4xx` (its validation held).
+- **missed** = the target accepted it (`2xx-3xx`) or crashed (`5xx`)
+  when the probe expected a rejection.
+
+A category that's all-missed is often the spec telling you that whole
 validator class isn't enforced. A category that's all-caught with no
 missed is the server doing its job. The interesting reads are
 partial-misses (some routes enforce, others don't) — those are
 usually middleware ordering bugs.
+
+### A high "missed" is not automatically a bug
+
+Many probes are **spec-valid by construction**, so the contract itself
+permits them and a correct target is *right* to accept them (counted as
+"missed" only because the probe hoped for a rejection). Examples:
+
+- a `string` field accepts any string, so an `owasp:sqli` payload like
+  `' OR '1'='1` satisfies the schema — only an app-layer WAF, not the
+  contract, would reject it;
+- an *optional* query parameter can be dropped (`parameters:missing-query`);
+- an unconstrained `{id}` path segment accepts any value
+  (`parameters:bad-path-param`).
+
+These land in `conformance-request-violations.json` as typed
+`parameter_negative_probe` (or equivalent) rows with a note explaining
+why they are not a schema breach and that rejecting them is the target's
+responsibility. So when `parameters` or `owasp` shows `0 caught / N
+missed`, read it as "the contract permits these, and the target chose to
+accept them" — check the per-probe rows to see which are genuinely
+unenforced validations versus spec-permitted inputs. The same summary is
+printed inline under each `Negatives [...]` line so you don't have to
+come back to this page.
 
 ## HTML drill-down cap
 

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -769,6 +769,7 @@ fn default_bench_command(output_dir: &Path) -> BenchCommand {
         geo_source_ips: Vec::new(),
         geo_source_headers: Vec::new(),
         report_missed_cap: None,
+        discard_response_bodies: false,
         owasp_api_top10: false,
         owasp_categories: None,
         owasp_auth_header: "Authorization".to_string(),

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -256,6 +256,14 @@ pub struct BenchCommand {
     /// browser-choking HTML file by default.
     pub report_missed_cap: Option<u32>,
 
+    /// Round 57 (#79) — when true, run k6 load with
+    /// `K6_DISCARD_RESPONSE_BODIES=true` so it does not buffer response bodies
+    /// in memory. Exposes the r56 env var as a first-class flag for scale /
+    /// stress runs. Only affects the plain (status-only) load paths; the
+    /// conformance / self-test / CRUD-extraction paths that read the body
+    /// ignore it. Multi-target load already discards by default (r56).
+    pub discard_response_bodies: bool,
+
     // === OWASP API Security Top 10 Testing ===
     /// Enable OWASP API Security Top 10 testing mode
     pub owasp_api_top10: bool,
@@ -911,7 +919,12 @@ impl BenchCommand {
 
         // Execute k6
         TerminalReporter::print_progress("Executing load test...");
-        let executor = K6Executor::new()?.with_local_ips(self.source_ips.join(","));
+        // Round 57 (#79) — `--discard-response-bodies` opts a single-target
+        // load run into K6_DISCARD_RESPONSE_BODIES. Safe here: this is the
+        // plain load path (status/latency only), not conformance/extraction.
+        let executor = K6Executor::new()?
+            .with_local_ips(self.source_ips.join(","))
+            .with_discard_response_bodies(self.discard_response_bodies);
 
         std::fs::create_dir_all(&self.output)?;
 
@@ -1040,6 +1053,10 @@ impl BenchCommand {
                 geo_source_ips: self.geo_source_ips.clone(),
                 geo_source_headers: self.geo_source_headers.clone(),
                 report_missed_cap: None,
+                // Round 57 (#79) — carry the flag through; the multi-target
+                // plain-load path already discards by default (r56), so this
+                // keeps the per-target command faithful to the parent.
+                discard_response_bodies: self.discard_response_bodies,
             },
             targets,
             max_concurrency,
@@ -2088,7 +2105,11 @@ impl BenchCommand {
         std::fs::write(&script_path, &script)?;
 
         if !self.generate_only {
-            let executor = K6Executor::new()?.with_local_ips(self.source_ips.join(","));
+            // Round 57 (#79) — honour `--discard-response-bodies` on the
+            // standard (status-only) load path too.
+            let executor = K6Executor::new()?
+                .with_local_ips(self.source_ips.join(","))
+                .with_discard_response_bodies(self.discard_response_bodies);
             let output_dir = self.output.join(format!("{}_results", spec_name.replace('.', "_")));
             std::fs::create_dir_all(&output_dir)?;
 
@@ -4106,6 +4127,7 @@ mod tests {
             geo_source_ips: Vec::new(),
             geo_source_headers: Vec::new(),
             report_missed_cap: None,
+            discard_response_bodies: false,
         };
 
         let headers = cmd.parse_headers().unwrap();
@@ -4209,6 +4231,7 @@ mod tests {
             geo_source_ips: Vec::new(),
             geo_source_headers: Vec::new(),
             report_missed_cap: None,
+            discard_response_bodies: false,
         };
 
         assert_eq!(cmd.get_spec_display_name(), "test.yaml");
@@ -4292,6 +4315,7 @@ mod tests {
             geo_source_ips: Vec::new(),
             geo_source_headers: Vec::new(),
             report_missed_cap: None,
+            discard_response_bodies: false,
         };
 
         assert_eq!(cmd_multi.get_spec_display_name(), "2 spec files");

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -383,6 +383,18 @@ impl SelfTestReport {
             self.negative_caught.keys().chain(self.negative_missed.keys()).collect();
         keys.sort();
         keys.dedup();
+        // Round 57 (#79) — Srikanth asked what "caught" vs "missed" mean.
+        // Spell it out once, inline, so the console output is self-explanatory.
+        if !keys.is_empty() {
+            out.push_str(
+                "  (negatives are deliberately-bad requests that SHOULD draw a 4xx from the TARGET: \
+                 \"caught\" = the target rejected it, \"missed\" = the target accepted it. \
+                 A high \"missed\" is not automatically a target bug: many probes are spec-valid by \
+                 construction, e.g. a string field accepts any string or an optional query param can \
+                 be dropped, so the contract permits them; those are the parameter_negative_probe / \
+                 informational rows in conformance-request-violations.json.)\n",
+            );
+        }
         for cat in keys {
             let caught = self.negative_caught.get(cat).copied().unwrap_or(0);
             let missed = self.negative_missed.get(cat).copied().unwrap_or(0);
@@ -2151,7 +2163,26 @@ mod tests {
         assert!(summary.contains("Positives: 3 pass / 0 fail"));
         assert!(summary.contains("Negatives [request-body]: 2 caught / 1 missed"));
         assert!(summary.contains("⚠"));
+        // Round 57 (#79) — the caught/missed legend is printed once when there
+        // are negatives, so the console explains the terms inline.
+        assert!(summary.contains("\"caught\" = the target rejected it"));
+        assert!(summary.contains("spec-valid by construction"));
         assert!(!r.all_passed());
+    }
+
+    #[test]
+    fn report_summary_omits_legend_when_no_negatives() {
+        // Round 57 (#79) — a positives-only report has no Negatives lines, so
+        // the legend would be noise; it must not appear.
+        let r = SelfTestReport {
+            positive_pass: 1,
+            positive_fail: 0,
+            negative_caught: BTreeMap::new(),
+            negative_missed: BTreeMap::new(),
+            operations: Vec::new(),
+        };
+        let summary = r.render_summary();
+        assert!(!summary.contains("deliberately-bad requests"));
     }
 
     #[test]

--- a/crates/mockforge-bench/tests/multi_target_test.rs
+++ b/crates/mockforge-bench/tests/multi_target_test.rs
@@ -202,6 +202,7 @@ async fn test_bench_command_parse_headers() {
         geo_source_ips: Vec::new(),
         geo_source_headers: Vec::new(),
         report_missed_cap: None,
+        discard_response_bodies: false,
     };
 
     let headers = cmd.parse_headers().unwrap();
@@ -291,6 +292,7 @@ async fn test_bench_command_parse_headers_invalid_format() {
         geo_source_ips: Vec::new(),
         geo_source_headers: Vec::new(),
         report_missed_cap: None,
+        discard_response_bodies: false,
     };
 
     let result = cmd.parse_headers();

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2336,6 +2336,17 @@ enum Commands {
         /// browser-choking file by default.
         #[arg(long = "report-missed-cap", value_name = "N")]
         report_missed_cap: Option<u32>,
+
+        /// Issue #79 round 57 — run k6 with `K6_DISCARD_RESPONSE_BODIES=true`
+        /// so it does not buffer response bodies in memory. For scale / stress
+        /// load runs where you only care about status codes and latency: keeps
+        /// k6's RSS bounded on long, high-VU runs (guards the OOM / SIGKILL
+        /// failure mode). This is the first-class flag for the env var wired in
+        /// 0.3.204. Multi-target load already discards by default; this enables
+        /// it for single-target load runs too. No effect on conformance /
+        /// self-test / CRUD-extraction runs, which need the response body.
+        #[arg(long = "discard-response-bodies")]
+        discard_response_bodies: bool,
     },
 
     /// Native Rust chunked-encoding traffic generator.
@@ -3304,6 +3315,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             geo_source_ips,
             geo_source_headers,
             report_missed_cap,
+            discard_response_bodies,
         } => {
             // Validate that either --target or --targets-file is provided, but not both
             match (&target, &targets_file) {
@@ -3426,6 +3438,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 geo_source_ips,
                 geo_source_headers,
                 report_missed_cap,
+                discard_response_bodies,
             };
 
             if let Err(e) = bench_cmd.execute().await {


### PR DESCRIPTION
Two follow-ups from Srikanth on 0.3.204 (#79).

## 1. `--discard-response-bodies` flag
Exposes `K6_DISCARD_RESPONSE_BODIES=true` as a first-class option so scale/stress runs don't need the env var. Wired into the single-target plain-load paths (multi-target load already discards by default since 0.3.204). It is a no-op on conformance / self-test / CRUD-extraction runs, which need the response body.

```
mockforge bench --spec api.yaml --target https://api.example.com --duration 1h --vus 50 --discard-response-bodies
```

**Verified with the real binary:** with the flag, the launched k6 child process carries `K6_DISCARD_RESPONSE_BODIES=true` in its environment; without it, the env is unset.

## 2. caught/missed legend
Srikanth asked how to read `Negatives [owasp]: 0 caught / 9009 missed`. The self-test console summary now prints a one-line legend under the `Negatives [...]` lines: **caught** = the target rejected a deliberately-bad request with a 4xx; **missed** = the target accepted it. It also notes that a high "missed" is not automatically a bug, because many probes are spec-valid by construction (a `string` field accepts any string, an optional query param can be dropped, an unconstrained `{id}` accepts any value) — those are the `parameter_negative_probe` rows added in 0.3.204. The self-test-probes and capacity-sizing reference pages gain the same nuance.

## Verification
- `cargo test -p mockforge-bench` green (516 tests, incl. 2 new legend tests); fmt + clippy clean
- `--discard-response-bodies` appears in `bench --help`
- legend renders inline above the `Negatives` lines against a real `mockforge serve` target
- release smoke-test (`--fast`) + release-guardian **GO**