### PR TITLE
ci: run the smoke tests on hosted runners so prod monitoring stops going blind (#1000)

### DIFF
--- a/.github/workflows/hosted-mocks-smoke.yml
+++ b/.github/workflows/hosted-mocks-smoke.yml
@@ -47,7 +47,10 @@ jobs:
   smoke:
     name: Smoke staging hosted mocks
     # Per repo CI-cost policy: prefer self-hosted runners over GHA-hosted.
-    runs-on: [self-hosted, linux, x64, rust]
+    # #1000: GitHub-hosted, not the self-hosted pool. Pure HTTP checks with no
+    # Rust toolchain needed, and mockforge has only two self-hosted runners.
+    # The repo is public, so hosted minutes are free.
+    runs-on: ubuntu-latest
     timeout-minutes: 25
 
     env:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -26,7 +26,13 @@ permissions:
 jobs:
   smoke:
     name: Smoke api.mockforge.dev
-    runs-on: [self-hosted, linux, x64, rust]
+    # #1000: runs on a GitHub-hosted runner, NOT the self-hosted pool. This job
+    # is curl plus an issue-creation script: it needs no Rust toolchain, and
+    # mockforge has only two self-hosted runners. Sitting in that queue meant a
+    # */15 cron combined with `cancel-in-progress: true` cancelled every run
+    # before it could start, so production monitoring was silently blind for
+    # hours at a time. The repo is public, so hosted minutes are free.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
Follow-up to #1000, found while verifying that PR's fix.

## The problem

`production-smoke.yml` runs every 15 minutes with `cancel-in-progress: true`, pinned to `[self-hosted, linux, x64, rust]`. mockforge has **two** self-hosted runners. Once queue wait exceeded 15 minutes, each scheduled run was cancelled by its successor before it ever started:

```
12:25 cancelled
12:09 cancelled
11:54 cancelled
11:40 cancelled
11:24 cancelled
11:00 cancelled
10:44 cancelled
```

Production monitoring was therefore **blind for hours**, while looking superficially fine: the runs are `cancelled`, not `failure`, so nothing pages and the run list does not obviously look broken. (Production itself was healthy throughout: `{"status":"ok","version":"0.3.214"}`.)

## The fix

Neither smoke workflow needs a Rust toolchain. Both are HTTP checks plus an issue-creation script, and `grep -c 'cargo |rustc|rustup|target/'` returns **0** for each. There was never a reason for them to occupy a build runner.

mockforge is a **public** repository, so GitHub-hosted minutes are free. Moving them:
- costs nothing
- removes two recurring consumers from a two-runner pool
- makes the monitoring actually run, because on a hosted runner the job starts immediately rather than queueing behind Rust builds, so the 15-minute cadence works as designed

`hosted-mocks-smoke.yml` moves for the same reason (daily cron, same zero-toolchain profile).

Both already declare `timeout-minutes`, and `scripts/check-workflow-timeouts.sh` still passes (it now reports 40 self-hosted jobs rather than 42, since these two left the pool).

## Why this kept hiding

Same shape as the rest of #1000: **a check that cannot complete is indistinguishable from a check that passes** unless someone reads the run list closely. Worth remembering that `cancelled` is a silence mode, not a success mode.