### PR TITLE
fix(ci): stop installing nonexistent Rust 1.100.0 across 8 workflows

### DIFF
--- a/.github/workflows/chaos-testing.yml
+++ b/.github/workflows/chaos-testing.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
 
       - name: Install protoc
         run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,7 +36,7 @@ jobs:
         mdbook-version: '0.4.40'
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@1.100.0
+      uses: ./.github/actions/rust-toolchain
 
     - name: Build book
       run: |

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -32,7 +32,7 @@ jobs:
           mdbook-version: '0.4.40'
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
 
       - name: Cache mdBook plugins
         uses: actions/cache@v6

--- a/.github/workflows/jcs-fuzz.yml
+++ b/.github/workflows/jcs-fuzz.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
 
       - name: Install k6
         run: 'command -v k6 > /dev/null 2>&1 || { echo "::error::k6 missing on self-hosted runner. Install: see https://k6.io/docs/getting-started/installation/"; exit 1; }'
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
 
       - name: Install k6
         run: 'command -v k6 > /dev/null 2>&1 || { echo "::error::k6 missing on self-hosted runner. Install: see https://k6.io/docs/getting-started/installation/"; exit 1; }'
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
 
       - name: Install protoc
         run: 'dpkg -s protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev > /dev/null 2>&1 || { echo "::error::Required system deps missing on self-hosted runner. Run on the runner host: sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev"; exit 1; }'

--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
         with:
           components: clippy
 
@@ -162,7 +162,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
         with:
           components: clippy
 
@@ -216,7 +216,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: ./.github/actions/rust-toolchain
         with:
           components: clippy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@1.100.0
+      uses: ./.github/actions/rust-toolchain
 
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libfontconfig1-dev libglib2.0-dev libgtk-3-dev libsoup2.4-dev libasound2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev
@@ -138,7 +138,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@1.100.0
+      uses: ./.github/actions/rust-toolchain
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Problem

Dependabot's `github-actions` group update (#909) bumped `dtolnay/rust-toolchain@<ver>` to `@1.100.0` across the repo. The `dtolnay/rust-toolchain` action pre-creates future version tags from a date formula, so the bump selected a tag for a Rust release **that does not exist yet**. At runtime the step tries to download toolchain `1.100.0` and 404s:

```
error: could not download nonexistent rust version `1.100.0-x86_64-unknown-linux-gnu` ... 404
```

This has silently failed the **Release** workflow's "Create Release" job on every tagged release since v0.3.187 (the last GitHub Release object is v0.3.186), and breaks 7 other workflows the same way: chaos-testing, deploy-docs, docs-check, jcs-fuzz, load-testing (×3), mutation-testing, plugin-publish (×3), release (×2). The crates.io publish and git tags were unaffected because those are done manually via `scripts/publish-crates.sh`.

## Fix

Point all 13 sites at the repo's own composite action `./.github/actions/rust-toolchain`, which already wraps `dtolnay/rust-toolchain@stable` with `toolchain: 1.96.0` (matching `rust-toolchain.toml`) and passes `components` through.

This:
- installs a real, pinned toolchain (1.96.0) instead of a nonexistent one;
- single-sources the version in the composite action (per the note in `rust-toolchain.toml`);
- **removes the `dtolnay/rust-toolchain@<ver>` ref that Dependabot was bumping**, so the bomb cannot be re-introduced. The composite action's own `@stable` ref survived #909 untouched, so it is Dependabot-safe.

`fuzz.yml@nightly` is intentionally left alone (fuzzing needs nightly).

## Verification

- All 8 changed files validated as parseable YAML.
- Every broken site has `actions/checkout@v7` before the toolchain step, so the local composite action is on disk.
- `with: components:` blocks (clippy / rustfmt) preserved; indentation (6- and 8-space) preserved.
- Since `@1.100.0` always failed at the toolchain step, these jobs never ran further, so any valid install is strictly an improvement.