### PR TITLE
fix(docker): align every Dockerfile builder with rust-toolchain.toml (1.96)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,3 +121,15 @@ repos:
     stages: [pre-push]
     pass_filenames: false
     always_run: true
+  - id: dockerfile-rust-drift
+    name: Dockerfile rust toolchain drift guard
+    # Blocks a commit whose Dockerfile builder stage no longer matches
+    # rust-toolchain.toml. The Dockerfiles had drifted to 1.75/1.90/1.91 while
+    # the workspace moved to 1.96.0; nothing noticed until aws-smithy-types
+    # raised its MSRV to 1.94.1 and broke `flyctl deploy` for the production
+    # registry — on a change that had nothing to do with it. Stale builders fail
+    # silently and late, so this is a guard rather than a convention.
+    entry: scripts/check-dockerfile-rust-drift.sh
+    language: system
+    pass_filenames: false
+    files: '(^|/)(Dockerfile[^/]*|rust-toolchain\.toml)$'

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pnpm build
 
 # Stage 1: Build the Rust application
 # Use rust:1.90-slim (Trixie/testing-based) which has GLIBC 2.39+ required by native dependencies
-FROM rust:1.90-slim AS builder
+FROM rust:1.96-slim AS builder
 
 # Install required dependencies for building (including C++ for Kafka support)
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.cloud-plugins
+++ b/Dockerfile.cloud-plugins
@@ -30,7 +30,7 @@ COPY crates/mockforge-ui/ui/ ./
 RUN pnpm build
 
 # ─── Stage 1: Rust builder ──────────────────────────────────────────
-FROM rust:1.90-slim AS builder
+FROM rust:1.96-slim AS builder
 
 RUN apt-get update && apt-get install -y \
         pkg-config \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Development Dockerfile for MockForge with hot reload
-FROM rust:1.75 AS development
+FROM rust:1.96 AS development
 
 # Install required dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -2,7 +2,7 @@
 # Builds only the registry server binary (not the full CLI)
 
 # Stage 1: Build
-FROM rust:1.91-slim AS builder
+FROM rust:1.96-slim AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -8,7 +8,7 @@
 # so wafbench runs work without the operator pre-uploading rules.
 
 # Stage 1: Build
-FROM rust:1.91-slim AS builder
+FROM rust:1.96-slim AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \

--- a/Dockerfile.tunnel
+++ b/Dockerfile.tunnel
@@ -12,7 +12,7 @@
 # See docs/cloud/CLOUD_TUNNEL_RELAY_DEPLOYMENT.md for the full
 # deployment story.
 
-FROM rust:1.91-slim AS builder
+FROM rust:1.96-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev protobuf-compiler build-essential g++ cmake ca-certificates \

--- a/crates/mockforge-registry-server/Dockerfile
+++ b/crates/mockforge-registry-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75 as builder
+FROM rust:1.96 as builder
 
 WORKDIR /app
 

--- a/scripts/check-dockerfile-rust-drift.sh
+++ b/scripts/check-dockerfile-rust-drift.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Guard: every `FROM rust:<version>` builder stage must match the workspace
+# toolchain pinned in rust-toolchain.toml.
+#
+# Why this exists: the Dockerfiles drifted to 1.75 / 1.90 / 1.91 while
+# rust-toolchain.toml (and CI) moved to 1.96.0. Nothing caught it, because a
+# stale builder keeps working right up until a transitive dependency raises its
+# MSRV past the pinned version. On 2026-07-30 that happened:
+#
+#   error: rustc 1.91.1 is not supported by the following package:
+#     aws-smithy-types@1.6.1 requires rustc 1.94.1
+#
+# which broke `flyctl deploy --config fly.registry.toml` — i.e. production
+# registry deploys — with a failure that has nothing to do with the change
+# being deployed. The failure mode is silent and time-delayed, so it needs a
+# guard rather than vigilance.
+#
+# Usage: scripts/check-dockerfile-rust-drift.sh
+
+set -euo pipefail
+
+unset CDPATH
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)"
+cd "$REPO_ROOT" >/dev/null
+
+TOOLCHAIN_FILE="rust-toolchain.toml"
+[ -f "$TOOLCHAIN_FILE" ] || { echo "error: $TOOLCHAIN_FILE not found" >&2; exit 1; }
+
+# channel = "1.96.0"  ->  1.96.0
+pinned="$(grep -E '^\s*channel\s*=' "$TOOLCHAIN_FILE" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+[ -n "$pinned" ] || { echo "error: could not parse channel from $TOOLCHAIN_FILE" >&2; exit 1; }
+
+# Docker tags are usually major.minor (rust:1.96-slim) while the toolchain is
+# major.minor.patch. Compare on major.minor so `rust:1.96-slim` satisfies
+# `channel = "1.96.0"`.
+pinned_mm="$(cut -d. -f1,2 <<<"$pinned")"
+
+fail=0
+found=0
+while IFS= read -r line; do
+  file="${line%%:*}"
+  rest="${line#*:}"
+  lineno="${rest%%:*}"
+  version="$(sed -E 's/.*FROM rust:([0-9]+(\.[0-9]+)*).*/\1/' <<<"$line")"
+  found=$((found + 1))
+  version_mm="$(cut -d. -f1,2 <<<"$version")"
+  if [ "$version_mm" != "$pinned_mm" ]; then
+    echo "DRIFT  $file:$lineno  FROM rust:$version  (rust-toolchain.toml pins $pinned)"
+    fail=1
+  fi
+done < <(grep -rnE '^FROM rust:[0-9]' --include='Dockerfile*' . 2>/dev/null || true)
+
+if [ "$found" -eq 0 ]; then
+  echo "warning: no 'FROM rust:<version>' stages found — did the Dockerfiles move?" >&2
+fi
+
+if [ "$fail" -ne 0 ]; then
+  cat <<EOF
+
+Docker builder images have drifted from the workspace toolchain.
+
+Bump the offending 'FROM rust:<version>' lines to rust:$pinned_mm so container
+builds use the same compiler as CI and local development. A stale builder does
+not fail immediately — it fails whenever a dependency raises its MSRV, and it
+fails on whatever change happens to be deploying at that moment.
+EOF
+  exit 1
+fi
+
+echo "OK: all $found rust builder stage(s) match rust-toolchain.toml ($pinned)"


### PR DESCRIPTION
## The failure

Production registry deploys cannot build:

```
error: rustc 1.91.1 is not supported by the following package:
  aws-smithy-types@1.6.1 requires rustc 1.94.1
```

`Dockerfile.registry` pinned `rust:1.91-slim`; `rust-toolchain.toml` and CI are on **1.96.0**. Every Dockerfile had drifted, by different amounts:

| file | was | now |
|---|---|---|
| `Dockerfile` | 1.90 | 1.96 |
| `Dockerfile.dev` | 1.75 | 1.96 |
| `Dockerfile.cloud-plugins` | 1.90 | 1.96 |
| `Dockerfile.tunnel` | 1.91 | 1.96 |
| `Dockerfile.runner` | 1.91 | 1.96 |
| `Dockerfile.registry` | 1.91 | 1.96 |
| `crates/mockforge-registry-server/Dockerfile` | 1.75 | 1.96 |

## Why it matters more than it looks

This drift is invisible until some transitive dependency raises its MSRV past the pinned builder. Then it breaks whatever change happens to be deploying, with an error unrelated to that diff.

It also compounds with the release gate: `deploy-registry` in `release.yml` has `needs: release`, so the doctest failure fixed in #964 had already been skipping the Fly deploy on every tag since v0.3.206. **Production is serving 0.3.183 from 2026-06-19** — there were two independent reasons it could not move, and fixing only one would not have been enough.

## The guard

`scripts/check-dockerfile-rust-drift.sh` parses the pinned channel from `rust-toolchain.toml` and asserts every `FROM rust:<version>` builder matches on major.minor (so `rust:1.96-slim` satisfies `channel = "1.96.0"`). Wired into `.pre-commit-config.yaml`, scoped to `Dockerfile*` and `rust-toolchain.toml`.

It earned its place immediately: it caught `crates/mockforge-registry-server/Dockerfile` at 1.75, which a root-level glob missed.

## Verification

- Guard passes on all 7 builder stages; fails as expected when a stage is reverted (negative-tested).
- The registry image now builds, unblocking `flyctl deploy --config fly.registry.toml`.