### PR TITLE
fix(ci): typo 'unparseable' in the workflow-timeout guard (#1000)

### DIFF
--- a/scripts/check-workflow-timeouts.sh
+++ b/scripts/check-workflow-timeouts.sh
@@ -29,7 +29,7 @@ for f in sorted(pathlib.Path('.github/workflows').glob('*.yml')):
         doc = yaml.safe_load(f.read_text())
     except Exception as e:
         print(f"  {f.name}: YAML parse error: {e}")
-        missing.append(f"{f.name}: unparseable")
+        missing.append(f"{f.name}: unparsable")
         continue
     for name, job in (doc.get('jobs') or {}).items():
         if not isinstance(job, dict):


### PR DESCRIPTION
One-word fix. `crate-ci/typos` failed Spell Check on #1002 with ```unparseable``` should be ```unparsable```, in the guard script added by that PR. #1002 merged anyway because Spell Check is not a required check.

Same word I got wrong on #988, which is a good argument for the guard-script habit generally: the check was right both times.