### PR TITLE
fix(bench): verbatim mode no longer appends attack payloads or sends unfalsifiable baselines (#997)

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -515,6 +515,28 @@ fn expand_cidr(
 }
 
 impl BenchCommand {
+    /// Whether the k6 script should carry the security payload-injection layer.
+    ///
+    /// This is the ONLY place the answer is computed. It used to be spelled out
+    /// at four separate call sites, which is the #79 drift shape: the template
+    /// gates `{{#if security_testing_enabled}}` on it, so any site that
+    /// disagreed with another produced either dead code or a call to an
+    /// undefined function.
+    ///
+    /// #997: `--wafbench-verbatim` turns it OFF. In verbatim mode
+    /// `--wafbench-dir` supplies the REQUESTS, not a payload pool, so treating
+    /// it as a pool made the injector append `&test=<payload>` to requests the
+    /// user asked to be sent exactly as written. That corrupted the very cases
+    /// under test and, worse, appended attack payloads to `expected: 200` cases,
+    /// so a correctly-behaving WAF would block them and the run would report a
+    /// failure the user did not write.
+    pub fn security_testing_enabled(&self) -> bool {
+        if self.wafbench_verbatim {
+            return false;
+        }
+        self.security_test || self.wafbench_dir.is_some()
+    }
+
     /// Load and merge specs from --spec files and --spec-dir
     pub async fn load_and_merge_specs(&self) -> Result<OpenApiSpec> {
         let mut all_specs: Vec<(PathBuf, OpenApiSpec)> = Vec::new();
@@ -674,9 +696,27 @@ impl BenchCommand {
             return self.execute_conformance_test().await;
         }
 
-        // Load and parse spec(s)
-        TerminalReporter::print_progress("Loading OpenAPI specification(s)...");
-        let merged_spec = self.load_and_merge_specs().await?;
+        // Load and parse spec(s).
+        //
+        // #997: verbatim mode derives every request from the traffic file, so a
+        // spec supplies nothing. Requiring one anyway forced users to pass an
+        // unrelated file just to satisfy the check. It stays OPTIONAL rather
+        // than ignored: a spec is still honoured for --base-path resolution.
+        let spec_supplied = !self.spec.is_empty() || self.spec_dir.is_some();
+        let merged_spec = if self.wafbench_verbatim && !spec_supplied {
+            tracing::info!(
+                target: "mockforge::bench",
+                "--wafbench-verbatim without --spec: sending only the traffic file's requests"
+            );
+            OpenApiSpec {
+                spec: Default::default(),
+                file_path: None,
+                raw_document: None,
+            }
+        } else {
+            TerminalReporter::print_progress("Loading OpenAPI specification(s)...");
+            self.load_and_merge_specs().await?
+        };
         let parser = SpecParser::from_spec(merged_spec);
         if self.spec.len() > 1 || self.spec_dir.is_some() {
             TerminalReporter::print_success(&format!(
@@ -724,7 +764,12 @@ impl BenchCommand {
             }
         }
 
-        if operations.is_empty() {
+        // #997: in verbatim mode the spec is optional, so an empty operation set
+        // is expected rather than an error — the traffic file supplies the
+        // requests. Erroring here would make --wafbench-verbatim unusable
+        // without an unrelated spec, which is the thing that check exists to
+        // prevent in every OTHER mode.
+        if operations.is_empty() && !self.wafbench_verbatim {
             return Err(BenchError::Other("No operations found in spec".to_string()));
         }
 
@@ -795,7 +840,7 @@ impl BenchCommand {
         let scenario =
             LoadScenario::from_str(&self.scenario).map_err(BenchError::InvalidScenario)?;
 
-        let security_testing_enabled = self.security_test || self.wafbench_dir.is_some();
+        let security_testing_enabled = self.security_testing_enabled();
 
         // Issue #79 round 6 follow-up — Srikanth reported k6 emitting
         // "Insufficient VUs, reached 5 active VUs and cannot initialize more"
@@ -1629,10 +1674,32 @@ impl BenchCommand {
             ));
         }
 
-        // Add security testing code
-        let security_config = self.build_security_config();
-        let wafbench_payloads = self.load_wafbench_payloads();
-        let security_requested = security_config.is_some() || self.wafbench_dir.is_some();
+        // Add security testing code.
+        //
+        // #997: in verbatim mode nothing may be injected — see
+        // `security_testing_enabled`. Both the payload pool and the
+        // "requested" flag must go quiet together, otherwise the else-branch
+        // below emits a warning about payloads that were never wanted.
+        let verbatim = self.wafbench_verbatim;
+        if verbatim && self.security_test {
+            TerminalReporter::print_warning(
+                "--security-test is ignored under --wafbench-verbatim: verbatim mode sends your \
+                 traffic cases exactly as written and will not append attack payloads to them. \
+                 Drop --wafbench-verbatim if you want payload injection.",
+            );
+        }
+        let security_config = if verbatim {
+            None
+        } else {
+            self.build_security_config()
+        };
+        let wafbench_payloads = if verbatim {
+            Vec::new()
+        } else {
+            self.load_wafbench_payloads()
+        };
+        let security_requested =
+            !verbatim && (security_config.is_some() || self.wafbench_dir.is_some());
 
         if security_config.is_some() || !wafbench_payloads.is_empty() {
             TerminalReporter::print_progress("Adding security testing support...");
@@ -2064,7 +2131,7 @@ impl BenchCommand {
         let required_globals = DynamicParamProcessor::get_required_globals(&all_placeholders);
 
         // Check if security testing is enabled
-        let security_testing_enabled = self.wafbench_dir.is_some() || self.security_test;
+        let security_testing_enabled = self.security_testing_enabled();
 
         let data = serde_json::json!({
             "base_url": self.target,
@@ -2169,7 +2236,7 @@ impl BenchCommand {
         let scenario =
             LoadScenario::from_str(&self.scenario).map_err(BenchError::InvalidScenario)?;
 
-        let security_testing_enabled = self.security_test || self.wafbench_dir.is_some();
+        let security_testing_enabled = self.security_testing_enabled();
 
         let k6_config = K6Config {
             target_url: self.target.clone(),
@@ -2473,7 +2540,7 @@ impl BenchCommand {
         }
 
         // Check if security testing is enabled
-        let security_testing_enabled = self.wafbench_dir.is_some() || self.security_test;
+        let security_testing_enabled = self.security_testing_enabled();
 
         let data = serde_json::json!({
             "base_url": self.target,
@@ -4616,5 +4683,147 @@ mod tests {
         let dir = tempdir().unwrap();
         let extracted = BenchCommand::parse_extracted_values(dir.path()).unwrap();
         assert!(extracted.values.is_empty());
+    }
+
+    /// Full `BenchCommand` literal for tests. Extracted from the existing
+    /// header-parsing test so new tests do not have to restate 80+ fields.
+    fn sample_bench_command() -> BenchCommand {
+        BenchCommand {
+            spec: vec![PathBuf::from("test.yaml")],
+            spec_dir: None,
+            merge_conflicts: "error".to_string(),
+            spec_mode: "merge".to_string(),
+            dependency_config: None,
+            target: "http://localhost".to_string(),
+            base_path: None,
+            duration: "1m".to_string(),
+            vus: 10,
+            scenario: "ramp-up".to_string(),
+            operations: None,
+            exclude_operations: None,
+            auth: None,
+            headers: vec![
+                "X-API-Key:test123".to_string(),
+                "X-Client-ID:client456".to_string(),
+            ],
+            output: PathBuf::from("output"),
+            generate_only: false,
+            script_output: None,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            abort_on_error: true,
+            abort_on_error_rate: 0.95,
+            verbose: false,
+            skip_tls_verify: false,
+            chunked_request_bodies: false,
+            target_rps: None,
+            no_keep_alive: false,
+            targets_file: None,
+            max_concurrency: None,
+            results_format: "both".to_string(),
+            params_file: None,
+            crud_flow: false,
+            flow_config: None,
+            extract_fields: None,
+            parallel_create: None,
+            data_file: None,
+            data_distribution: "unique-per-vu".to_string(),
+            data_mappings: None,
+            per_uri_control: false,
+            error_rate: None,
+            error_types: None,
+            security_test: false,
+            security_payloads: None,
+            security_categories: None,
+            security_target_fields: None,
+            wafbench_dir: None,
+            wafbench_cycle_all: false,
+            wafbench_verbatim: false,
+            owasp_api_top10: false,
+            owasp_categories: None,
+            owasp_auth_header: "Authorization".to_string(),
+            owasp_auth_token: None,
+            owasp_admin_paths: None,
+            owasp_id_fields: None,
+            owasp_report: None,
+            owasp_report_format: "json".to_string(),
+            owasp_iterations: 1,
+            conformance: false,
+            conformance_api_key: None,
+            conformance_basic_auth: None,
+            conformance_report: PathBuf::from("conformance-report.json"),
+            conformance_categories: None,
+            conformance_report_format: "json".to_string(),
+            conformance_headers: vec![],
+            conformance_all_operations: false,
+            conformance_custom: None,
+            conformance_delay_ms: 0,
+            use_k6: false,
+            conformance_custom_filter: None,
+            export_requests: false,
+            validate_requests: false,
+            conformance_self_test: false,
+            conformance_self_test_capture: false,
+            conformance_self_test_iterations: 1,
+            conformance_self_test_duration: None,
+            validate_response_schemas: false,
+            source_ips: Vec::new(),
+            geo_source_ips: Vec::new(),
+            geo_source_headers: Vec::new(),
+            report_missed_cap: None,
+            discard_response_bodies: false,
+            dns_policy: None,
+        }
+    }
+
+    /// #997 regression. `--wafbench-dir` in verbatim mode supplies the REQUESTS,
+    /// not a payload pool. If the payload-injection layer stays on, the k6
+    /// script appends `&test=<payload>` to every request, which (a) mutates the
+    /// cases the user asked to be sent exactly as written and (b) attaches an
+    /// attack payload to `expected: 200` cases, so a correct WAF blocks them and
+    /// the run reports a failure the user never wrote. Verified on the wire
+    /// against a logging listener before this test was written.
+    #[test]
+    fn verbatim_disables_security_payload_injection() {
+        let mut cmd = sample_bench_command();
+        cmd.wafbench_dir = Some("traffic.yaml".to_string());
+
+        assert!(
+            cmd.security_testing_enabled(),
+            "--wafbench-dir alone must still enable payload injection"
+        );
+
+        cmd.wafbench_verbatim = true;
+        assert!(
+            !cmd.security_testing_enabled(),
+            "verbatim mode must not inject payloads into requests sent as written"
+        );
+
+        // Explicitly asking for both is contradictory; verbatim wins and the
+        // command warns rather than silently mutating the traffic.
+        cmd.security_test = true;
+        assert!(
+            !cmd.security_testing_enabled(),
+            "--security-test must not re-enable injection under --wafbench-verbatim"
+        );
+    }
+
+    /// The template gates `{{#if security_testing_enabled}}` on this flag, and
+    /// it was previously recomputed inline at four render sites. Any site that
+    /// disagreed produced dead code or a call to an undefined function -- the
+    /// #79 drift shape. Keep exactly one definition.
+    #[test]
+    fn security_testing_enabled_has_a_single_definition() {
+        let src = include_str!("command.rs");
+        // Assembled at runtime: a literal needle would match itself in this file.
+        let a = format!("self.{} || self.{}.is_some()", "security_test", "wafbench_dir");
+        let b = format!("self.{}.is_some() || self.{}", "wafbench_dir", "security_test");
+        let inline = src.matches(a.as_str()).count() + src.matches(b.as_str()).count();
+        assert_eq!(
+            inline, 1,
+            "expected the security_testing_enabled() method to be the only place this is \
+             computed, found {inline} inline copies -- collapse them or the render paths drift"
+        );
     }
 }

--- a/crates/mockforge-bench/src/wafbench.rs
+++ b/crates/mockforge-bench/src/wafbench.rs
@@ -252,6 +252,13 @@ pub struct SimpleTrafficCase {
     pub request: SimpleTrafficRequest,
     /// Expected status. Accepts `403`, `[403, 406]`, or `{ status: 403 }`.
     pub expected: Option<serde_yaml::Value>,
+    /// WAFBench's baseline marker: send this case with the rule under test
+    /// disabled. mockforge cannot honour it, because disabling a rule is
+    /// WAF-side configuration and not something a traffic generator controls.
+    /// Parsed only so the case can be reported and skipped instead of being
+    /// silently sent as an unfalsifiable duplicate (#997).
+    #[serde(default)]
+    pub omit_rule: Option<bool>,
 }
 
 /// The request half of a [`SimpleTrafficCase`].
@@ -432,9 +439,34 @@ pub fn parse_traffic_file(content: &str, source: &str) -> Result<WafBenchFile> {
         Ok(file) => Ok(file),
         Err(wafbench_err) => match serde_yaml::from_str::<Vec<SimpleTrafficCase>>(content) {
             Ok(cases) => {
+                let parsed = cases.len();
+                let (omitted, cases): (Vec<_>, Vec<_>) =
+                    cases.into_iter().partition(|c| c.omit_rule == Some(true));
+
+                for case in &omitted {
+                    tracing::warn!(
+                        "{source}: skipping `{}` -- it sets `omit_rule: true`, which asks for the \
+                         request to be sent with the rule under test disabled. mockforge sends \
+                         traffic; it cannot toggle your WAF's rules. Sending it anyway would put \
+                         a byte-identical request on the wire as its non-omitted twin while \
+                         asserting the opposite status, so exactly one of the pair would always \
+                         fail regardless of whether the rule works. Run the same file against a \
+                         WAF configuration with that rule disabled to get the baseline.",
+                        case.title.as_deref().unwrap_or("<untitled>")
+                    );
+                }
+
                 tracing::info!(
-                    "{source}: parsed {} case(s) in the simple request/expected format",
-                    cases.len()
+                    "{source}: parsed {parsed} case(s) in the simple request/expected format{}",
+                    if omitted.is_empty() {
+                        String::new()
+                    } else {
+                        format!(
+                            "; {} skipped for `omit_rule: true`, {} will be sent",
+                            omitted.len(),
+                            cases.len()
+                        )
+                    }
                 );
                 Ok(WafBenchFile {
                     meta: WafBenchMeta {
@@ -1794,5 +1826,50 @@ mod verbatim_tests {
     fn verbatim_skips_cases_without_a_uri() {
         let t = load("- title: no uri\n  request:\n    method: GET\n");
         assert!(t.is_empty(), "a case with no uri yields no request");
+    }
+
+    /// #997: a case marked `omit_rule: true` asks for the request to be sent
+    /// with the rule under test disabled. mockforge cannot do that, and sending
+    /// it anyway produces a byte-identical twin of the non-omitted case with the
+    /// opposite expectation, so one of the pair always fails no matter what the
+    /// WAF does. It must be dropped, not silently sent.
+    #[test]
+    fn omit_rule_cases_are_skipped_not_silently_sent() {
+        let yaml = r#"
+- title: unsupported response_type blocked
+  omit_rule: false
+  request:
+    method: GET
+    uri: /oauth/authorize?response_type=totally-unsupported&redirect_uri=https%3A%2F%2Fevil.example%2Flanding
+  expected: 403
+- title: "baseline: same payload with rule omitted"
+  omit_rule: true
+  request:
+    method: GET
+    uri: /oauth/authorize?response_type=totally-unsupported&redirect_uri=https%3A%2F%2Fevil.example%2Flanding
+  expected: 200
+- title: legitimate flow allowed
+  request:
+    method: GET
+    uri: /oauth/authorize?response_type=code&client_id=abc123
+  expected: 200
+"#;
+        let parsed = parse_traffic_file(yaml, "oauth.yaml").expect("simple format should parse");
+
+        let titles: Vec<_> = parsed.tests.iter().map(|t| t.test_title.clone()).collect();
+        assert_eq!(
+            parsed.tests.len(),
+            2,
+            "the omit_rule:true case must be dropped, got {titles:?}"
+        );
+        assert!(
+            !titles.iter().any(|t| t.contains("rule omitted")),
+            "baseline case leaked into the run: {titles:?}"
+        );
+        // omit_rule:false is an ordinary case and must survive.
+        assert!(
+            titles.iter().any(|t| t.contains("unsupported response_type blocked")),
+            "omit_rule:false must not be treated as omitted: {titles:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #997. Found while verifying #995 for the reporter on #79: I captured what `--wafbench-verbatim` actually put on the wire instead of reading the generated script, and it was not sending his requests as written.

## 1. Payload injection was still active in verbatim mode

`--wafbench-dir` feeds two different consumers. In verbatim mode it supplies the **requests**; the security layer kept treating it as a payload **pool**. So every request went out mutated:

```
GET /oauth/authorize?response_type=totally-unsupported&redirect_uri=https%3A%2F%2Fevil.example%2Flanding&state=s1&test=code
GET /oauth/authorize?response_type=code&client_id=abc123&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback&test=https%3A%2F%2Fevil.example%2Flanding
```

Two consequences, the second worse than the first:
- it corrupts the exact cases the user asked to be sent literally, and
- it appends an attack payload to `expected: 200` cases, so a **correctly-behaving WAF blocks them** and the run reports a failure the user never wrote. A security tool reporting invented failures is as bad as one reporting invented passes (#994 was the pass-side of this).

The gating flag was recomputed inline at **four** render sites. That is the #79 drift shape: the template gates `{{#if security_testing_enabled}}` on it, so any site disagreeing with another produces dead code or a call to an undefined function. Collapsed into a single `BenchCommand::security_testing_enabled()`, plus a test that fails if inline copies reappear.

`--security-test` combined with `--wafbench-verbatim` is contradictory; verbatim wins and the command says so rather than silently mutating traffic.

## 2. `omit_rule` was parsed and silently dropped

It marks a baseline case to be sent with the rule under test disabled. mockforge cannot toggle a WAF rule, so the case went out byte-identical to its non-omitted twin while asserting the opposite status. Exactly one of the pair always failed regardless of whether the rule worked, which defeats the only purpose of a baseline. Now skipped, with a warning naming the case and explaining how to get a real baseline (run the file against a WAF config with the rule off).

## 3. `--spec` is now optional under `--wafbench-verbatim`

The traffic file supplies every request, so requiring a spec meant passing an unrelated file to satisfy a check that is meaningless in this mode. A spec is still honoured when supplied, for `--base-path`.

## Verification

Wire capture against a logging listener, his 7-case file, after the fix:

```
GET /oauth/authorize?response_type=&redirect_uri=https%3A%2F%2Fevil.example%2Flanding
GET /oauth/authorize?response_type=code%20id_token&client_id=abc123&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback
GET /oauth/authorize?response_type=code&client_id=abc123&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback&state=%E7%8A%B6%E6%80%81%E5%80%BC
GET /oauth/authorize?response_type=code&client_id=abc123&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback&state=s1
GET /oauth/authorize?response_type=totally-unsupported&client_id=abc123
GET /oauth/authorize?response_type=totally-unsupported&redirect_uri=https%3A%2F%2Fevil.example%2Flanding&state=s1
```

Six non-omitted cases, byte-for-byte, no `test=`. The percent-encoded `redirect_uri` his rule chains on is present, as are the CJK `state` and the empty `response_type`.

`cargo test -p mockforge-bench` 537 passed; `cargo fmt --all --check` clean; clippy clean for this crate (the `mockforge-core` errors are the known pre-existing debt).