### PR TITLE
fix(bench): honor --wafbench-verbatim on --targets-file runs (#79)

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -1351,7 +1351,9 @@ impl BenchCommand {
     /// Reuses the same loader as the payload path, so every input form keeps
     /// working: a single file, a directory (recursive), or a glob. Only the
     /// interpretation changes.
-    fn load_verbatim_templates(&self) -> Result<Vec<crate::request_gen::RequestTemplate>> {
+    pub(crate) fn load_verbatim_templates(
+        &self,
+    ) -> Result<Vec<crate::request_gen::RequestTemplate>> {
         let Some(pattern) = self.wafbench_dir.as_ref() else {
             return Err(BenchError::Other(
                 "--wafbench-verbatim requires --wafbench-dir pointing at your traffic file(s)"
@@ -4819,6 +4821,7 @@ mod tests {
     #[test]
     fn security_testing_enabled_has_a_single_definition() {
         let src = include_str!("command.rs");
+        let parallel = include_str!("parallel_executor.rs");
         // Assembled at runtime: a literal needle would match itself in this file.
         let a = format!("self.{} || self.{}.is_some()", "security_test", "wafbench_dir");
         let b = format!("self.{}.is_some() || self.{}", "wafbench_dir", "security_test");
@@ -4827,6 +4830,39 @@ mod tests {
             inline, 1,
             "expected the security_testing_enabled() method to be the only place this is \
              computed, found {inline} inline copies -- collapse them or the render paths drift"
+        );
+
+        // ParallelExecutor used to recompute this as
+        // `security_test || wafbench_dir.is_some()`, which ignored
+        // --wafbench-verbatim and re-enabled payload injection on
+        // --targets-file runs (#79).
+        let parallel_inline = format!(
+            "{}.{} || {}.{}.is_some()",
+            "base_command", "security_test", "self.base_command", "wafbench_dir"
+        );
+        assert!(
+            !parallel.contains(&parallel_inline),
+            "ParallelExecutor must not recompute the security flag inline"
+        );
+        assert!(
+            parallel.contains("security_testing_enabled()"),
+            "ParallelExecutor must call security_testing_enabled() so --wafbench-verbatim \
+             turns injection off on --targets-file runs too"
+        );
+    }
+
+    /// #79: --targets-file dispatched into ParallelExecutor before the
+    /// single-target verbatim path ran, so the flag required a spec and
+    /// still sent spec-derived (fuzzed) URLs. A behavioural test cannot
+    /// reach that executor without k6, so this guards the source.
+    #[test]
+    fn multi_target_path_honors_verbatim_templates() {
+        let src = include_str!("parallel_executor.rs");
+        assert!(
+            src.contains("load_verbatim_templates"),
+            "ParallelExecutor must load traffic-file requests under --wafbench-verbatim. \
+             Requiring a spec and generating templates from its operations is how \
+             --targets-file ignored the flag and fuzzed spec URLs (#79)."
         );
     }
 }

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -373,6 +373,7 @@ impl SelfTestReport {
     ///   2. ANY probe, positive or negative, that drew a 5xx — the target
     ///      crashed instead of replying cleanly (a bad request should get a
     ///      clean 4xx, never a 500).
+    ///
     /// Deliberately EXCLUDES "missed" negatives on spec-valid probes: those are
     /// the ones that genuinely need per-probe analysis (see the caught/missed
     /// legend), so keeping them out is the whole point of this view.
@@ -2497,7 +2498,7 @@ mod tests {
             label: label.into(),
             expected_4xx: true,
             actual_status: status,
-            passed: status >= 400 && status < 500,
+            passed: (400..500).contains(&status),
         };
         let mut r = SelfTestReport::default();
         r.operations.push(OperationResult {

--- a/crates/mockforge-bench/src/k6_gen.rs
+++ b/crates/mockforge-bench/src/k6_gen.rs
@@ -367,11 +367,7 @@ impl K6ScriptGenerator {
                 // Process path for dynamic placeholders
                 // Prepend base_path if configured
                 let raw_path = template.generate_path();
-                let full_path = if base_path.is_empty() {
-                    raw_path
-                } else {
-                    format!("{}{}", base_path, raw_path)
-                };
+                let full_path = join_base_path(base_path, &raw_path);
                 let processed_path = DynamicParamProcessor::process_path(&full_path);
                 all_placeholders.extend(processed_path.placeholders.clone());
 
@@ -611,9 +607,42 @@ impl K6ScriptGenerator {
     }
 }
 
+/// Join `--base-path` onto a request path without producing `//`.
+///
+/// `--base-path /` means root, not a prefix named `/`. Concatenating it
+/// with a traffic-file URI that already starts with `/` sent
+/// `//oauth/authorize` on Srikanth's --targets-file + verbatim command (#79).
+fn join_base_path(base_path: &str, raw_path: &str) -> String {
+    match base_path {
+        "" | "/" => raw_path.to_string(),
+        bp => {
+            let bp = bp.trim_end_matches('/');
+            if raw_path.starts_with('/') {
+                format!("{}{}", bp, raw_path)
+            } else {
+                format!("{}/{}", bp, raw_path)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn root_base_path_does_not_double_slash() {
+        assert_eq!(
+            join_base_path(
+                "/",
+                "/oauth/authorize?redirect_uri=https%3A%2F%2Fevil.example%2Flanding"
+            ),
+            "/oauth/authorize?redirect_uri=https%3A%2F%2Fevil.example%2Flanding"
+        );
+        assert_eq!(join_base_path("", "/pets"), "/pets");
+        assert_eq!(join_base_path("/v1", "/pets"), "/v1/pets");
+        assert_eq!(join_base_path("/v1/", "pets"), "/v1/pets");
+    }
 
     #[test]
     fn test_k6_config_creation() {

--- a/crates/mockforge-bench/src/parallel_executor.rs
+++ b/crates/mockforge-bench/src/parallel_executor.rs
@@ -14,6 +14,7 @@ use crate::scenarios::LoadScenario;
 use crate::spec_parser::SpecParser;
 use crate::target_parser::TargetConfig;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use mockforge_openapi::spec::OpenApiSpec;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -204,39 +205,77 @@ impl ParallelExecutor {
             return Err(BenchError::K6NotFound);
         }
 
-        // Load and parse spec(s) (shared across all targets)
-        TerminalReporter::print_progress("Loading OpenAPI specification(s)...");
-        let merged_spec = self.base_command.load_and_merge_specs().await?;
-        let parser = SpecParser::from_spec(merged_spec);
-        TerminalReporter::print_success("Specification(s) loaded");
+        // #79: --targets-file used to ignore --wafbench-verbatim. It always
+        // required a spec and built templates from spec operations, so the
+        // command either died with "No spec files provided" or fuzzed spec
+        // URLs instead of sending the traffic file as written.
+        let spec_supplied =
+            !self.base_command.spec.is_empty() || self.base_command.spec_dir.is_some();
+        let verbatim = self.base_command.wafbench_verbatim;
 
-        // Get operations
-        let operations = if let Some(filter) = &self.base_command.operations {
-            parser.filter_operations(filter)?
+        let (templates, parser) = if verbatim {
+            let verbatim_templates = self.base_command.load_verbatim_templates()?;
+            if verbatim_templates.is_empty() {
+                return Err(BenchError::Other(
+                    "--wafbench-verbatim was set but no traffic cases were loaded. Check \
+                     --wafbench-dir points at a file, directory or glob containing cases with \
+                     a `request.uri`."
+                        .to_string(),
+                ));
+            }
+            TerminalReporter::print_success(&format!(
+                "Verbatim mode: {} request(s) will be sent exactly as written (spec endpoints not used)",
+                verbatim_templates.len()
+            ));
+            let parser = if spec_supplied {
+                TerminalReporter::print_progress("Loading OpenAPI specification(s)...");
+                let merged_spec = self.base_command.load_and_merge_specs().await?;
+                TerminalReporter::print_success("Specification(s) loaded (base path only)");
+                SpecParser::from_spec(merged_spec)
+            } else {
+                SpecParser::from_spec(OpenApiSpec {
+                    spec: Default::default(),
+                    file_path: None,
+                    raw_document: None,
+                })
+            };
+            (verbatim_templates, parser)
         } else {
-            parser.get_operations()
+            TerminalReporter::print_progress("Loading OpenAPI specification(s)...");
+            let merged_spec = self.base_command.load_and_merge_specs().await?;
+            let parser = SpecParser::from_spec(merged_spec);
+            TerminalReporter::print_success("Specification(s) loaded");
+
+            let operations = if let Some(filter) = &self.base_command.operations {
+                parser.filter_operations(filter)?
+            } else {
+                parser.get_operations()
+            };
+
+            if operations.is_empty() {
+                return Err(BenchError::Other("No operations found in spec".to_string()));
+            }
+
+            TerminalReporter::print_success(&format!("Found {} operations", operations.len()));
+
+            TerminalReporter::print_progress("Generating request templates...");
+            let templates: Vec<_> = operations
+                .iter()
+                .map(RequestGenerator::generate_template)
+                .collect::<Result<Vec<_>>>()?;
+            TerminalReporter::print_success("Request templates generated");
+            (templates, parser)
         };
 
-        if operations.is_empty() {
-            return Err(BenchError::Other("No operations found in spec".to_string()));
-        }
-
-        TerminalReporter::print_success(&format!("Found {} operations", operations.len()));
-
-        // Generate request templates (shared across all targets)
-        TerminalReporter::print_progress("Generating request templates...");
-        let templates: Vec<_> = operations
-            .iter()
-            .map(RequestGenerator::generate_template)
-            .collect::<Result<Vec<_>>>()?;
-        TerminalReporter::print_success("Request templates generated");
-
-        // Pre-load per-target specs
+        // Pre-load per-target specs. In verbatim mode a per-target spec may
+        // still resolve --base-path, but it must not replace the traffic-file
+        // templates. That swap is how --targets-file kept fuzzing spec URLs
+        // after --wafbench-verbatim was added (#79).
         let mut per_target_data: HashMap<
             PathBuf,
             (Vec<crate::request_gen::RequestTemplate>, Option<String>),
         > = HashMap::new();
-        {
+        if !verbatim {
             let mut unique_specs: Vec<PathBuf> = Vec::new();
             for t in &self.targets {
                 if let Some(spec_path) = &t.spec {
@@ -325,16 +364,13 @@ impl ParallelExecutor {
 
         let duration_secs_val = BenchCommand::parse_duration(&self.base_command.duration)?;
 
-        // Compute security testing flag
-        let security_testing_enabled_val =
-            self.base_command.security_test || self.base_command.wafbench_dir.is_some();
+        let security_testing_enabled_val = self.base_command.security_testing_enabled();
 
         // Pre-compute enhancement code once (same for all targets)
         let has_advanced_features = self.base_command.data_file.is_some()
             || self.base_command.error_rate.is_some()
-            || self.base_command.security_test
-            || self.base_command.parallel_create.is_some()
-            || self.base_command.wafbench_dir.is_some();
+            || self.base_command.security_testing_enabled()
+            || self.base_command.parallel_create.is_some();
 
         let enhancement_code = if has_advanced_features {
             let dummy_script = "export const options = {};";
@@ -403,8 +439,12 @@ impl ParallelExecutor {
             let geo_source_ips = self.base_command.geo_source_ips.clone();
             let geo_source_headers = self.base_command.geo_source_headers.clone();
 
-            // Select per-target templates/base_path if this target has a custom spec
-            let (templates, base_path) = if let Some(spec_path) = &target.spec {
+            // Select per-target templates/base_path if this target has a custom spec.
+            // Verbatim templates stay the traffic file's requests even when a
+            // target lists its own spec.
+            let (templates, base_path) = if verbatim {
+                (templates.clone(), base_path.clone())
+            } else if let Some(spec_path) = &target.spec {
                 if let Some((t, bp)) = per_target_data.get(spec_path) {
                     (t.clone(), bp.clone())
                 } else {

--- a/crates/mockforge-bench/src/pipeline_bench.rs
+++ b/crates/mockforge-bench/src/pipeline_bench.rs
@@ -120,12 +120,10 @@ impl StreamBody {
             // One synthetic file part, framed by the multipart boundary
             // declared in BodyKind::content_type().
             Multipart => (
-                format!(
-                    "--mockforge-pipeline\r\n\
+                b"--mockforge-pipeline\r\n\
                      Content-Disposition: form-data; name=\"file\"; filename=\"synthetic.bin\"\r\n\
                      Content-Type: application/octet-stream\r\n\r\n"
-                )
-                .into_bytes(),
+                    .to_vec(),
                 b"\r\n--mockforge-pipeline--\r\n".to_vec(),
             ),
         };
@@ -309,10 +307,7 @@ async fn read_response(stream: &mut TcpStream, buf: &mut Vec<u8>) -> std::io::Re
         .and_then(|v| v.trim().parse().ok());
     let chunked = lower.contains("transfer-Encoding:")
         || lower.contains("transfer-encoding:")
-            && lower
-                .split("transfer-encoding:")
-                .nth(1)
-                .map_or(false, |v| v.contains("chunked"));
+            && lower.split("transfer-encoding:").nth(1).is_some_and(|v| v.contains("chunked"));
 
     // --- body ---
     if chunked {

--- a/crates/mockforge-core/src/chain_execution.rs
+++ b/crates/mockforge-core/src/chain_execution.rs
@@ -617,18 +617,15 @@ impl ChainExecutionEngine {
                 Value::Object(map) => {
                     current = map.get(*part)?;
                 }
-                Value::Array(arr) => {
-                    if part.starts_with('[') && part.ends_with(']') {
-                        let index_str = &part[1..part.len() - 1];
-                        if let Ok(index) = index_str.parse::<usize>() {
-                            current = arr.get(index)?;
-                        } else {
-                            return None;
-                        }
+                Value::Array(arr) if part.starts_with('[') && part.ends_with(']') => {
+                    let index_str = &part[1..part.len() - 1];
+                    if let Ok(index) = index_str.parse::<usize>() {
+                        current = arr.get(index)?;
                     } else {
                         return None;
                     }
                 }
+                Value::Array(_) => return None,
                 _ => return None,
             }
         }

--- a/crates/mockforge-core/src/consumer_contracts/usage_recorder.rs
+++ b/crates/mockforge-core/src/consumer_contracts/usage_recorder.rs
@@ -110,12 +110,10 @@ impl UsageRecorder {
                     paths.extend(Self::extract_field_paths(val, &path));
                 }
             }
-            Value::Array(arr) => {
-                if !arr.is_empty() {
-                    // For arrays, extract paths from first element
-                    paths.extend(Self::extract_field_paths(&arr[0], prefix));
-                }
+            Value::Array(arr) if !arr.is_empty() => {
+                paths.extend(Self::extract_field_paths(&arr[0], prefix));
             }
+            Value::Array(_) => {}
             _ => {
                 // Primitive value - path is already added
             }

--- a/crates/mockforge-core/src/generative_schema/entity_inference.rs
+++ b/crates/mockforge-core/src/generative_schema/entity_inference.rs
@@ -224,11 +224,8 @@ impl EntityInference {
         // Handle both nested structure (with "properties") and flat structure
         let properties = if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
             props
-        } else if let Some(obj) = schema.as_object() {
-            // Flat structure - treat the object itself as properties
-            obj
         } else {
-            return None;
+            schema.as_object()?
         };
 
         // Common primary key patterns

--- a/crates/mockforge-core/src/import/import_utils.rs
+++ b/crates/mockforge-core/src/import/import_utils.rs
@@ -70,15 +70,12 @@ pub fn detect_format(content: &str, file_path: Option<&Path>) -> FormatDetection
                         };
                     }
                 }
-                "txt" | "sh" | "bash" => {
-                    // Could be curl commands
-                    if is_curl_content(content) {
-                        return FormatDetection {
-                            format: ImportFormat::Curl,
-                            confidence: 0.8,
-                            details: "File contains curl commands".to_string(),
-                        };
-                    }
+                "txt" | "sh" | "bash" if is_curl_content(content) => {
+                    return FormatDetection {
+                        format: ImportFormat::Curl,
+                        confidence: 0.8,
+                        details: "File contains curl commands".to_string(),
+                    };
                 }
                 _ => {}
             }

--- a/crates/mockforge-core/src/import/postman_environment.rs
+++ b/crates/mockforge-core/src/import/postman_environment.rs
@@ -85,10 +85,13 @@ pub fn import_postman_environment(content: &str) -> Result<EnvironmentImportResu
     for env_value in environment.values {
         total_count += 1;
 
-        if env_value.enabled && env_value.value.is_some() {
+        if env_value.enabled {
+            let Some(value) = env_value.value else {
+                continue;
+            };
             enabled_count += 1;
             let variable = EnvironmentVariable {
-                value: env_value.value.unwrap(),
+                value,
                 description: env_value.description,
                 enabled: env_value.enabled,
                 source: VariableSource::Environment(env_name.clone()),

--- a/crates/mockforge-core/src/incidents/store.rs
+++ b/crates/mockforge-core/src/incidents/store.rs
@@ -141,7 +141,7 @@ impl IncidentStore {
         }
 
         // Sort by detected_at descending (newest first)
-        results.sort_by(|a, b| b.detected_at.cmp(&a.detected_at));
+        results.sort_by_key(|b| std::cmp::Reverse(b.detected_at));
 
         // Apply pagination
         let offset = query.offset.unwrap_or(0);

--- a/crates/mockforge-core/src/record_replay.rs
+++ b/crates/mockforge-core/src/record_replay.rs
@@ -265,7 +265,7 @@ pub async fn list_fixtures(fixtures_dir: &Path) -> Result<Vec<RecordedRequest>> 
     }
 
     // Sort by timestamp (newest first)
-    fixtures.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    fixtures.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
 
     Ok(fixtures)
 }
@@ -352,7 +352,7 @@ pub async fn list_ready_fixtures(fixtures_dir: &Path) -> Result<Vec<RecordedRequ
     }
 
     // Sort by timestamp (newest first)
-    fixtures.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    fixtures.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
 
     Ok(fixtures)
 }

--- a/crates/mockforge-core/src/snapshots/manager.rs
+++ b/crates/mockforge-core/src/snapshots/manager.rs
@@ -568,7 +568,7 @@ impl SnapshotManager {
         }
 
         // Sort by creation date (newest first)
-        snapshots.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        snapshots.sort_by_key(|b| std::cmp::Reverse(b.created_at));
         Ok(snapshots)
     }
 

--- a/crates/mockforge-core/src/workspace.rs
+++ b/crates/mockforge-core/src/workspace.rs
@@ -1158,7 +1158,7 @@ impl MockRequest {
             self.response_history.remove(0);
         }
         // Sort by execution time (newest first)
-        self.response_history.sort_by(|a, b| b.executed_at.cmp(&a.executed_at));
+        self.response_history.sort_by_key(|b| std::cmp::Reverse(b.executed_at));
     }
 
     /// Get response history (sorted by execution time, newest first)

--- a/crates/mockforge-core/src/workspace/request.rs
+++ b/crates/mockforge-core/src/workspace/request.rs
@@ -753,7 +753,7 @@ impl RequestProcessor {
 
         // Get popular requests (top 5)
         let mut popular_requests: Vec<_> = request_counts.into_iter().collect();
-        popular_requests.sort_by(|a, b| b.1.cmp(&a.1));
+        popular_requests.sort_by_key(|b| std::cmp::Reverse(b.1));
         popular_requests.truncate(5);
 
         RequestMetrics {

--- a/crates/mockforge-core/src/workspace_persistence.rs
+++ b/crates/mockforge-core/src/workspace_persistence.rs
@@ -631,7 +631,7 @@ impl WorkspacePersistence {
         }
 
         // Sort by modification time (newest first)
-        backup_files.sort_by(|a, b| b.1.cmp(&a.1));
+        backup_files.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         // Remove old backups
         let mut removed_count = 0;

--- a/crates/mockforge-proxy/src/conformance.rs
+++ b/crates/mockforge-proxy/src/conformance.rs
@@ -191,7 +191,7 @@ impl ConformanceTap {
         }
 
         // 2. Declared + JSON body → schema check.
-        let Some(schema_value) = declared_json_schema(responses, status as u16) else {
+        let Some(schema_value) = declared_json_schema(responses, status) else {
             return;
         };
         let Some(bytes) = body else { return };
@@ -283,7 +283,7 @@ fn urlencoding_decode(v: &str) -> Result<String, ()> {
 fn parse_body(body: Option<&[u8]>) -> (Option<Value>, bool) {
     match body {
         None => (None, false),
-        Some(b) if b.is_empty() => (None, false),
+        Some([]) => (None, false),
         Some(b) => (serde_json::from_slice::<Value>(b).ok(), true),
     }
 }

--- a/crates/mockforge-proxy/src/egress.rs
+++ b/crates/mockforge-proxy/src/egress.rs
@@ -363,15 +363,12 @@ mod tests {
     async fn dns_rebinding_to_private_is_blocked() {
         let guard = EgressGuard::new(None);
         let decision = guard
-            .check_with_resolver("http://evil.example.com/", |host| {
-                let host = host;
-                async move {
-                    assert_eq!(host, "evil.example.com");
-                    Ok(vec![
-                        IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)),
-                        IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    ])
-                }
+            .check_with_resolver("http://evil.example.com/", |host| async move {
+                assert_eq!(host, "evil.example.com");
+                Ok(vec![
+                    IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)),
+                    IpAddr::V4(Ipv4Addr::LOCALHOST),
+                ])
             })
             .await;
         assert_eq!(

--- a/crates/mockforge-proxy/src/server.rs
+++ b/crates/mockforge-proxy/src/server.rs
@@ -194,9 +194,9 @@ async fn proxy_handler(
             path = %uri.path(),
             "Rejected absolute-URL-in-path proxying; set allow_absolute_url_upstream=true to opt in (#1012)"
         );
-        let body = format!(
+        let body =
             "Forbidden: absolute-URL proxying is disabled (allow_absolute_url_upstream=false)"
-        );
+                .to_string();
         return Ok(Response::builder()
             .status(StatusCode::FORBIDDEN)
             .body(body)
@@ -206,7 +206,7 @@ async fn proxy_handler(
     let full_upstream_url = if is_absolute_upstream {
         use crate::egress::{EgressDecision, EgressGuard};
         let guard = EgressGuard::new(config.upstream_allowlist.clone());
-        match guard.check(&candidate).await {
+        match guard.check(candidate).await {
             EgressDecision::Allowed => candidate.to_string(),
             EgressDecision::Blocked(reason) => {
                 warn!(target = %stripped_path, %reason, "Blocked request-derived upstream by egress guard");
@@ -303,7 +303,7 @@ async fn proxy_handler(
             .validate_request(
                 method.as_str(),
                 uri.path(),
-                uri.query().as_deref(),
+                uri.query(),
                 &headers,
                 Some(transformed_request_body.as_deref().unwrap_or(&[])),
             )
@@ -524,9 +524,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_absolute_url_in_path_rejected_by_default() {
-        let mut config = ProxyConfig::default();
-        config.enabled = true;
-        config.prefix = Some("/proxy/".to_string());
+        let config = ProxyConfig {
+            enabled: true,
+            prefix: Some("/proxy/".to_string()),
+            ..Default::default()
+        };
         // allow_absolute_url_upstream defaults to false (#1012)
         let server = Arc::new(ProxyServer::new(config, false, false));
 
@@ -541,11 +543,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_optin_absolute_url_still_blocked_for_metadata_ip() {
-        let mut config = ProxyConfig::default();
-        config.enabled = true;
-        config.prefix = Some("/proxy/".to_string());
-        config.allow_absolute_url_upstream = true;
+    async fn test_opt_in_absolute_url_still_blocked_for_metadata_ip() {
+        let config = ProxyConfig {
+            enabled: true,
+            prefix: Some("/proxy/".to_string()),
+            allow_absolute_url_upstream: true,
+            ..Default::default()
+        };
         let server = Arc::new(ProxyServer::new(config, false, false));
 
         let request = http::Request::builder()
@@ -560,11 +564,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_optin_absolute_url_blocked_for_loopback() {
-        let mut config = ProxyConfig::default();
-        config.enabled = true;
-        config.prefix = Some("/proxy/".to_string());
-        config.allow_absolute_url_upstream = true;
+    async fn test_opt_in_absolute_url_blocked_for_loopback() {
+        let config = ProxyConfig {
+            enabled: true,
+            prefix: Some("/proxy/".to_string()),
+            allow_absolute_url_upstream: true,
+            ..Default::default()
+        };
         let server = Arc::new(ProxyServer::new(config, false, false));
 
         let request = http::Request::builder()

--- a/crates/mockforge-recorder/src/scrubbing.rs
+++ b/crates/mockforge-recorder/src/scrubbing.rs
@@ -427,10 +427,8 @@ impl Scrubber {
                     field,
                     replacement,
                     target,
-                } => {
-                    if *target == location || *target == ScrubTarget::All {
-                        result = self.scrub_json_field(&result, field, replacement);
-                    }
+                } if *target == location || *target == ScrubTarget::All => {
+                    result = self.scrub_json_field(&result, field, replacement);
                 }
                 _ => {}
             }

--- a/crates/mockforge-registry-core/src/incident_bus.rs
+++ b/crates/mockforge-registry-core/src/incident_bus.rs
@@ -16,6 +16,7 @@
 
 #[cfg(feature = "postgres")]
 use crate::models::incident::{Incident, RaiseIncidentInput};
+#[cfg(feature = "postgres")]
 use std::future::Future;
 
 /// Map a contract-diff finding severity to an incident severity.


### PR DESCRIPTION
## Why

`--wafbench-verbatim` was only wired on the single-target bench path. Srikanth's 0.3.214 command uses `--targets-file`, so `ParallelExecutor` still required a spec and built templates from its operations. Result: `No spec files provided` without `--spec`, and spec-URL fuzzing with `--spec`. `--base-path /` also produced `//oauth/authorize`.

## Scope

- `ParallelExecutor` loads verbatim traffic-file templates when `--wafbench-verbatim` is set. Spec is optional. Per-target specs cannot replace those templates.
- Shared `security_testing_enabled()` so the multi-target path stops ignoring verbatim.
- `join_base_path` treats `/` as root, not a prefix that doubles the slash.
- Source-scan tests lock the multi-target verbatim call site and the single definition of `security_testing_enabled`.
- Mechanical clippy/typos in core, proxy, and recorder so scoped pre-commit can pass. No behavior change there.

Unreleased changelog and WAF docs stay local until the 0.3.215 release commit. Staging them trips workspace clippy on unrelated crates.

## Tradeoffs

Fix lives in `ParallelExecutor` rather than extracting a shared loader. Single-target and multi-target still have two entry points, with tests that fail if the multi-target path drifts again.

## Blast Radius

- `--targets-file` + `--wafbench-verbatim`: traffic file is sent as written. `--spec` optional. `--security-test` ignored under verbatim (same as single-target).
- `--targets-file` without verbatim: unchanged. Spec still required.
- `--base-path /` on any k6 generation path: paths stay `/oauth/...` instead of `//oauth/...`.

## Verification

- Unit tests for `security_testing_enabled` scan + `load_verbatim_templates` in `parallel_executor.rs`.
- Real CLI without `--spec` + `--targets-file` + verbatim: no "No spec files provided"; prints `Verbatim mode: 2 request(s) will be sent exactly as written`.
- Same flags with petstore `--spec` + `--security-test`: generated k6 has `/oauth/authorize?...` with the YAML query params. No `/pets`. No `test=` injection.
- k6 run of that script (640 requests): only the two YAML authorize URLs. No `/pets`. No `test=`.
- `cargo clippy -p mockforge-bench -p mockforge-core -p mockforge-proxy -p mockforge-recorder --all-targets --all-features -- -D warnings`

## Test plan

- [x] CLI: `--targets-file` + verbatim, no `--spec`
- [x] CLI: `--targets-file` + verbatim + `--spec` + `--security-test`
- [x] Wire: k6 against a local logger
- [ ] CI green on this PR
- [ ] crates.io 0.3.215 after merge (do not tell Srikanth to install before that)

Closes nothing. Continues #79.