### PR TITLE
fix(bench): clear the unused_qualifications that red every PR's Test job

### DIFF
--- a/crates/mockforge-bench/src/conformance/request_validator.rs
+++ b/crates/mockforge-bench/src/conformance/request_validator.rs
@@ -946,7 +946,7 @@ pub async fn validate_emitted_requests_with_base_path(
         // and non-string type mismatches are all caught.
         let body_str = req.get("body").and_then(|v| v.as_str()).unwrap_or("");
         if !body_str.is_empty() {
-            if let Ok(body_json) = serde_json::from_str::<serde_json::Value>(body_str) {
+            if let Ok(body_json) = serde_json::from_str::<Value>(body_str) {
                 validate_emitted_body(
                     &check,
                     &method,
@@ -1071,8 +1071,7 @@ fn group_violations_by_probe(flat: &[serde_json::Value]) -> serde_json::Value {
     use serde_json::{Map, Value};
 
     let mut by_probe_order: Vec<(String, String, String)> = Vec::new();
-    let mut by_probe: std::collections::HashMap<(String, String, String), Vec<(String, String)>> =
-        std::collections::HashMap::new();
+    let mut by_probe: HashMap<(String, String, String), Vec<(String, String)>> = HashMap::new();
 
     // Round 50 (#79) — Srikanth on 0.3.194: "I see same violation is
     // getting printed in logs for 22 times" on a multi-iteration run.
@@ -1148,10 +1147,8 @@ fn group_violations_by_request(flat: &[serde_json::Value]) -> serde_json::Value 
     use serde_json::{Map, Value};
 
     let mut order: Vec<(String, String)> = Vec::new();
-    let mut checks_by_key: std::collections::HashMap<(String, String), Vec<String>> =
-        std::collections::HashMap::new();
-    let mut viols_by_key: std::collections::HashMap<(String, String), Vec<(String, String)>> =
-        std::collections::HashMap::new();
+    let mut checks_by_key: HashMap<(String, String), Vec<String>> = HashMap::new();
+    let mut viols_by_key: HashMap<(String, String), Vec<(String, String)>> = HashMap::new();
     // Per-(method,path) dedup sets so a check fired across 22 iterations,
     // or the same (vt,msg) surfaced by several checks, is counted once.
     let mut seen_check: std::collections::HashSet<(String, String, String)> =


### PR DESCRIPTION
Second instance of the same failure as #969, in a different crate.

`Test (1.96.0)` in `ci.yml` runs clippy with `-D unused_qualifications` across the workspace, so these seven errors in one file abort the step and fail the whole job on **every** pull request that compiles `mockforge-bench`:

```
crates/mockforge-bench/src/conformance/request_validator.rs:949
                                                            :1074 :1075
                                                            :1151 :1152 :1153 :1154
```

All are redundant prefixes on names the file already imports: `HashMap` (imported at line 11) written as `std::collections::HashMap`, and `serde_json::Value` as the turbofish of `serde_json::from_str`.

Applied via `cargo clippy --fix`, so the edits are clippy's own suggestions rather than hand-transcribed. No behaviour change.

## Verified

- clippy clean for the crate under both `-D clippy::correctness` and `-D unused_qualifications`
- `cargo fmt --all --check` clean
- full `mockforge-bench` lib suite: 522 tests pass

## Why bother

A check that is red on every PR regardless of content is a check nobody reads. The stale doctest fixed in #964 sat unnoticed for two months inside this same job for exactly that reason.