### PR TITLE
feat(bench): r59 — surface OWASP-accepted probes for WAF testing (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.207] - 2026-07-19
+
+### Added
+
+- **[Contracts]** New "Security probes (owasp injection)" view in the conformance self-test (#79 round 59 / Srikanth on 0.3.206 was testing a WAF and saw `owasp: 0 caught / 8127 missed` but `Definite issues: none`, and asked whether real issues were being hidden). The self-test now prints a per-injection-family breakdown of how many OWASP payloads the target accepted (status < 400) vs blocked (4xx), and writes a `conformance-owasp-accepted.json` sidecar listing every accepted payload with its method + URL. For a WAF / security proxy, each accepted payload is one it did NOT block; for a plain API this is expected (a `string` field accepts any string, so an SQLi string is spec-valid). It is deliberately kept out of "Definite issues" (which is for spec violations), but surfaced on its own line so a security tester sees it without eyeballing the caught/missed rollup. Verified against Srikanth's own capture: the summary reports the target accepted all 8127 injection payloads across all 7 families (sqli / xss / command-injection / path-traversal / ssti / ldap-injection / xxe), and real-binary verified against `mockforge serve` that the section and sidecar render.
+
 ## [0.3.206] - 2026-07-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7822,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8053,7 +8053,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8502,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8943,7 +8943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.206"
+version = "0.3.207"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.206"
+version = "0.3.207"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.207] - 2026-07-19
+
+### Added
+
+- **[Contracts]** New "Security probes (owasp injection)" view in the self-test (#79 round 59 / Srikanth on 0.3.206 was WAF-testing and saw `owasp: 0 caught / 8127 missed` but `Definite issues: none`). The self-test now prints a per-injection-family breakdown of how many OWASP payloads the target accepted (status < 400) vs blocked (4xx), plus a `conformance-owasp-accepted.json` sidecar listing every accepted payload with method + URL. For a WAF each accepted payload is one it did NOT block; for a plain API it is expected (a string field accepts any string). Kept out of "Definite issues" (spec violations only) but surfaced on its own line. Verified against Srikanth's capture (all 8127 payloads across 7 families accepted) and real-binary against `mockforge serve`.
+
 ## [0.3.206] - 2026-07-16
 
 ### Fixed

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -2830,6 +2830,21 @@ impl BenchCommand {
                     ));
                 }
             }
+            // Round 59 (#79) — owasp injection payloads the target accepted, so
+            // a WAF tester can grep which URLs let which payloads through.
+            let owasp_accepted = report.owasp_accepted_probes();
+            if !owasp_accepted.is_empty() {
+                let owasp_path = self.output.join("conformance-owasp-accepted.json");
+                if let Ok(json) = serde_json::to_string_pretty(&owasp_accepted) {
+                    if std::fs::write(&owasp_path, json).is_ok() {
+                        TerminalReporter::print_warning(&format!(
+                            "{} owasp injection probe(s) accepted by the target — see {}",
+                            owasp_accepted.len(),
+                            owasp_path.display()
+                        ));
+                    }
+                }
+            }
             // Round 18.1 — surface the "every positive failed with
             // the same status" case loudly. Without this, a user
             // who forgot `--base-path /api` saw 404 for every
@@ -3333,6 +3348,20 @@ impl BenchCommand {
                         issues.len(),
                         issues_path.display()
                     ));
+                }
+            }
+            // Round 59 (#79) — per-target owasp-accepted sidecar (mirror).
+            let owasp_accepted = report.owasp_accepted_probes();
+            if !owasp_accepted.is_empty() {
+                if let Ok(json) = serde_json::to_string_pretty(&owasp_accepted) {
+                    let owasp_path = target_dir.join("conformance-owasp-accepted.json");
+                    if std::fs::write(&owasp_path, json).is_ok() {
+                        TerminalReporter::print_warning(&format!(
+                            "  {} owasp injection probe(s) accepted by the target — see {}",
+                            owasp_accepted.len(),
+                            owasp_path.display()
+                        ));
+                    }
                 }
             }
             TerminalReporter::print_progress(&report.render_summary());

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -328,6 +328,36 @@ pub struct DefiniteIssue {
     pub detail: String,
 }
 
+/// Round 59 (#79) — per-injection-type tally of OWASP probes. Srikanth on
+/// 0.3.206 was testing a WAF (`waaptest.net` targets): "owasp: 0 caught / 8127
+/// missed" but "Definite issues: none", and asked whether real issues were
+/// being hidden. They are not hidden from the CONTRACT view (an SQLi string in
+/// a string field is spec-valid, so it is correctly not a schema violation),
+/// but for a WAF each ACCEPTED injection payload is one it did not block. This
+/// surfaces that count so a security tester sees it without eyeballing rows.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SecurityProbeStat {
+    /// Injection family, e.g. `sqli`, `xss`, `command-injection`.
+    pub injection: String,
+    /// Probes the target let through (status < 400): for a WAF, NOT blocked.
+    pub accepted: usize,
+    /// Probes the target blocked with a `4xx`.
+    pub blocked: usize,
+    /// Probes that made the target return a `5xx` (also a Definite issue).
+    pub errored: usize,
+}
+
+/// Round 59 (#79) — a single OWASP injection probe the target ACCEPTED, for the
+/// `conformance-owasp-accepted.json` sidecar so a WAF tester can grep which URLs
+/// let which payloads through (matching their proxy's own logs).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AcceptedOwaspProbe {
+    pub method: String,
+    pub path: String,
+    pub injection: String,
+    pub status: u16,
+}
+
 impl SelfTestReport {
     /// All-pass means every positive case got 2xx-3xx and every
     /// negative case got 4xx.
@@ -389,6 +419,65 @@ impl SelfTestReport {
             }
         }
         issues
+    }
+
+    /// Round 59 (#79) — split the `owasp:*` injection probes by family and count
+    /// how many the target accepted (status < 400), blocked (4xx), or errored on
+    /// (5xx). Empty when the run fired no owasp probes. Labels are `owasp:<fam>`
+    /// (optionally `owasp:<fam>:<scope>`).
+    pub fn owasp_summary(&self) -> Vec<SecurityProbeStat> {
+        // (accepted, blocked, errored) per injection family, name-sorted.
+        let mut by_type: BTreeMap<String, (usize, usize, usize)> = BTreeMap::new();
+        for op in &self.operations {
+            for neg in &op.negatives {
+                let mut parts = neg.label.splitn(3, ':');
+                if parts.next() != Some("owasp") {
+                    continue;
+                }
+                let injection = parts.next().unwrap_or("other").to_string();
+                let slot = by_type.entry(injection).or_insert((0, 0, 0));
+                if neg.actual_status >= 500 {
+                    slot.2 += 1;
+                } else if neg.actual_status >= 400 {
+                    slot.1 += 1;
+                } else {
+                    slot.0 += 1;
+                }
+            }
+        }
+        by_type
+            .into_iter()
+            .map(|(injection, (accepted, blocked, errored))| SecurityProbeStat {
+                injection,
+                accepted,
+                blocked,
+                errored,
+            })
+            .collect()
+    }
+
+    /// Round 59 (#79) — the individual `owasp:*` probes the target ACCEPTED
+    /// (status < 400), for the grep-able sidecar. For a WAF, each row is an
+    /// injection payload that reached the origin unblocked.
+    pub fn owasp_accepted_probes(&self) -> Vec<AcceptedOwaspProbe> {
+        let mut out = Vec::new();
+        for op in &self.operations {
+            for neg in &op.negatives {
+                let mut parts = neg.label.splitn(3, ':');
+                if parts.next() != Some("owasp") {
+                    continue;
+                }
+                if neg.actual_status < 400 {
+                    out.push(AcceptedOwaspProbe {
+                        method: op.method.clone(),
+                        path: op.path.clone(),
+                        injection: parts.next().unwrap_or("other").to_string(),
+                        status: neg.actual_status,
+                    });
+                }
+            }
+        }
+        out
     }
 
     /// Round 18.1 — detect the "self-test target is misconfigured"
@@ -497,6 +586,37 @@ impl SelfTestReport {
             }
             if issues.len() > CAP {
                 out.push_str(&format!("  ... and {} more\n", issues.len() - CAP));
+            }
+        }
+        // Round 59 (#79) — OWASP injection breakdown. For a WAF / security
+        // proxy this is the headline: how many injection payloads the target
+        // let through. It is deliberately NOT folded into "Definite issues"
+        // because an injection string is spec-valid (a string field accepts
+        // any string), so whether "accepted" is a bug depends on whether you
+        // expect a WAF to block it.
+        let owasp = self.owasp_summary();
+        if !owasp.is_empty() {
+            let total_accepted: usize = owasp.iter().map(|s| s.accepted).sum();
+            let total: usize = owasp.iter().map(|s| s.accepted + s.blocked + s.errored).sum();
+            out.push_str(&format!(
+                "Security probes (owasp injection): target ACCEPTED {}/{} payloads (status < 400). \
+                 For a WAF/security proxy each accepted payload is one it did NOT block (review it); \
+                 for a plain API this is expected (the schema permits arbitrary strings). \
+                 Accepted payloads + URLs are in conformance-owasp-accepted.json.\n",
+                total_accepted, total
+            ));
+            for s in &owasp {
+                out.push_str(&format!(
+                    "  owasp:{}: {} accepted / {} blocked{}\n",
+                    s.injection,
+                    s.accepted,
+                    s.blocked,
+                    if s.errored > 0 {
+                        format!(" / {} 5xx", s.errored)
+                    } else {
+                        String::new()
+                    }
+                ));
             }
         }
         out
@@ -2368,6 +2488,79 @@ mod tests {
         };
         assert!(r.definite_issues().is_empty());
         assert!(r.render_summary().contains("Definite issues: none"));
+    }
+
+    #[test]
+    fn owasp_summary_splits_by_injection_and_counts_accepted_vs_blocked() {
+        // Round 59 (#79) — a WAF that lets SQLi through (200) but blocks XSS (403).
+        let neg = |label: &str, status: u16| CaseOutcome {
+            label: label.into(),
+            expected_4xx: true,
+            actual_status: status,
+            passed: status >= 400 && status < 500,
+        };
+        let mut r = SelfTestReport::default();
+        r.operations.push(OperationResult {
+            method: "POST".into(),
+            path: "/v1/orgs".into(),
+            positive: None,
+            negatives: vec![
+                neg("owasp:sqli", 200),               // accepted (not blocked)
+                neg("owasp:xss", 403),                // blocked
+                neg("owasp:command-injection", 500),  // errored (5xx)
+                neg("parameters:missing-query", 200), // not owasp -> ignored here
+            ],
+        });
+        r.operations.push(OperationResult {
+            method: "GET".into(),
+            path: "/v1/items".into(),
+            positive: None,
+            negatives: vec![neg("owasp:sqli", 200)], // second accepted sqli
+        });
+
+        let s = r.owasp_summary();
+        let sqli = s.iter().find(|x| x.injection == "sqli").unwrap();
+        assert_eq!((sqli.accepted, sqli.blocked, sqli.errored), (2, 0, 0));
+        let xss = s.iter().find(|x| x.injection == "xss").unwrap();
+        assert_eq!((xss.accepted, xss.blocked, xss.errored), (0, 1, 0));
+        let cmd = s.iter().find(|x| x.injection == "command-injection").unwrap();
+        assert_eq!((cmd.accepted, cmd.blocked, cmd.errored), (0, 0, 1));
+        // parameters:* must not appear in the owasp summary.
+        assert!(!s.iter().any(|x| x.injection.contains("query")));
+
+        // Accepted-probes sidecar lists only the two accepted sqli (URLs).
+        let accepted = r.owasp_accepted_probes();
+        assert_eq!(accepted.len(), 2);
+        assert!(accepted.iter().all(|p| p.injection == "sqli" && p.status == 200));
+
+        // Console section renders with the WAF framing.
+        let summary = r.render_summary();
+        assert!(summary.contains("Security probes (owasp injection)"));
+        assert!(summary.contains("target ACCEPTED 2/4 payloads"));
+        assert!(summary.contains("owasp:sqli: 2 accepted / 0 blocked"));
+    }
+
+    #[test]
+    fn owasp_summary_empty_when_no_owasp_probes() {
+        let r = SelfTestReport {
+            positive_pass: 1,
+            positive_fail: 0,
+            negative_caught: BTreeMap::new(),
+            negative_missed: BTreeMap::from([("parameters".into(), 2)]),
+            operations: vec![OperationResult {
+                method: "GET".into(),
+                path: "/x".into(),
+                positive: None,
+                negatives: vec![CaseOutcome {
+                    label: "parameters:missing-query".into(),
+                    expected_4xx: true,
+                    actual_status: 200,
+                    passed: false,
+                }],
+            }],
+        };
+        assert!(r.owasp_summary().is_empty());
+        assert!(!r.render_summary().contains("Security probes (owasp"));
     }
 
     #[test]


### PR DESCRIPTION
From Srikanth on 0.3.206 (#79). He was testing a **WAF** (`waaptest.net` / `waf-policy-learning` targets) and saw `owasp: 0 caught / 8127 missed` but `Definite issues: none`, and asked whether real issues were being hidden.

## The gap
They were not hidden from the contract view (an SQLi string in a `string` field is spec-valid, so it's correctly not a schema violation), but for a WAF that is the entire point of the test. His target answered **200 to all 8127 injection payloads** (SQLi, XSS, command-injection, path-traversal, SSTI, LDAP-injection, XXE), i.e. the WAF blocked none of them, and mockforge buried that under "missed".

## The fix
The self-test now prints a **Security probes (owasp injection)** section with a per-injection-family breakdown of accepted (status < 400) vs blocked (4xx), and writes a `conformance-owasp-accepted.json` sidecar listing every accepted payload with its method + URL (so he can line them up with the URLs his proxy flagged). It stays **out** of "Definite issues" (spec violations only) but gets its own line so a security tester sees it immediately.

Example against his exact data:
```
Security probes (owasp injection): target ACCEPTED 8127/8127 payloads (status < 400).
  owasp:sqli: 1161 accepted / 0 blocked
  owasp:xss:  1161 accepted / 0 blocked
  ... (7 families, all 1161 accepted / 0 blocked)
```

## Verification
- Ran the new logic against Srikanth's own `conformance-self-test.json`: 8127/8127 accepted across 7 families (matches his console).
- Real-binary verified against `mockforge serve`: the section renders and `conformance-owasp-accepted.json` is written with method/path/injection/status rows.
- `cargo test -p mockforge-bench` green (521 tests, incl. 2 new owasp tests); fmt + clippy clean; smoke-test (`--fast`) + release-guardian **GO**.

(His IPv6 SIGKILL/exit-2 is a separate k6 OOM + startup issue, being diagnosed on the issue thread; not part of this PR.)