### PR TITLE
fix(bench): r58 — ephemeral k6 REST-API port + definite-issues view (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.206] - 2026-07-16
+
+### Fixed
+
+- **[Reality]** Multi-target load no longer fails to start with `k6 exited with status: exit status: 106` and zero requests (#79 round 58 / Srikanth on 0.3.205: all 10 targets failed this way, so no traffic ran and `--discard-response-bodies` appeared to "not help"). Exit 106 is k6's `CannotStartRESTAPI`: each parallel k6 was pinned to a FIXED REST API port (`6565 + index` → 6566, 6567, ...), which collides whenever those ports are already taken (orphaned k6 from a previous OOM-killed run, a second concurrent bench, or any local service). Each k6 instance now binds an OS-assigned ephemeral port (`--address localhost:0`) for its REST API, so it can never collide; MockForge never queries that API (results come from `summary.json` on disk). Real-binary verified: with ports 6566 and 6567 deliberately occupied, a multi-target load that previously exited 106 on every target now starts cleanly and generates traffic on all targets.
+
+### Added
+
+- **[Contracts]** New "Definite issues" view in the conformance self-test (#79 round 58 / Srikanth on 0.3.205 asked for a way to say "for sure this is an issue" without eyeballing every caught/missed row across all APIs). A `Definite issues (N)` section is printed under the `Negatives [...]` summary and a `conformance-definite-issues.json` sidecar is written next to the report. It surfaces only the unambiguous problems that need no per-probe analysis: (1) a spec-valid request the target rejected, and (2) any probe that drew a 5xx (the target crashed instead of replying cleanly). Spec-valid "missed" negatives (which genuinely need judgement) are deliberately excluded. Real-binary verified: a clean target prints "Definite issues: none"; a target that 404s a valid request surfaces it as a `valid_request_rejected` row in both the console and the JSON. Also clarified in the docs that a "caught" 4xx is the target doing its job (rejecting a bad request), not a violation.
+
 ## [0.3.205] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7822,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8053,7 +8053,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8502,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8943,7 +8943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15428,7 +15428,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.205"
+version = "0.3.206"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.205"
+version = "0.3.206"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,15 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.206] - 2026-07-16
+
+### Fixed
+
+- **[Reality]** Multi-target load no longer fails to start with `exit status: 106` (k6 `CannotStartRESTAPI`) and zero requests (#79 round 58 / Srikanth on 0.3.205). Each parallel k6 was pinned to a fixed REST API port (`6565 + index`) that collides when already taken (orphaned k6 from a prior OOM-killed run, a second bench, a local service). k6 now binds an ephemeral port (`--address localhost:0`) instead; MockForge reads results from `summary.json` on disk, never the API. Real-binary verified with ports 6566/6567 occupied: a load that used to exit 106 on every target now runs.
+
+### Added
+
+- **[Contracts]** New "Definite issues" view in the self-test (#79 round 58 / Srikanth on 0.3.205 asked for a "for sure this is an issue" filter). A `Definite issues (N)` console section plus a `conformance-definite-issues.json` sidecar surface only unambiguous problems: a spec-valid request the target rejected, or any probe that drew a 5xx. Spec-valid "missed" negatives are excluded. Clarified that a "caught" 4xx is the target correctly rejecting a bad request, not a violation.
+
 ## [0.3.205] - 2026-07-14
 
 ### Added

--- a/book/src/reference/conformance-self-test-probes.md
+++ b/book/src/reference/conformance-self-test-probes.md
@@ -242,6 +242,26 @@ unenforced validations versus spec-permitted inputs. The same summary is
 printed inline under each `Negatives [...]` line so you don't have to
 come back to this page.
 
+## Definite issues
+
+Because "missed" needs interpretation, the self-test also prints a
+`Definite issues (N)` section and writes a `conformance-definite-issues.json`
+sidecar containing ONLY the unambiguous problems, so you can triage many
+APIs by reading one short list:
+
+- **`valid_request_rejected`** — the target refused a spec-valid (positive)
+  request. It broke a legitimate call; this is always a real problem.
+- **`server_error`** — a probe (positive or negative) drew a 5xx. Even a
+  deliberately-bad request should get a clean 4xx, never a crash.
+
+Spec-valid "missed" negatives are deliberately excluded from this view:
+those are the ones the caught/missed rollup exists to help you judge. A
+"caught" 4xx is never listed here — a caught negative means the target did
+its job (rejected a bad request), so it is not a violation even if that
+exact error status isn't enumerated in the spec (use
+`--validate-response-schemas` if you want to check error bodies against
+the spec separately).
+
 ## HTML drill-down cap
 
 The "Missed negatives" table in `conformance-report.html` caps at 200

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -2816,6 +2816,20 @@ impl BenchCommand {
                     json_path.display()
                 ));
             }
+            // Round 58 (#79) — write the "definite issues" sidecar so the
+            // unambiguous problems are grep-able / automatable without eyeballing
+            // the caught/missed rollup.
+            let issues = report.definite_issues();
+            let issues_path = self.output.join("conformance-definite-issues.json");
+            if let Ok(json) = serde_json::to_string_pretty(&issues) {
+                if std::fs::write(&issues_path, json).is_ok() && !issues.is_empty() {
+                    TerminalReporter::print_warning(&format!(
+                        "{} definite issue(s) — see {}",
+                        issues.len(),
+                        issues_path.display()
+                    ));
+                }
+            }
             // Round 18.1 — surface the "every positive failed with
             // the same status" case loudly. Without this, a user
             // who forgot `--base-path /api` saw 404 for every
@@ -3307,6 +3321,19 @@ impl BenchCommand {
             let json_path = target_dir.join("conformance-self-test.json");
             if let Ok(json) = serde_json::to_string_pretty(&report) {
                 let _ = std::fs::write(&json_path, json);
+            }
+            // Round 58 (#79) — per-target "definite issues" sidecar (mirror of
+            // the single-target path).
+            let issues = report.definite_issues();
+            if let Ok(json) = serde_json::to_string_pretty(&issues) {
+                let issues_path = target_dir.join("conformance-definite-issues.json");
+                if std::fs::write(&issues_path, json).is_ok() && !issues.is_empty() {
+                    TerminalReporter::print_warning(&format!(
+                        "  {} definite issue(s) — see {}",
+                        issues.len(),
+                        issues_path.display()
+                    ));
+                }
             }
             TerminalReporter::print_progress(&report.render_summary());
 

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -313,11 +313,82 @@ pub struct SelfTestReport {
     pub operations: Vec<OperationResult>,
 }
 
+/// Round 58 (#79) — an unambiguous, no-analysis-needed problem surfaced by the
+/// self-test. Srikanth on 0.3.205: "Is it possible to give another option ...
+/// that should say for sure this is an issue. Currently both caught and missed
+/// needs manual intervention and deep analysis ... very time consuming."
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DefiniteIssue {
+    pub method: String,
+    pub path: String,
+    /// `valid_request_rejected` (target refused a spec-valid request) or
+    /// `server_error` (target returned 5xx / crashed instead of a clean reply).
+    pub kind: String,
+    pub status: u16,
+    pub detail: String,
+}
+
 impl SelfTestReport {
     /// All-pass means every positive case got 2xx-3xx and every
     /// negative case got 4xx.
     pub fn all_passed(&self) -> bool {
         self.positive_fail == 0 && self.negative_missed.values().sum::<usize>() == 0
+    }
+
+    /// Round 58 (#79) — the subset of findings that are unambiguously wrong, so
+    /// a user does not have to eyeball every caught/missed row across every API.
+    /// Two classes need no judgement:
+    ///   1. a POSITIVE (spec-valid) request the target REJECTED (4xx) — it broke
+    ///      a legitimate call;
+    ///   2. ANY probe, positive or negative, that drew a 5xx — the target
+    ///      crashed instead of replying cleanly (a bad request should get a
+    ///      clean 4xx, never a 500).
+    /// Deliberately EXCLUDES "missed" negatives on spec-valid probes: those are
+    /// the ones that genuinely need per-probe analysis (see the caught/missed
+    /// legend), so keeping them out is the whole point of this view.
+    pub fn definite_issues(&self) -> Vec<DefiniteIssue> {
+        let mut issues = Vec::new();
+        for op in &self.operations {
+            if let Some(pos) = &op.positive {
+                if !pos.passed {
+                    let (kind, detail) = if pos.actual_status >= 500 {
+                        (
+                            "server_error",
+                            "target returned 5xx for a spec-valid request (crashed instead of serving it)"
+                                .to_string(),
+                        )
+                    } else {
+                        (
+                            "valid_request_rejected",
+                            "target refused a spec-valid request (a legitimate call it should accept)"
+                                .to_string(),
+                        )
+                    };
+                    issues.push(DefiniteIssue {
+                        method: op.method.clone(),
+                        path: op.path.clone(),
+                        kind: kind.to_string(),
+                        status: pos.actual_status,
+                        detail,
+                    });
+                }
+            }
+            for neg in &op.negatives {
+                if neg.actual_status >= 500 {
+                    issues.push(DefiniteIssue {
+                        method: op.method.clone(),
+                        path: op.path.clone(),
+                        kind: "server_error".to_string(),
+                        status: neg.actual_status,
+                        detail: format!(
+                            "target returned 5xx for the '{}' negative probe (should reject a bad request with a clean 4xx, not crash)",
+                            neg.label
+                        ),
+                    });
+                }
+            }
+        }
+        issues
     }
 
     /// Round 18.1 — detect the "self-test target is misconfigured"
@@ -403,6 +474,30 @@ impl SelfTestReport {
                 "Negatives [{}]: {} caught / {} missed  {}\n",
                 cat, caught, missed, mark
             ));
+        }
+        // Round 58 (#79) — surface the unambiguous problems up front so they
+        // don't have to be dug out of the caught/missed rollup. Capped in the
+        // console; the full set is in conformance-definite-issues.json.
+        let issues = self.definite_issues();
+        if issues.is_empty() {
+            out.push_str(
+                "Definite issues: none (no spec-valid request was rejected and no probe drew a 5xx)\n",
+            );
+        } else {
+            out.push_str(&format!(
+                "Definite issues ({}) — unambiguous, no per-probe analysis needed (full list in conformance-definite-issues.json):\n",
+                issues.len()
+            ));
+            const CAP: usize = 20;
+            for iss in issues.iter().take(CAP) {
+                out.push_str(&format!(
+                    "  {} {} -> {} [{}]: {}\n",
+                    iss.method, iss.path, iss.status, iss.kind, iss.detail
+                ));
+            }
+            if issues.len() > CAP {
+                out.push_str(&format!("  ... and {} more\n", issues.len() - CAP));
+            }
         }
         out
     }
@@ -2183,6 +2278,96 @@ mod tests {
         };
         let summary = r.render_summary();
         assert!(!summary.contains("deliberately-bad requests"));
+    }
+
+    #[test]
+    fn definite_issues_flags_rejected_positives_and_5xx_but_not_spec_valid_misses() {
+        // Round 58 (#79) — the "for sure this is an issue" view.
+        let mut r = SelfTestReport::default();
+        // (1) valid request the target rejected with 4xx -> definite issue.
+        r.operations.push(OperationResult {
+            method: "POST".into(),
+            path: "/v1/organizations".into(),
+            positive: Some(CaseOutcome {
+                label: "positive".into(),
+                expected_4xx: false,
+                actual_status: 400,
+                passed: false,
+            }),
+            negatives: vec![],
+        });
+        // (2) negative probe that crashed the target with 5xx -> definite issue.
+        r.operations.push(OperationResult {
+            method: "GET".into(),
+            path: "/v1/items".into(),
+            positive: Some(CaseOutcome {
+                label: "positive".into(),
+                expected_4xx: false,
+                actual_status: 200,
+                passed: true,
+            }),
+            negatives: vec![CaseOutcome {
+                label: "owasp:sqli".into(),
+                expected_4xx: true,
+                actual_status: 500,
+                passed: false,
+            }],
+        });
+        // (3) spec-valid negative the target accepted (2xx) -> NOT a definite
+        // issue (this is a "missed" that needs judgement, must be excluded).
+        r.operations.push(OperationResult {
+            method: "GET".into(),
+            path: "/v1/ok".into(),
+            positive: Some(CaseOutcome {
+                label: "positive".into(),
+                expected_4xx: false,
+                actual_status: 200,
+                passed: true,
+            }),
+            negatives: vec![CaseOutcome {
+                label: "parameters:missing-query".into(),
+                expected_4xx: true,
+                actual_status: 200,
+                passed: false,
+            }],
+        });
+
+        let issues = r.definite_issues();
+        assert_eq!(issues.len(), 2, "only the rejected-positive and the 5xx");
+        assert!(issues.iter().any(|i| i.kind == "valid_request_rejected"
+            && i.path == "/v1/organizations"
+            && i.status == 400));
+        assert!(issues
+            .iter()
+            .any(|i| i.kind == "server_error" && i.path == "/v1/items" && i.status == 500));
+        // The spec-valid missed negative is not present.
+        assert!(!issues.iter().any(|i| i.path == "/v1/ok"));
+
+        let summary = r.render_summary();
+        assert!(summary.contains("Definite issues (2)"));
+    }
+
+    #[test]
+    fn definite_issues_empty_renders_none_line() {
+        let r = SelfTestReport {
+            positive_pass: 1,
+            positive_fail: 0,
+            negative_caught: BTreeMap::from([("owasp".into(), 3)]),
+            negative_missed: BTreeMap::new(),
+            operations: vec![OperationResult {
+                method: "GET".into(),
+                path: "/v1/ok".into(),
+                positive: Some(CaseOutcome {
+                    label: "positive".into(),
+                    expected_4xx: false,
+                    actual_status: 200,
+                    passed: true,
+                }),
+                negatives: vec![],
+            }],
+        };
+        assert!(r.definite_issues().is_empty());
+        assert!(r.render_summary().contains("Definite issues: none"));
     }
 
     #[test]

--- a/crates/mockforge-bench/src/executor.rs
+++ b/crates/mockforge-bench/src/executor.rs
@@ -189,7 +189,10 @@ impl K6Executor {
     /// `api_port` — when set, overrides k6's default API server address (`localhost:6565`)
     /// to `localhost:<api_port>`. This prevents "address already in use" errors when
     /// running multiple k6 instances in parallel (e.g., multi-target bench).
-    /// Pass `None` for single-target runs (uses k6's default).
+    /// Pass `Some(0)` to bind an OS-assigned ephemeral port — the collision-proof
+    /// choice for parallel runs, since the kernel never hands out a busy port
+    /// (see the k6 `CannotStartRESTAPI` / exit-106 fix in `parallel_executor`).
+    /// Pass `None` for single-target runs (uses k6's default `localhost:6565`).
     pub async fn execute(
         &self,
         script_path: &Path,

--- a/crates/mockforge-bench/src/parallel_executor.rs
+++ b/crates/mockforge-bench/src/parallel_executor.rs
@@ -621,16 +621,30 @@ impl ParallelExecutor {
         let script_path = output_dir.join("k6-script.js");
         std::fs::write(&script_path, script)?;
 
-        // Execute k6 with a unique API server port per target to avoid port conflicts.
-        // k6 defaults to localhost:6565 for its REST API; parallel instances collide.
-        let api_port = 6565 + (target_index as u16) + 1; // 6566, 6567, ...
-                                                         // Issue #79 r54 — forward `--source-ip` (as k6 `--local-ips`) so each
-                                                         // target's VUs rotate through the configured source IP pool. Without
-                                                         // this, `--source-ip` was a silent no-op in multi-target mode.
-                                                         // Issue #79 r56 — plain multi-target load only checks status codes, so
-                                                         // discard response bodies to keep k6's RSS bounded on long, high-VU runs.
-                                                         // Without this, 10+ targets * 10 VUs * 70 min buffered every body and the
-                                                         // kernel OOM-killer sent k6 `signal: 9 (SIGKILL)`.
+        // Execute k6 with its own REST API server port per target. k6 defaults
+        // to localhost:6565 and parallel instances collide on it.
+        //
+        // Issue #79 r58 — Srikanth on 0.3.205: every one of 10 targets failed
+        // with `exit status: 106` (k6 `CannotStartRESTAPI`) and 0 requests, so
+        // NO load ran at all (which read as "--discard-response-bodies isn't
+        // helping"). The old scheme pinned each k6 to a FIXED port
+        // (6565 + index → 6566, 6567, ...), which collides whenever those
+        // ports are already taken — e.g. orphaned k6 processes left behind by
+        // a previous run that was OOM-killed (his r56/r57 SIGKILL), a second
+        // concurrent bench, or any local service. Bind an OS-assigned
+        // ephemeral port (`:0`) instead: k6 asks the kernel for a free port at
+        // start, so it can never be "already in use". We never query the REST
+        // API (results come from summary.json on disk), so a random port is
+        // fine. Verified: two concurrent k6 with `--address localhost:0` both
+        // start cleanly where the fixed port yields exit 106.
+        let api_port = 0; // ephemeral: kernel picks a free port, no collision
+                          // Issue #79 r54 — forward `--source-ip` (as k6 `--local-ips`) so each
+                          // target's VUs rotate through the configured source IP pool. Without
+                          // this, `--source-ip` was a silent no-op in multi-target mode.
+                          // Issue #79 r56 — plain multi-target load only checks status codes, so
+                          // discard response bodies to keep k6's RSS bounded on long, high-VU runs.
+                          // Without this, 10+ targets * 10 VUs * 70 min buffered every body and the
+                          // kernel OOM-killer sent k6 `signal: 9 (SIGKILL)`.
         let executor = K6Executor::new()?
             .with_local_ips(local_ips.to_string())
             .with_discard_response_bodies(true);


### PR DESCRIPTION
Two follow-ups from Srikanth on 0.3.205 (#79).

## 1. Multi-target load produced zero traffic (`exit status: 106`)
All 10 of his targets failed with `k6 exited with status: exit status: 106` and `total_requests: 0`, so no load ran at all (which read as "`--discard-response-bodies` isn't helping"). Exit 106 is k6's `CannotStartRESTAPI`: each parallel k6 was pinned to a **fixed** REST API port (`6565 + index` → 6566, 6567, ...), which collides whenever those ports are already taken — most likely orphaned k6 processes left by his earlier run that got OOM-killed (the prior SIGKILL).

Fix: each k6 instance now binds an **OS-assigned ephemeral port** (`--address localhost:0`), so it can never collide. MockForge never queries that API (results come from `summary.json` on disk), so a random port is fine.

**Real-binary verified:** with ports 6566 and 6567 deliberately occupied, a multi-target load that previously exited 106 on every target now starts cleanly and generates traffic on all targets (10 reqs each, no error).

## 2. "Definite issues" view
He asked for a way to say "for sure this is an issue" without eyeballing every caught/missed row across all APIs. The self-test now prints a `Definite issues (N)` section under the `Negatives [...]` summary and writes a `conformance-definite-issues.json` sidecar, listing only the unambiguous problems:
- a **spec-valid request the target rejected** (`valid_request_rejected`), and
- **any probe that drew a 5xx** (`server_error` — the target crashed instead of replying cleanly).

Spec-valid "missed" negatives (which genuinely need judgement) are deliberately excluded. Also clarified that a "caught" 4xx is the target correctly rejecting a bad request, **not** a violation (error-body-vs-spec is the separate `--validate-response-schemas` check).

**Real-binary verified:** a clean target prints "Definite issues: none"; a target that 404s a valid request surfaces it as a `valid_request_rejected` row in both the console and the JSON.

## Verification
`cargo test -p mockforge-bench` green (519 tests, incl. 2 new definite-issues tests); fmt + clippy clean; smoke-test (`--fast`) + release-guardian **GO**.