### PR TITLE
fix(ci): RLS gate collided with itself across concurrent runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ crates/mockforge-collab/*.db-wal
 /mockforge-analytics.db-shm
 /mockforge-analytics.db-wal
 /rls-gate-registry-server.pid
+/.rls-gate-state
 # Generated benchmark results
 bench-results/
 # Analytics SQLite databases (generated at runtime)

--- a/docker-compose.rls-gate.yml
+++ b/docker-compose.rls-gate.yml
@@ -24,13 +24,19 @@
 # deliberately left untouched so this change cannot regress the job that gates
 # every PR.
 #
-# Ports are still overridable (PG_PORT / MINIO_PORT) for anyone running two
-# gates at once locally.
+# There are deliberately NO `container_name:` entries. A fixed container name is
+# global to the docker daemon, so it defeats compose's project-name isolation and
+# two runs of THIS job collide on it — the host runs several runners side by
+# side. That showed up as `Error response from daemon: No such container: <id>`
+# when one run's teardown raced the other's `up`. Names are left to compose so
+# COMPOSE_PROJECT_NAME keeps concurrent runs apart; the script sets a unique one.
+#
+# Ports default to free ephemeral ports picked at runtime (see the script) and
+# stay overridable via PG_PORT / MINIO_PORT for local use.
 
 services:
   db:
     image: postgres:15-alpine
-    container_name: mockforge-rls-gate-db
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
@@ -47,7 +53,6 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2024-10-13T13-34-11Z
-    container_name: mockforge-rls-gate-minio
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -65,7 +70,6 @@ services:
 
   minio-init:
     image: minio/mc:RELEASE.2024-10-08T09-37-26Z
-    container_name: mockforge-rls-gate-minio-init
     depends_on:
       minio:
         condition: service_healthy

--- a/scripts/rls-e2e-gate.sh
+++ b/scripts/rls-e2e-gate.sh
@@ -55,9 +55,42 @@ cd "$REPO_ROOT" >/dev/null
 # "failed to bind host port 0.0.0.0:55432/tcp: address already in use").
 # See docker-compose.rls-gate.yml.
 COMPOSE_FILE_GATE="${COMPOSE_FILE_GATE:-docker-compose.rls-gate.yml}"
-PG_PORT="${PG_PORT:-55434}"
-MINIO_PORT="${MINIO_PORT:-59010}"
-REGISTRY_PORT="${REGISTRY_PORT:-58090}"
+
+# Keep concurrent runs of THIS job apart. The CI host runs several runners side
+# by side, so two PRs can be in this script at the same moment. Anything global
+# to the docker daemon (a fixed container name) or to the host (a fixed port) is
+# a collision waiting to happen — the first version of this gate used both and
+# knocked over a run with `No such container` when one teardown raced another's
+# `up`.
+# Ports are ephemeral, so `up` must hand them to the later `test` / `down`
+# invocations — otherwise each process picks different ones and `test` looks for
+# a server that isn't there. `up`/`all` allocate fresh and write this file;
+# every other subcommand reads it.
+STATE_FILE="${STATE_FILE:-$REPO_ROOT/.rls-gate-state}"
+__SUBCMD="${1:-all}"
+if [ "$__SUBCMD" != "up" ] && [ "$__SUBCMD" != "all" ] && [ -f "$STATE_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$STATE_FILE"
+fi
+
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-rlsgate-$$-${RUNNER_NAME:-local}}"
+
+# Free ephemeral ports, chosen now, rather than fixed ones. Explicit
+# PG_PORT/MINIO_PORT/REGISTRY_PORT still win so a local run can pin them.
+pick_free_port() {
+  python3 - <<'PYPORT'
+import socket
+s = socket.socket()
+s.bind(('', 0))
+print(s.getsockname()[1])
+s.close()
+PYPORT
+}
+PG_PORT="${PG_PORT:-$(pick_free_port)}"
+MINIO_PORT="${MINIO_PORT:-$(pick_free_port)}"
+MINIO_CONSOLE_PORT="${MINIO_CONSOLE_PORT:-$(pick_free_port)}"
+REGISTRY_PORT="${REGISTRY_PORT:-$(pick_free_port)}"
+export PG_PORT MINIO_PORT MINIO_CONSOLE_PORT
 
 PG_SUPERUSER="postgres"
 PG_SUPERPASS="password"
@@ -122,26 +155,44 @@ require_tools() {
   [ ${#missing[@]} -eq 0 ] || die "missing required tools: ${missing[*]}"
 }
 
+# Health of a compose SERVICE, resolved through the project rather than a fixed
+# container name.
+svc_health() {
+  local cid
+  cid="$(docker compose -f "$COMPOSE_FILE_GATE" ps -q "$1" 2>/dev/null | head -1)"
+  [ -n "$cid" ] || { echo "missing"; return; }
+  docker inspect --format='{{.State.Health.Status}}' "$cid" 2>/dev/null || echo "unknown"
+}
+
+write_state() {
+  cat >"$STATE_FILE" <<EOF
+COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME"
+PG_PORT="$PG_PORT"
+MINIO_PORT="$MINIO_PORT"
+MINIO_CONSOLE_PORT="$MINIO_CONSOLE_PORT"
+REGISTRY_PORT="$REGISTRY_PORT"
+EOF
+}
+
 compose_up() {
   log "Starting Postgres + MinIO ($COMPOSE_FILE_GATE)"
   # Same leftover-state guard as registry-e2e.yml: a killed prior run can hold
   # the fixed host ports.
+  # Scoped to THIS compose project, so it cannot reach a sibling run's stack.
   docker compose -f "$COMPOSE_FILE_GATE" down --remove-orphans --volumes >/dev/null 2>&1 || true
-  docker ps -aq --filter "name=mockforge-rls-gate" | xargs -r docker rm -f >/dev/null 2>&1 || true
   docker compose -f "$COMPOSE_FILE_GATE" up -d
 
   local i
   for i in $(seq 1 60); do
-    if docker inspect --format='{{.State.Health.Status}}' mockforge-rls-gate-db 2>/dev/null | grep -q healthy; then
+    if [ "$(svc_health db)" = "healthy" ]; then
       break
     fi
     sleep 1
   done
-  docker inspect --format='{{.State.Health.Status}}' mockforge-rls-gate-db 2>/dev/null | grep -q healthy \
-    || die "postgres never became healthy"
+  [ "$(svc_health db)" = "healthy" ] || die "postgres never became healthy"
 
   for i in $(seq 1 60); do
-    if docker inspect --format='{{.State.Health.Status}}' mockforge-rls-gate-minio 2>/dev/null | grep -q healthy; then
+    if [ "$(svc_health minio)" = "healthy" ]; then
       break
     fi
     sleep 1
@@ -159,8 +210,10 @@ stop_server() {
     kill "$(cat "$SERVER_PID_FILE")" 2>/dev/null || true
     rm -f "$SERVER_PID_FILE"
   fi
+  # Deliberately NOT a blanket `pkill -f mockforge-registry-server`: that would
+  # kill the server belonging to a concurrent run of this same gate. The recorded
+  # pid plus our (now unique) port are enough.
   fuser -k "${REGISTRY_PORT}/tcp" 2>/dev/null || true
-  pkill -f 'debug/mockforge-registry-server' 2>/dev/null || true
   sleep 1
 }
 
@@ -250,6 +303,7 @@ verify_gate_armed() {
 
 cmd_up() {
   require_tools
+  write_state
   compose_up
   build_server
 
@@ -345,6 +399,7 @@ cmd_down() {
   log "Tearing down"
   stop_server
   docker compose -f "$COMPOSE_FILE_GATE" down -v >/dev/null 2>&1 || true
+  rm -f "$STATE_FILE"
   echo "done"
 }
 


### PR DESCRIPTION
## Symptom

The first time this job actually ran in CI (it had been skipped while the base Registry E2E was failing), it died before starting anything:

```
==> Starting Postgres + MinIO (docker-compose.rls-gate.yml)
Error response from daemon: No such container: ce7c189bd60d...
```

## Cause

Giving the gate its own compose file separated it from the required Registry E2E job, but not from **itself**. The CI host runs several runners side by side, so two PRs can be inside this script at the same moment — and both a fixed `container_name` and a fixed host port are global to the daemon/host. One run's teardown raced the other's `up`.

## Fix — remove every globally-unique resource

1. **Dropped all `container_name:` entries.** A fixed name is daemon-global and defeats compose's own project isolation. Names are now generated, with `COMPOSE_PROJECT_NAME` unique per pid + runner. Health checks resolve containers via `docker compose ps -q <service>` rather than a hardcoded name.
2. **Ephemeral ports** picked at runtime instead of fixed 55434 / 59010 / 58090. Explicit `PG_PORT` / `MINIO_PORT` / `REGISTRY_PORT` still win for local pinning.
3. **Removed the blanket `pkill -f debug/mockforge-registry-server`** from teardown — with concurrent runs that killed a *sibling* run's server. The recorded pid plus our now-unique port are enough.

## One thing that fell out of it

Ephemeral ports broke the `up` → `test` → `down` dev loop: each invocation is a separate process, so they picked different ports and `test` reported *"no registry-server on :38955"* against a stack listening on :39913. `up`/`all` now write the chosen ports to a gitignored `.rls-gate-state`; the other subcommands read it, and `down` removes it.

## Verified

Locally, end to end on ephemeral ports, across **separate** up/test/down invocations:

- gate arms correctly: `mockforge_app` is NOBYPASSRLS, 5/5 covered tables ENABLE+FORCE RLS, unbound reads see 0 rows
- all 7 E2E targets pass with RLS active — **21 tests, 0 failures**

## Why bother, given it's advisory

This job is not a required check, so it wasn't blocking merges. But a gate that fails for reasons unrelated to what it guards is one people learn to ignore — which is exactly how the stale doctest in #964 survived two months inside an already-red job.