### PR TITLE
fix(registry): migration advisory lock leaked, hanging the next deploy

### DIFF
--- a/crates/mockforge-registry-server/src/database.rs
+++ b/crates/mockforge-registry-server/src/database.rs
@@ -30,11 +30,45 @@ impl Database {
         // across multiple replicas. Lock ID 8675309 is an arbitrary but stable identifier.
         const MIGRATION_LOCK_ID: i64 = 8675309;
 
+        // Pin ONE connection for the lock/unlock pair.
+        //
+        // `pg_advisory_lock` is SESSION-scoped, but this used to run via
+        // `&self.pool`, which hands out an arbitrary pooled connection per
+        // statement. Lock and unlock could therefore land on *different*
+        // sessions. `pg_advisory_unlock` on a session that doesn't hold the lock
+        // returns `false` — it is NOT an error — so the old `if let Err(..)`
+        // never fired and the leak was logged as "Migration advisory lock
+        // released". The lock then stayed held for the life of that pooled
+        // connection, and the NEXT deploy blocked forever inside
+        // `pg_advisory_lock`, before the HTTP listener bound. Health checks
+        // failed, the deploy was rolled back, and the replacement machine hit
+        // the same wall. That took production down on 2026-07-30 (v94) until
+        // the orphaned backend was terminated by hand.
+        let mut conn = self.pool.acquire().await?;
+
+        // Fail fast instead of hanging boot forever. An unreachable lock is an
+        // operational problem that needs a human; blocking indefinitely turns it
+        // into an opaque outage where the app looks "starting" but never binds.
+        // 60s is far longer than an uncontended acquisition and far shorter than
+        // a deploy health-check budget.
+        sqlx::query("SET lock_timeout = '60s'").execute(&mut *conn).await?;
+
         tracing::info!("Acquiring advisory lock for database migrations...");
-        sqlx::query("SELECT pg_advisory_lock($1)")
+        if let Err(e) = sqlx::query("SELECT pg_advisory_lock($1)")
             .bind(MIGRATION_LOCK_ID)
-            .execute(&self.pool)
-            .await?;
+            .execute(&mut *conn)
+            .await
+        {
+            tracing::error!(
+                "Could not acquire the migration advisory lock ({MIGRATION_LOCK_ID}) within \
+                 the timeout: {e}. Another instance may be mid-migration, or a previous one \
+                 leaked the lock. Inspect with: SELECT l.pid, a.state, a.query FROM pg_locks l \
+                 JOIN pg_stat_activity a USING (pid) WHERE l.locktype = 'advisory' AND \
+                 l.objid = {MIGRATION_LOCK_ID}; and clear a confirmed-stale holder with \
+                 pg_terminate_backend(<pid>)."
+            );
+            return Err(e.into());
+        }
         tracing::info!("Advisory lock acquired, running migrations...");
 
         // Run migrations. Any error aborts boot — `sqlx::migrate!().run()` bails
@@ -64,16 +98,29 @@ impl Database {
                     e.into()
                 });
 
-        // Release the advisory lock regardless of migration outcome
-        if let Err(unlock_err) = sqlx::query("SELECT pg_advisory_unlock($1)")
+        // Release on the SAME connection that took it, and check the RETURN
+        // VALUE, not just the transport error. `pg_advisory_unlock` reports
+        // failure by returning false; treating "no error" as "released" is what
+        // let the leak go unnoticed.
+        match sqlx::query_scalar::<_, bool>("SELECT pg_advisory_unlock($1)")
             .bind(MIGRATION_LOCK_ID)
-            .execute(&self.pool)
+            .fetch_one(&mut *conn)
             .await
         {
-            tracing::error!("Failed to release migration advisory lock: {}", unlock_err);
-        } else {
-            tracing::info!("Migration advisory lock released");
+            Ok(true) => tracing::info!("Migration advisory lock released"),
+            Ok(false) => tracing::error!(
+                "pg_advisory_unlock({MIGRATION_LOCK_ID}) returned false — this session did not \
+                 hold the lock. It is now leaked and WILL block the next deploy's boot. Clear it \
+                 with pg_terminate_backend(<pid>) against the holder in pg_locks."
+            ),
+            Err(unlock_err) => {
+                tracing::error!("Failed to release migration advisory lock: {}", unlock_err)
+            }
         }
+
+        // Drop the pinned connection explicitly: returning it to the pool while
+        // it might still hold the lock is precisely the failure being fixed.
+        drop(conn);
 
         result
     }


### PR DESCRIPTION
## What happened

This took **production down** on 2026-07-30 (release v94). Both machines hung at:

```
INFO mockforge_registry_server::database: Acquiring advisory lock for database migrations...
```

They never bound `:8080`, so health checks failed, the deploy rolled back, and the replacement machine hit the same wall. Recovery required terminating the orphaned Postgres backend by hand:

```sql
SELECT l.pid, l.granted, a.state, a.query
FROM pg_locks l JOIN pg_stat_activity a USING (pid)
WHERE l.locktype='advisory' AND l.objid = 8675309;
-- pid 7873 | granted=true | idle   | SELECT * FROM hosted_mocks ...   <-- leaked holder
-- pid 8046 | granted=false| active | SELECT pg_advisory_lock($1)      <-- new machine, blocked
-- pid 8376 | granted=false| active | SELECT pg_advisory_lock($1)      <-- other machine, blocked
```

## Root cause

`pg_advisory_lock` is **session-scoped**, but lock and unlock were both issued via `&self.pool`, which hands out an arbitrary pooled connection per statement:

```rust
sqlx::query("SELECT pg_advisory_lock($1)").execute(&self.pool).await?;   // session A
// ... migrations ...
sqlx::query("SELECT pg_advisory_unlock($1)").execute(&self.pool).await   // maybe session B
```

When they land on different sessions, `pg_advisory_unlock` returns **`false`** — a return value, not an error — so the old `if let Err(..)` treated it as success and logged *"Migration advisory lock released"* while the lock was still held. It then stayed held for the life of that pooled connection, and the next boot blocked in `pg_advisory_lock` forever.

Neon's pgbouncer in front of the app makes the mismatch likelier, since server connections are shared between clients.

The bug is self-concealing in three ways at once: the unlock silently no-ops, the log claims success, and the consequence lands on a *later* deploy rather than the one that caused it.

## Fix

1. **Pin one connection** (`pool.acquire()`) for the lock/unlock pair so they are the same session, and drop it explicitly rather than returning a possibly-lock-holding connection to the pool.
2. **Check the return value** of `pg_advisory_unlock`. A `false` now logs loudly and names the remedy.
3. **`SET lock_timeout = '60s'`** before acquiring. Boot now fails fast with an error containing the diagnostic query and the `pg_terminate_backend` remedy, instead of hanging as an opaque "starting but never listening" outage.

## Operator follow-up (not changed here)

`DATABASE_URL` points at Neon's `-pooler` endpoint. Running migrations/DDL through a transaction pooler is inherently fragile for session-scoped state; pointing the migration path at the direct endpoint would eliminate the rest of this class. That is a deployment-config change rather than a code one, so it is left as a follow-up.