### PR TITLE
fix(bench): r61 — --dns-policy flag to force IPv6 hostname resolution (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.209] - 2026-07-22
+
+### Added
+
+- **[Reality]** New `mockforge bench --dns-policy <policy>` flag that passes k6's DNS resolution policy through as `--dns "policy=<value>"` (#79 round 61 / Srikanth on 0.3.208). Values: `preferIPv4` (k6's default when unset), `preferIPv6`, `onlyIPv4`, `onlyIPv6`, `any`. This unblocks GEODB IPv6 load tests where the target must stay a hostname (the proxy routes by Host/SNI, so a bracket IP can't be used) but the dial has to use the AAAA record: k6/Go default to the A (IPv4) record, which then can't be dialed from an IPv6 `--source-ip` and fails with `no suitable address found`. `--dns-policy preferIPv6` makes k6 pick the AAAA record while keeping the hostname on the wire. Wired through the single-target and multi-target (`--targets-file`) k6 paths. Real-binary verified: `--dns-policy preferIPv6` makes the launched k6 child run with `--dns policy=preferIPv6` in its argv.
+
 ## [0.3.208] - 2026-07-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7822,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7901,7 +7901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8053,7 +8053,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8502,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8943,7 +8943,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9293,14 +9293,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9360,7 +9360,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15429,7 +15429,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.208"
+version = "0.3.209"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.208"
+version = "0.3.209"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.209] - 2026-07-22
+
+### Added
+
+- **[Reality]** New `mockforge bench --dns-policy <policy>` flag → k6 `--dns "policy=<value>"` (#79 round 61 / Srikanth on 0.3.208). Values: `preferIPv4` (default), `preferIPv6`, `onlyIPv4`, `onlyIPv6`, `any`. Unblocks GEODB IPv6 tests where the target must stay a hostname (proxy routes by Host/SNI) but must be dialed over its AAAA record; k6/Go default to IPv4, which can't be dialed from an IPv6 `--source-ip` (`no suitable address found`). `preferIPv6` picks the AAAA record while keeping the hostname on the wire. Wired through single- and multi-target k6 paths; real-binary verified the launched k6 runs with `--dns policy=preferIPv6`.
+
 ## [0.3.208] - 2026-07-21
 
 ### Fixed

--- a/crates/mockforge-bench/src/cloud_api.rs
+++ b/crates/mockforge-bench/src/cloud_api.rs
@@ -770,6 +770,7 @@ fn default_bench_command(output_dir: &Path) -> BenchCommand {
         geo_source_headers: Vec::new(),
         report_missed_cap: None,
         discard_response_bodies: false,
+        dns_policy: None,
         owasp_api_top10: false,
         owasp_categories: None,
         owasp_auth_header: "Authorization".to_string(),

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -264,6 +264,13 @@ pub struct BenchCommand {
     /// ignore it. Multi-target load already discards by default (r56).
     pub discard_response_bodies: bool,
 
+    /// Round 61 (#79) — k6 DNS resolution policy (`preferIPv6`, `onlyIPv6`,
+    /// `preferIPv4`, `onlyIPv4`, `any`). `None` → k6 default (`preferIPv4`).
+    /// Passed to k6 as `--dns "policy=<value>"`. Lets a GEODB IPv6 test pin
+    /// hostname targets to their AAAA record while keeping the hostname on the
+    /// wire (Srikanth's WAF routes by Host/SNI, so the target must be a name).
+    pub dns_policy: Option<String>,
+
     // === OWASP API Security Top 10 Testing ===
     /// Enable OWASP API Security Top 10 testing mode
     pub owasp_api_top10: bool,
@@ -924,6 +931,7 @@ impl BenchCommand {
         // plain load path (status/latency only), not conformance/extraction.
         let executor = K6Executor::new()?
             .with_local_ips(self.source_ips.join(","))
+            .with_dns_policy(self.dns_policy.clone().unwrap_or_default())
             .with_discard_response_bodies(self.discard_response_bodies);
 
         std::fs::create_dir_all(&self.output)?;
@@ -1057,6 +1065,9 @@ impl BenchCommand {
                 // plain-load path already discards by default (r56), so this
                 // keeps the per-target command faithful to the parent.
                 discard_response_bodies: self.discard_response_bodies,
+                // Round 61 (#79) — carry the DNS policy so per-target k6 runs
+                // resolve hostnames with the same IPv6/IPv4 preference.
+                dns_policy: self.dns_policy.clone(),
             },
             targets,
             max_concurrency,
@@ -1996,7 +2007,9 @@ impl BenchCommand {
         std::fs::write(&script_path, &script)?;
 
         if !self.generate_only {
-            let executor = K6Executor::new()?.with_local_ips(self.source_ips.join(","));
+            let executor = K6Executor::new()?
+                .with_local_ips(self.source_ips.join(","))
+                .with_dns_policy(self.dns_policy.clone().unwrap_or_default());
             std::fs::create_dir_all(&output_dir)?;
 
             executor.execute(&script_path, Some(&output_dir), self.verbose).await?;
@@ -2109,6 +2122,7 @@ impl BenchCommand {
             // standard (status-only) load path too.
             let executor = K6Executor::new()?
                 .with_local_ips(self.source_ips.join(","))
+                .with_dns_policy(self.dns_policy.clone().unwrap_or_default())
                 .with_discard_response_bodies(self.discard_response_bodies);
             let output_dir = self.output.join(format!("{}_results", spec_name.replace('.', "_")));
             std::fs::create_dir_all(&output_dir)?;
@@ -2435,7 +2449,9 @@ impl BenchCommand {
 
         // Execute k6
         TerminalReporter::print_progress("Executing CRUD flow test...");
-        let executor = K6Executor::new()?.with_local_ips(self.source_ips.join(","));
+        let executor = K6Executor::new()?
+            .with_local_ips(self.source_ips.join(","))
+            .with_dns_policy(self.dns_policy.clone().unwrap_or_default());
         std::fs::create_dir_all(&self.output)?;
 
         let results = executor.execute(&script_path, Some(&self.output), self.verbose).await?;
@@ -3012,7 +3028,9 @@ impl BenchCommand {
             }
 
             TerminalReporter::print_progress("Running conformance tests via k6...");
-            let executor = K6Executor::new()?.with_local_ips(self.source_ips.join(","));
+            let executor = K6Executor::new()?
+                .with_local_ips(self.source_ips.join(","))
+                .with_dns_policy(self.dns_policy.clone().unwrap_or_default());
             executor.execute(&script_path, Some(&self.output), self.verbose).await?;
 
             let report_path = self.output.join("conformance-report.json");
@@ -3594,7 +3612,9 @@ impl BenchCommand {
                     "Running conformance tests via k6 against {}...",
                     target.url
                 ));
-                let k6 = K6Executor::new()?.with_local_ips(self.source_ips.join(","));
+                let k6 = K6Executor::new()?
+                    .with_local_ips(self.source_ips.join(","))
+                    .with_dns_policy(self.dns_policy.clone().unwrap_or_default());
                 // Unique k6 API port per target to avoid collisions.
                 let api_port = 6565u16.saturating_add(idx as u16);
                 k6.execute_with_port(&script_path, Some(&target_dir), self.verbose, Some(api_port))
@@ -3963,7 +3983,9 @@ impl BenchCommand {
 
         // Execute k6
         TerminalReporter::print_progress("Executing OWASP security tests...");
-        let executor = K6Executor::new()?.with_local_ips(self.source_ips.join(","));
+        let executor = K6Executor::new()?
+            .with_local_ips(self.source_ips.join(","))
+            .with_dns_policy(self.dns_policy.clone().unwrap_or_default());
         std::fs::create_dir_all(&self.output)?;
 
         let results = executor.execute(&script_path, Some(&self.output), self.verbose).await?;
@@ -4184,6 +4206,7 @@ mod tests {
             geo_source_headers: Vec::new(),
             report_missed_cap: None,
             discard_response_bodies: false,
+            dns_policy: None,
         };
 
         let headers = cmd.parse_headers().unwrap();
@@ -4288,6 +4311,7 @@ mod tests {
             geo_source_headers: Vec::new(),
             report_missed_cap: None,
             discard_response_bodies: false,
+            dns_policy: None,
         };
 
         assert_eq!(cmd.get_spec_display_name(), "test.yaml");
@@ -4372,6 +4396,7 @@ mod tests {
             geo_source_headers: Vec::new(),
             report_missed_cap: None,
             discard_response_bodies: false,
+            dns_policy: None,
         };
 
         assert_eq!(cmd_multi.get_spec_display_name(), "2 spec files");

--- a/crates/mockforge-bench/src/executor.rs
+++ b/crates/mockforge-bench/src/executor.rs
@@ -131,6 +131,14 @@ pub struct K6Executor {
     /// accumulation exhaust RAM. Plain load only checks status codes, so
     /// dropping the bodies is safe there.
     discard_response_bodies: bool,
+    /// Round 61 (#79) — value for `k6 run --dns "policy=<...>"`. Empty → flag
+    /// omitted (k6 default `preferIPv4`). Srikanth on 0.3.208 GEODB-tests a WAF
+    /// via hostnames (his proxy routes by Host/SNI, so he can't pass bracket
+    /// IPs), but needs those hostnames resolved to their AAAA/IPv6 record;
+    /// k6/Go default to IPv4, which then can't be dialed from his IPv6
+    /// `--local-ips` source ("no suitable address found"). `preferIPv6` /
+    /// `onlyIPv6` fix that while keeping the hostname on the wire.
+    dns_policy: String,
 }
 
 impl K6Executor {
@@ -145,6 +153,7 @@ impl K6Executor {
             k6_path,
             local_ips: String::new(),
             discard_response_bodies: false,
+            dns_policy: String::new(),
         })
     }
 
@@ -161,6 +170,14 @@ impl K6Executor {
     /// do NOT use where the script inspects/extracts response bodies.
     pub fn with_discard_response_bodies(mut self, discard: bool) -> Self {
         self.discard_response_bodies = discard;
+        self
+    }
+
+    /// Round 61 (#79) — set the `--dns` resolution policy (e.g. `preferIPv6`,
+    /// `onlyIPv6`, `preferIPv4`, `onlyIPv4`, `any`). Empty string → flag omitted
+    /// (k6 default). Passed to k6 as `--dns "policy=<value>"`.
+    pub fn with_dns_policy(mut self, policy: impl Into<String>) -> Self {
+        self.dns_policy = policy.into();
         self
     }
 
@@ -233,6 +250,14 @@ impl K6Executor {
         // high-concurrency runs (guards against the SIGKILL/OOM Srikanth hit).
         if self.discard_response_bodies {
             cmd.env("K6_DISCARD_RESPONSE_BODIES", "true");
+        }
+
+        // Round 61 (#79) — force a DNS resolution policy so hostname targets can
+        // be pinned to IPv6 (or IPv4). Needed for GEODB IPv6 tests where the
+        // proxy routes by Host/SNI (so the target must stay a hostname) but the
+        // dial has to use the AAAA record to match an IPv6 `--local-ips` source.
+        if !self.dns_policy.is_empty() {
+            cmd.arg("--dns").arg(format!("policy={}", self.dns_policy));
         }
 
         // summary.json is written by the k6 script's handleSummary() function
@@ -631,10 +656,27 @@ mod tests {
             k6_path: "k6".to_string(),
             local_ips: String::new(),
             discard_response_bodies: false,
+            dns_policy: String::new(),
         };
         assert!(!exec.discard_response_bodies);
         let exec = exec.with_discard_response_bodies(true);
         assert!(exec.discard_response_bodies);
+    }
+
+    #[test]
+    fn dns_policy_defaults_empty_and_builder_sets_it() {
+        // Round 61 (#79) — empty default → k6's `--dns` flag is omitted; the
+        // builder records the policy string the executor turns into
+        // `--dns "policy=<value>"`.
+        let exec = K6Executor {
+            k6_path: "k6".to_string(),
+            local_ips: String::new(),
+            discard_response_bodies: false,
+            dns_policy: String::new(),
+        };
+        assert!(exec.dns_policy.is_empty());
+        let exec = exec.with_dns_policy("preferIPv6");
+        assert_eq!(exec.dns_policy, "preferIPv6");
     }
 
     #[test]

--- a/crates/mockforge-bench/src/parallel_executor.rs
+++ b/crates/mockforge-bench/src/parallel_executor.rs
@@ -393,6 +393,7 @@ impl ParallelExecutor {
             // source IPs (as the k6 `--local-ips` list) and geo config through
             // to each target's run.
             let local_ips = self.base_command.source_ips.join(",");
+            let dns_policy = self.base_command.dns_policy.clone().unwrap_or_default();
             let geo_source_ips = self.base_command.geo_source_ips.clone();
             let geo_source_headers = self.base_command.geo_source_headers.clone();
 
@@ -452,6 +453,7 @@ impl ParallelExecutor {
                     no_keep_alive,
                     &enhancement_code,
                     &local_ips,
+                    &dns_policy,
                     &geo_source_ips,
                     &geo_source_headers,
                 )
@@ -559,6 +561,7 @@ impl ParallelExecutor {
         no_keep_alive: bool,
         enhancement_code: &str,
         local_ips: &str,
+        dns_policy: &str,
         geo_source_ips: &[String],
         geo_source_headers: &[String],
     ) -> Result<TargetResult> {
@@ -647,6 +650,7 @@ impl ParallelExecutor {
                           // kernel OOM-killer sent k6 `signal: 9 (SIGKILL)`.
         let executor = K6Executor::new()?
             .with_local_ips(local_ips.to_string())
+            .with_dns_policy(dns_policy.to_string())
             .with_discard_response_bodies(true);
         let results = executor
             .execute_with_port(&script_path, Some(&output_dir), verbose, Some(api_port))

--- a/crates/mockforge-bench/tests/multi_target_test.rs
+++ b/crates/mockforge-bench/tests/multi_target_test.rs
@@ -203,6 +203,7 @@ async fn test_bench_command_parse_headers() {
         geo_source_headers: Vec::new(),
         report_missed_cap: None,
         discard_response_bodies: false,
+        dns_policy: None,
     };
 
     let headers = cmd.parse_headers().unwrap();
@@ -293,6 +294,7 @@ async fn test_bench_command_parse_headers_invalid_format() {
         geo_source_headers: Vec::new(),
         report_missed_cap: None,
         discard_response_bodies: false,
+        dns_policy: None,
     };
 
     let result = cmd.parse_headers();

--- a/crates/mockforge-cli/src/main.rs
+++ b/crates/mockforge-cli/src/main.rs
@@ -2347,6 +2347,17 @@ enum Commands {
         /// self-test / CRUD-extraction runs, which need the response body.
         #[arg(long = "discard-response-bodies")]
         discard_response_bodies: bool,
+
+        /// Issue #79 round 61 — DNS resolution policy passed to k6 as
+        /// `--dns "policy=<value>"`. Use `preferIPv6` (or `onlyIPv6`) to make a
+        /// GEODB IPv6 test dial hostname targets over their AAAA record while
+        /// keeping the hostname on the wire (needed when the proxy routes by
+        /// Host/SNI so the target must be a name, not a bracket IP). Without it
+        /// k6/Go default to IPv4, which then can't be dialed from an IPv6
+        /// `--source-ip` ("no suitable address found"). Values: preferIPv4
+        /// (default when unset), preferIPv6, onlyIPv4, onlyIPv6, any.
+        #[arg(long = "dns-policy")]
+        dns_policy: Option<String>,
     },
 
     /// Native Rust chunked-encoding traffic generator.
@@ -3316,6 +3327,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             geo_source_headers,
             report_missed_cap,
             discard_response_bodies,
+            dns_policy,
         } => {
             // Validate that either --target or --targets-file is provided, but not both
             match (&target, &targets_file) {
@@ -3439,6 +3451,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 geo_source_headers,
                 report_missed_cap,
                 discard_response_bodies,
+                dns_policy,
             };
 
             if let Err(e) = bench_cmd.execute().await {


### PR DESCRIPTION
## Round 61 (#79 / Srikanth)

Srikanth's hostname GEODB targets (e.g. `waaptest.net`) fail under an IPv6 `--source-ip` with:

```
dial tcp: address [fc00:172:22:0:ca00::4]:0: no suitable address found
```

k6/Go's default resolver prefers the **A (IPv4)** record, and that IPv4 remote can't be dialed from an IPv6 local address (Go `net` "no suitable address found" = LocalAddr family mismatch vs. resolved remote family). His target has to stay a hostname because the proxy routes on Host/SNI.

## Fix

Add a `--dns-policy` flag, passed straight to k6 as `--dns "policy=<value>"`:

- `preferIPv6` makes k6 pick the **AAAA** record when one exists (falling back to IPv4), so the hostname resolves to a dialable IPv6 address while the hostname still goes out in Host/SNI (proxy routing unchanged).
- Cleaner than a k6 `hosts` map, which would pin each hostname to a fixed IP and defeat the geo-aware DNS the GEODB test exercises.

Valid values: `preferIPv4` (k6 default when the flag is absent), `preferIPv6`, `onlyIPv4`, `onlyIPv6`, `any`.

Wired through `K6Executor`, `BenchCommand`, the multi-target clone, and `parallel_executor` so single- and multi-target runs both apply it.

## Verification

- Real-binary: `mockforge bench ... --dns-policy preferIPv6` produces k6 argv `run --dns policy=preferIPv6 script.js`.
- `cargo test -p mockforge-bench`: 520 passed (incl. new `dns_policy_defaults_empty_and_builder_sets_it`).
- clippy `-p mockforge-bench -p mockforge-cli --all-targets -D warnings`: clean.
- `cargo fmt --all --check`: clean.

Releases as **v0.3.209**.