### PR TITLE
fix(registry): audit events silently dropped on long X-Forwarded-For

### DIFF
--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -347,6 +347,10 @@ struct AuditChainRow {
 
 #[cfg(feature = "postgres")]
 impl AuditLog {
+    /// Maximum length of the `audit_logs.ip_address` column (`varchar(45)`),
+    /// sized for a full-length IPv6 literal.
+    const IP_ADDRESS_MAX_CHARS: usize = 45;
+
     /// Create a new audit log entry, extending the org's tamper-evident hash
     /// chain (#872).
     ///
@@ -368,6 +372,12 @@ impl AuditLog {
         ip_address: Option<&str>,
         user_agent: Option<&str>,
     ) -> sqlx::Result<Self> {
+        // Normalize BEFORE hashing so the canonical form and the stored column
+        // agree — otherwise `verify_chain` would recompute a different hash and
+        // report the chain broken.
+        let ip_address = normalize_client_ip(ip_address);
+        let ip_address = ip_address.as_deref();
+
         let mut tx = pool.begin().await?;
 
         // Lock + read the previous entry's hash for this org. FOR UPDATE
@@ -554,6 +564,37 @@ impl AuditLog {
     }
 }
 
+/// Reduce a client-IP header value to something the `ip_address` column can
+/// actually hold.
+///
+/// Handlers pass the raw `X-Forwarded-For` header. Behind a proxy chain that
+/// header is a comma-separated list (`"client, proxy1, proxy2"`), not a single
+/// address, and it routinely exceeds the column's 45 characters. Because
+/// [`record_audit_event`] is fire-and-forget — it logs a `WARN` and returns —
+/// the resulting
+///
+/// ```text
+/// error returned from database: value too long for type character varying(45)
+/// ```
+///
+/// was swallowed, silently dropping audit events in production. It was invisible
+/// twice over: the failure never reaches the caller, and `RUST_LOG` on the
+/// deployed registry only enables `mockforge_registry_server`, so the `WARN`
+/// from this crate was filtered out of the logs entirely.
+///
+/// Takes the first entry (the originating client, matching
+/// `middleware::trusted_proxy::extract_client_ip_from_headers`) and hard-caps
+/// the result, so no header — however long, malformed, or hostile — can cost us
+/// an audit record. Truncation counts characters, not bytes, because that is
+/// what Postgres `varchar(n)` counts.
+fn normalize_client_ip(ip: Option<&str>) -> Option<String> {
+    let first = ip?.split(',').next()?.trim();
+    if first.is_empty() {
+        return None;
+    }
+    Some(first.chars().take(AuditLog::IP_ADDRESS_MAX_CHARS).collect())
+}
+
 /// Helper function to record audit events from request context
 #[cfg(feature = "postgres")]
 #[allow(clippy::too_many_arguments)]
@@ -587,6 +628,43 @@ pub async fn record_audit_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The exact production failure: `X-Forwarded-For` behind a proxy chain is a
+    /// list, not an address, and the raw value overflowed `varchar(45)` — which
+    /// `record_audit_event` swallowed as a WARN, silently losing audit events.
+    #[test]
+    fn client_ip_takes_first_hop_and_fits_the_column() {
+        // Real shape of the header that broke prod on 2026-07-30.
+        let chain = "203.0.113.7, 198.51.100.22, 2001:db8:85a3:8d3:1319:8a2e:370:7348, 10.0.0.1";
+        let got = normalize_client_ip(Some(chain)).expect("should keep the client hop");
+        assert_eq!(got, "203.0.113.7");
+        assert!(chain.chars().count() > AuditLog::IP_ADDRESS_MAX_CHARS, "fixture must overflow");
+    }
+
+    #[test]
+    fn client_ip_is_capped_even_without_commas() {
+        // A single over-long token (malformed or hostile header) must still be
+        // stored rather than costing us the audit record.
+        let long = "x".repeat(300);
+        let got = normalize_client_ip(Some(&long)).expect("should truncate, not drop");
+        assert_eq!(got.chars().count(), AuditLog::IP_ADDRESS_MAX_CHARS);
+    }
+
+    #[test]
+    fn client_ip_handles_absent_and_empty() {
+        assert_eq!(normalize_client_ip(None), None);
+        assert_eq!(normalize_client_ip(Some("")), None);
+        assert_eq!(normalize_client_ip(Some("   ")), None);
+        assert_eq!(normalize_client_ip(Some(", 10.0.0.1")), None, "empty first hop is not an IP");
+    }
+
+    #[test]
+    fn client_ip_passes_through_a_plain_address() {
+        assert_eq!(normalize_client_ip(Some("198.51.100.4")).as_deref(), Some("198.51.100.4"));
+        let v6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+        assert_eq!(normalize_client_ip(Some(v6)).as_deref(), Some(v6));
+        assert!(v6.chars().count() <= AuditLog::IP_ADDRESS_MAX_CHARS);
+    }
 
     /// Every variant must round-trip through as_str → from_str. A new variant
     /// added without updating either method will fail this test.


### PR DESCRIPTION
## Symptom

**Production stopped recording audit events at 2026-07-30T14:10Z.** Found while smoke-testing a deploy: `POST /api/v1/organizations` returns 200, the org is created, and no `org_created` row appears. Nothing in the logs.

```sql
SELECT count(*) FROM audit_logs WHERE created_at > now() - interval '5 minutes';
-- 0
```

## Cause

```
error returned from database: value too long for type character varying(45)
```

`audit_logs.ip_address` is `varchar(45)`, sized for an IPv6 literal. Handlers pass the raw `X-Forwarded-For` header — but behind a proxy chain that header is a comma-separated **list** (`"client, proxy1, proxy2"`), not one address, and it easily exceeds 45 characters. Fly's proxy supplies exactly that shape, so whether a given event survived depended on how long the chain happened to be that request.

## Why nobody noticed

Two independent layers of silence:

1. `record_audit_event` is fire-and-forget — it logs a `WARN` and returns, so the failure never reaches the caller and the request still succeeds.
2. The deployed `RUST_LOG` is `mockforge_registry_server=info,tower_http=info`, which does not enable `mockforge_registry_core` — so the `WARN` was filtered out of production logs as well.

The audit log therefore looks populated while being incomplete, and it preferentially drops the requests that traversed more infrastructure. For a SOC2-oriented audit trail that is the wrong failure mode.

## Fix

At the data layer, not the 9 call sites that build the value, so no current or future caller can lose a record this way:

```rust
fn normalize_client_ip(ip: Option<&str>) -> Option<String> {
    let first = ip?.split(',').next()?.trim();
    if first.is_empty() { return None; }
    Some(first.chars().take(AuditLog::IP_ADDRESS_MAX_CHARS).collect())
}
```

Takes the first hop (same semantics as the existing `middleware::trusted_proxy::extract_client_ip_from_headers`) and hard-caps the result.

Two details that matter:

- **Normalization happens before the hash-chain canonical form is computed**, not just before the bind. `ip_address` is part of the hashed entry (#872), so normalizing only at insert time would make `verify_chain` recompute a different hash and report the chain broken.
- **Truncation counts characters, not bytes**, because that is what Postgres `varchar(n)` counts.

## Tests

Four new unit tests: the real header shape that broke prod, a comma-less over-long token (malformed/hostile header must still store, not drop), absent/empty/empty-first-hop, and plain IPv4/IPv6 pass-through. All 7 tests in the module pass; clippy `-D warnings` clean on the crate.

## Follow-ups (not here)

- The 9 handlers reading `x-forwarded-for` directly should use `extract_client_ip_from_headers`.
- `RUST_LOG` in `fly.registry.toml` should include `mockforge_registry_core` so this class of warning is visible in production at all. Right now a fire-and-forget failure in that crate is unobservable.