### PR TITLE
fix(bench): r60 — k6 abortOnFail safety valve to stop OOM on dead targets (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.208] - 2026-07-21
+
+### Fixed
+
+- **[Reality]** k6 no longer gets OOM-killed (`signal: 9 (SIGKILL)`) when a load target rejects or times out nearly every request (#79 round 60 / Srikanth on 0.3.207: an IPv6 run where the targets were unreachable ran the full 4200s and k6 climbed to an OOM). The generated k6 load scripts now carry an `abortOnFail` safety valve on `http_req_failed`: if a target fails `>=95%` of requests after a 60s grace period, that target's k6 run aborts (exit 99) instead of hammering a dead endpoint for the whole duration and accumulating per-request metric/error memory. Legitimate runs, even heavily degraded ones under 95% failure, are unaffected (the existing pass/fail error threshold is unchanged). Real-binary verified against a dead target (connection refused, 100% failure): k6 now stops at ~60s with "thresholds ... abortOnFail enabled, stopping test prematurely" instead of running the full 180s scenario. Applies to both the standard load and CRUD-flow k6 templates. Separately, the accompanying diagnosis on #79 covers the IPv6 dial failures behind the OOM (source-IP address-family mismatch on hostname targets, TLS/connection refusals on the `:443` targets), which are network/target-side, not memory.
+
 ## [0.3.207] - 2026-07-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7822,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8053,7 +8053,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8502,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8943,7 +8943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.207"
+version = "0.3.208"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.207"
+version = "0.3.208"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.208] - 2026-07-21
+
+### Fixed
+
+- **[Reality]** k6 no longer OOM-kills (`signal: 9`) when a load target rejects/times-out ~every request (#79 round 60 / Srikanth on 0.3.207). The generated k6 load scripts now carry an `abortOnFail` safety valve on `http_req_failed`: a target failing `>=95%` of requests after a 60s grace period aborts (exit 99) instead of hammering a dead endpoint for the full duration and accumulating per-request memory. Legitimate runs under 95% failure are unaffected. Real-binary verified against a dead target: k6 stops at ~60s instead of running the full scenario. Applies to the standard-load and CRUD-flow templates.
+
 ## [0.3.207] - 2026-07-19
 
 ### Added

--- a/crates/mockforge-bench/src/templates/k6_crud_flow.hbs
+++ b/crates/mockforge-bench/src/templates/k6_crud_flow.hbs
@@ -46,7 +46,13 @@ export const options = {
   },
   thresholds: {
     'http_req_duration': ['{{threshold_percentile}}<{{threshold_ms}}'],
-    'http_req_failed': ['rate<{{max_error_rate}}'],
+    // Round 60 (#79) — memory safety valve, mirrors k6_script.hbs: abort a
+    // ~fully-failing target (>=95% errors after 60s) instead of OOMing over
+    // the full run.
+    'http_req_failed': [
+      'rate<{{max_error_rate}}',
+      { threshold: 'rate<0.95', abortOnFail: true, delayAbortEval: '60s' },
+    ],
     'flow_success_rate': ['rate>0.95'],
   },
 };

--- a/crates/mockforge-bench/src/templates/k6_script.hbs
+++ b/crates/mockforge-bench/src/templates/k6_script.hbs
@@ -83,7 +83,18 @@ export const options = {
   },
   thresholds: {
     'http_req_duration': ['{{threshold_percentile}}<{{threshold_ms}}'],
-    'http_req_failed': ['rate<{{max_error_rate}}'],
+    // Round 60 (#79) — the pass/fail error threshold, plus a memory safety
+    // valve. If a target rejects or times out >=95% of requests after a 60s
+    // grace period, abort THIS k6 run instead of hammering a dead target for
+    // the full duration. Srikanth's unreachable IPv6 targets failed ~100% of
+    // requests and k6 accumulated per-request metric/error memory over a
+    // 70-minute run until the OS OOM-killed it (signal 9). Aborting a
+    // ~fully-failing target at 60s bounds that. Legitimate runs (even heavily
+    // degraded ones under 95% failure) are unaffected.
+    'http_req_failed': [
+      'rate<{{max_error_rate}}',
+      { threshold: 'rate<0.95', abortOnFail: true, delayAbortEval: '60s' },
+    ],
   },
 };
 


### PR DESCRIPTION
From Srikanth on 0.3.207 (#79). An IPv6 load run got k6 OOM-killed (`signal: 9 (SIGKILL)`).

## Root cause
The verbose k6 log has the key line: `thresholds on metrics 'http_req_failed' have been crossed` — but k6 kept running the full 4200s anyway, accumulating per-request metric/error memory against targets that failed ~100% of requests, until the OS killed it. The existing `http_req_failed: ['rate<0.05']` threshold marks pass/fail but never aborts.

## Fix
The generated k6 load scripts now add an `abortOnFail` safety valve:
```js
'http_req_failed': [
  'rate<{{max_error_rate}}',
  { threshold: 'rate<0.95', abortOnFail: true, delayAbortEval: '60s' },
],
```
If a target fails **>=95%** of requests after a 60s grace period, that target's k6 run aborts (exit 99) instead of hammering a dead endpoint for the whole duration. The existing pass/fail threshold is unchanged; legitimate runs (even heavily degraded ones under 95% failure) are unaffected. Applied to both `k6_script.hbs` and `k6_crud_flow.hbs`. No new Handlebars variable (static text + the existing `{{max_error_rate}}`), so the #79 3-render-path consistency holds.

## Verification
- Generated a script and ran `k6` against a dead target (`127.0.0.1:9`, connection refused, 100% failure): k6 **aborted at ~60s** (`abortOnFail enabled, stopping test prematurely`, exit 99, `testRunDurationMs ~62000`) instead of running the full 180s scenario.
- `cargo test -p mockforge-bench` green (519); fmt + clippy clean; smoke-test (`--fast`) + release-guardian **GO** (guardian confirmed no new template variable).

(The IPv6 dial failures *behind* the OOM — source-IP address-family mismatch on the `waaptest.net` hostname targets, TLS/connection refusals on the `:443` targets — are diagnosed on the issue thread and are network/target-side, not this fix.)