### PR TITLE
fix(deps): ignore RUSTSEC-2026-0235 (rkyv) with justification

### DIFF
--- a/audit.toml
+++ b/audit.toml
@@ -63,4 +63,28 @@ ignore = [
     { id = "RUSTSEC-2026-0098", reason = "rustls-webpki URI name constraints — pinned by transitive deps across 3 rustls majors" },
     { id = "RUSTSEC-2026-0099", reason = "rustls-webpki wildcard name constraints — pinned by transitive deps across 3 rustls majors" },
     { id = "RUSTSEC-2026-0104", reason = "rustls-webpki CRL parsing panic — pinned by transitive deps across 3 rustls majors" },
+
+    # rkyv 0.7.46, reached only as an UNENABLED optional feature of
+    # rust_decimal. This one is not reachable in anything we build, and
+    # unlike the entries above it is not waiting on an upstream bump —
+    # there is nothing to bump to:
+    #
+    #   * rust_decimal's `rkyv` feature is `["dep:rkyv"]`, pure opt-in. Its
+    #     defaults are ["serde", "std"].
+    #   * We depend on rust_decimal with default features and never enable
+    #     `rkyv`; sqlx-postgres pulls it with default-features = false and
+    #     only ["std"].
+    #   * rust_decimal 1.42.1 is the LATEST release and still requires
+    #     `rkyv ^0.7.46`, so the advisory's ">=0.8.17" has no path here.
+    #
+    # Cargo.lock is feature-agnostic: it records optional dependencies that
+    # no feature selection enables, and cargo-audit scans the lockfile, so
+    # it reports crates that are never compiled. Re-verify with:
+    #
+    #   cargo tree --workspace -e normal | grep -c rkyv     # expect 0
+    #   cargo tree -i rkyv                                  # expect "nothing to print"
+    #
+    # Drop this entry if either of those starts returning rkyv (someone
+    # enabled the feature), or once rust_decimal ships an rkyv 0.8 release.
+    { id = "RUSTSEC-2026-0235", reason = "rkyv OOB read — unenabled optional feature of rust_decimal, absent from the compiled graph (cargo tree -e normal finds 0); rust_decimal 1.42.1 (latest) still pins rkyv ^0.7.46 so there is no version to upgrade to" },
 ]


### PR DESCRIPTION
Security Audit is a required check, so this advisory is currently failing **every** open PR.

```
Crate:    rkyv
Version:  0.7.46
Title:    Insufficient archive validation can cause out-of-bounds reads in
          archives containing Rc/Arc
ID:       RUSTSEC-2026-0235
Solution: Upgrade to >=0.8.17
```

## Why this is an ignore rather than a bump

Unlike the other `audit.toml` entries, this one isn't waiting on an upstream release — there is nothing to bump to, and nothing is affected either way:

- `rust_decimal`'s `rkyv` feature is `["dep:rkyv"]`, pure opt-in. Its defaults are `["serde", "std"]`.
- We depend on `rust_decimal` with default features and never enable `rkyv`. `sqlx-postgres` pulls it with `default-features = false` and only `["std"]`.
- **`rust_decimal 1.42.1` is the latest release and still requires `rkyv ^0.7.46`.** 1.40, 1.41, 1.42.0 and 1.42.1 all pin `^0.7.46`, so the advisory's `>=0.8.17` has no path here. Upgrading `rust_decimal` does not help.

rkyv is never compiled into anything we ship:

```
cargo tree --workspace -e normal | grep -c rkyv   ->  0
cargo tree -i rkyv                                ->  "nothing to print"
```

The report is a lockfile artifact. `Cargo.lock` is feature-agnostic — it records optional dependencies that no feature selection enables — and cargo-audit scans the lockfile, so it flags crates that are never built.

## On writing the reasoning down

Ignoring an advisory is only defensible if the next person can cheaply re-check it, so the entry carries both verification commands and the two conditions that should retire it: someone enabling the feature, or `rust_decimal` shipping an rkyv 0.8 release. "False positive" on its own would not survive review in six months.

## Verified

`scripts/precommit/cargo_audit.py` — the wrapper CI actually runs, which applies this ignore list — exits **0**.