### PR TITLE
fix(openapi): drop the unnecessary qualification that reds every PR's Test job

### DIFF
--- a/crates/mockforge-openapi/src/openapi_routes.rs
+++ b/crates/mockforge-openapi/src/openapi_routes.rs
@@ -2403,7 +2403,7 @@ impl OpenApiRouteRegistry {
 /// down.
 fn inject_spec_response_headers(
     response: &mut axum::response::Response,
-    route: &crate::route::OpenApiRoute,
+    route: &OpenApiRoute,
     status_code: u16,
 ) {
     let synthesized = route.mock_response_headers_for_status(status_code);


### PR DESCRIPTION
## What

One line. `crates/mockforge-openapi/src/openapi_routes.rs:2406` writes `&crate::route::OpenApiRoute` when `OpenApiRoute` is already imported at line 20 of the same file.

## Why it matters

`Test (1.96.0)` in `ci.yml` runs:

```
cargo clippy --workspace --exclude mockforge-desktop --lib --bins --all-features \
  -- -D clippy::correctness -D unused_qualifications
```

That single `error: unnecessary qualification` aborts the clippy step with exit 101, so **the whole Test job is red on every PR that compiles this crate**, regardless of what the PR changed.

A permanently-red check is one nobody reads. That is exactly how the stale doctest fixed in #964 sat unnoticed for two months in this same job: `cargo test --workspace` was catching it the whole time, but the job was already failing for an unrelated reason, so the signal was worthless. It only surfaced when it blocked the release pipeline instead.

## Verification

```
cargo clippy -p mockforge-openapi --lib --bins -- -D clippy::correctness -D unused_qualifications
    Finished `dev` profile
```

No behaviour change.