### PR TITLE
fix(bench): r64 — multi-target dropped --conformance-basic-auth (#79)

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -1047,12 +1047,30 @@ impl BenchCommand {
                 owasp_report_format: self.owasp_report_format.clone(),
                 owasp_iterations: self.owasp_iterations,
                 conformance: false,
-                conformance_api_key: None,
-                conformance_basic_auth: None,
+                // Round 64 (#79) — Srikanth on 0.3.210 ran
+                //   mockforge bench --use-k6 --targets-file vs_list3.json \
+                //     --conformance-basic-auth user:pass ...
+                // and the credentials never reached the wire (absent from both
+                // his PCAP and his proxy). Round 47 taught `parse_headers()` to
+                // fold these auth shortcuts into the shared header map so the
+                // same flags work for plain bench, but THIS clone nulled them
+                // out before `ParallelExecutor` ever called `parse_headers()`.
+                // Single-target worked; multi-target silently sent nothing.
+                //
+                // These three must survive the clone or the fold has nothing to
+                // fold. `conformance_api_key` is still conformance-only by
+                // design (see parse_headers), but is preserved so multi-target
+                // emits the same "only fires under --conformance" warning as
+                // single-target rather than swallowing the flag.
+                conformance_api_key: self.conformance_api_key.clone(),
+                conformance_basic_auth: self.conformance_basic_auth.clone(),
                 conformance_report: PathBuf::from("conformance-report.json"),
                 conformance_categories: None,
                 conformance_report_format: "json".to_string(),
-                conformance_headers: vec![],
+                // Also carries round 46's `--auth-bearer`, which CLI dispatch
+                // injects here as `Authorization: Bearer ...`. Dropping it had
+                // the same effect as dropping --conformance-basic-auth.
+                conformance_headers: self.conformance_headers.clone(),
                 conformance_all_operations: false,
                 conformance_custom: None,
                 conformance_delay_ms: 0,
@@ -4247,6 +4265,57 @@ mod tests {
             Some(&"session=abc; expires=Thu, 01 Jan 2099 00:00:00 GMT".to_string())
         );
         assert_eq!(headers.get("X-Trace"), Some(&"1".to_string()));
+    }
+
+    /// Round 64 (#79). `execute_multi_target` hand-copies `BenchCommand` field
+    /// by field into the command it hands `ParallelExecutor`. It nulled the
+    /// conformance auth shortcuts, so `parse_headers()` — which has folded them
+    /// into the shared header map since round 47 — had nothing left to fold.
+    /// Single-target sent `Authorization`; multi-target silently sent nothing,
+    /// which is what Srikanth saw on 0.3.210: credentials absent from both his
+    /// PCAP and his proxy.
+    ///
+    /// A behavioural test cannot reach that clone (`execute_multi_target` is
+    /// async, parses a targets file and shells out to k6), so this guards the
+    /// source: every field `parse_headers()` reads must survive the clone.
+    /// Field-by-field struct literals silently drop things; this makes the drop
+    /// a test failure instead of an empty Authorization header.
+    #[test]
+    fn multi_target_clone_preserves_fields_parse_headers_reads() {
+        let src = include_str!("command.rs");
+
+        let fn_start = src
+            .find("async fn execute_multi_target(")
+            .expect("execute_multi_target should exist");
+        let block_start = src[fn_start..]
+            .find("ParallelExecutor::new(")
+            .map(|i| i + fn_start)
+            .expect("multi-target path should build a ParallelExecutor");
+        // The BenchCommand literal ends at the executor call's closing paren.
+        let block_end = src[block_start..]
+            .find("\n        );")
+            .map(|i| i + block_start)
+            .expect("ParallelExecutor::new(..) should be closed");
+        let block = &src[block_start..block_end];
+
+        // Read straight out of parse_headers' doc/body contract: these are the
+        // auth-bearing inputs it folds. Keep in sync if that fold grows.
+        for field in ["conformance_basic_auth", "conformance_headers"] {
+            for zeroed in [format!("{field}: None"), format!("{field}: vec![]")] {
+                assert!(
+                    !block.contains(&zeroed),
+                    "execute_multi_target zeroes `{zeroed}`. parse_headers() folds `{field}` \
+                     into the header map, so zeroing it here strips auth from every \
+                     multi-target run while single-target keeps working (#79 round 64)."
+                );
+            }
+            let passthrough = format!("{field}: self.{field}.clone()");
+            assert!(
+                block.contains(&passthrough),
+                "execute_multi_target must carry `{field}` through as `{passthrough}` so \
+                 parse_headers() can fold it (#79 round 64)."
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Report (#79, round 64)

Srikanth on 0.3.210:

```
mockforge bench --spec googleapis_apigee_oas.yaml -d 10 --vus 10 \
  --no-abort-on-error --max-concurrency 15 --rps 100 --insecure --use-k6 \
  --conformance-basic-auth username:password --validate-requests \
  --export-requests --targets-file vs_list3.json
```

No credentials on the wire: absent from his PCAP and from his proxy's view of the request headers.

## Cause

Both halves of the plumbing were already right:

- Round 47 (#906) taught `parse_headers()` to fold `--conformance-basic-auth` (and `--conformance-headers`, where round 46's `--auth-bearer` lands) into the shared header map, so the same flags work for a plain load run without `--conformance`.
- `ParallelExecutor` calls `base_command.parse_headers()`, and `K6ScriptGenerator::build_headers_json` merges `custom_headers` into every endpoint's header map.

The break is *between* them. `execute_multi_target` hand-copies `BenchCommand` field by field into the command it hands the executor, and set:

```rust
conformance_api_key: None,
conformance_basic_auth: None,
conformance_headers: vec![],
```

The fields were nulled **before** `parse_headers()` ever ran, so the round-47 fold had nothing to fold. `--targets-file` runs went out unauthenticated while the identical single-target invocation worked — exactly the asymmetry reported.

## Fix

Carry the three fields through the clone. `conformance_api_key` remains conformance-only in behaviour (by design, see `parse_headers`), but is preserved so multi-target emits the same *"only fires under --conformance"* warning instead of swallowing the flag.

## Real-binary verification

Two targets, same command, before and after:

| | `grep -c Authorization` per target |
|---|---|
| before | `0`, `0` |
| after | `3`, `3` |

```
"Authorization":"Basic dXNlcm5hbWU6cGFzc3dvcmQ="
$ base64 -d  ->  username:password
```

## Drift guard

Fixing the two lines is not enough on its own — field-by-field struct literals drop fields silently, and this clone is exactly where these flags were lost. The added test asserts that every field `parse_headers()` folds survives the clone, and fails with a message naming the consequence:

```
execute_multi_target zeroes `conformance_basic_auth: None`. parse_headers() folds
`conformance_basic_auth` into the header map, so zeroing it here strips auth from
every multi-target run while single-target keeps working (#79 round 64).
```

Negative-tested: reverting either line turns it red.

## Also worth knowing

The same clone still drops `--validate-requests` and `--export-requests`, which Srikanth also passed. `ParallelExecutor` never reads them, so multi-target simply does not implement those two features — they are ignored rather than mis-wired. Left out of this fix deliberately (it is a feature gap, not a regression), and called out in the issue reply so he is not waiting on output that will not appear.