### PR TITLE
fix(intelligence): repair stale doctest that reds every release run

### DIFF
--- a/crates/mockforge-intelligence/src/voice/hook_transpiler.rs
+++ b/crates/mockforge-intelligence/src/voice/hook_transpiler.rs
@@ -6,10 +6,10 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use mockforge_core::voice::HookTranspiler;
-//! use mockforge_core::intelligent_behavior::IntelligentBehaviorConfig;
+//! use mockforge_intelligence::voice::HookTranspiler;
+//! use mockforge_intelligence::intelligent_behavior::IntelligentBehaviorConfig;
 //!
-//! # async fn example() -> mockforge_core::Result<()> {
+//! # async fn example() -> mockforge_foundation::Result<()> {
 //! let config = IntelligentBehaviorConfig::default();
 //! let transpiler = HookTranspiler::new(config);
 //!


### PR DESCRIPTION
## What

The module doctest in `crates/mockforge-intelligence/src/voice/hook_transpiler.rs` imports from `mockforge_core`, but #562 phase 2 (#573, 2026-05-19) moved that code into `mockforge-intelligence`, which does not depend on `mockforge-core`. The example is `rust,no_run`, so rustdoc compiles it, and it has failed with `E0433` for over two months.

## Why it matters

`release.yml`'s **Create Release** job runs `cargo test --workspace --release`. This doctest aborts that step with exit 101, which skips everything after it:

| step | v0.3.211 result |
|---|---|
| Install Rust toolchain | ✅ (fixed by #956) |
| Build mockforge binary with all protocols | ✅ |
| **Run tests** | ❌ `doctest failed ... -p mockforge-intelligence --doc` |
| Build release binaries | ⏭ skipped |
| Smoke-test cargo install path | ⏭ skipped |
| Generate changelog / **Create GitHub Release** | ⏭ skipped |

That is why release pages have not been published automatically. The dtolnay/rust-toolchain `1.100.0` bomb fixed in #956 was failing the job earlier; with the toolchain repaired, this is the next thing in line.

CI's own `Test` job runs `cargo test --workspace` too and has been red on this the whole time, but it is not a required check, so it was merged over.

## Verification

- `cargo test -p mockforge-intelligence --doc` → 2 passed, 0 failed, 9 ignored
- `cargo test --workspace --doc --no-fail-fast` → clean (exit 0), so this was the only rotted example
- `cargo fmt --all --check` clean; pre-commit clippy/typos/fmt all pass

## Notes

- The v0.3.211 release page was missing entirely; I created it by hand from the CHANGELOG entry so the tag is not left bare.
- Other `mockforge_core` mentions in this crate are prose history notes ("this moved from X"), not examples, and are left alone.