### PR TITLE
test(foundation): fix flaky global-buffer conformance test that blocks auto-release

### DIFF
--- a/crates/mockforge-foundation/src/conformance_violations.rs
+++ b/crates/mockforge-foundation/src/conformance_violations.rs
@@ -590,6 +590,16 @@ pub fn clear() {
 mod tests {
     use super::*;
 
+    /// Serializes the tests that mutate the process-wide `VIOLATIONS`
+    /// buffer via the module-level `clear`/`record`/`len`/`snapshot`
+    /// functions. Under the default multi-threaded test runner these
+    /// otherwise race — one test's `clear()` interleaves with another's
+    /// `record()`, so `len()`/`snapshot()` observe a corrupted count.
+    /// The release workflow's full `cargo test` run flaked on
+    /// `buffer_drops_oldest_at_capacity` for exactly this reason. Tests
+    /// that only touch a local `UniqueBuffer` do not need this guard.
+    static GLOBAL_BUFFER_GUARD: Mutex<()> = Mutex::new(());
+
     fn v(method: &str, status: u16) -> ServerConformanceViolation {
         ServerConformanceViolation {
             timestamp: Utc::now(),
@@ -653,6 +663,7 @@ mod tests {
 
     #[test]
     fn record_and_snapshot_in_lifo_order() {
+        let _guard = GLOBAL_BUFFER_GUARD.lock();
         clear();
         record(v("GET", 400));
         record(v("POST", 422));
@@ -665,6 +676,7 @@ mod tests {
 
     #[test]
     fn buffer_drops_oldest_at_capacity() {
+        let _guard = GLOBAL_BUFFER_GUARD.lock();
         clear();
         for i in 0..(DEFAULT_BUFFER_SIZE + 50) {
             let mut entry = v("GET", 400);


### PR DESCRIPTION
## Problem

The release workflow's full `cargo test` run intermittently fails on `conformance_violations::buffer_drops_oldest_at_capacity`, which then **skips the "Create GitHub Release" step** — that's why the v0.3.209 and v0.3.210 release pages had to be created manually (the #956 toolchain fix got the job past the `1.100.0` bomb; this flaky test was the next blocker).

## Cause

`record_and_snapshot_in_lifo_order` and `buffer_drops_oldest_at_capacity` both mutate the **process-wide** `VIOLATIONS` ring buffer through the module-level `clear`/`record`/`len`/`snapshot` functions. Under the default multi-threaded test runner they race: one test's `clear()` interleaves with the other's `record()` loop, so `len()`/`snapshot()` observe a corrupted count and `assert_eq!(len(), DEFAULT_BUFFER_SIZE)` fails.

## Fix

A module-level `GLOBAL_BUFFER_GUARD: Mutex<()>` locked at the top of both tests, so they serialize with respect to each other (still parallel with every other test). The `unique_buffer_*` tests use a local `UniqueBuffer` and need no guard.

## Verification

- `conformance_violations` tests run 3× clean; full `mockforge-foundation` lib suite: **161 passed**.
- `cargo fmt --all --check` clean; `cargo clippy -p mockforge-foundation --all-targets -- -D warnings` clean.

With this + #956, the release workflow should create GitHub Release pages automatically again.