### PR TITLE
fix(bench): r63 — classify target HTTP protocol violations as `protocol` (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.211] - 2026-07-27
+
+### Fixed
+
+- **[Reality]** Target-side HTTP protocol violations now classify as `"kind": "protocol"` in `conformance-network-events.json` instead of the generic `"other"` (#79 round 63 / Srikanth on 0.3.210). His WAF answered blocked security probes (`1234 OR 1=1`, `waitfor delay`, ...) with a response body that disagreed with its own declared `Content-Length`, which Go's `net/http` rejects as `server replied with more than declared Content-Length; truncated`. Those 2,824 events were landing in the `other` bucket alongside genuinely unclassifiable failures, so a real protocol violation by the target (the class of defect behind request-smuggling and desync bugs) was indistinguishable from noise. The new branch also covers `malformed`, `protocol error`, and `invalid header`, and is evaluated **last** so the existing eof/timeout/tls/connect rules keep their meaning; it only re-labels what would otherwise be `other`. Applied to all three k6 script-generation paths (`generator.rs`, `spec_driven.rs`, `k6_script.hbs`) with a regression test asserting the branch exists, and stays ordered last, in every path so they cannot drift apart.
+
 ## [0.3.210] - 2026-07-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7708,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7725,7 +7725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7748,7 +7748,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7770,7 +7770,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9294,14 +9294,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15441,7 +15441,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.210"
+version = "0.3.211"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.210"
+version = "0.3.211"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,11 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.211] - 2026-07-27
+
+### Fixed
+
+- **[Reality]** Target-side HTTP protocol violations classify as `"kind": "protocol"` in `conformance-network-events.json` instead of generic `"other"` (#79 round 63 / Srikanth on 0.3.210). A WAF answering blocked security probes with a body that disagreed with its declared `Content-Length` trips Go's `server replied with more than declared Content-Length; truncated`; those events previously mixed in with unclassifiable failures. Also covers `malformed`, `protocol error`, `invalid header`. Evaluated last, so eof/timeout/tls/connect keep their meaning and only `other` is re-labelled. Applied to all three k6 render paths with a regression test guarding both presence and ordering.
+
 ## [0.3.210] - 2026-07-24
 
 ### Added

--- a/crates/mockforge-bench/src/conformance/generator.rs
+++ b/crates/mockforge-bench/src/conformance/generator.rs
@@ -420,6 +420,8 @@ impl ConformanceGenerator {
                  \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('eof') !== -1) kind = 'connect';\n                 \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('timeout') !== -1) kind = 'timeout';\n\
                  \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('tls') !== -1) kind = 'tls';\n\
                  \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('connect') !== -1 || em.toLowerCase().indexOf('refused') !== -1) kind = 'connect';\n\
+                 \x20\x20\x20\x20\x20\x20// Round 63 (#79) — target-side HTTP protocol violation (e.g. more bytes than the declared Content-Length). Checked last so it only re-labels what would be 'other'.\n\
+                 \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('declared content-length') !== -1 || em.toLowerCase().indexOf('malformed') !== -1 || em.toLowerCase().indexOf('protocol error') !== -1 || em.toLowerCase().indexOf('invalid header') !== -1) kind = 'protocol';\n\
                  \x20\x20\x20\x20\x20\x20console.log('MOCKFORGE_NETWORK_EVENT:' + JSON.stringify({\n\
                  \x20\x20\x20\x20\x20\x20  timestamp: new Date().toISOString(),\n\
                  \x20\x20\x20\x20\x20\x20  check: checkName,\n\
@@ -1472,5 +1474,49 @@ mod tests {
         let js = config.custom_headers_js_object();
         assert!(js.contains("'Authorization': 'Bearer abc123'"));
         assert!(js.contains("'X-Custom': 'value'"));
+    }
+
+    /// Round 63 (#79) — the k6 network-event `kind` ladder lives in THREE
+    /// render paths (this file, `spec_driven.rs`, and `k6_script.hbs`). The
+    /// classic #79 failure is fixing one and silently leaving the others
+    /// behind, so assert every path carries the `protocol` branch that labels
+    /// target-side HTTP violations (Srikanth's WAF answering blocked probes
+    /// with a body that disagreed with its declared Content-Length, which
+    /// previously landed in the useless `other` bucket).
+    #[test]
+    fn protocol_kind_present_in_all_three_render_paths() {
+        const PATHS: [(&str, &str); 3] = [
+            ("generator.rs", include_str!("generator.rs")),
+            ("spec_driven.rs", include_str!("spec_driven.rs")),
+            ("k6_script.hbs", include_str!("../templates/k6_script.hbs")),
+        ];
+        // NOTE: this test's own source is one of the inputs (generator.rs
+        // includes itself), so every needle is assembled at runtime — a
+        // literal here would satisfy the assertion even if the real ladder
+        // were deleted.
+        let kind_of = |k: &str| format!("kind = '{k}'");
+        let cl_needle = format!("declared content-{}", "length");
+
+        for (name, src) in PATHS {
+            assert!(
+                src.contains(&kind_of("protocol")),
+                "{name} is missing the `protocol` network-event classification (#79 r63)"
+            );
+            assert!(
+                src.contains(&cl_needle),
+                "{name} is missing the declared-Content-Length match (#79 r63)"
+            );
+            // The protocol branch must stay LAST so it only re-labels what
+            // would otherwise be `other`; the eof/timeout/tls/connect rules
+            // above it keep their existing meaning.
+            let protocol_at = src.find(&kind_of("protocol")).expect("checked above");
+            for earlier in ["connect", "timeout", "tls"] {
+                let needle = kind_of(earlier);
+                assert!(
+                    src.find(&needle).expect("ladder rule present") < protocol_at,
+                    "{name}: `{needle}` must be classified before `protocol` (#79 r63)"
+                );
+            }
+        }
     }
 }

--- a/crates/mockforge-bench/src/conformance/spec_driven.rs
+++ b/crates/mockforge-bench/src/conformance/spec_driven.rs
@@ -967,6 +967,8 @@ impl SpecDrivenConformanceGenerator {
                  \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('eof') !== -1) kind = 'connect';\n                 \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('timeout') !== -1) kind = 'timeout';\n\
                  \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('tls') !== -1) kind = 'tls';\n\
                  \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('connect') !== -1 || em.toLowerCase().indexOf('refused') !== -1) kind = 'connect';\n\
+                 \x20\x20\x20\x20\x20\x20// Round 63 (#79) — target-side HTTP protocol violation (e.g. more bytes than the declared Content-Length). Checked last so it only re-labels what would be 'other'.\n\
+                 \x20\x20\x20\x20\x20\x20else if (em.toLowerCase().indexOf('declared content-length') !== -1 || em.toLowerCase().indexOf('malformed') !== -1 || em.toLowerCase().indexOf('protocol error') !== -1 || em.toLowerCase().indexOf('invalid header') !== -1) kind = 'protocol';\n\
                  \x20\x20\x20\x20\x20\x20console.log('MOCKFORGE_NETWORK_EVENT:' + JSON.stringify({\n\
                  \x20\x20\x20\x20\x20\x20  timestamp: new Date().toISOString(),\n\
                  \x20\x20\x20\x20\x20\x20  check: checkName,\n\

--- a/crates/mockforge-bench/src/templates/k6_script.hbs
+++ b/crates/mockforge-bench/src/templates/k6_script.hbs
@@ -290,6 +290,17 @@ export default function () {
       else if (em.toLowerCase().indexOf('timeout') !== -1) kind = 'timeout';
       else if (em.toLowerCase().indexOf('tls') !== -1) kind = 'tls';
       else if (em.toLowerCase().indexOf('connect') !== -1 || em.toLowerCase().indexOf('refused') !== -1) kind = 'connect';
+      // Round 63 (#79) — target-side HTTP protocol violations. Srikanth's WAF
+      // answered blocked probe URLs with a Content-Length that disagreed with
+      // the bytes it actually sent ("server replied with more than declared
+      // Content-Length; truncated"), which Go's net/http rejects. These were
+      // landing in the useless `other` bucket. Checked LAST so the eof/timeout/
+      // tls/connect rules above keep their current meaning; this only re-labels
+      // what would otherwise be `other`.
+      else if (em.toLowerCase().indexOf('declared content-length') !== -1
+            || em.toLowerCase().indexOf('malformed') !== -1
+            || em.toLowerCase().indexOf('protocol error') !== -1
+            || em.toLowerCase().indexOf('invalid header') !== -1) kind = 'protocol';
       console.log('MOCKFORGE_NETWORK_EVENT:' + JSON.stringify({
         timestamp: new Date().toISOString(),
         check: '{{this.display_name}}',


### PR DESCRIPTION
## Round 63 (#79 / Srikanth)

On 0.3.210 he saw 2,824 events on one target:

```
"kind": "other",
"error_code": 1000,
"message": "net/http: server replied with more than declared Content-Length; truncated"
```

all in the generic `other` bucket of `conformance-network-events.json`.

## Diagnosis

That message is Go's `net/http` refusing a response whose body disagrees with its own declared `Content-Length`. It fires **only on the WAF-blocked security probes** (`1234 OR 1=1`, `EmptyValue' and 526=527`, `waitfor delay`), so the WAF's block-page path is the malformed responder. His `curl` looks clean because curl is lenient about this; Go is strict.

That is a **real protocol violation by the target** (the class of defect behind request-smuggling and desync bugs), so burying it in `other` next to genuinely unclassifiable failures loses a finding worth reporting.

## Fix

New `protocol` kind matching `declared content-length`, `malformed`, `protocol error`, `invalid header`.

Evaluated **last** in the ladder, so existing rules keep their exact meaning and only `other` is re-labelled. Verified no regression:

| error | before | after |
|---|---|---|
| `...declared Content-Length; truncated` | other | **protocol** |
| `unexpected EOF` | connect | connect |
| `http2: timeout awaiting response headers` | timeout | timeout |
| `dial tcp: connection refused` (ec 1200) | connect | connect |
| `something unknown` | other | other |

The ladder lives in **three** render paths (`generator.rs`, `spec_driven.rs`, `k6_script.hbs`) — the classic #79 drift trap — so all three are updated, plus a regression test asserting each path has the branch **and** keeps it ordered after connect/timeout/tls. The test builds its needles at runtime, because `generator.rs` `include_str!`s itself and literal needles would make the assertions self-satisfying.

## Also answered on the issue (from his bundle)

- **Are those requests dropped?** No. Sent, server responds, k6 errors reading the body, records `status=0`; still counted in `http_reqs` and as a failure in `http_req_failed`. Iteration continues.
- **"RPS has gone low on target_8"** is not what the data shows: target_8 did **120,840 requests at 199.3 req/s** (2nd highest of 10; others 41-82), with **214 connections for 120,840 requests** (connecting avg 0.00 ms), so no reconnect churn. The errors are 2.5% of its requests and 2.8% of its failures.
- The genuinely degraded target is **target_1**: 107,638 connections for 114,120 requests (~1 fresh connection per request, connecting avg 1.7 ms), 98.4% failure, ~3 successful req/s.

## Verification

- Real binary: `mockforge bench --generate-only` emits the branch; generated script passes `node --check`.
- `cargo test -p mockforge-bench`: **522 passed**; `cargo fmt --all --check` clean.

Releases as **v0.3.211**.