### PR TITLE
security(registry): bump SAML quick-xml to 0.41 + accurate audit note (#919)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9057,7 +9057,7 @@ dependencies = [
  "prometheus",
  "prost 0.14.4",
  "qrcode",
- "quick-xml 0.31.0",
+ "quick-xml 0.41.0",
  "rand 0.9.4",
  "redis",
  "regex",
@@ -12152,6 +12152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/audit.toml
+++ b/audit.toml
@@ -27,12 +27,17 @@ ignore = [
     { id = "RUSTSEC-2026-0187", reason = "lopdf stack overflow on deeply nested PDFs — only on the mockforge-reporting PDF emit path; we don't parse untrusted PDFs" },
 
     # quick-xml < 0.41.0 DoS advisories (published 2026-07-02, fixed in
-    # >=0.41.0). Four versions in the tree: one direct (registry-server SAML,
-    # 0.31, feature-gated) plus three transitive (0.37/0.38/0.39) that can't
-    # reach 0.41 without upstream releases. Tracked in #919; the direct SAML
-    # dep (the only untrusted-XML path) is the priority upgrade.
-    { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic runtime on duplicate attrs (DoS) — transitive versions have no 0.41 upstream yet; direct SAML bump tracked in #919" },
-    { id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace allocation (DoS) — transitive versions have no 0.41 upstream yet; direct SAML bump tracked in #919" },
+    # >=0.41.0). #919 assumed the only <0.41 path was registry-server's direct
+    # SAML dep parsing untrusted XML, but that turned out wrong on two counts:
+    # (1) the SAML code parses via regex (`extract_xml_value`), not quick-xml,
+    # so the direct dep was UNUSED — now bumped to 0.41 anyway so any future
+    # use is safe; (2) the vulnerable 0.31 in the tree is really pulled by
+    # `azure_core` 0.21 (the feature-gated Azure blob-storage SDK), which
+    # parses TRUSTED Azure responses, not untrusted user input. That plus the
+    # transitive 0.37/0.38/0.39 can't reach 0.41 without an azure-SDK / upstream
+    # bump, so these stay ignored. DoS-only (not RCE), no untrusted-XML path.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic runtime on duplicate attrs (DoS) — remaining <0.41 copies are azure-SDK (trusted XML) + transitive; no untrusted-XML path (#919)" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace allocation (DoS) — remaining <0.41 copies are azure-SDK (trusted XML) + transitive; no untrusted-XML path (#919)" },
 
     # wasmtime 36.x is pinned by mockforge-plugin-loader's current API
     # surface. Every one of these needs a major-version bump to resolve,

--- a/crates/mockforge-registry-server/Cargo.toml
+++ b/crates/mockforge-registry-server/Cargo.toml
@@ -152,8 +152,11 @@ governor = "0.6"
 redis = { version = "0.24", features = ["tokio-comp", "connection-manager"], optional = true }
 
 # SAML 2.0 for SSO (feature: `saml`)
-# Using quick-xml for parsing and ring/rustls for signature verification
-quick-xml = { version = "0.31", features = ["serialize", "overlapped-lists"], optional = true }
+# Pulled in for the `saml` feature; the current SAML parse/emit path uses
+# regex + `format!` templates, so quick-xml is not yet called (kept for the
+# planned move to a real XML parser). Held at >= 0.41 to clear the
+# RUSTSEC-2026-0194 / -0195 DoS advisories on the direct dep (#919).
+quick-xml = { version = "0.41", features = ["serialize", "overlapped-lists"], optional = true }
 regex = "1.10"
 url = { workspace = true }
 urlencoding = "2.1"


### PR DESCRIPTION
Addresses #919 (RUSTSEC-2026-0194 / -0195 quick-xml DoS advisories).

## What I found
The issue assumed registry-server's direct quick-xml 0.31 was the untrusted-XML attack surface. Two corrections:

1. **registry-server doesn't use quick-xml.** `parse_saml_response` extracts values with regex (`extract_xml_value`) and generates AuthnRequests with a `format!` template. There's no `use quick_xml` anywhere — the dep was declared-but-unused. Bumped it to **0.41** so the declaration is on a patched version (and any future move to a real XML parser starts safe). Verified the `saml` feature builds clean on 0.41.

2. **The real <0.41 copy is transitive, from `azure_core` 0.21** (the feature-gated Azure blob-storage SDK: `azure_storage` / `azure_storage_blobs` / `azure_identity`). It parses **trusted** Azure responses, not untrusted user input. That copy plus transitive 0.37/0.38/0.39 can't reach 0.41 without an azure-SDK / upstream bump, so the `audit.toml` ignores stay. I rewrote the ignore comment to reflect the real source instead of the (nonexistent) registry-server untrusted-XML path.

## Risk
DoS-only (not RCE); no untrusted-XML path reaches any <0.41 quick-xml. The advisories remain ignored in `audit.toml` (unchanged posture) but with an accurate rationale.

## Scope
- `crates/mockforge-registry-server/Cargo.toml`: quick-xml 0.31 → 0.41 (+ accurate comment)
- `audit.toml`: corrected ignore rationale
- `Cargo.lock`: adds quick-xml 0.41

No version bump / CHANGELOG (dep hygiene; rides the next release). #919 stays open as the tracker for the remaining transitive/azure-SDK copies.