### PR TITLE
fix(deps): RUSTSEC-2026-0258 — bump h2 to 0.4.17, justify the 0.3 holdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -257,7 +257,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1212,7 +1212,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.15",
+ "h2 0.4.17",
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
@@ -2573,7 +2573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4272,7 +4272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5263,7 +5263,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "h2 0.4.15",
+ "h2 0.4.17",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -5561,9 +5561,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6065,7 +6065,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.17",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
@@ -6182,7 +6182,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6597,7 +6597,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9647,7 +9647,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12169,7 +12169,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -12207,9 +12207,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13127,7 +13127,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13264,7 +13264,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14245,7 +14245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15378,7 +15378,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15990,7 +15990,7 @@ dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.15",
+ "h2 0.4.17",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -16329,7 +16329,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/audit.toml
+++ b/audit.toml
@@ -86,5 +86,28 @@ ignore = [
     #
     # Drop this entry if either of those starts returning rkyv (someone
     # enabled the feature), or once rust_decimal ships an rkyv 0.8 release.
+    # h2 0.3.27 only. The 0.4.x instance, which is what actually serves HTTP here
+    # (hyper 1.x / axum), IS patched: bumped 0.4.15 -> 0.4.17 in the same change.
+    #
+    # 0.3.27 arrives ONLY through the AWS SDK client path:
+    #   h2 0.3.27 <- aws-smithy-http-client <- aws-smithy-runtime
+    #             <- aws-config / aws-sdk-kms <- mockforge-platform-signing,
+    #                                            mockforge-registry-server
+    #
+    # It is genuinely compiled (unlike the rkyv entry below), so this is a real
+    # ignore rather than a lockfile artifact. Two reasons it is defensible:
+    #
+    #   * There is nothing to upgrade to. 0.3.27 IS the latest 0.3.x; upstream
+    #     patched only the 0.4 line (`patched = [">= 0.4.16"]`), and the AWS
+    #     crates pin `h2 ^0.3.24` behind their legacy hyper-0.14 path.
+    #   * The flaw is queueing unbounded EMPTY DATA FRAMES FROM A PEER. On this
+    #     path we are the CLIENT, and the peer is an AWS KMS/STS endpoint over
+    #     TLS. Exploiting it would require controlling AWS's own responses.
+    #     Advisory is rated LOW severity for this reason.
+    #
+    # Retire this once the AWS SDK drops its hyper-0.14 path (`cargo tree -i
+    # h2@0.3.27` goes empty), or if h2 ever backports to 0.3.x.
+    { id = "RUSTSEC-2026-0258", reason = "h2 0.3.27 empty-DATA-frame DoS (LOW) — client-only via aws-sdk; 0.3.x is unpatched upstream (fix is 0.4.16+, and our 0.4 instance is bumped to 0.4.17)" },
+
     { id = "RUSTSEC-2026-0235", reason = "rkyv OOB read — unenabled optional feature of rust_decimal, absent from the compiled graph (cargo tree -e normal finds 0); rust_decimal 1.42.1 (latest) still pins rkyv ^0.7.46 so there is no version to upgrade to" },
 ]


### PR DESCRIPTION
Security Audit is a required check, so this blocks every open PR. Published 2026-08-17, so it landed mid-flight on the two #79 fixes (#986, #988).

```
Crate:    h2
Title:    h2 unbounded empty DATA frames
ID:       RUSTSEC-2026-0258
Solution: >= 0.4.16
```

Two h2 versions are in the tree and they need different treatment.

## 0.4.15 → 0.4.17 — fixed

This is the instance that actually **serves HTTP** here, via hyper 1.x / axum. Straight patch bump, lockfile only.

## 0.3.27 — ignored, with reasoning

Unlike the rkyv entry added in #982, this one **is** compiled (`cargo tree -e normal` finds it), so it is a real ignore rather than a lockfile artifact. Two things make it defensible:

**Nothing to upgrade to.** 0.3.27 is the latest 0.3.x; upstream patched only the 0.4 line (`patched = [">= 0.4.16"]`). The AWS crates pin `h2 ^0.3.24` behind their legacy hyper-0.14 path, and bumping `aws-smithy-runtime` / `aws-config` / `aws-sdk-kms` does not move it.

**The exposure is inverted from the threat.** The flaw is queueing unbounded empty DATA frames *from a peer*. On this path we are the **client**, and the peer is an AWS KMS/STS endpoint over TLS — exploiting it would mean controlling AWS's own responses. The advisory is rated **LOW** for that reason.

```
h2 0.3.27 <- aws-smithy-http-client <- aws-smithy-runtime
          <- aws-config / aws-sdk-kms <- mockforge-platform-signing,
                                         mockforge-registry-server
```

The entry records its retirement condition: drop it when the AWS SDK sheds its hyper-0.14 path (`cargo tree -i h2@0.3.27` goes empty), or if h2 backports to 0.3.x.

## Verified

- `scripts/precommit/cargo_audit.py` (the wrapper CI runs) exits **0**
- `mockforge-registry-server` builds against 0.4.17