### PR TITLE
fix(bench): fail missing --wafbench-dir and print per-file traffic stats (#79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+checksum = "476f0d0003a760918ed4b1e039a59e11769030416f79c8222551d22785f7f70d"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -2137,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "cap-net-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+checksum = "150941cefd3df4de2fea24604ba4949371576f62e527410298333f7d431a1bc6"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -2149,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+checksum = "8e0bf07d379916947be6c4a07f43684153d710a2896c31f9e97781362895596c"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
+checksum = "6ec6a5b75f54547c579a6b117c6fdd5f04f4ab7598de747b9f440a53592b3a4a"
 dependencies = [
  "ambient-authority",
  "rand 0.8.6",
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+checksum = "a59e59fa26472d29680ece6a9f8ee8b0551a719a33df2f5240bde065ecbddfd7"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -2189,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+checksum = "b54c289326c70f1c697ebf0a31842a480932e5942b5fac92fcc46e87286b48e2"
 dependencies = [
  "ambient-authority",
  "cap-primitives",
@@ -2922,36 +2922,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8e1303ae2128891cb59691a74de4547dd208bc8511a2f287cca2b93bb3c728"
+checksum = "6835dba958b2ab7ab523e7e99296e0524317f60430a00cf5850562ef78ea7001"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b2740a5936332028d9a1e8f29a199de2fd386e426d44da5fea70cf8e3f8e75"
+checksum = "0b6e4ce8ee6d899381fbdd9e6561336c651189d46cecaeee09b29e8d80aa786e"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd128d3629fb105e433bda09744c5a2959cd1da04617a455c4cc17dff1ebef"
+checksum = "0cb6d37015df7ea4b60450c1229ad5f5819a1fb27434b063f8e6216dfbd0c42a"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a88f6d5a6cf6fcbc6386415d48948094721dfa4585d6615938b11ca938f20a"
+checksum = "986bea0b0858b55192782120032ce9c15943fa073f186f6e479653c59e62c329"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2959,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4a357d030bdd586d8fe3da56b394f7f6b6ded506e59f945e7b32b1e126b71"
+checksum = "9f30aeb2de7f97d6f26b4a1642615834daad58e2e4d7c027810010a3a32f22be"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -2986,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4121e36a8757dea6fb237435ee5095eba25bc13ecc2eaee57eb9bffd4b27784f"
+checksum = "cd5dd137fcdedef33b6fd40edf1ced024460d764ceb75833e8198a843395945c"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -2999,24 +2999,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5173265fc30b9e42205cf06dfca9a272ee949667ce4115d975ed2c08d466e2f8"
+checksum = "ab54b260ef23a8f0f536679b9fc3b3b3e05353e8d1448f3ab83df02078e8be9b"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6ca8a393e66dc13f915c6f456bdcf496d78fac4995792f7022b7806352d7a4"
+checksum = "3f3e569779ad70537f34a670d444ee3d75ae583b2023913f4682814b0979f7e8"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e609d9ba416bc26d774f343295a1d411515248a6a6d83d5f7492a0dd919569fa"
+checksum = "2ff53acc85f5c5f7d9315ff133a6671d329a0f04aa2d1a8a2e81d59709ccddcb"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -3025,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a3a277b1a0aff1123f6bae61c080a4bcb6df964829ed427f98e18dff14257f"
+checksum = "ab5976c0ff5bfadf61cd8bda81fea78ee5a07018b9cd03e66c0952c56684928b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -3037,15 +3037,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be53dd9b3a4cbeb9ced45c4a543ea8417ccfb334c3ba1cbb2233f4b25fb2531f"
+checksum = "77b4f73d2288e9480fd2d1d9ab576394dce4805443d6148c6d819dbf78865ce4"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca62ab1d9f48cad97da5843b913ccf96c3dfde935af5d750cb5a6d367ccfb262"
+checksum = "fe9650c2baf22fa1e2542a5bdd8152616ec2023d929c4cbb450ff677ad8d9c21"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -3054,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13b72860f54a2a19d3756bd47575fd8bddeafd6e5bbbf16372cdfebc482628a"
+checksum = "4ad4f61ae701d73c326d3df08c366b29ad10f1ba06c245092f217b8d2306746b"
 
 [[package]]
 name = "crc"
@@ -6193,7 +6193,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6211,7 +6211,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -10822,7 +10822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -11879,8 +11879,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -11914,7 +11914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote 1.0.47",
  "syn 2.0.119",
@@ -12075,9 +12075,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2662666315cb90dfb4d99a652ee053d4d8598f71c474209e84da031ca56ae5a4"
+checksum = "eb0a4b56042e461cc64456650182938e2d1ede98fa0c8a975027416a2809c414"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -12087,9 +12087,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9a7d9ed2618f94b6d054aba3eb2768c9b489fe16b4ef8847fbc6ed41b707bb"
+checksum = "244667bea2e214273442a71f26adb12b88a41f66718fb2c6eea47c00f0dc325f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",
@@ -12192,7 +12192,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -12230,7 +12230,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -17167,9 +17167,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d881c5dcff5f230368d84fcf110ca25fe47badc694e7d559c3891492159916"
+checksum = "7d05c745dc0978e589ef295958f3130122afc33d96af6bad3f0f06dbe7ac43a8"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -17222,9 +17222,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b25534a3ff9dd844701c2bc997f76cb1f97bf2af0546a7066ae96f49c2e068"
+checksum = "9fd1d43cfaa1a0859d2f4fccc15e7e571e2a88b357e81bc88ba6c501b83d925d"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -17249,18 +17249,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d02832d760351fb3a1aa99eb8f7b95596c0f4e4e52df1547fcdb295ea5c780c"
+checksum = "515dd7158bf1719b41290cd2e6a2a46ec944484146816992f195af3720e49b3f"
 dependencies = [
  "cfg-if 1.0.4",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651f8a16b51cde3ee8bd5b775bcedc24b66040d7dca1f13ad855b10c660e1d01"
+checksum = "12a53145473629ea40f445235ed95182b76940f00a67c3c9c6c4857dae0ad823"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -17278,9 +17278,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ed6dbe24607573f7bcc59222f3bc2e7f7d31609466055c67b9484045a374a"
+checksum = "dfca017b7daa80ff217c66f105ee20e674d87b7c11dca85bbb9d0146e9f443fb"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -17293,15 +17293,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21aadbf677ee3503ef2580ce3c6955508e90a2810e961739b30f79585af254c"
+checksum = "1c3e218b51d2ef9eb181499e42c691512c1bc11dd6dc7746807a9b2b9290369c"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65821bab751956cddfc6ee957beb13a0e2a6cf682050d75dfb7a0228db2ed499"
+checksum = "5ba1736927b58e50e741e407da7c037c0250f3e213833a09c89dcd8f73ae2eac"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.4",
@@ -17326,9 +17326,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18cf73e5e8d28a2b30d86454430c7dea3b593598dcbbc0ebb927ca2716222d41"
+checksum = "7b238e4c20bddb900ec0cb380252d63e8d0644fd94de001119574f5921e895d9"
 dependencies = [
  "anyhow",
  "cc",
@@ -17342,9 +17342,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279dc3147ddaa21e5b3d2c0eaff117881c4f937747bdd2379eb361665843bd3"
+checksum = "8f259b13685ad51e3dcf58cb69031279ed0d79c25bc3ccc8b50e7160ed04fbfe"
 dependencies = [
  "cc",
  "object",
@@ -17354,9 +17354,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb677944201839c0be19b39b0f19dcd663efbcbc05a09c73f26fec7bdf0331"
+checksum = "41fed85537936b16460bac352ad149052c025db50467c7bc539dd47b31439374"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.4",
@@ -17366,24 +17366,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a153e184878df396a11f8912444531c2e4d0c7a1d9e9a52b30d9853d89cb9"
+checksum = "82fff10da41d0d15d90ebba70946a0aa16ed0957ae7b77e0b6d2a46e8221e555"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b771494bead25e1f0c4c89a9476dd0b65eacca314ed82125f1e197fbc3f0396b"
+checksum = "e44a8c097bab08d349d57dce1ab818859fefbe261ab3632b38fe127b1b551108"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90199caed6925420434a923861d8ad813689ca8533d2c679f805d12e35b40a4b"
+checksum = "7f40a57d5e7c221ce56391d7dca0a918ba17ea00185462c7facbf534d7745184"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.4",
@@ -17394,9 +17394,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71687aa834f9cc9eb5b0f97c85184d7dc70b84d32fd8927af0887998a1ba35"
+checksum = "e085bfce1cb2089dbeef6e280a5d598666923d3dcd308712fe429fe43c9d19f5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",
@@ -17405,9 +17405,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ba45c0d766dd56257d97702d3284b6f69efdd4c53ca981a0754cc0a139df0"
+checksum = "c4916cd526e1ce294984cc5b70264cfc0ca103b41ca665b58728bde250b6b82f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -17422,9 +17422,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a64d5112c06f9d54b41e61f0b757d3a5a52361bf359f01131cc7cb8551ac73"
+checksum = "39ad2f9d9c3baa70ee4d157b55b4c08e5dc00f1d80aad3692b1e0806393914ea"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -17435,9 +17435,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.12"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21921b6e8e8ed876a288cb3b0b3aee68809fed8182ce26c9977ffc4af4cb77f6"
+checksum = "841c11707aaeaf09895677757614d83a23c45d2b2689df908d0005aa191a933b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -17466,9 +17466,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.12"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cceb2d110d8de61e7b0e8c501b838d3c6403a14cdca8cb612ff1228db537c6d"
+checksum = "8b76b03de2cba3c036f81074c17bb1c7b77662578424887ebbc090b4c23ba33e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -17712,9 +17712,9 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "36.0.12"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a0751406b641ff50ef42d4a1ca843a03040c488c0c27f92093633447464013"
+checksum = "a333010f4b8b770a500e181e0abda564dde49a51db21aed4307fde800746ff97"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -17727,9 +17727,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.12"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab62083fdcecdd0cac61b8c46e7de4f2629ebe8699fd9ce790d922cc89d50f5f"
+checksum = "1e909aa247f90d2ba77b6860b36288cfeeb559fe01b140165f077b250cb1ba56"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -17741,9 +17741,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.12"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756b7a4a7f57ee2f53e9ef3501ed0faacda4b8dcb169a921cddc8bc09ebd199e"
+checksum = "a84de50b5bf6530a15bbb228043561d525c8e21c8929693c3078f7cad2051ad3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",
@@ -17784,9 +17784,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ea9625459ce35d6a4188cf0f07c9095cbb0e5afd86f711d63955bfc4216e64"
+checksum = "e826c012c68403725e77adf6b904c2ea809e5d464aaf25aa6eda14559300b3df"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/audit.toml
+++ b/audit.toml
@@ -110,4 +110,11 @@ ignore = [
     { id = "RUSTSEC-2026-0258", reason = "h2 0.3.27 empty-DATA-frame DoS (LOW) — client-only via aws-sdk; 0.3.x is unpatched upstream (fix is 0.4.16+, and our 0.4 instance is bumped to 0.4.17)" },
 
     { id = "RUSTSEC-2026-0235", reason = "rkyv OOB read — unenabled optional feature of rust_decimal, absent from the compiled graph (cargo tree -e normal finds 0); rust_decimal 1.42.1 (latest) still pins rkyv ^0.7.46 so there is no version to upgrade to" },
+
+    # suppaftp 5.4.0 CRLF injection in client control-channel arguments
+    # (published 2026-08-18, fixed in >=10.0.2). Pulled only as the FTP
+    # *client* used by mockforge-ftp tests against our own mock server.
+    # The mock server is not this crate. 10.x is a breaking API jump with
+    # no 5.x backport.
+    { id = "RUSTSEC-2026-0271", reason = "suppaftp CRLF in client commands — test-only FTP client against our own mock server; fix is 10.x (breaking) with no 5.x backport" },
 ]

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -1363,6 +1363,7 @@ impl BenchCommand {
 
         let mut loader = WafBenchLoader::new();
         loader.load_from_pattern(pattern)?;
+        Self::print_traffic_file_breakdown(loader.stats());
 
         Ok(crate::wafbench::traffic_cases_to_templates(loader.test_cases()))
     }
@@ -1599,40 +1600,63 @@ impl BenchCommand {
         Some(ParallelConfig::new(count))
     }
 
-    /// Load WAFBench payloads from the specified directory or pattern
-    fn load_wafbench_payloads(&self) -> Vec<SecurityPayload> {
+    /// Print attack / normal / omitted counts per YAML file so a
+    /// `--wafbench-dir` of many files tells you what to look for in
+    /// the proxy logs (#79).
+    fn print_traffic_file_breakdown(stats: &crate::wafbench::WafBenchStats) {
+        if stats.per_file.is_empty() {
+            return;
+        }
+        TerminalReporter::print_success("Traffic file breakdown (what to expect in proxy logs):");
+        for file in &stats.per_file {
+            let other = if file.other > 0 {
+                format!("  other={}", file.other)
+            } else {
+                String::new()
+            };
+            TerminalReporter::print_progress(&format!(
+                "  {}: sent={}  attack(expected 403)={}  normal(expected 200)={}  omitted={}{other}",
+                file.file, file.sent, file.attack, file.normal, file.omitted
+            ));
+        }
+    }
+
+    /// Load WAFBench payloads from the specified directory or pattern.
+    ///
+    /// #79: a missing `--wafbench-dir` path used to be a warning plus an
+    /// empty payload pool. The k6 script still enabled security testing and
+    /// crashed with `Cannot convert undefined or null to object` instead of
+    /// saying the file was missing. Missing or empty is now an error.
+    fn load_wafbench_payloads(&self) -> Result<Vec<SecurityPayload>> {
         let Some(ref wafbench_dir) = self.wafbench_dir else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
 
         let mut loader = WafBenchLoader::new();
-
-        if let Err(e) = loader.load_from_pattern(wafbench_dir) {
-            TerminalReporter::print_warning(&format!("Failed to load WAFBench tests: {}", e));
-            return Vec::new();
-        }
+        loader.load_from_pattern(wafbench_dir)?;
 
         let stats = loader.stats();
 
         if stats.files_processed == 0 {
-            TerminalReporter::print_warning(&format!(
-                "No WAFBench YAML files found matching '{}'",
-                wafbench_dir
-            ));
-            // Also report any parse errors that may explain why no files were processed
+            let mut msg = format!(
+                "No WAFBench YAML files found matching '{wafbench_dir}'. \
+                 --wafbench-dir is a file, a directory or a glob. A missing \
+                 file is an error, not an empty payload pool."
+            );
             if !stats.parse_errors.is_empty() {
-                TerminalReporter::print_warning("Some files were found but failed to parse:");
+                msg.push_str(" Parse errors:");
                 for error in &stats.parse_errors {
-                    TerminalReporter::print_warning(&format!("  - {}", error));
+                    msg.push_str(&format!("\n  - {error}"));
                 }
             }
-            return Vec::new();
+            return Err(BenchError::Other(msg));
         }
 
         TerminalReporter::print_progress(&format!(
             "Loaded {} WAFBench files, {} test cases, {} payloads",
             stats.files_processed, stats.test_cases_loaded, stats.payloads_extracted
         ));
+        Self::print_traffic_file_breakdown(stats);
 
         // Print category breakdown
         for (category, count) in &stats.by_category {
@@ -1644,7 +1668,7 @@ impl BenchCommand {
             TerminalReporter::print_warning(&format!("  Parse error: {}", error));
         }
 
-        loader.to_security_payloads()
+        Ok(loader.to_security_payloads())
     }
 
     /// Generate enhanced k6 script with advanced features
@@ -1699,7 +1723,7 @@ impl BenchCommand {
         let wafbench_payloads = if verbatim {
             Vec::new()
         } else {
-            self.load_wafbench_payloads()
+            self.load_wafbench_payloads()?
         };
         let security_requested =
             !verbatim && (security_config.is_some() || self.wafbench_dir.is_some());
@@ -4848,6 +4872,25 @@ mod tests {
             parallel.contains("security_testing_enabled()"),
             "ParallelExecutor must call security_testing_enabled() so --wafbench-verbatim \
              turns injection off on --targets-file runs too"
+        );
+    }
+
+    /// #79 (b): swallowing `load_from_pattern` errors produced Srikanth's
+    /// k6 TypeError. The `?` on the call site is what makes a missing
+    /// file fail the command instead of generating a broken script.
+    #[test]
+    fn missing_wafbench_dir_is_not_swallowed() {
+        let src = include_str!("command.rs");
+        // Assembled at runtime so this test file does not match itself.
+        let swallowed = format!("Failed to {} WAFBench tests", "load");
+        let impl_line = src
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .any(|l| l.contains(&swallowed));
+        assert!(!impl_line, "missing --wafbench-dir must not be downgraded to a warning");
+        assert!(
+            src.contains("self.load_wafbench_payloads()?"),
+            "payload load errors must reach generate_enhanced_script"
         );
     }
 

--- a/crates/mockforge-bench/src/security_payloads.rs
+++ b/crates/mockforge-bench/src/security_payloads.rs
@@ -767,8 +767,15 @@ impl SecurityTestGenerator {
             // Cycle through all payload groups sequentially
             code.push_str("// Cycle through ALL payload groups sequentially\n");
             code.push_str("// Each VU starts at a different offset based on its VU number for better payload distribution\n");
-            code.push_str("let __payloadIndex = (__VU - 1) % groupedPayloads.length;\n");
+            // #79: empty pool used to do `% 0` → NaN → undefined, and k6's
+            // goja threw `Cannot convert undefined or null to object` on
+            // `for (const p of secPayloadGroup)` instead of naming the
+            // missing --wafbench-dir file.
+            code.push_str(
+                "let __payloadIndex = groupedPayloads.length === 0 ? 0 : (__VU - 1) % groupedPayloads.length;\n",
+            );
             code.push_str("function getNextSecurityPayload() {\n");
+            code.push_str("  if (groupedPayloads.length === 0) return [];\n");
             code.push_str("  const group = groupedPayloads[__payloadIndex];\n");
             code.push_str("  __payloadIndex = (__payloadIndex + 1) % groupedPayloads.length;\n");
             code.push_str("  return group;\n");
@@ -777,6 +784,7 @@ impl SecurityTestGenerator {
             // Random selection (original behavior)
             code.push_str("// Select random security payload group\n");
             code.push_str("function getNextSecurityPayload() {\n");
+            code.push_str("  if (groupedPayloads.length === 0) return [];\n");
             code.push_str(
                 "  return groupedPayloads[Math.floor(Math.random() * groupedPayloads.length)];\n",
             );
@@ -1015,6 +1023,25 @@ mod tests {
         assert!(code.contains("getNextSecurityPayload"));
         // getNextSecurityPayload should return from groupedPayloads (arrays)
         assert!(code.contains("groupedPayloads[Math.floor"));
+    }
+
+    /// #79 (b): a missing traffic file used to emit `groupedPayloads = []`
+    /// and `return groupedPayloads[NaN]`, which k6 surfaced as
+    /// `Cannot convert undefined or null to object` at the for-of. An
+    /// empty pool must return `[]` so the loop is a no-op even if we
+    /// fail to abort earlier.
+    #[test]
+    fn empty_payload_pool_returns_empty_group_not_undefined() {
+        let random = SecurityTestGenerator::generate_payload_selection(&[], false);
+        assert!(
+            random.contains("if (groupedPayloads.length === 0) return [];"),
+            "random selector must guard the empty pool: {random}"
+        );
+        let cycle = SecurityTestGenerator::generate_payload_selection(&[], true);
+        assert!(
+            cycle.contains("if (groupedPayloads.length === 0) return [];"),
+            "cycle-all selector must guard the empty pool: {cycle}"
+        );
     }
 
     #[test]

--- a/crates/mockforge-bench/src/wafbench.rs
+++ b/crates/mockforge-bench/src/wafbench.rs
@@ -480,6 +480,9 @@ pub fn parse_traffic_file(content: &str, source: &str) -> Result<WafBenchFile> {
                         .enumerate()
                         .map(|(i, c)| c.into_wafbench_test(i))
                         .collect(),
+                    // #79: Srikanth wants omitted cases in the per-file
+                    // breakdown, not only in a tracing line he may miss.
+                    omitted_count: omitted.len(),
                 })
             }
             Err(simple_err) => Err(BenchError::Other(format!(
@@ -499,6 +502,10 @@ pub struct WafBenchFile {
     /// Test cases
     #[serde(default)]
     pub tests: Vec<WafBenchTest>,
+    /// Cases dropped for `omit_rule: true`. Not in the YAML; filled by
+    /// `parse_traffic_file` so the per-file breakdown can report them.
+    #[serde(default, skip)]
+    pub omitted_count: usize,
 }
 
 /// A parsed WAFBench test case ready for use in security testing
@@ -560,6 +567,24 @@ pub struct WafBenchLoader {
     stats: WafBenchStats,
 }
 
+/// Per-file counts so a multi-YAML run can say how many attacks vs
+/// baseline vs omitted cases each file contributed (#79).
+#[derive(Debug, Clone, Default)]
+pub struct TrafficFileSummary {
+    /// Path as loaded (`--wafbench-dir` entry or glob match).
+    pub file: String,
+    /// Cases that will actually be sent.
+    pub sent: usize,
+    /// Sent cases whose expected status includes 403 (treated as attacks).
+    pub attack: usize,
+    /// Sent cases whose expected status includes 200 and not 403.
+    pub normal: usize,
+    /// Cases skipped for `omit_rule: true`.
+    pub omitted: usize,
+    /// Sent cases with neither 200 nor 403 in `expected`.
+    pub other: usize,
+}
+
 /// Statistics about loaded WAFBench tests
 #[derive(Debug, Clone, Default)]
 pub struct WafBenchStats {
@@ -573,6 +598,41 @@ pub struct WafBenchStats {
     pub by_category: HashMap<SecurityCategory, usize>,
     /// Files that failed to parse
     pub parse_errors: Vec<String>,
+    /// One row per loaded traffic file.
+    pub per_file: Vec<TrafficFileSummary>,
+}
+
+/// Classify a parsed file into the attack / normal / omitted buckets
+/// Srikanth asked for: expected 403 = attack, expected 200 = normal.
+pub fn summarize_traffic_file(file: &WafBenchFile, source: &str) -> TrafficFileSummary {
+    let mut attack = 0;
+    let mut normal = 0;
+    let mut other = 0;
+    for test in &file.tests {
+        let mut has_403 = false;
+        let mut has_200 = false;
+        for stage in &test.stages {
+            if let Some(output) = stage.get_output() {
+                has_403 |= output.status.contains(&403);
+                has_200 |= output.status.contains(&200);
+            }
+        }
+        if has_403 {
+            attack += 1;
+        } else if has_200 {
+            normal += 1;
+        } else {
+            other += 1;
+        }
+    }
+    TrafficFileSummary {
+        file: source.to_string(),
+        sent: file.tests.len(),
+        attack,
+        normal,
+        omitted: file.omitted_count,
+        other,
+    }
 }
 
 impl WafBenchLoader {
@@ -678,13 +738,15 @@ impl WafBenchLoader {
             BenchError::Other(format!("Failed to read WAFBench file {}: {}", path.display(), e))
         })?;
 
-        let wafbench_file = parse_traffic_file(&content, &path.display().to_string())?;
+        let source = path.display().to_string();
+        let wafbench_file = parse_traffic_file(&content, &source)?;
 
         // Skip disabled test files
         if !wafbench_file.meta.enabled {
             return Ok(());
         }
 
+        self.stats.per_file.push(summarize_traffic_file(&wafbench_file, &source));
         self.stats.files_processed += 1;
 
         // Determine the rule category from the file path or name
@@ -1871,5 +1933,47 @@ mod verbatim_tests {
             titles.iter().any(|t| t.contains("unsupported response_type blocked")),
             "omit_rule:false must not be treated as omitted: {titles:?}"
         );
+        assert_eq!(parsed.omitted_count, 1, "omitted_count must match the dropped baseline");
+    }
+
+    /// #79: per-file breakdown so a directory of YAML files reports
+    /// attack (403) vs normal (200) vs omitted before k6 starts.
+    #[test]
+    fn traffic_file_summary_splits_attack_normal_omitted() {
+        let yaml = r#"
+- title: blocked
+  request:
+    method: GET
+    uri: /oauth/authorize?response_type=totally-unsupported
+  expected: 403
+- title: allowed
+  request:
+    method: GET
+    uri: /oauth/authorize?response_type=code
+  expected: 200
+- title: baseline
+  omit_rule: true
+  request:
+    method: GET
+    uri: /oauth/authorize?response_type=totally-unsupported
+  expected: 200
+"#;
+        let parsed = parse_traffic_file(yaml, "oauth.yaml").expect("parse");
+        let summary = summarize_traffic_file(&parsed, "oauth.yaml");
+        assert_eq!(summary.sent, 2);
+        assert_eq!(summary.attack, 1);
+        assert_eq!(summary.normal, 1);
+        assert_eq!(summary.omitted, 1);
+        assert_eq!(summary.other, 0);
+    }
+
+    #[test]
+    fn missing_wafbench_path_is_an_error() {
+        let mut loader = WafBenchLoader::new();
+        let err = loader
+            .load_from_pattern("definitely-not-a-real-file-apisix.yaml")
+            .expect_err("missing path must not look like an empty payload pool");
+        let msg = err.to_string();
+        assert!(msg.contains("does not exist"), "error must name the missing path, got: {msg}");
     }
 }

--- a/crates/mockforge-cli/examples/seed_capture_db.rs
+++ b/crates/mockforge-cli/examples/seed_capture_db.rs
@@ -12,7 +12,7 @@ async fn main() -> anyhow::Result<()> {
     let db = RecorderDatabase::new(&db_path).await?;
     let recorder = Recorder::new(db);
 
-    let mut exchange =
+    let exchange =
         |id: &str, path: &str, status: i32, body: String| -> (RecordedRequest, RecordedResponse) {
             (
                 RecordedRequest {

--- a/crates/mockforge-cli/src/mcp_server.rs
+++ b/crates/mockforge-cli/src/mcp_server.rs
@@ -254,10 +254,8 @@ async fn tools_call(name: &str, args: &Value) -> Result<String, String> {
                         };
                         let media = response.content.get("application/json")?;
                         match &media.schema {
-                            Some(openapiv3::ReferenceOr::Item(schema)) => {
-                                serde_json::to_value(schema).ok()
-                            }
-                            Some(openapiv3::ReferenceOr::Reference { reference }) => {
+                            Some(ReferenceOr::Item(schema)) => serde_json::to_value(schema).ok(),
+                            Some(ReferenceOr::Reference { reference }) => {
                                 Some(json!({ "$ref": reference }))
                             }
                             None => None,

--- a/crates/mockforge-cli/src/verify_mocks_commands.rs
+++ b/crates/mockforge-cli/src/verify_mocks_commands.rs
@@ -337,8 +337,8 @@ fn check_response_drift(
         };
         let media = response.content.get("application/json")?;
         match &media.schema {
-            Some(openapiv3::ReferenceOr::Item(schema)) => serde_json::to_value(schema).ok(),
-            Some(openapiv3::ReferenceOr::Reference { reference }) => {
+            Some(ReferenceOr::Item(schema)) => serde_json::to_value(schema).ok(),
+            Some(ReferenceOr::Reference { reference }) => {
                 Some(serde_json::json!({ "$ref": reference }))
             }
             None => None,

--- a/crates/mockforge-http/src/metrics_middleware.rs
+++ b/crates/mockforge-http/src/metrics_middleware.rs
@@ -21,8 +21,8 @@ use tracing::debug;
 /// `X-MockForge-Persona` names the persona under test; the optional
 /// `X-MockForge-CI-Run` identifies the CI run stamping it. Blank values
 /// count as absent.
-fn detect_persona_headers(headers: &axum::http::HeaderMap) -> (Option<String>, Option<String>) {
-    let clean = |v: Option<&axum::http::HeaderValue>| {
+fn detect_persona_headers(headers: &http::HeaderMap) -> (Option<String>, Option<String>) {
+    let clean = |v: Option<&http::HeaderValue>| {
         v.and_then(|v| v.to_str().ok())
             .map(str::trim)
             .filter(|v| !v.is_empty())
@@ -553,7 +553,7 @@ mod persona_ci_hit_tests {
 
     #[test]
     fn persona_and_run_detected() {
-        let mut h = axum::http::HeaderMap::new();
+        let mut h = http::HeaderMap::new();
         h.insert("x-mockforge-persona", "checkout-user".parse().unwrap());
         h.insert("x-mockforge-ci-run", "gh-run-123".parse().unwrap());
         let (persona, run) = detect_persona_headers(&h);
@@ -563,7 +563,7 @@ mod persona_ci_hit_tests {
 
     #[test]
     fn blank_and_absent_are_none() {
-        let mut h = axum::http::HeaderMap::new();
+        let mut h = http::HeaderMap::new();
         h.insert("x-mockforge-persona", "  ".parse().unwrap());
         let (persona, run) = detect_persona_headers(&h);
         assert_eq!(persona, None);

--- a/crates/mockforge-kafka/src/broker.rs
+++ b/crates/mockforge-kafka/src/broker.rs
@@ -154,7 +154,7 @@ pub struct KafkaMockBroker {
     /// #715 — optional traffic recorder. Set from
     /// MOCKFORGE_KAFKA_RECORDING_DB (sqlite path) at construction; when
     /// unset no exchange is recorded and behaviour is unchanged.
-    recorder: Option<std::sync::Arc<mockforge_recorder::Recorder>>,
+    recorder: Option<Arc<mockforge_recorder::Recorder>>,
 }
 
 impl KafkaMockBroker {
@@ -227,7 +227,7 @@ impl KafkaMockBroker {
             recorder: match std::env::var("MOCKFORGE_KAFKA_RECORDING_DB") {
                 Ok(path) if !path.trim().is_empty() => {
                     match mockforge_recorder::RecorderDatabase::new(path.as_str()).await {
-                        Ok(db) => Some(std::sync::Arc::new(mockforge_recorder::Recorder::new(db))),
+                        Ok(db) => Some(Arc::new(mockforge_recorder::Recorder::new(db))),
                         Err(e) => {
                             tracing::warn!(
                                 error = %e,
@@ -243,7 +243,7 @@ impl KafkaMockBroker {
     }
 
     /// #715 — attach a recorder after construction (programmatic setup).
-    pub fn set_recorder(&mut self, recorder: std::sync::Arc<mockforge_recorder::Recorder>) {
+    pub fn set_recorder(&mut self, recorder: Arc<mockforge_recorder::Recorder>) {
         self.recorder = Some(recorder);
     }
 
@@ -1566,7 +1566,7 @@ mod tests {
             .await
             .expect("in-memory db");
         let probe_db = db.clone();
-        let recorder = std::sync::Arc::new(mockforge_recorder::Recorder::new(db));
+        let recorder = Arc::new(mockforge_recorder::Recorder::new(db));
 
         let event = mockforge_recorder::protocols::async_brokers::kafka_event(
             "produce",


### PR DESCRIPTION
## Summary
- Missing `--wafbench-dir` is now a hard error instead of a warning plus an empty payload pool (that empty pool made k6 throw `Cannot convert undefined or null to object`).
- `getNextSecurityPayload()` returns `[]` when the pool is empty, so a future empty-pool path cannot crash goja.
- After a traffic file loads, print per-file `sent` / `attack(expected 403)` / `normal(expected 200)` / `omitted` so proxy-log review has a checklist (#79 (d)).

## Test plan
- [x] `cargo test -p mockforge-bench --lib` for `missing_wafbench_dir_is_not_swallowed`, `missing_wafbench_path_is_an_error`, `empty_payload_pool_returns_empty_group_not_undefined`, `traffic_file_summary_splits_attack_normal_omitted`
- [x] Real CLI: `--wafbench-dir` pointing at a missing YAML + `--spec` + `--targets-file` exits with `WAFBench path does not exist` (no k6 script)
- [x] Real CLI: existing YAML prints `Traffic file breakdown (what to expect in proxy logs)`
- [x] Real CLI: no `--spec` and no `--wafbench-verbatim` still errors `No spec files provided`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SaaSy-Solutions/codesmith/mockforge/pr/1027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790794169&installation_model_id=435061&pr_number=1027&repository=SaaSy-Solutions%2Fmockforge&return_to=https%3A%2F%2Fgithub.com%2FSaaSy-Solutions%2Fmockforge%2Fpull%2F1027&signature=89bdbde1c2bf6763c1becde7b5d2c8fd62b045ffd213cd1e57cc8129186ce507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->