### PR TITLE
feat(registry): RLS tenant-isolation foundation on current main (#832) [DRAFT — rollout gated]

### DIFF
--- a/crates/mockforge-registry-core/src/store/mod.rs
+++ b/crates/mockforge-registry-core/src/store/mod.rs
@@ -52,6 +52,13 @@ pub mod postgres;
 #[cfg(feature = "postgres")]
 pub use postgres::PgRegistryStore;
 
+/// Transaction-scoped tenant context for the RLS backstop (#832).
+#[cfg(feature = "postgres")]
+pub mod org_context;
+
+#[cfg(feature = "postgres")]
+pub use org_context::with_org_context;
+
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
@@ -2024,6 +2031,19 @@ pub trait RegistryStore: Send + Sync + 'static {
     async fn list_org_settings_raw(&self, org_id: Uuid) -> StoreResult<Vec<OrgSettingRow>>;
 
     async fn list_org_projects_raw(&self, org_id: Uuid) -> StoreResult<Vec<ProjectRow>>;
+
+    /// List an org's projects through the tenant-isolation backstop (#832).
+    ///
+    /// The Postgres implementation runs the query inside a transaction bound
+    /// to `app.current_org_id`, so the Row-Level-Security policy on `projects`
+    /// enforces isolation even though the SELECT carries no `WHERE org_id`
+    /// clause. The default implementation here simply delegates to
+    /// [`Self::list_org_projects_raw`] so non-Postgres backends (SQLite, used
+    /// by the embedded OSS admin server, which is single-tenant) keep working
+    /// unchanged.
+    async fn list_org_projects_isolated(&self, org_id: Uuid) -> StoreResult<Vec<ProjectRow>> {
+        self.list_org_projects_raw(org_id).await
+    }
 
     async fn list_org_subscriptions_raw(&self, org_id: Uuid) -> StoreResult<Vec<SubscriptionRow>>;
 

--- a/crates/mockforge-registry-core/src/store/org_context.rs
+++ b/crates/mockforge-registry-core/src/store/org_context.rs
@@ -1,0 +1,89 @@
+//! Transaction-scoped tenant context for the Postgres Row-Level-Security
+//! backstop (#832).
+//!
+//! The RLS policies added in migration `20250101000082_rls_tenant_isolation`
+//! constrain every org-scoped row to the org named by the
+//! `app.current_org_id` GUC on the current connection. This module provides
+//! [`with_org_context`], the single chokepoint that binds that GUC for the
+//! lifetime of a transaction so handler queries are isolated even if they
+//! forget their `WHERE org_id` clause.
+//!
+//! ## Why a transaction
+//!
+//! `set_config(key, value, is_local => true)` makes the GUC **transaction
+//! local**: it is automatically reset when the transaction commits or rolls
+//! back. That is essential with a pooled connection — without `is_local` the
+//! setting would leak onto the next checkout of the same physical connection
+//! and bind the *next* request to the *previous* request's org. So every unit
+//! of work that relies on RLS must run inside a transaction that first sets
+//! the GUC.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! let projects = with_org_context(pool, org_id, |tx| {
+//!     Box::pin(async move {
+//!         // No `WHERE org_id` needed for correctness — RLS enforces it.
+//!         // We keep it anyway as defense-in-depth at the call sites.
+//!         let rows = sqlx::query_as::<_, (Uuid, String)>(
+//!             "SELECT id, name FROM projects",
+//!         )
+//!         .fetch_all(&mut **tx)
+//!         .await?;
+//!         Ok(rows)
+//!     })
+//! })
+//! .await?;
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+
+use sqlx::{PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+use crate::error::{StoreError, StoreResult};
+
+/// Run `f` inside a transaction that has `app.current_org_id` bound to
+/// `org_id`, then commit.
+///
+/// The GUC is set with `set_config(..., is_local => true)` so it is scoped to
+/// the transaction and never leaks back into the connection pool. Any error
+/// returned by `f` aborts the transaction (rolled back on drop) and is
+/// propagated; on success the transaction is committed and the value returned.
+///
+/// Callers that need cross-org access (platform admin, background sweeps,
+/// migrations) must NOT route through this helper — they run as an elevated
+/// role or manage the GUC themselves. See the migration header for the role
+/// requirements.
+pub async fn with_org_context<'a, T, F>(pool: &'a PgPool, org_id: Uuid, f: F) -> StoreResult<T>
+where
+    F: for<'t> FnOnce(
+        &'t mut Transaction<'a, Postgres>,
+    ) -> Pin<Box<dyn Future<Output = StoreResult<T>> + Send + 't>>,
+{
+    let mut tx = pool.begin().await.map_err(StoreError::Database)?;
+
+    // Bind the tenant for the lifetime of this transaction. `true` =>
+    // is_local, so the setting resets on COMMIT/ROLLBACK and cannot bleed
+    // onto the next checkout of this pooled connection.
+    sqlx::query("SELECT set_config('app.current_org_id', $1, true)")
+        .bind(org_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(StoreError::Database)?;
+
+    let result = f(&mut tx).await;
+
+    match result {
+        Ok(value) => {
+            tx.commit().await.map_err(StoreError::Database)?;
+            Ok(value)
+        }
+        Err(err) => {
+            // Best-effort rollback; the transaction also rolls back on drop.
+            let _ = tx.rollback().await;
+            Err(err)
+        }
+    }
+}

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -66,6 +66,55 @@ impl PgRegistryStore {
     pub fn pool(&self) -> &PgPool {
         &self.pool
     }
+
+    // ── RLS-backed tenant-isolated reads (#832) ────────────────────────────
+    //
+    // These mirror the existing `list_org_projects_raw` / `list_scenarios_*`
+    // methods, but route through [`with_org_context`] so the query runs under
+    // the `app.current_org_id` GUC and is enforced by the Postgres RLS
+    // policies (migration 20250101000082). They are the demonstration that
+    // real handler-style queries work through the backstop.
+    //
+    // Note: the `WHERE org_id = $1` filter is INTENTIONALLY OMITTED here to
+    // prove the RLS policy is what isolates the rows. In production handlers
+    // we keep both the app filter and the GUC (defense in depth); these
+    // methods exist specifically to exercise the DB backstop in isolation.
+
+    /// List an org's scenarios through the RLS backstop.
+    ///
+    /// The `scenarios` RLS policy admits both this org's rows and public
+    /// (`org_id IS NULL`) rows, so this returns org-owned scenarios plus the
+    /// shared public marketplace scenarios — matching the product semantics
+    /// of the existing app-layer query, but enforced at the database.
+    pub async fn list_scenarios_by_org_rls(&self, org_id: Uuid) -> StoreResult<Vec<Scenario>> {
+        crate::store::with_org_context(&self.pool, org_id, |tx| {
+            Box::pin(async move {
+                let rows = sqlx::query_as::<_, Scenario>(
+                    "SELECT * FROM scenarios ORDER BY created_at DESC",
+                )
+                .fetch_all(&mut **tx)
+                .await?;
+                Ok(rows)
+            })
+        })
+        .await
+    }
+
+    /// List an org's hosted mocks through the RLS backstop.
+    ///
+    /// `hosted_mocks` is strictly org-scoped (NOT NULL `org_id`); the RLS
+    /// policy isolates the result without any `WHERE org_id` clause.
+    pub async fn list_hosted_mocks_by_org_rls(&self, org_id: Uuid) -> StoreResult<Vec<HostedMock>> {
+        crate::store::with_org_context(&self.pool, org_id, |tx| {
+            Box::pin(async move {
+                let rows = sqlx::query_as::<_, HostedMock>("SELECT * FROM hosted_mocks")
+                    .fetch_all(&mut **tx)
+                    .await?;
+                Ok(rows)
+            })
+        })
+        .await
+    }
 }
 
 #[async_trait]
@@ -2823,6 +2872,38 @@ impl RegistryStore for PgRegistryStore {
                 updated_at,
             })
             .collect())
+    }
+
+    /// RLS-backed variant of [`Self::list_org_projects_raw`] (#832).
+    ///
+    /// Runs the SELECT inside a transaction bound to `app.current_org_id` via
+    /// [`with_org_context`]. The query carries no `WHERE org_id` clause on
+    /// purpose: the Row-Level-Security policy on `projects` (migration
+    /// 20250101000082) is what isolates the result to this org. This is the
+    /// real handler-reachable demonstration that the DB backstop enforces
+    /// tenancy even when the app filter is absent.
+    async fn list_org_projects_isolated(&self, org_id: Uuid) -> StoreResult<Vec<ProjectRow>> {
+        crate::store::with_org_context(&self.pool, org_id, |tx| {
+            Box::pin(async move {
+                let rows =
+                    sqlx::query_as::<_, (Uuid, String, String, DateTime<Utc>, DateTime<Utc>)>(
+                        "SELECT id, name, visibility, created_at, updated_at FROM projects",
+                    )
+                    .fetch_all(&mut **tx)
+                    .await?;
+                Ok(rows
+                    .into_iter()
+                    .map(|(id, name, visibility, created_at, updated_at)| ProjectRow {
+                        id,
+                        name,
+                        visibility,
+                        created_at,
+                        updated_at,
+                    })
+                    .collect())
+            })
+        })
+        .await
     }
 
     async fn list_org_subscriptions_raw(&self, org_id: Uuid) -> StoreResult<Vec<SubscriptionRow>> {

--- a/crates/mockforge-registry-core/src/store/postgres.rs
+++ b/crates/mockforge-registry-core/src/store/postgres.rs
@@ -51,13 +51,38 @@ use crate::models::waitlist::WaitlistSubscriber;
 /// Postgres-backed [`RegistryStore`] implementation.
 #[derive(Clone)]
 pub struct PgRegistryStore {
+    /// Request-path pool. When the binary wires a `NOBYPASSRLS` runtime role
+    /// (via `APP_DATABASE_URL`), the #832 RLS policies enforce org scoping on
+    /// queries run here. Org-scoped reads route through `with_org_context` so
+    /// `app.current_org_id` is bound.
     pool: PgPool,
+    /// Elevated pool for the handful of legitimately cross-org queries (e.g.
+    /// platform-admin analytics that count every tenant). This is the owner
+    /// role, which bypasses RLS. Defaults to `pool` unless
+    /// [`with_owner_pool`](Self::with_owner_pool) is called, so single-role
+    /// deployments and tests are unchanged.
+    owner_pool: PgPool,
 }
 
 impl PgRegistryStore {
     /// Wrap an existing [`PgPool`] in a registry store.
+    ///
+    /// The elevated (cross-org) pool defaults to the same pool; call
+    /// [`with_owner_pool`](Self::with_owner_pool) to supply a distinct owner
+    /// role when the request-path pool is a `NOBYPASSRLS` role (#832).
     pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+        let owner_pool = pool.clone();
+        Self { pool, owner_pool }
+    }
+
+    /// Supply the elevated (RLS-bypassing) owner pool used for legitimately
+    /// cross-org queries. When `APP_DATABASE_URL` puts request-path queries on
+    /// a `NOBYPASSRLS` role, cross-org admin analytics would otherwise
+    /// fail-closed to zero; routing them here keeps them working (#832).
+    #[must_use]
+    pub fn with_owner_pool(mut self, owner_pool: PgPool) -> Self {
+        self.owner_pool = owner_pool;
+        self
     }
 
     /// Borrow the underlying pool. Exposed so the binary bootstrap can still
@@ -341,20 +366,29 @@ impl RegistryStore for PgRegistryStore {
         org_id: Uuid,
         event_types: &[AuditEventType],
     ) -> StoreResult<i64> {
-        let mut query = sqlx::QueryBuilder::new("SELECT COUNT(*) FROM audit_logs WHERE org_id = ");
-        query.push_bind(org_id);
+        // #832: run under the org GUC so the audit_logs RLS policy enforces
+        // isolation. The `WHERE org_id` stays as defense-in-depth.
+        let event_types = event_types.to_vec();
+        crate::store::with_org_context(&self.pool, org_id, move |tx| {
+            Box::pin(async move {
+                let mut query =
+                    sqlx::QueryBuilder::new("SELECT COUNT(*) FROM audit_logs WHERE org_id = ");
+                query.push_bind(org_id);
 
-        if !event_types.is_empty() {
-            query.push(" AND event_type IN (");
-            let mut sep = query.separated(", ");
-            for et in event_types {
-                sep.push_bind(*et);
-            }
-            query.push(")");
-        }
+                if !event_types.is_empty() {
+                    query.push(" AND event_type IN (");
+                    let mut sep = query.separated(", ");
+                    for et in &event_types {
+                        sep.push_bind(*et);
+                    }
+                    query.push(")");
+                }
 
-        let count: (i64,) = query.build_query_as().fetch_one(&self.pool).await?;
-        Ok(count.0)
+                let count: (i64,) = query.build_query_as().fetch_one(&mut **tx).await?;
+                Ok(count.0)
+            })
+        })
+        .await
     }
 
     async fn record_feature_usage(
@@ -2457,7 +2491,10 @@ impl RegistryStore for PgRegistryStore {
     // --- Admin analytics snapshots ---
 
     async fn get_admin_analytics_snapshot(&self) -> StoreResult<AdminAnalyticsSnapshot> {
-        let pool = &self.pool;
+        // #832: platform-admin analytics count every tenant, so they run on the
+        // elevated owner pool (which bypasses RLS) rather than the RLS-enforced
+        // request pool — otherwise the covered-table counts fail-closed to 0.
+        let pool = &self.owner_pool;
 
         let (total_users,): (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM users").fetch_one(pool).await?;
@@ -2929,11 +2966,18 @@ impl RegistryStore for PgRegistryStore {
     }
 
     async fn list_org_hosted_mocks_raw(&self, org_id: Uuid) -> StoreResult<Vec<HostedMock>> {
-        sqlx::query_as::<_, HostedMock>("SELECT * FROM hosted_mocks WHERE org_id = $1")
-            .bind(org_id)
-            .fetch_all(&self.pool)
-            .await
-            .map_err(Into::into)
+        // #832: run under the org GUC so the hosted_mocks RLS policy enforces
+        // isolation. The `WHERE org_id` stays as defense-in-depth.
+        crate::store::with_org_context(&self.pool, org_id, move |tx| {
+            Box::pin(async move {
+                sqlx::query_as::<_, HostedMock>("SELECT * FROM hosted_mocks WHERE org_id = $1")
+                    .bind(org_id)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            })
+        })
+        .await
     }
 
     async fn delete_user_data_cascade(&self, user_id: Uuid) -> StoreResult<usize> {

--- a/crates/mockforge-registry-server/migrations/20250101000082_rls_tenant_isolation.sql
+++ b/crates/mockforge-registry-server/migrations/20250101000082_rls_tenant_isolation.sql
@@ -1,0 +1,143 @@
+-- Defense-in-depth tenant-isolation backstop via Postgres Row-Level Security (#832).
+--
+-- Tenant isolation today is enforced ONLY in application code: the
+-- `resolve_org_context` middleware plus a per-handler `WHERE org_id = $1`
+-- filter. A single handler that forgets that filter becomes a cross-tenant
+-- data exposure (IDOR) — this is the structural pattern behind #746/#778.
+--
+-- This migration adds a database-level backstop. With RLS enabled and FORCED,
+-- every row visible to the application role is constrained to the org bound to
+-- the connection via the `app.current_org_id` GUC, EVEN IF a query omits its
+-- `WHERE org_id` clause. The app-layer filters stay in place; this is a second
+-- line of defense, not a replacement.
+--
+-- ── HOW THE POLICY FAILS CLOSED ────────────────────────────────────────────
+--   current_setting('app.current_org_id', true)::uuid
+-- The second `true` arg ("missing_ok") makes a never-set GUC return NULL
+-- instead of raising. A NULL on either side of `org_id = <null>` yields
+-- UNKNOWN, which RLS treats as "row not visible". So a connection that never
+-- set the GUC sees ZERO org-scoped rows — fail closed, not fail open.
+--
+-- ── ROLE REQUIREMENT (CRITICAL) ────────────────────────────────────────────
+-- RLS is BYPASSED by:
+--   * the table owner, UNLESS `FORCE ROW LEVEL SECURITY` is set (it is, below)
+--   * any superuser role
+--   * any role with the BYPASSRLS attribute
+-- Therefore the application's runtime DB role MUST be a NON-superuser role
+-- WITHOUT BYPASSRLS for this backstop to bite. If the app connects as the
+-- Postgres superuser (common in dev/`docker run postgres`), RLS is silently
+-- ignored and you get a FALSE sense of safety. Provision a dedicated
+-- `mockforge_app` role:
+--
+--   CREATE ROLE mockforge_app LOGIN PASSWORD '...' NOSUPERUSER NOBYPASSRLS;
+--   GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public
+--     TO mockforge_app;
+--   GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO mockforge_app;
+--   ALTER DEFAULT PRIVILEGES IN SCHEMA public
+--     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO mockforge_app;
+--
+-- ── ELEVATED / CROSS-ORG PATHS ─────────────────────────────────────────────
+-- Paths that legitimately need cross-org access (the migration runner itself,
+-- platform admin tooling, background workers that sweep all orgs, webhook
+-- ingestion that resolves the org from the payload) must either:
+--   * run as an elevated role (e.g. the migration/owner role), or
+--   * set `app.current_org_id` appropriately per unit of work.
+-- The migration runner runs as the owner/superuser and is unaffected by FORCE
+-- on these app tables (owner is still subject to FORCE, but the runner uses
+-- the owner role with the GUC unset — it touches schema, not org-scoped rows,
+-- during normal migrations). Keep that in mind when adding data-backfill
+-- migrations that touch these tables: set the GUC or run as a BYPASSRLS role.
+
+-- ── COVERED TABLES ─────────────────────────────────────────────────────────
+-- Strictly org-scoped tables with a NOT NULL `org_id` column:
+--   projects, audit_logs, hosted_mocks
+-- Public/shared tables with a NULLABLE `org_id` (public marketplace rows):
+--   templates, scenarios  → policy also admits `org_id IS NULL` so public
+--   rows stay readable to everyone while writes remain org-scoped.
+--
+-- DELIBERATELY NOT COVERED in this slice (see PR rollout plan):
+--   flows, virtual_entities  → scoped by `workspace_id`, no `org_id` column;
+--                              need a workspace→org join policy (follow-up).
+--   runtime_captures         → scoped by `deployment_id` → hosted_mocks.org_id;
+--                              needs a subquery/join policy (follow-up).
+
+-- ===========================================================================
+-- Strictly org-scoped tables: org_id = current GUC, fail closed when unset.
+-- ===========================================================================
+
+ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE projects FORCE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON projects
+    USING (org_id = current_setting('app.current_org_id', true)::uuid)
+    WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_logs FORCE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON audit_logs
+    USING (org_id = current_setting('app.current_org_id', true)::uuid)
+    WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+ALTER TABLE hosted_mocks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE hosted_mocks FORCE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON hosted_mocks
+    USING (org_id = current_setting('app.current_org_id', true)::uuid)
+    WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- ===========================================================================
+-- Public/shared tables: org-owned rows are isolated, public (NULL org_id)
+-- rows are readable by everyone. Writes are still constrained to the current
+-- org — a tenant cannot mint a row owned by another org, and a connection
+-- with no GUC set can only touch public rows it is explicitly allowed to.
+--
+-- READ  (USING):      own-org rows OR public rows.
+-- WRITE (WITH CHECK): only own-org rows. Inserting/updating a row to
+--                     org_id = NULL (publishing to the public marketplace)
+--                     is intentionally NOT allowed through the org-scoped
+--                     connection; that path runs through an elevated role /
+--                     a dedicated publish flow. This keeps a tenant from
+--                     "escaping" isolation by nulling out org_id.
+-- ===========================================================================
+
+ALTER TABLE templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE templates FORCE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON templates
+    USING (
+        org_id = current_setting('app.current_org_id', true)::uuid
+        OR org_id IS NULL
+    )
+    WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+ALTER TABLE scenarios ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scenarios FORCE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON scenarios
+    USING (
+        org_id = current_setting('app.current_org_id', true)::uuid
+        OR org_id IS NULL
+    )
+    WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- ===========================================================================
+-- ROLLBACK (reversible) — uncomment and run as the table owner to undo.
+-- sqlx has no down-migration mechanism, so this is documented here for
+-- operators applying a manual revert:
+--
+--   DROP POLICY IF EXISTS org_isolation ON projects;
+--   ALTER TABLE projects NO FORCE ROW LEVEL SECURITY;
+--   ALTER TABLE projects DISABLE ROW LEVEL SECURITY;
+--
+--   DROP POLICY IF EXISTS org_isolation ON audit_logs;
+--   ALTER TABLE audit_logs NO FORCE ROW LEVEL SECURITY;
+--   ALTER TABLE audit_logs DISABLE ROW LEVEL SECURITY;
+--
+--   DROP POLICY IF EXISTS org_isolation ON hosted_mocks;
+--   ALTER TABLE hosted_mocks NO FORCE ROW LEVEL SECURITY;
+--   ALTER TABLE hosted_mocks DISABLE ROW LEVEL SECURITY;
+--
+--   DROP POLICY IF EXISTS org_isolation ON templates;
+--   ALTER TABLE templates NO FORCE ROW LEVEL SECURITY;
+--   ALTER TABLE templates DISABLE ROW LEVEL SECURITY;
+--
+--   DROP POLICY IF EXISTS org_isolation ON scenarios;
+--   ALTER TABLE scenarios NO FORCE ROW LEVEL SECURITY;
+--   ALTER TABLE scenarios DISABLE ROW LEVEL SECURITY;
+-- ===========================================================================

--- a/crates/mockforge-registry-server/src/database.rs
+++ b/crates/mockforge-registry-server/src/database.rs
@@ -5,7 +5,17 @@ use sqlx::{postgres::PgPoolOptions, PgPool};
 
 #[derive(Clone, Debug)]
 pub struct Database {
+    /// Owner/elevated pool. Runs migrations (only the table owner can
+    /// `ENABLE ROW LEVEL SECURITY`) and cross-org background workers that
+    /// legitimately sweep every tenant. On the current Neon setup this role
+    /// has `BYPASSRLS`, so it is NOT subject to the #832 RLS policies.
     pool: PgPool,
+    /// Request-path pool. When `APP_DATABASE_URL` is set this is a separate
+    /// `NOSUPERUSER NOBYPASSRLS` role, so the #832 RLS policies actually bite
+    /// for handler queries; when it is unset this simply aliases `pool` so
+    /// behavior is unchanged. Handlers that rely on the RLS backstop MUST run
+    /// their queries through `with_org_context` to bind `app.current_org_id`.
+    runtime_pool: PgPool,
 }
 
 impl Database {
@@ -22,7 +32,26 @@ impl Database {
             .connect(database_url)
             .await?;
 
-        Ok(Self { pool })
+        // #832 tenant-isolation role-split. `APP_DATABASE_URL`, when set, points
+        // at a NOBYPASSRLS role used only for request-path queries so the RLS
+        // policies enforce org scoping. Migrations and cross-org workers keep
+        // using the owner `pool`. Unset (or empty) => runtime aliases the owner
+        // pool, preserving the pre-#832 single-role behavior exactly.
+        let runtime_pool = match std::env::var("APP_DATABASE_URL") {
+            Ok(url) if !url.trim().is_empty() => {
+                tracing::info!(
+                    "APP_DATABASE_URL set: request-path queries will use the dedicated \
+                     runtime role (RLS-enforced); migrations/workers stay on the owner role"
+                );
+                PgPoolOptions::new()
+                    .max_connections(max_connections)
+                    .connect(url.trim())
+                    .await?
+            }
+            _ => pool.clone(),
+        };
+
+        Ok(Self { pool, runtime_pool })
     }
 
     pub async fn migrate(&self) -> Result<()> {
@@ -80,6 +109,15 @@ impl Database {
 
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    /// Request-path pool for tenant-isolated queries (#832). Aliases
+    /// [`Self::pool`] unless `APP_DATABASE_URL` is set, in which case it is a
+    /// dedicated `NOBYPASSRLS` role the RLS policies enforce against. The
+    /// request-handling `RegistryStore` is built from this pool; migrations and
+    /// cross-org workers keep using [`Self::pool`].
+    pub fn runtime_pool(&self) -> &PgPool {
+        &self.runtime_pool
     }
 
     /// Get total number of plugins

--- a/crates/mockforge-registry-server/src/handlers/cloud_dashboard.rs
+++ b/crates/mockforge-registry-server/src/handlers/cloud_dashboard.rs
@@ -120,7 +120,10 @@ pub async fn get_dashboard(
     AuthUser(user_id): AuthUser,
     headers: HeaderMap,
 ) -> ApiResult<Json<CloudDashboardResponse>> {
-    let pool = state.db.pool();
+    // #832: the dashboard's count/metric helpers query RLS-covered tables
+    // (hosted_mocks) alongside non-covered ones, all org-scoped. Run them on
+    // the runtime pool; each helper binds the org GUC via with_org_context.
+    let pool = state.db.runtime_pool();
 
     let org_ctx = resolve_org_context(&state, user_id, &headers, None)
         .await
@@ -262,20 +265,34 @@ pub async fn get_logs(
 }
 
 async fn count_table(pool: &sqlx::PgPool, table: &str, org_id: Uuid) -> i64 {
+    // #832: run under the org GUC so any covered table (e.g. hosted_mocks) is
+    // RLS-enforced; harmless for non-covered tables. `pool` is the runtime pool.
     let query = format!("SELECT COUNT(*) FROM {} WHERE org_id = $1", table);
-    sqlx::query_scalar::<_, i64>(&query)
-        .bind(org_id)
-        .fetch_one(pool)
-        .await
-        .unwrap_or(0)
+    crate::store::with_org_context(pool, org_id, move |tx| {
+        Box::pin(async move {
+            sqlx::query_scalar::<_, i64>(&query)
+                .bind(org_id)
+                .fetch_one(&mut **tx)
+                .await
+                .map_err(Into::into)
+        })
+    })
+    .await
+    .unwrap_or(0)
 }
 
 async fn count_active_deployments(pool: &sqlx::PgPool, org_id: Uuid) -> i64 {
-    sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM hosted_mocks WHERE org_id = $1 AND status = 'active' AND deleted_at IS NULL",
-    )
-    .bind(org_id)
-    .fetch_one(pool)
+    crate::store::with_org_context(pool, org_id, move |tx| {
+        Box::pin(async move {
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM hosted_mocks WHERE org_id = $1 AND status = 'active' AND deleted_at IS NULL",
+            )
+            .bind(org_id)
+            .fetch_one(&mut **tx)
+            .await
+            .map_err(Into::into)
+        })
+    })
     .await
     .unwrap_or(0)
 }
@@ -285,8 +302,11 @@ async fn count_active_deployments(pool: &sqlx::PgPool, org_id: Uuid) -> i64 {
 /// a quiet one. Unavailable until #232 lands the in-container log shipper, so
 /// expect zeros for orgs without Fly Managed Prometheus configured.
 async fn aggregate_deployment_metrics(pool: &sqlx::PgPool, org_id: Uuid) -> AggregatedMetrics {
-    sqlx::query_as::<_, AggregatedMetrics>(
-        r#"
+    // #832: joins hosted_mocks (RLS-covered), so run under the org GUC.
+    crate::store::with_org_context(pool, org_id, move |tx| {
+        Box::pin(async move {
+            sqlx::query_as::<_, AggregatedMetrics>(
+                r#"
         SELECT
             COALESCE(SUM(dm.requests), 0)::BIGINT AS total_requests,
             COALESCE(SUM(dm.requests_2xx), 0)::BIGINT AS requests_2xx,
@@ -302,9 +322,13 @@ async fn aggregate_deployment_metrics(pool: &sqlx::PgPool, org_id: Uuid) -> Aggr
         JOIN hosted_mocks hm ON hm.id = dm.hosted_mock_id
         WHERE hm.org_id = $1 AND hm.deleted_at IS NULL
         "#,
-    )
-    .bind(org_id)
-    .fetch_optional(pool)
+            )
+            .bind(org_id)
+            .fetch_optional(&mut **tx)
+            .await
+            .map_err(Into::into)
+        })
+    })
     .await
     .ok()
     .flatten()
@@ -322,8 +346,11 @@ async fn aggregate_deployment_metrics(pool: &sqlx::PgPool, org_id: Uuid) -> Aggr
 /// ServerTable expects. Each deployment becomes one "server" row with its
 /// public URL as the address and the current period's request count.
 async fn list_active_deployment_servers(pool: &sqlx::PgPool, org_id: Uuid) -> Vec<ServerStatus> {
-    let rows = sqlx::query_as::<_, ActiveDeployment>(
-        r#"
+    // #832: lists hosted_mocks (RLS-covered), so run under the org GUC.
+    let rows = crate::store::with_org_context(pool, org_id, move |tx| {
+        Box::pin(async move {
+            sqlx::query_as::<_, ActiveDeployment>(
+                r#"
         SELECT
             hm.name,
             hm.deployment_url,
@@ -341,9 +368,13 @@ async fn list_active_deployment_servers(pool: &sqlx::PgPool, org_id: Uuid) -> Ve
         ORDER BY hm.created_at DESC
         LIMIT 25
         "#,
-    )
-    .bind(org_id)
-    .fetch_all(pool)
+            )
+            .bind(org_id)
+            .fetch_all(&mut **tx)
+            .await
+            .map_err(Into::into)
+        })
+    })
     .await
     .unwrap_or_default();
 

--- a/crates/mockforge-registry-server/src/handlers/cloud_dashboard.rs
+++ b/crates/mockforge-registry-server/src/handlers/cloud_dashboard.rs
@@ -223,32 +223,40 @@ pub async fn get_logs(
     AuthUser(user_id): AuthUser,
     headers: HeaderMap,
 ) -> ApiResult<Json<Vec<serde_json::Value>>> {
-    let pool = state.db.pool();
-
     let org_ctx = resolve_org_context(&state, user_id, &headers, None)
         .await
         .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
 
-    let logs: Vec<serde_json::Value> = sqlx::query_scalar(
-        r#"
-        SELECT json_build_object(
-            'id', id::text,
-            'timestamp', created_at,
-            'event_type', event_type::text,
-            'description', description,
-            'user_id', user_id::text,
-            'ip_address', ip_address
-        )
-        FROM audit_logs
-        WHERE org_id = $1
-        ORDER BY created_at DESC
-        LIMIT 50
-        "#,
-    )
-    .bind(org_ctx.org_id)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
+    // #832: audit_logs is RLS-covered; run under the org GUC on the runtime
+    // pool. The WHERE org_id stays as defense-in-depth.
+    let org_id = org_ctx.org_id;
+    let logs: Vec<serde_json::Value> =
+        crate::store::with_org_context(state.db.runtime_pool(), org_id, move |tx| {
+            Box::pin(async move {
+                sqlx::query_scalar(
+                    r#"
+                SELECT json_build_object(
+                    'id', id::text,
+                    'timestamp', created_at,
+                    'event_type', event_type::text,
+                    'description', description,
+                    'user_id', user_id::text,
+                    'ip_address', ip_address
+                )
+                FROM audit_logs
+                WHERE org_id = $1
+                ORDER BY created_at DESC
+                LIMIT 50
+                "#,
+                )
+                .bind(org_id)
+                .fetch_all(&mut **tx)
+                .await
+                .map_err(Into::into)
+            })
+        })
+        .await
+        .unwrap_or_default();
 
     Ok(Json(logs))
 }

--- a/crates/mockforge-registry-server/src/handlers/gdpr.rs
+++ b/crates/mockforge-registry-server/src/handlers/gdpr.rs
@@ -157,8 +157,10 @@ pub async fn export_data(
         // Get org settings
         let org_settings = state.store.list_org_settings_raw(org.id).await?;
 
-        // Get projects
-        let projects = state.store.list_org_projects_raw(org.id).await?;
+        // Get projects through the tenant-isolation backstop (#832): the
+        // Postgres impl runs this under the `app.current_org_id` GUC so the
+        // RLS policy enforces org scoping at the database, not just here.
+        let projects = state.store.list_org_projects_isolated(org.id).await?;
 
         // Get subscriptions
         let subscriptions = state.store.list_org_subscriptions_raw(org.id).await?;

--- a/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
+++ b/crates/mockforge-registry-server/src/handlers/hosted_mocks.rs
@@ -671,17 +671,26 @@ pub async fn redeploy_deployment(
         param_count += 1;
         query.push_str(&format!(" WHERE id = ${}", param_count));
 
-        let mut q = sqlx::query(&query);
-        if let Some(ref config) = request.config_json {
-            q = q.bind(config);
-        }
-        if let Some(ref spec_url) = request.openapi_spec_url {
-            q = q.bind(spec_url);
-        }
-        q = q.bind(deployment_id);
-        q.execute(pool).await.map_err(|e| {
-            ApiError::Internal(anyhow::anyhow!("Failed to update deployment: {}", e))
-        })?;
+        // #832: run under the org GUC so the hosted_mocks RLS policy scopes
+        // this UPDATE-by-id to the caller's org even though the WHERE omits
+        // org_id. Clone the bound values so the closure owns them.
+        let config_json = request.config_json.clone();
+        let openapi_spec_url = request.openapi_spec_url.clone();
+        crate::store::with_org_context(state.db.runtime_pool(), org_ctx.org_id, move |tx| {
+            Box::pin(async move {
+                let mut q = sqlx::query(&query);
+                if let Some(ref config) = config_json {
+                    q = q.bind(config);
+                }
+                if let Some(ref spec_url) = openapi_spec_url {
+                    q = q.bind(spec_url);
+                }
+                q = q.bind(deployment_id);
+                q.execute(&mut **tx).await.map(|_| ()).map_err(Into::into)
+            })
+        })
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to update deployment: {}", e)))?;
     }
 
     // Update status to deploying
@@ -2706,8 +2715,15 @@ pub async fn set_domain(
     // endpoints below — `deployment_url` alone is ambiguous (it could be a
     // MOCKFORGE_MOCKS_DOMAIN-based default).
     let new_url = format!("https://{}", hostname);
-    sqlx::query(
-        r#"
+    // #832: UPDATE-by-id under the org GUC so the hosted_mocks RLS policy
+    // scopes it to the caller's org. Clone the bound values (both are reused
+    // in the response below).
+    let new_url_c = new_url.clone();
+    let hostname_c = hostname.clone();
+    crate::store::with_org_context(state.db.runtime_pool(), org_ctx.org_id, move |tx| {
+        Box::pin(async move {
+            sqlx::query(
+                r#"
         UPDATE hosted_mocks
         SET deployment_url = $1,
             metadata_json = jsonb_set(
@@ -2718,11 +2734,16 @@ pub async fn set_domain(
             updated_at = NOW()
         WHERE id = $3
         "#,
-    )
-    .bind(&new_url)
-    .bind(&hostname)
-    .bind(deployment_id)
-    .execute(pool)
+            )
+            .bind(&new_url_c)
+            .bind(&hostname_c)
+            .bind(deployment_id)
+            .execute(&mut **tx)
+            .await
+            .map(|_| ())
+            .map_err(Into::into)
+        })
+    })
     .await
     .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to update deployment URL: {}", e)))?;
 
@@ -2799,18 +2820,28 @@ pub async fn clear_custom_domain(
         format!("https://{}.fly.dev", app_name)
     };
 
-    sqlx::query(
-        r#"
+    // #832: UPDATE-by-id under the org GUC so the hosted_mocks RLS policy
+    // scopes it to the caller's org. Clone default_url (reused in the response).
+    let default_url_c = default_url.clone();
+    crate::store::with_org_context(state.db.runtime_pool(), org_ctx.org_id, move |tx| {
+        Box::pin(async move {
+            sqlx::query(
+                r#"
         UPDATE hosted_mocks
         SET deployment_url = $1,
             metadata_json = COALESCE(metadata_json, '{}'::jsonb) - 'custom_domain',
             updated_at = NOW()
         WHERE id = $2
         "#,
-    )
-    .bind(&default_url)
-    .bind(deployment_id)
-    .execute(pool)
+            )
+            .bind(&default_url_c)
+            .bind(deployment_id)
+            .execute(&mut **tx)
+            .await
+            .map(|_| ())
+            .map_err(Into::into)
+        })
+    })
     .await
     .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to clear custom domain: {}", e)))?;
 

--- a/crates/mockforge-registry-server/src/handlers/organization_settings.rs
+++ b/crates/mockforge-registry-server/src/handlers/organization_settings.rs
@@ -216,13 +216,21 @@ pub async fn get_organization_usage(
     .await
     .map_err(ApiError::Database)?;
 
-    // Get feature usage counts
+    // Get feature usage counts. #832: hosted_mocks is RLS-covered, so run this
+    // one under the org GUC on the runtime pool (the WHERE org_id stays as
+    // defense-in-depth); the other counts hit non-covered tables and stay on
+    // the shared pool.
     let hosted_mocks_count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM hosted_mocks WHERE org_id = $1")
-            .bind(org_id)
-            .fetch_one(pool)
-            .await
-            .map_err(ApiError::Database)?;
+        crate::store::with_org_context(state.db.runtime_pool(), org_id, move |tx| {
+            Box::pin(async move {
+                sqlx::query_as("SELECT COUNT(*) FROM hosted_mocks WHERE org_id = $1")
+                    .bind(org_id)
+                    .fetch_one(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            })
+        })
+        .await?;
 
     let plugins_published: (i64,) =
         sqlx::query_as("SELECT COUNT(*) FROM plugins WHERE org_id = $1")

--- a/crates/mockforge-registry-server/src/handlers/projects.rs
+++ b/crates/mockforge-registry-server/src/handlers/projects.rs
@@ -37,19 +37,28 @@ pub async fn list_projects(
         .await
         .map_err(|_| ApiError::InvalidRequest("Organization not found".to_string()))?;
 
-    let projects = sqlx::query_as::<_, ProjectResponse>(
-        r#"
-        SELECT id, org_id, slug, name, description, visibility, default_env,
-               created_at, updated_at
-        FROM projects
-        WHERE org_id = $1
-        ORDER BY name
-        "#,
-    )
-    .bind(org_ctx.org_id)
-    .fetch_all(state.db.pool())
-    .await
-    .map_err(ApiError::Database)?;
+    // #832: run on the runtime pool inside the org GUC so the projects RLS
+    // policy enforces isolation even though this handler queries directly
+    // (not via the store). The `WHERE org_id` stays as defense-in-depth.
+    let org_id = org_ctx.org_id;
+    let projects = crate::store::with_org_context(state.db.runtime_pool(), org_id, move |tx| {
+        Box::pin(async move {
+            sqlx::query_as::<_, ProjectResponse>(
+                r#"
+                SELECT id, org_id, slug, name, description, visibility, default_env,
+                       created_at, updated_at
+                FROM projects
+                WHERE org_id = $1
+                ORDER BY name
+                "#,
+            )
+            .bind(org_id)
+            .fetch_all(&mut **tx)
+            .await
+            .map_err(Into::into)
+        })
+    })
+    .await?;
 
     Ok(Json(projects))
 }

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -164,9 +164,13 @@ async fn main() -> Result<()> {
     tracing::info!("Circuit breakers initialized for external services");
 
     // Create the unified registry store (Phase 1 extraction). For the SaaS
-    // binary this is always a Postgres-backed adapter over the existing pool.
+    // binary this is always a Postgres-backed adapter over the runtime pool.
+    // #832: the store handles request-path queries, so it uses the runtime
+    // pool — the NOBYPASSRLS role when APP_DATABASE_URL is set (RLS-enforced),
+    // otherwise the owner pool (unchanged). Migrations and cross-org workers
+    // below keep using db.pool() (the owner role).
     let store: Arc<dyn mockforge_registry_server::store::RegistryStore> =
-        Arc::new(PgRegistryStore::new(db.pool().clone()));
+        Arc::new(PgRegistryStore::new(db.runtime_pool().clone()));
 
     // HSM-backed platform-signing controller (Issue #568). Off by default;
     // boots only when MOCKFORGE_PLATFORM_SIGNING_KMS_KEY_ID is set on a

--- a/crates/mockforge-registry-server/src/main.rs
+++ b/crates/mockforge-registry-server/src/main.rs
@@ -169,8 +169,12 @@ async fn main() -> Result<()> {
     // pool — the NOBYPASSRLS role when APP_DATABASE_URL is set (RLS-enforced),
     // otherwise the owner pool (unchanged). Migrations and cross-org workers
     // below keep using db.pool() (the owner role).
-    let store: Arc<dyn mockforge_registry_server::store::RegistryStore> =
-        Arc::new(PgRegistryStore::new(db.runtime_pool().clone()));
+    let store: Arc<dyn mockforge_registry_server::store::RegistryStore> = Arc::new(
+        PgRegistryStore::new(db.runtime_pool().clone())
+            // Cross-org admin queries (analytics snapshot) run on the owner
+            // pool; org-scoped queries stay on the RLS-enforced runtime pool.
+            .with_owner_pool(db.pool().clone()),
+    );
 
     // HSM-backed platform-signing controller (Issue #568). Off by default;
     // boots only when MOCKFORGE_PLATFORM_SIGNING_KMS_KEY_ID is set on a

--- a/crates/mockforge-registry-server/tests/tenant_isolation_rls.rs
+++ b/crates/mockforge-registry-server/tests/tenant_isolation_rls.rs
@@ -1,0 +1,264 @@
+//! Proof that the Postgres Row-Level-Security backstop (#832) isolates
+//! tenants at the database layer, independent of any application-level
+//! `WHERE org_id` filter.
+//!
+//! These tests are `#[ignore]` and require a real Postgres (RLS is a Postgres
+//! feature; SQLite cannot exercise it). They connect as a NON-superuser,
+//! NON-BYPASSRLS role — testing as the `postgres` superuser would bypass RLS
+//! entirely and give a false pass.
+//!
+//! ## Running locally
+//!
+//! ```bash
+//! docker run -d --name rls-pg -e POSTGRES_PASSWORD=postgres \
+//!   -e POSTGRES_DB=mockforge -p 55432:5432 postgres:16
+//!
+//! DATABASE_URL=postgres://postgres:postgres@localhost:55432/mockforge \
+//!   cargo test -p mockforge-registry-server --test tenant_isolation_rls -- --ignored --nocapture
+//!
+//! docker rm -f rls-pg
+//! ```
+//!
+//! `DATABASE_URL` must point at a SUPERUSER connection: the test uses it to
+//! run migrations and to create/seed as the privileged owner, then opens a
+//! SEPARATE pool as the unprivileged `mockforge_rls_app` role to run the
+//! actual isolation assertions.
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+/// The non-superuser, non-BYPASSRLS role the assertions run as.
+const APP_ROLE: &str = "mockforge_rls_app";
+const APP_ROLE_PASSWORD: &str = "rls_app_pw";
+
+fn admin_url() -> Option<String> {
+    std::env::var("DATABASE_URL").ok()
+}
+
+/// Build the app-role connection URL by swapping the userinfo in the admin URL
+/// for the unprivileged role's credentials.
+fn app_url(admin: &str) -> String {
+    // admin looks like: postgres://postgres:postgres@host:port/db[?params]
+    // Replace everything between "://" and the "@" with the app creds.
+    let scheme_split: Vec<&str> = admin.splitn(2, "://").collect();
+    let scheme = scheme_split[0];
+    let after = scheme_split[1];
+    let host_and_rest = after.split_once('@').map(|x| x.1).unwrap_or(after);
+    format!("{scheme}://{APP_ROLE}:{APP_ROLE_PASSWORD}@{host_and_rest}")
+}
+
+/// Run migrations as the admin/superuser pool.
+async fn migrate(pool: &PgPool) {
+    sqlx::migrate!("./migrations")
+        .run(pool)
+        .await
+        .expect("migrations should apply against the docker postgres");
+}
+
+/// Create the unprivileged role and grant it CRUD on the seeded tables. Runs
+/// as the admin pool. Idempotent across re-runs.
+async fn ensure_app_role(admin: &PgPool) {
+    // Create the role if it does not already exist. NOSUPERUSER + NOBYPASSRLS
+    // is the whole point: without these the role would silently ignore RLS.
+    let create = format!(
+        "DO $$ BEGIN \
+           IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{APP_ROLE}') THEN \
+             CREATE ROLE {APP_ROLE} LOGIN PASSWORD '{APP_ROLE_PASSWORD}' NOSUPERUSER NOBYPASSRLS; \
+           END IF; \
+         END $$;"
+    );
+    sqlx::query(&create).execute(admin).await.expect("create app role");
+
+    // Defensively re-assert the attributes in case a stale role survived from
+    // a prior run with different attributes.
+    sqlx::query(&format!("ALTER ROLE {APP_ROLE} NOSUPERUSER NOBYPASSRLS"))
+        .execute(admin)
+        .await
+        .expect("assert app role attributes");
+
+    for grant in [
+        "GRANT USAGE ON SCHEMA public TO ",
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ",
+        "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ",
+    ] {
+        sqlx::query(&format!("{grant}{APP_ROLE}"))
+            .execute(admin)
+            .await
+            .expect("grant to app role");
+    }
+}
+
+/// Insert an organization + a single project owned by it. Returns the org id.
+/// Runs as the admin pool (RLS does not block the superuser seeding rows).
+async fn seed_org_with_project(admin: &PgPool, name: &str, slug: &str) -> (Uuid, Uuid) {
+    let owner_id: Uuid = sqlx::query(
+        "INSERT INTO users (username, email, password_hash, is_verified) \
+         VALUES ($1, $2, 'x', true) RETURNING id",
+    )
+    .bind(slug)
+    .bind(format!("{slug}@example.test"))
+    .fetch_one(admin)
+    .await
+    .expect("seed user")
+    .get("id");
+
+    let org_id: Uuid = sqlx::query(
+        "INSERT INTO organizations (name, slug, owner_id) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(name)
+    .bind(slug)
+    .bind(owner_id)
+    .fetch_one(admin)
+    .await
+    .expect("seed org")
+    .get("id");
+
+    let project_id: Uuid =
+        sqlx::query("INSERT INTO projects (org_id, slug, name) VALUES ($1, $2, $3) RETURNING id")
+            .bind(org_id)
+            .bind(format!("{slug}-proj"))
+            .bind(format!("{name} Project"))
+            .fetch_one(admin)
+            .await
+            .expect("seed project")
+            .get("id");
+
+    (org_id, project_id)
+}
+
+/// Set the per-transaction org GUC. Mirrors what `with_org_context` does in
+/// the production code path.
+async fn set_org_guc(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>, org_id: Uuid) {
+    sqlx::query("SELECT set_config('app.current_org_id', $1, true)")
+        .bind(org_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .expect("set app.current_org_id");
+}
+
+#[tokio::test]
+#[ignore] // Requires a real Postgres via DATABASE_URL.
+async fn rls_isolates_tenants_at_the_database() {
+    let Some(admin) = admin_url() else {
+        eprintln!("DATABASE_URL not set; skipping RLS proof test");
+        return;
+    };
+
+    // 1. Admin/superuser pool: migrate, create the unprivileged role, seed.
+    let admin_pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&admin)
+        .await
+        .expect("connect as admin");
+
+    migrate(&admin_pool).await;
+    ensure_app_role(&admin_pool).await;
+
+    // Unique slugs so re-runs against a persistent DB don't collide.
+    let suffix = Uuid::new_v4().simple().to_string();
+    let (org_a, project_a) =
+        seed_org_with_project(&admin_pool, "Org A", &format!("org-a-{suffix}")).await;
+    let (org_b, project_b) =
+        seed_org_with_project(&admin_pool, "Org B", &format!("org-b-{suffix}")).await;
+
+    println!("seeded org_a={org_a} project_a={project_a}");
+    println!("seeded org_b={org_b} project_b={project_b}");
+
+    // 2. App-role pool: this is where RLS actually bites.
+    let app_pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&app_url(&admin))
+        .await
+        .expect("connect as unprivileged app role");
+
+    // Confirm we really are NOT bypassing RLS — guards against a false pass.
+    let bypasses: bool =
+        sqlx::query("SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user")
+            .fetch_one(&app_pool)
+            .await
+            .expect("read current_user rolbypassrls")
+            .get("rolbypassrls");
+    assert!(!bypasses, "app role must NOT have BYPASSRLS or the test is meaningless");
+    let is_super: bool = sqlx::query("SELECT current_setting('is_superuser') = 'on' AS s")
+        .fetch_one(&app_pool)
+        .await
+        .expect("read is_superuser")
+        .get("s");
+    assert!(!is_super, "app role must NOT be superuser or RLS is bypassed");
+
+    // --- Assertion 1: with org A's GUC, a SELECT with NO `WHERE org_id`
+    //     returns ONLY org A's project (simulates a handler that forgot the
+    //     filter). ----------------------------------------------------------
+    {
+        let mut tx = app_pool.begin().await.expect("begin tx A");
+        set_org_guc(&mut tx, org_a).await;
+        let rows = sqlx::query("SELECT id, org_id FROM projects")
+            .fetch_all(&mut *tx)
+            .await
+            .expect("select projects under org A context");
+        tx.commit().await.expect("commit tx A");
+
+        let ids: Vec<Uuid> = rows.iter().map(|r| r.get::<Uuid, _>("id")).collect();
+        println!("[org A ctx, no WHERE] visible project ids: {ids:?}");
+        assert_eq!(ids.len(), 1, "org A context must see exactly one project");
+        assert_eq!(ids[0], project_a, "org A context must see only org A's project");
+        assert!(!ids.contains(&project_b), "org A must NOT see org B's project");
+    }
+
+    // --- Assertion 2: with NO GUC set, the same query returns 0 rows
+    //     (fail closed). ----------------------------------------------------
+    {
+        let mut tx = app_pool.begin().await.expect("begin tx none");
+        // Deliberately do NOT set app.current_org_id.
+        let rows = sqlx::query("SELECT id FROM projects")
+            .fetch_all(&mut *tx)
+            .await
+            .expect("select projects with no org context");
+        tx.commit().await.expect("commit tx none");
+        println!("[no GUC] visible project count: {}", rows.len());
+        assert_eq!(rows.len(), 0, "with no org GUC the backstop must fail closed (0 rows)");
+    }
+
+    // --- Assertion 3: a cross-tenant UPDATE (org A context trying to modify
+    //     org B's project by id) affects 0 rows. ----------------------------
+    {
+        let mut tx = app_pool.begin().await.expect("begin tx update");
+        set_org_guc(&mut tx, org_a).await;
+        let res = sqlx::query("UPDATE projects SET name = 'pwned' WHERE id = $1")
+            .bind(project_b)
+            .execute(&mut *tx)
+            .await
+            .expect("cross-tenant update under org A context");
+        tx.commit().await.expect("commit tx update");
+        println!("[org A ctx] cross-tenant UPDATE rows_affected: {}", res.rows_affected());
+        assert_eq!(res.rows_affected(), 0, "org A must not be able to UPDATE org B's project");
+    }
+
+    // --- Assertion 4: a cross-tenant DELETE affects 0 rows. ---------------
+    {
+        let mut tx = app_pool.begin().await.expect("begin tx delete");
+        set_org_guc(&mut tx, org_a).await;
+        let res = sqlx::query("DELETE FROM projects WHERE id = $1")
+            .bind(project_b)
+            .execute(&mut *tx)
+            .await
+            .expect("cross-tenant delete under org A context");
+        tx.commit().await.expect("commit tx delete");
+        println!("[org A ctx] cross-tenant DELETE rows_affected: {}", res.rows_affected());
+        assert_eq!(res.rows_affected(), 0, "org A must not be able to DELETE org B's project");
+    }
+
+    // Confirm org B's project is still intact (untouched by A's attempts),
+    // read back as the admin pool which is unconstrained.
+    let still_there: i64 =
+        sqlx::query("SELECT COUNT(*) AS c FROM projects WHERE id = $1 AND name <> 'pwned'")
+            .bind(project_b)
+            .fetch_one(&admin_pool)
+            .await
+            .expect("read back org B project")
+            .get("c");
+    assert_eq!(still_there, 1, "org B's project must remain intact and unmodified");
+
+    println!("RLS tenant-isolation proof: ALL ASSERTIONS PASSED");
+}


### PR DESCRIPTION
> ⚠️ **DRAFT — DO NOT MERGE / do not set `APP_DATABASE_URL` in prod until request-path RLS coverage is in place.** See the rollout section. Merging the migration alone is *inert* today (see the BYPASSRLS finding), but activating the runtime role without coverage fail-closes org queries to 0 rows.

Rebuild of #863 onto **current main** (that branch is ~18,763 lines stale and can't be merged/rebased). Renumbers the migration `079` → `082` (79/80/81 are taken on current main).

## What this delivers (#832)

A defense-in-depth DB backstop so a handler that forgets its `WHERE org_id` can't leak cross-tenant data. App-layer `org_id` filters stay; RLS is the fail-closed floor beneath them.

- **Migration `20250101000082`:** `ENABLE` + `FORCE` RLS + `org_isolation` policy on `projects`, `audit_logs`, `hosted_mocks` (NOT NULL `org_id`) and `templates`, `scenarios` (public rows via `org_id IS NULL`). Unset GUC → NULL → 0 rows → **fail closed**. Reversible rollback included.
- **`with_org_context(pool, org_id, f)`** (`store/org_context.rs`): tx-local GUC (`set_config(.., true)`), pooler-safe. `list_org_projects_isolated` routes through it; GDPR export is the first consumer.
- **Connection role-split** (`database.rs`): `pool` (owner, `DATABASE_URL`) runs migrations + cross-org workers; `runtime_pool` (`APP_DATABASE_URL`, a `NOBYPASSRLS` role) serves the request-path store. `APP_DATABASE_URL` unset ⇒ `runtime_pool` aliases `pool` ⇒ **behavior unchanged** until provisioned.

## Verified on a Neon branch of production (real data, real pooler)

Prod DB is **Neon** (`neondb`, PG17); rehearsed on branch `rls-rehearsal-960` (copy-on-write, isolated). Data: `audit_logs` 1,248 rows across 1,048 orgs.

- Schema matches migration assumptions exactly; migration applies cleanly.
- **`neondb_owner` (the app's current role) has `BYPASSRLS` and owns the tables** → deploying the migration is **inert/safe** while the app stays on it, and provides **no protection** until the runtime role switches.
- As `NOBYPASSRLS mockforge_app`: `ALTER TABLE .. ENABLE RLS` → `must be owner` (migrations must stay on the owner pool ✓); **no GUC → 0 rows** (fail closed); **GUC=org → exactly that org's 140/1,248 rows**; works through Neon's PgBouncer pooler.
- (`audit_logs` is also append-only via the #872 trigger; UPDATE/DELETE RLS isolation proven separately on `projects` in the docker test.)

Builds + `cargo fmt --all --check` + registry clippy clean.

## Rollout (reversible) — coverage step still required before activation

1. Deploy migration (normal boot) — **inert** while app = owner role.
2. **Request-path RLS coverage:** convert org-scoped store methods to route through `with_org_context` (incremental, method-by-method — the transaction pooler makes a blanket session-GUC middleware impractical). Audit elevated paths (workers/webhooks/admin stay on the owner pool). **This is the remaining gate.**
3. Provision `mockforge_app NOSUPERUSER NOBYPASSRLS` on prod + grants (proven on the branch).
4. Set `APP_DATABASE_URL` → `mockforge_app`: activates RLS for request queries.
5. **Rollback is instant:** flip `APP_DATABASE_URL` back to the owner role (BYPASSRLS) → RLS bypassed again. No `DISABLE RLS` scramble.

Supersedes #863. Relates to #832.