### PR TITLE
chore(release): v0.3.213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.3.213] - 2026-08-20
+
+### Fixed
+
+- **[Contracts]** OpenAPI specs whose operations omit `responses` now load instead of aborting the run (#79 round 65 / Srikanth on 0.3.212). His proxy-generated spec failed outright with `missing field \`responses\``, and the error named no path or method. The spec is genuinely non-conformant (OpenAPI 3.x marks `responses` required, and 63 of its 70 operations omit it), but refusing it is the wrong trade: request generation, load testing and conformance probing all derive from paths, parameters and `requestBody` and never read `responses`, so the missing field costs nothing we use while rejecting the document costs the whole run. Proxies and API-discovery tools emit specs like this routinely, because they observe requests and have nothing to say about responses. A narrow repair pass fills in only the mandatory field, never invents response content, and warns with the count of affected operations and what is lost (response-schema validation has nothing to check for them). Real-binary verified against his attachment: the run now loads and finds all 70 operations.
+
+### Added
+
+- **[Reality]** `--wafbench-dir` now accepts a simple `{title, request, expected}` YAML list in addition to the WAFBench document shape (#987, #79 round 65 / Srikanth). His LLM-generated traffic file was rejected with `invalid type: sequence, expected struct WafBenchFile`, which was accurate about what failed but silent about what would have worked. The WAFBench shape exists to carry CRS rule IDs and provenance that a generated file has no reason to contain. The simple form maps 1:1 onto the internal representation (`body` becomes `data`, titles are synthesised when absent), so the rest of the security-test pipeline is untouched. `expected` accepts `403`, `[403, 406]`, or `{status: ...}`, and an unparsable expectation yields no status rather than dropping the case, since the request is still valid traffic. When both shapes fail, the error now names both with the parse error for each. Real-binary verified against his unmodified file: 8 cases, 24 payloads.
+
+### Security
+
+- **[Security]** RUSTSEC-2026-0258 (`h2` unbounded empty DATA frames): bumped `h2` 0.4.15 to 0.4.17, which is the instance that serves HTTP here via hyper 1.x / axum. The remaining `h2` 0.3.27 is reached only through the AWS SDK client path and is ignored with reasoning recorded in `audit.toml`: 0.3.27 is the latest 0.3.x and upstream patched only the 0.4 line, and the flaw concerns queueing empty frames from a peer, where on that path we are the client talking to AWS KMS/STS over TLS. Advisory is rated low severity.
+
 ## [0.3.212] - 2026-08-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7708,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ai-core"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7725,7 +7725,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-amqp"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7748,7 +7748,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-analytics"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7770,7 +7770,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-behavioral-cloning"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-bench"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-ml"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-orchestration"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-chaos-proxy"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "axum 0.8.9",
  "mockforge-bench",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-cli"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-collab"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-config"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-contracts"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-core"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-data"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-desktop"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-federation"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-foundation"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ftp"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-graphql"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-grpc"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-http"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-import"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-integration-tests"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-intelligence"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-k8s-operator"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-kafka"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-mqtt"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-observability"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-openapi"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-performance"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-pipelines"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-platform-signing"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-cli"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-core"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-egress"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-host"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-loader"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-registry"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-response-graphql"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-plugin-sdk"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-proxy"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-recorder"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8978,7 +8978,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-core"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-registry-server"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-reporting"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-route-chaos"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-runtime-daemon"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-scenarios"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-sdk"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-security-core"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-smtp"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tcp"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9294,14 +9294,14 @@ dependencies = [
 
 [[package]]
 name = "mockforge-template-expansion"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mockforge-test"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-integration-examples"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "mockforge-test",
  "tokio",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-test-runner"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tracing"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tui"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-tunnel"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ui"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-vbr"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-workspace"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "globwalk",
  "mockforge-core",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-world-state"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "mockforge-ws"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -15441,7 +15441,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-openapi"
-version = "0.3.212"
+version = "0.3.213"
 dependencies = [
  "mockforge-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ resolver = "2"
 
 # Workspace-wide package metadata
 [workspace.package]
-version = "0.3.212"
+version = "0.3.213"
 edition = "2021"
 authors = ["SaaSy Solutions LLC <ray.clanan@saasysolutionsllc.com>"]
 license = "MIT OR Apache-2.0"

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -1,5 +1,28 @@
 > This reference page mirrors the root changelog in [`CHANGELOG.md`](../../../CHANGELOG.md) so the book and repository stay aligned.
 
+## [0.3.213] - 2026-08-20
+
+### Fixed
+
+- **[Contracts]** OpenAPI specs whose operations omit `responses` now load instead of aborting the run (#79 round 65 / Srikanth on 0.3.212). His proxy-generated spec failed outright with `missing field \`responses\``, and the error named no path or method. The spec is genuinely non-conformant (OpenAPI 3.x marks `responses` required, and 63 of its 70 operations omit it), but refusing it is the wrong trade: request generation, load testing and conformance probing all derive from paths, parameters and `requestBody` and never read `responses`, so the missing field costs nothing we use while rejecting the document costs the whole run. Proxies and API-discovery tools emit specs like this routinely, because they observe requests and have nothing to say about responses. A narrow repair pass fills in only the mandatory field, never invents response content, and warns with the count of affected operations and what is lost (response-schema validation has nothing to check for them). Real-binary verified against his attachment: the run now loads and finds all 70 operations.
+
+### Added
+
+- **[Reality]** `--wafbench-dir` now accepts a simple `{title, request, expected}` YAML list in addition to the WAFBench document shape (#987, #79 round 65 / Srikanth). His LLM-generated traffic file was rejected with `invalid type: sequence, expected struct WafBenchFile`, which was accurate about what failed but silent about what would have worked. The WAFBench shape exists to carry CRS rule IDs and provenance that a generated file has no reason to contain. The simple form maps 1:1 onto the internal representation (`body` becomes `data`, titles are synthesised when absent), so the rest of the security-test pipeline is untouched. `expected` accepts `403`, `[403, 406]`, or `{status: ...}`, and an unparsable expectation yields no status rather than dropping the case, since the request is still valid traffic. When both shapes fail, the error now names both with the parse error for each. Real-binary verified against his unmodified file: 8 cases, 24 payloads.
+
+### Security
+
+- **[Security]** RUSTSEC-2026-0258 (`h2` unbounded empty DATA frames): bumped `h2` 0.4.15 to 0.4.17, which is the instance that serves HTTP here via hyper 1.x / axum. The remaining `h2` 0.3.27 is reached only through the AWS SDK client path and is ignored with reasoning recorded in `audit.toml`: 0.3.27 is the latest 0.3.x and upstream patched only the 0.4 line, and the flaw concerns queueing empty frames from a peer, where on that path we are the client talking to AWS KMS/STS over TLS. Advisory is rated low severity.
+
+## [0.3.212] - 2026-08-03
+
+### Fixed
+
+- **[Reality]** `--conformance-basic-auth` (and `--conformance-headers`, where `--auth-bearer` lands) now reach the wire on multi-target runs (#79 round 64 / Srikanth on 0.3.210). His `mockforge bench --use-k6 --targets-file vs_list3.json --conformance-basic-auth user:pass ...` sent no credentials at all, absent from both his PCAP and his proxy, while the identical single-target invocation worked. Round 47 taught `parse_headers()` to fold those auth shortcuts into the shared header map so the same flags work for a plain load run without `--conformance`, and both ends of the chain were already correct (`ParallelExecutor` calls `parse_headers()`; the k6 generator merges `custom_headers` into every endpoint). The break was between them: `execute_multi_target` hand-copies `BenchCommand` field by field and set `conformance_basic_auth: None` / `conformance_headers: vec![]`, nulling the fields *before* `parse_headers()` ran, so the fold had nothing to fold. Real-binary verified across two targets: `grep -c Authorization` on the generated k6 scripts goes 0,0 to 3,3, carrying `Basic dXNlcm5hbWU6cGFzc3dvcmQ=`. Adds a drift guard asserting every field `parse_headers()` folds survives that clone, because field-by-field struct literals drop fields silently. Note that `--validate-requests` and `--export-requests` are conformance-run features (read only inside `execute_conformance_test`); they no-op on a plain load run in single- and multi-target alike, and need `--conformance`.
+- **[Security]** RUSTSEC-2026-0222: `wasmtime` 36.0.12 to 36.0.13, reached via `wasmtime-wasi` -> `wiggle` -> `mockforge-plugin-loader`. Lockfile only, a patch bump inside the existing 36.x line.
+- **[Contracts]** `mockforge-registry-core` no longer fails to compile for default-feature consumers. An associated const added in 0.3.211's audit fix sat inside a `#[cfg(feature = "postgres")]` impl while its ungated caller and tests still referenced it, so `cargo install mockforge-cli` could not build. Nothing in CI covered that combination: the workspace test job runs `--all-features` and the registry server always builds with `postgres`. Moved to a module-level const.
+- **[Contracts]** Repaired the release pipeline itself. A stale doctest in `mockforge-intelligence` (broken since May) was failing `cargo test --workspace --release` in the Create Release job, which skipped everything after it, including the GitHub Release **and** the Fly deploy, which has `needs: release`. Production had therefore been serving 0.3.183 since 2026-06-19. Also aligned every Dockerfile builder with `rust-toolchain.toml` (1.75/1.90/1.91 to 1.96) after `aws-smithy-types` raised its MSRV past the pinned builder and broke container builds outright, and cleared the `unused_qualifications` errors that were reddening the Test job on every PR regardless of content.
+
 ## [0.3.211] - 2026-07-27
 
 ### Fixed


### PR DESCRIPTION
Release for **#79 round 65** (both of Srikanth's items) plus a security bump.

| | |
|---|---|
| **#986** | OpenAPI specs whose operations omit `responses` now load instead of aborting. His proxy-generated spec (63 of 70 operations affected) runs. |
| **#988** | `--wafbench-dir` accepts a simple `{title, request, expected}` YAML list. His unmodified LLM-generated file loads: 8 cases, 24 payloads. |
| **#989** | RUSTSEC-2026-0258: `h2` 0.4.15 → 0.4.17. The 0.3.27 holdout is client-only via the AWS SDK and justified in `audit.toml`. |

## Pre-flight

- `scripts/check-publish-drift.sh` — every publishable member is in the publish list
- `cargo check -p mockforge-cli --bin mockforge` — the default-feature consumer build that broke in #976 is clean
- workspace and `Cargo.lock` both at 0.3.213; crates.io max is 0.3.212, so no partial-publish state
- **both of his real attachments re-verified against a build from this main** before tagging

After the release lands I will install from crates.io and run both files through the published binary before replying on #79. A local build passing is not the same claim.