### PR TITLE
ci: give every self-hosted job a timeout so one job cannot halve CI capacity (#1000)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,6 +35,7 @@ jobs:
   benchmark:
     name: Run Benchmarks
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 45
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   detect-breaking-changes:
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/chaos-testing.yml
+++ b/.github/workflows/chaos-testing.yml
@@ -36,6 +36,7 @@ jobs:
   build:
     name: Build Test Binary
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 60
     outputs:
       binary_path: ${{ steps.build.outputs.binary_path }}
 
@@ -70,6 +71,7 @@ jobs:
     name: Network Partition Test
     needs: build
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     if: github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'network-partition' || github.event.inputs.scenario == ''
 
     steps:
@@ -130,6 +132,7 @@ jobs:
     name: High Latency Test
     needs: build
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     if: github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'high-latency' || github.event.inputs.scenario == ''
 
     steps:
@@ -188,6 +191,7 @@ jobs:
     name: Packet Loss Test
     needs: build
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     if: github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'packet-loss' || github.event.inputs.scenario == ''
 
     steps:
@@ -242,6 +246,7 @@ jobs:
     name: Resource Exhaustion Test
     needs: build
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     if: github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'resource-exhaustion' || github.event.inputs.scenario == ''
 
     steps:
@@ -320,6 +325,7 @@ jobs:
     name: Connection Storm Test
     needs: build
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     if: github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'connection-storm' || github.event.inputs.scenario == ''
 
     steps:
@@ -388,6 +394,7 @@ jobs:
     name: Chaos Test Summary
     needs: [network-partition, high-latency, packet-loss, resource-exhaustion, connection-storm]
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 15
     if: always()
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
   changes:
     name: Detect change scope
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
@@ -81,6 +82,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 60
     env:
       CARGO_INCREMENTAL: "0"
     strategy:
@@ -179,6 +181,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 40
 
     steps:
       - name: Set per-runner CARGO_HOME
@@ -239,6 +242,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 40
     env:
       CARGO_INCREMENTAL: "0"
     steps:
@@ -271,6 +275,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 40
     continue-on-error: true
     env:
       CARGO_INCREMENTAL: "0"
@@ -304,6 +309,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     steps:
     - name: Set per-runner CARGO_HOME
       # `runner.name` is unavailable in workflow- or job-level `env:` blocks
@@ -379,6 +385,7 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 45
     # Coverage only runs on main pushes — per-PR runs took a full workspace
     # rebuild with llvm-cov instrumentation (~15 min on a warm runner) for a
     # signal that was never acted on at PR-review time. Codecov tracks the
@@ -424,6 +431,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     env:
       CARGO_INCREMENTAL: "0"
     steps:
@@ -461,6 +469,7 @@ jobs:
     # public so standard runners are free. Keeps the contended self-hosted Rust
     # slot for jobs that actually compile. (No per-runner CARGO_HOME needed.)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
@@ -473,6 +482,7 @@ jobs:
     # GitHub-hosted: a git-diff + shell check needs no Rust toolchain; public
     # repo → free standard runner, and it frees the self-hosted Rust slot.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'pull_request'
     steps:
     - name: Checkout repository
@@ -505,6 +515,7 @@ jobs:
   build-binaries:
     name: Build Release Binaries
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     needs: [test, warning-gate, security-audit, typos]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     env:
@@ -638,6 +649,7 @@ jobs:
   release:
     name: Create Release
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 120
     needs: build-binaries
     if: startsWith(github.ref, 'refs/tags/')
     permissions:

--- a/.github/workflows/contract-diff.yml
+++ b/.github/workflows/contract-diff.yml
@@ -55,6 +55,7 @@ jobs:
   contract-diff:
     name: Contract Diff Analysis
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,6 +41,7 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 90
     # Skip drafts to avoid burning minutes on in-progress PRs
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     permissions:
@@ -166,6 +167,7 @@ jobs:
     name: Security Scan and Analysis
     needs: build-and-push
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     if: github.event_name != 'pull_request'
     permissions:
       security-events: write

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -21,6 +21,7 @@ jobs:
   docs:
     name: Verify mdBook Docs
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,6 +22,7 @@ jobs:
   fuzz:
     name: Fuzz Tests
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -19,6 +19,7 @@ jobs:
   validate-manifests:
     name: Validate Kubernetes Manifests
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -54,6 +55,7 @@ jobs:
   lint-helm-charts:
     name: Lint Helm Charts
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -93,6 +95,7 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -128,6 +131,7 @@ jobs:
   test-in-kind:
     name: Test in KinD Cluster
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -192,6 +196,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     needs: test-in-kind
 
     steps:
@@ -275,6 +280,7 @@ jobs:
   chaos-tests:
     name: Chaos Engineering Tests
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
@@ -365,6 +371,7 @@ jobs:
   cost-estimation:
     name: Cost Estimation
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 30
     if: github.event_name == 'workflow_dispatch'  # Only run on manual trigger
 
     steps:

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -31,12 +31,17 @@ on:
 # Concurrency keys are GitHub-internal context, safe to interpolate.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  # #1000: supersede an older run rather than queueing behind it. These jobs are
+  # a post-merge regression signal, so only the newest main is interesting, and
+  # mockforge has just TWO self-hosted runners: a stale load test holding one of
+  # them starves the required checks on everything else.
+  cancel-in-progress: true
 
 jobs:
   standard-load-test:
     name: Standard Load Test
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 60
     if: |
       github.ref == 'refs/heads/main' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.test_type == 'standard')
@@ -137,6 +142,7 @@ jobs:
   performance-benchmarks:
     name: Performance Benchmarks
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 60
     if: |
       github.ref == 'refs/heads/main' ||
       github.event_name == 'workflow_dispatch'

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -114,6 +114,7 @@ jobs:
     name: Aggregate Mutation Results
     needs: mutation-test
     runs-on: [self-hosted, linux, x64, rust]
+    timeout-minutes: 15
     if: always()
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,3 +133,15 @@ repos:
     language: system
     pass_filenames: false
     files: '(^|/)(Dockerfile[^/]*|rust-toolchain\.toml)$'
+  - id: workflow-timeouts
+    name: Self-hosted job timeout guard
+    # Blocks a commit that leaves a self-hosted job without `timeout-minutes`.
+    # mockforge has exactly TWO dedicated runner registrations, so a job with no
+    # timeout inherits GitHub's 360-minute default and one hung job removes half
+    # of CI capacity for six hours. A 2h16m load test on main did exactly that
+    # on 2026-08-23, stalling the required Security Audit for the v0.3.214
+    # release by roughly two hours (#1000).
+    entry: scripts/check-workflow-timeouts.sh
+    language: system
+    pass_filenames: false
+    files: '^\.github/workflows/.*\.ya?ml$'

--- a/scripts/check-workflow-timeouts.sh
+++ b/scripts/check-workflow-timeouts.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Fail if any self-hosted job omits `timeout-minutes` (#1000).
+#
+# Why this guard exists: mockforge has exactly TWO dedicated self-hosted runner
+# registrations. A job without an explicit timeout inherits GitHub's default of
+# 360 minutes, so one hung or pathologically slow job removes 50% of CI capacity
+# for six hours. On 2026-08-23 a 2h16m `Load Testing` job on main held one slot
+# while the required `Security Audit` for the v0.3.214 release sat queued behind
+# it, delaying a customer-facing release by roughly two hours.
+#
+# GitHub-hosted jobs are exempt: there the default is merely wasteful, not a
+# capacity outage.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+python3 - <<'PY'
+import sys, pathlib
+try:
+    import yaml
+except ImportError:
+    print("check-workflow-timeouts: PyYAML not available, skipping")
+    sys.exit(0)
+
+missing = []
+checked = 0
+for f in sorted(pathlib.Path('.github/workflows').glob('*.yml')):
+    try:
+        doc = yaml.safe_load(f.read_text())
+    except Exception as e:
+        print(f"  {f.name}: YAML parse error: {e}")
+        missing.append(f"{f.name}: unparseable")
+        continue
+    for name, job in (doc.get('jobs') or {}).items():
+        if not isinstance(job, dict):
+            continue
+        if 'self-hosted' not in str(job.get('runs-on')):
+            continue
+        checked += 1
+        if job.get('timeout-minutes') is None:
+            missing.append(f"{f.name}: job '{name}'")
+
+if missing:
+    print(f"workflow-timeouts: {len(missing)} self-hosted job(s) without timeout-minutes:")
+    for m in missing:
+        print(f"  - {m}")
+    print()
+    print("Add an explicit `timeout-minutes:` to each. Size it generously (roughly")
+    print("3x the observed maximum) so host contention cannot turn a slow but")
+    print("passing job into a timeout failure.")
+    sys.exit(1)
+
+print(f"workflow-timeouts: OK -- all {checked} self-hosted jobs declare timeout-minutes")
+PY


### PR DESCRIPTION
Closes #1000.

## The problem

mockforge has exactly **two** dedicated self-hosted runner registrations:

```
actions.runner.SaaSy-Solutions-mockforge.saasy-ci-runner-01.service
actions.runner.SaaSy-Solutions-mockforge.saasy-ci-runner-01-mockforge-2.service
```

36 jobs declared no `timeout-minutes`, so they inherited GitHub's default of **360 minutes**. On a two-runner pool, one hung or pathologically slow job removes 50% of CI capacity for six hours.

Not hypothetical: on 2026-08-23 a `Load Testing & Performance Regression` run on main executed for **2h16m** holding one slot while the **required** `Security Audit` for the v0.3.214 release sat queued behind it, delaying a customer-facing release by roughly two hours. `load-testing.yml` already had `timeout-minutes: 60` on `extended-load-test` and nothing on its two siblings, so this was inconsistency rather than a deliberate policy.

## Sizing

Timeouts are derived from **observed durations**, not guessed. I pulled job runtimes from recent successful runs and set each at roughly 3-5x the maximum seen, so contention from the other repos sharing the host cannot turn a slow-but-passing job into a timeout failure.

| Job | observed max | set to |
|---|---|---|
| docker `build-and-push` | 26.0m | 90 |
| chaos `build` | 20.1m | 60 |
| `fuzz` | 15.7m | 45 |
| ci `test` | 10.9m | 60 |
| `benchmark` | 10.7m | 45 |
| `security-audit` | 6.4m | 30 |
| `coverage` | 4.5m | 45 |
| `msrv` | 2.4m | 30 |
| spell/changelog/detect | 0.2m | 15 |

`k8s-tests` and `contract-diff` had no recent successful runs to measure, so they get the 30m default.

## cancel-in-progress

`load-testing.yml` goes to `cancel-in-progress: true`. It is a post-merge regression signal, so only the newest main is interesting and queueing an older run ahead of newer work is pure waste. `benchmarks.yml` already cancels on PRs and runs ~11m, so it is left alone.

## Guard

Adds `scripts/check-workflow-timeouts.sh`, wired into pre-commit next to the existing publish-drift and Dockerfile-drift guards. It parses each workflow and fails on any self-hosted job missing `timeout-minutes`, naming the file and job. GitHub-hosted jobs are exempt, since there the default is merely wasteful rather than a capacity outage.

Verified in both directions: with a timeout removed it fails and names `docs-check.yml: job 'docs'`; restored, it reports `OK -- all 42 self-hosted jobs declare timeout-minutes`. Every workflow still parses as valid YAML, and an audit over the parsed documents confirms no stray `timeout-minutes` landed outside a job.

## Also cleaned up while diagnosing

A queued run from **2026-05-26** on `feat/issue-79-r13-conformance-self-test` was still sitting in the queue three months later; cancelled manually.