### PR TITLE
fix(registry-core): audit IP const broke the default-feature build

### DIFF
--- a/crates/mockforge-registry-core/src/models/audit_log.rs
+++ b/crates/mockforge-registry-core/src/models/audit_log.rs
@@ -347,10 +347,6 @@ struct AuditChainRow {
 
 #[cfg(feature = "postgres")]
 impl AuditLog {
-    /// Maximum length of the `audit_logs.ip_address` column (`varchar(45)`),
-    /// sized for a full-length IPv6 literal.
-    const IP_ADDRESS_MAX_CHARS: usize = 45;
-
     /// Create a new audit log entry, extending the org's tamper-evident hash
     /// chain (#872).
     ///
@@ -564,6 +560,16 @@ impl AuditLog {
     }
 }
 
+/// Maximum length of the `audit_logs.ip_address` column (`varchar(45)`), sized
+/// for a full-length IPv6 literal.
+///
+/// Module-level and deliberately NOT inside the `#[cfg(feature = "postgres")]`
+/// `impl AuditLog`: `normalize_client_ip` below is ungated (its tests run
+/// without the postgres feature), so a gated associated const would leave this
+/// crate uncompilable for default-feature consumers — which is precisely the
+/// build `cargo install mockforge-cli` performs.
+const IP_ADDRESS_MAX_CHARS: usize = 45;
+
 /// Reduce a client-IP header value to something the `ip_address` column can
 /// actually hold.
 ///
@@ -592,7 +598,7 @@ fn normalize_client_ip(ip: Option<&str>) -> Option<String> {
     if first.is_empty() {
         return None;
     }
-    Some(first.chars().take(AuditLog::IP_ADDRESS_MAX_CHARS).collect())
+    Some(first.chars().take(IP_ADDRESS_MAX_CHARS).collect())
 }
 
 /// Helper function to record audit events from request context
@@ -638,7 +644,7 @@ mod tests {
         let chain = "203.0.113.7, 198.51.100.22, 2001:db8:85a3:8d3:1319:8a2e:370:7348, 10.0.0.1";
         let got = normalize_client_ip(Some(chain)).expect("should keep the client hop");
         assert_eq!(got, "203.0.113.7");
-        assert!(chain.chars().count() > AuditLog::IP_ADDRESS_MAX_CHARS, "fixture must overflow");
+        assert!(chain.chars().count() > IP_ADDRESS_MAX_CHARS, "fixture must overflow");
     }
 
     #[test]
@@ -647,7 +653,7 @@ mod tests {
         // stored rather than costing us the audit record.
         let long = "x".repeat(300);
         let got = normalize_client_ip(Some(&long)).expect("should truncate, not drop");
-        assert_eq!(got.chars().count(), AuditLog::IP_ADDRESS_MAX_CHARS);
+        assert_eq!(got.chars().count(), IP_ADDRESS_MAX_CHARS);
     }
 
     #[test]
@@ -663,7 +669,7 @@ mod tests {
         assert_eq!(normalize_client_ip(Some("198.51.100.4")).as_deref(), Some("198.51.100.4"));
         let v6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
         assert_eq!(normalize_client_ip(Some(v6)).as_deref(), Some(v6));
-        assert!(v6.chars().count() <= AuditLog::IP_ADDRESS_MAX_CHARS);
+        assert!(v6.chars().count() <= IP_ADDRESS_MAX_CHARS);
     }
 
     /// Every variant must round-trip through as_str → from_str. A new variant


### PR DESCRIPTION
## Main does not currently build for `cargo install`

```
error[E0599]: no associated function or constant named `IP_ADDRESS_MAX_CHARS`
              found for struct `AuditLog` in the current scope
  --> crates/mockforge-registry-core/src/models/audit_log.rs
```

Introduced by #967. `IP_ADDRESS_MAX_CHARS` was declared as an associated const inside `impl AuditLog`, which carries `#[cfg(feature = "postgres")]`. But `normalize_client_ip` — and its unit tests — are deliberately **ungated**, since string truncation has nothing to do with the database driver. Without the postgres feature the const vanishes while its callers remain, so the crate stops compiling for every default-feature consumer.

## Why CI didn't catch it

| gate | covers this? |
|---|---|
| `Test (1.96.0)` | no — runs `--all-features` |
| Registry E2E | no — registry server always builds with `postgres` |
| `scripts/smoke-test-install.sh` (release job) | **yes** — but hasn't run since v0.3.206 |

The release job has been dying earlier, at `Run tests`, on the stale doctest fixed in #964. So the one gate that reproduces the consumer build has been dark for six weeks. This would have surfaced either as a failed v0.3.212 release or, if the smoke step were skipped, as a broken `cargo install mockforge-cli` in users' hands — the v0.3.142 failure mode, which cost 18 yanks.

Found while cutting v0.3.212, before tagging.

## Fix

Move the const to module level, ungated, with a comment recording why it must not go back inside the gated `impl`.

## Verified in both configurations

```
cargo check -p mockforge-cli --bin mockforge               (no postgres) -> ok
cargo test -p mockforge-registry-core --features postgres  -> 7 passed
cargo test -p mockforge-registry-core                      -> 4 passed
```