### PR TITLE
fix(bench): Content-Length skip, unique k6 metrics, traffic-breakdown JSON (#79)

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -1054,6 +1054,7 @@ impl BenchCommand {
             Some(num_ops),
         );
 
+        self.reprint_traffic_file_breakdown();
         println!("\nResults saved to: {}", self.output.display());
 
         Ok(())
@@ -1308,6 +1309,7 @@ impl BenchCommand {
         }
         let _ = std::fs::write(&csv_path, &csv);
 
+        self.reprint_traffic_file_breakdown();
         println!("\nResults saved to: {}", self.output.display());
         println!("  - Per-target results: {}", self.output.join("target_*").display());
         println!("  - All targets CSV:    {}", csv_path.display());
@@ -1363,7 +1365,7 @@ impl BenchCommand {
 
         let mut loader = WafBenchLoader::new();
         loader.load_from_pattern(pattern)?;
-        Self::print_traffic_file_breakdown(loader.stats());
+        self.emit_traffic_file_breakdown(loader.stats(), "what to expect in proxy logs");
 
         Ok(crate::wafbench::traffic_cases_to_templates(loader.test_cases()))
     }
@@ -1600,14 +1602,42 @@ impl BenchCommand {
         Some(ParallelConfig::new(count))
     }
 
-    /// Print attack / normal / omitted counts per YAML file so a
-    /// `--wafbench-dir` of many files tells you what to look for in
-    /// the proxy logs (#79).
-    fn print_traffic_file_breakdown(stats: &crate::wafbench::WafBenchStats) {
+    /// Unique vs total for one bucket. When `--rps` is set, total is
+    /// unique * RPS (Srikanth's #79 (d) example: 5 unique at 50 RPS → 250).
+    fn format_unique_total(unique: usize, rps: Option<u32>) -> String {
+        match rps {
+            Some(r) if r > 0 => {
+                let total = unique.saturating_mul(r as usize);
+                format!("unique={unique} total={total} ({unique} * {r} RPS)")
+            }
+            _ => format!("unique={unique}"),
+        }
+    }
+
+    fn traffic_bucket_json(
+        unique: usize,
+        rps: Option<u32>,
+        duration_secs: Option<u64>,
+    ) -> serde_json::Value {
+        let multiplier = rps.filter(|&r| r > 0).unwrap_or(1) as u64;
+        let total = (unique as u64).saturating_mul(multiplier);
+        let expected_over_duration =
+            duration_secs.map(|d| (unique as u64).saturating_mul(multiplier).saturating_mul(d));
+        serde_json::json!({
+            "unique": unique,
+            "total": total,
+            "expected_over_duration": expected_over_duration,
+        })
+    }
+
+    /// Print attack / normal / omitted counts per YAML file and write
+    /// `traffic-breakdown.json` next to the other bench artifacts (#79 (d)(e)).
+    fn emit_traffic_file_breakdown(&self, stats: &crate::wafbench::WafBenchStats, phase: &str) {
         if stats.per_file.is_empty() {
             return;
         }
-        TerminalReporter::print_success("Traffic file breakdown (what to expect in proxy logs):");
+        let rps = self.target_rps.filter(|&r| r > 0);
+        TerminalReporter::print_success(&format!("Traffic file breakdown ({phase}):"));
         for file in &stats.per_file {
             let other = if file.other > 0 {
                 format!("  other={}", file.other)
@@ -1615,10 +1645,100 @@ impl BenchCommand {
                 String::new()
             };
             TerminalReporter::print_progress(&format!(
-                "  {}: sent={}  attack(expected 403)={}  normal(expected 200)={}  omitted={}{other}",
-                file.file, file.sent, file.attack, file.normal, file.omitted
+                "  {}: sent {}  attack(expected 403) {}  normal(expected 200) {}  omitted={}{other}",
+                file.file,
+                Self::format_unique_total(file.sent, rps),
+                Self::format_unique_total(file.attack, rps),
+                Self::format_unique_total(file.normal, rps),
+                file.omitted
             ));
         }
+        self.write_traffic_breakdown_json(stats);
+    }
+
+    /// Persist the same breakdown for automation (#79 (e)).
+    fn write_traffic_breakdown_json(&self, stats: &crate::wafbench::WafBenchStats) {
+        if stats.per_file.is_empty() {
+            return;
+        }
+        let rps = self.target_rps.filter(|&r| r > 0);
+        let duration_secs = Self::parse_duration(&self.duration).ok();
+        let files: Vec<serde_json::Value> = stats
+            .per_file
+            .iter()
+            .map(|file| {
+                serde_json::json!({
+                    "file": file.file,
+                    "sent": Self::traffic_bucket_json(file.sent, rps, duration_secs),
+                    "attack": Self::traffic_bucket_json(file.attack, rps, duration_secs),
+                    "normal": Self::traffic_bucket_json(file.normal, rps, duration_secs),
+                    "omitted": file.omitted,
+                    "other": file.other,
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "rps": rps,
+            "duration_secs": duration_secs,
+            "files": files,
+        });
+        if let Some(parent) = self.output.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::create_dir_all(&self.output);
+        let path = self.output.join("traffic-breakdown.json");
+        if let Ok(body) = serde_json::to_string_pretty(&payload) {
+            if std::fs::write(&path, body).is_ok() {
+                TerminalReporter::print_progress(&format!(
+                    "Traffic breakdown written to: {}",
+                    path.display()
+                ));
+            }
+        }
+    }
+
+    /// Long runs scroll the load-time breakdown off the screen. Print it
+    /// again after k6 finishes, from the JSON we already wrote (#79 (d)).
+    fn reprint_traffic_file_breakdown(&self) {
+        let path = self.output.join("traffic-breakdown.json");
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            return;
+        };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            return;
+        };
+        let Some(files) = v.get("files").and_then(|f| f.as_array()) else {
+            return;
+        };
+        if files.is_empty() {
+            return;
+        }
+        TerminalReporter::print_success("Traffic file breakdown (end of run):");
+        for file in files {
+            let name = file.get("file").and_then(|x| x.as_str()).unwrap_or("?");
+            let bucket = |key: &str| -> String {
+                let unique = file
+                    .get(key)
+                    .and_then(|b| b.get("unique"))
+                    .and_then(|u| u.as_u64())
+                    .unwrap_or(0) as usize;
+                Self::format_unique_total(unique, self.target_rps.filter(|&r| r > 0))
+            };
+            let omitted = file.get("omitted").and_then(|o| o.as_u64()).unwrap_or(0);
+            let other = file.get("other").and_then(|o| o.as_u64()).unwrap_or(0);
+            let other = if other > 0 {
+                format!("  other={other}")
+            } else {
+                String::new()
+            };
+            TerminalReporter::print_progress(&format!(
+                "  {name}: sent {}  attack(expected 403) {}  normal(expected 200) {}  omitted={omitted}{other}",
+                bucket("sent"),
+                bucket("attack"),
+                bucket("normal"),
+            ));
+        }
+        TerminalReporter::print_progress(&format!("  (also in {})", path.display()));
     }
 
     /// Load WAFBench payloads from the specified directory or pattern.
@@ -1656,7 +1776,7 @@ impl BenchCommand {
             "Loaded {} WAFBench files, {} test cases, {} payloads",
             stats.files_processed, stats.test_cases_loaded, stats.payloads_extracted
         ));
-        Self::print_traffic_file_breakdown(stats);
+        self.emit_traffic_file_breakdown(stats, "what to expect in proxy logs");
 
         // Print category breakdown
         for (category, count) in &stats.by_category {
@@ -4907,5 +5027,50 @@ mod tests {
              Requiring a spec and generating templates from its operations is how \
              --targets-file ignored the flag and fuzzed spec URLs (#79)."
         );
+    }
+
+    /// #79 (d)(e): unique vs total (unique * RPS) plus a JSON sidecar.
+    #[test]
+    fn traffic_breakdown_json_multiplies_unique_by_rps() {
+        let dir = std::env::temp_dir().join(format!(
+            "mf-traffic-breakdown-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let mut cmd = sample_bench_command();
+        cmd.output = dir.clone();
+        cmd.target_rps = Some(50);
+        cmd.duration = "1200s".to_string();
+        let stats = crate::wafbench::WafBenchStats {
+            per_file: vec![crate::wafbench::TrafficFileSummary {
+                file: "apisix_cve-2026-44087.yaml".into(),
+                sent: 5,
+                attack: 3,
+                normal: 2,
+                omitted: 1,
+                other: 0,
+            }],
+            ..Default::default()
+        };
+        cmd.emit_traffic_file_breakdown(&stats, "what to expect in proxy logs");
+        let raw = std::fs::read_to_string(dir.join("traffic-breakdown.json"))
+            .expect("traffic-breakdown.json");
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["rps"], 50);
+        assert_eq!(v["duration_secs"], 1200);
+        assert_eq!(v["files"][0]["sent"]["unique"], 5);
+        assert_eq!(v["files"][0]["sent"]["total"], 250);
+        assert_eq!(v["files"][0]["sent"]["expected_over_duration"], 300000);
+        assert_eq!(v["files"][0]["attack"]["total"], 150);
+        assert_eq!(v["files"][0]["normal"]["total"], 100);
+        assert_eq!(
+            BenchCommand::format_unique_total(5, Some(50)),
+            "unique=5 total=250 (5 * 50 RPS)"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/mockforge-bench/src/k6_gen.rs
+++ b/crates/mockforge-bench/src/k6_gen.rs
@@ -286,6 +286,37 @@ impl K6ScriptGenerator {
         format!("{}_{}", prefix, hash_suffix)
     }
 
+    /// Deduplicate a sanitized identifier among `used`.
+    ///
+    /// Two WAFBench YAML files often share titles like "normal request
+    /// allowed". Those collapse to the same JS identifier, and k6 exits
+    /// 107 (ScriptException: Identifier has already been declared) before
+    /// sending a single request. Srikanth's 32-target verbatim run (#79
+    /// (g)) hit this: 10 colliding `const` names in one script.
+    fn uniquify_name(base: String, used: &mut HashSet<String>) -> String {
+        if used.insert(base.clone()) {
+            return base;
+        }
+        let mut n = 2u32;
+        loop {
+            let candidate = format!("{base}_{n}");
+            if used.insert(candidate.clone()) {
+                return candidate;
+            }
+            n = n.saturating_add(1);
+            if n == u32::MAX {
+                use std::collections::hash_map::DefaultHasher;
+                use std::hash::{Hash, Hasher};
+                let mut hasher = DefaultHasher::new();
+                base.hash(&mut hasher);
+                used.len().hash(&mut hasher);
+                let fallback = format!("{base}_{:08x}", hasher.finish() as u32);
+                used.insert(fallback.clone());
+                return fallback;
+            }
+        }
+    }
+
     /// Sanitize a name to be a valid JavaScript identifier
     ///
     /// Replaces invalid characters (dots, spaces, special chars) with underscores.
@@ -341,67 +372,75 @@ impl K6ScriptGenerator {
 
         // Track all placeholders used across all operations
         let mut all_placeholders: HashSet<DynamicPlaceholder> = HashSet::new();
+        // Issue #79 (g) — colliding titles across many YAML files must not
+        // emit two `const foo_latency = new Trend(...)` lines.
+        let mut used_js_names: HashSet<String> = HashSet::new();
+        let mut used_metric_names: HashSet<String> = HashSet::new();
 
-        let operations = self
-            .templates
-            .iter()
-            .enumerate()
-            .map(|(idx, template)| {
-                let display_name = template.operation.display_name();
-                let sanitized_name = Self::sanitize_js_identifier(&display_name);
-                // metric_name must satisfy k6's 128-char limit AND leave room
-                // for suffixes like `_latency` / `_errors` / `_stepN_*`.
-                // Long deeply-nested operationIds (e.g. Microsoft Graph) exceed
-                // this; sanitize_k6_metric_name truncates with a hash suffix
-                // for uniqueness. (See issue #79 — Srikanth's microsoft-graph.yaml run.)
-                let metric_name = Self::sanitize_k6_metric_name(&display_name);
-                // k6 uses 'del' instead of 'delete' for HTTP DELETE method
-                let k6_method = match template.operation.method.to_lowercase().as_str() {
-                    "delete" => "del".to_string(),
-                    m => m.to_string(),
-                };
-                // GET and HEAD methods only take 2 arguments in k6: http.get(url, params)
-                // Other methods take 3 arguments: http.post(url, body, params)
-                let is_get_or_head = matches!(k6_method.as_str(), "get" | "head");
+        let mut operations = Vec::with_capacity(self.templates.len());
+        for (idx, template) in self.templates.iter().enumerate() {
+            let display_name = template.operation.display_name();
+            let sanitized_name = Self::uniquify_name(
+                Self::sanitize_js_identifier(&display_name),
+                &mut used_js_names,
+            );
+            // metric_name must satisfy k6's 128-char limit AND leave room
+            // for suffixes like `_latency` / `_errors` / `_stepN_*`.
+            // Long deeply-nested operationIds (e.g. Microsoft Graph) exceed
+            // this; sanitize_k6_metric_name truncates with a hash suffix
+            // for uniqueness. (See issue #79 — Srikanth's microsoft-graph.yaml run.)
+            // uniquify_name then splits short-name collisions that the hash
+            // path does not see (two "normal request allowed" cases).
+            let metric_name = Self::uniquify_name(
+                Self::sanitize_k6_metric_name(&display_name),
+                &mut used_metric_names,
+            );
+            // k6 uses 'del' instead of 'delete' for HTTP DELETE method
+            let k6_method = match template.operation.method.to_lowercase().as_str() {
+                "delete" => "del".to_string(),
+                m => m.to_string(),
+            };
+            // GET and HEAD methods only take 2 arguments in k6: http.get(url, params)
+            // Other methods take 3 arguments: http.post(url, body, params)
+            let is_get_or_head = matches!(k6_method.as_str(), "get" | "head");
 
-                // Process path for dynamic placeholders
-                // Prepend base_path if configured
-                let raw_path = template.generate_path();
-                let full_path = join_base_path(base_path, &raw_path);
-                let processed_path = DynamicParamProcessor::process_path(&full_path);
-                all_placeholders.extend(processed_path.placeholders.clone());
+            // Process path for dynamic placeholders
+            // Prepend base_path if configured
+            let raw_path = template.generate_path();
+            let full_path = join_base_path(base_path, &raw_path);
+            let processed_path = DynamicParamProcessor::process_path(&full_path);
+            all_placeholders.extend(processed_path.placeholders.clone());
 
-                // Process body for dynamic placeholders
-                let (body_value, body_is_dynamic) = if let Some(body) = &template.body {
-                    let processed_body = DynamicParamProcessor::process_json_body(body);
-                    all_placeholders.extend(processed_body.placeholders.clone());
-                    (Some(processed_body.value), processed_body.is_dynamic)
-                } else {
-                    (None, false)
-                };
+            // Process body for dynamic placeholders
+            let (body_value, body_is_dynamic) = if let Some(body) = &template.body {
+                let processed_body = DynamicParamProcessor::process_json_body(body);
+                all_placeholders.extend(processed_body.placeholders.clone());
+                (Some(processed_body.value), processed_body.is_dynamic)
+            } else {
+                (None, false)
+            };
 
-                let path_value = if processed_path.is_dynamic {
-                    processed_path.value
-                } else {
-                    full_path
-                };
+            let path_value = if processed_path.is_dynamic {
+                processed_path.value
+            } else {
+                full_path
+            };
 
-                K6OperationData {
-                    index: idx,
-                    name: sanitized_name,
-                    metric_name,
-                    display_name,
-                    method: k6_method,
-                    path: Value::String(path_value),
-                    path_is_dynamic: processed_path.is_dynamic,
-                    headers: Value::String(self.build_headers_json(template)),
-                    body: body_value.map(Value::String),
-                    body_is_dynamic,
-                    has_body: template.body.is_some(),
-                    is_get_or_head,
-                }
-            })
-            .collect::<Vec<_>>();
+            operations.push(K6OperationData {
+                index: idx,
+                name: sanitized_name,
+                metric_name,
+                display_name,
+                method: k6_method,
+                path: Value::String(path_value),
+                path_is_dynamic: processed_path.is_dynamic,
+                headers: Value::String(self.build_headers_json(template)),
+                body: body_value.map(Value::String),
+                body_is_dynamic,
+                has_body: template.body.is_some(),
+                is_get_or_head,
+            });
+        }
 
         // Get required imports and global initializations based on placeholders used
         let required_imports: Vec<String> =
@@ -520,11 +559,30 @@ impl K6ScriptGenerator {
         // k6 metric names must only contain ASCII letters, numbers, or underscores
         // and start with a letter or underscore
         let lines: Vec<&str> = script.lines().collect();
+        let mut seen_metric_consts: HashSet<String> = HashSet::new();
         for (line_num, line) in lines.iter().enumerate() {
             let trimmed = line.trim();
 
             // Check for Trend/Rate constructors with invalid metric names
             if trimmed.contains("new Trend(") || trimmed.contains("new Rate(") {
+                // Duplicate `const foo_latency = new Trend(...)` is a parse
+                // error in k6 (exit 107). Catch it here so generate() fails
+                // in-process instead of after a 32-target spawn.
+                if let Some(name) = trimmed
+                    .strip_prefix("const ")
+                    .and_then(|rest| rest.split('=').next())
+                    .map(str::trim)
+                    .filter(|n| {
+                        !n.is_empty() && n.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                    })
+                {
+                    if !seen_metric_consts.insert(name.to_string()) {
+                        errors.push(format!(
+                            "Line {}: duplicate const '{name}'. k6 exits 107 (ScriptException) when two traffic cases sanitize to the same identifier.",
+                            line_num + 1
+                        ));
+                    }
+                }
                 // Extract the metric name from the string literal
                 // Pattern: new Trend('metric_name') or new Rate("metric_name")
                 if let Some(start) = trimmed.find('\'') {
@@ -696,6 +754,75 @@ mod tests {
         let generator = K6ScriptGenerator::new(config, templates);
 
         assert_eq!(generator.templates.len(), 0);
+    }
+
+    #[test]
+    fn colliding_operation_titles_get_unique_const_names() {
+        // #79 (g): two YAML cases titled "normal request allowed" used to
+        // emit `const normal_request_allowed_latency` twice. k6 then exited
+        // 107 on every target with 0 requests.
+        use crate::spec_parser::ApiOperation;
+        use openapiv3::Operation;
+
+        fn tmpl(id: &str, path: &str) -> RequestTemplate {
+            RequestTemplate {
+                operation: ApiOperation {
+                    method: "get".to_string(),
+                    path: path.to_string(),
+                    operation: Operation::default(),
+                    operation_id: Some(id.to_string()),
+                },
+                path_params: HashMap::new(),
+                query_params: HashMap::new(),
+                headers: HashMap::new(),
+                body: None,
+            }
+        }
+
+        let config = K6Config {
+            target_url: "https://example.test".to_string(),
+            base_path: None,
+            scenario: LoadScenario::Constant,
+            duration_secs: 5,
+            max_vus: 1,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            auth_header: None,
+            custom_headers: HashMap::new(),
+            skip_tls_verify: false,
+            security_testing_enabled: false,
+            chunked_request_bodies: false,
+            target_rps: None,
+            no_keep_alive: false,
+            geo_source_ips: Vec::new(),
+            geo_source_headers: Vec::new(),
+        };
+        let generator = K6ScriptGenerator::new(
+            config,
+            vec![
+                tmpl("normal request allowed", "/a"),
+                tmpl("normal request allowed", "/b"),
+            ],
+        );
+        let script = generator.generate().expect("script generates");
+        let latency = script
+            .lines()
+            .filter(|l| l.contains("new Trend(") && l.contains("normal_request_allowed"))
+            .collect::<Vec<_>>();
+        assert_eq!(latency.len(), 2, "expected two Trend consts, got {latency:#?}");
+        assert!(
+            script.contains("const normal_request_allowed_latency = new Trend"),
+            "first collision keeps the base name"
+        );
+        assert!(
+            script.contains("const normal_request_allowed_2_latency = new Trend")
+                || script.contains("const normal_request_allowed_latency_2 = new Trend"),
+            "second collision must be renamed, script snippet:\n{}",
+            latency.join("\n")
+        );
+        let errors = K6ScriptGenerator::validate_script(&script);
+        assert!(errors.is_empty(), "validate_script: {errors:#?}");
     }
 
     #[test]

--- a/crates/mockforge-bench/src/request_gen.rs
+++ b/crates/mockforge-bench/src/request_gen.rs
@@ -149,7 +149,19 @@ impl RequestGenerator {
                 template.path_params.insert(param_data.name.clone(), value);
             }
             "header" => {
-                template.headers.insert(param_data.name.clone(), value);
+                // Issue #79 (f) — S3 (and others) list Content-Length / Host as
+                // header parameters. Filling those from the schema invents
+                // `Content-Length: 42` on a 0-byte body. k6 then drops the
+                // request: the declared length does not match the body.
+                // Skip hop-by-hop / transport-owned names unless the user
+                // overrode them on purpose (WAF CL-mismatch cases).
+                let from_override =
+                    overrides.and_then(|o| o.get_header(&param_data.name)).is_some();
+                if Self::is_transport_owned_header(&param_data.name) && !from_override {
+                    // Leave it to k6 / the HTTP client.
+                } else {
+                    template.headers.insert(param_data.name.clone(), value);
+                }
             }
             "cookie" => {
                 // Append cookie to existing Cookie header or create new one
@@ -167,6 +179,24 @@ impl RequestGenerator {
         }
 
         Ok(())
+    }
+
+    /// Headers the HTTP client computes. Auto-filling them from an OpenAPI
+    /// schema is how Srikanth's Amazon S3 spec produced `Content-Length: 42`
+    /// on every empty POST and sent no useful traffic (#79 (f)).
+    pub(crate) fn is_transport_owned_header(name: &str) -> bool {
+        matches!(
+            name.to_ascii_lowercase().as_str(),
+            "content-length"
+                | "transfer-encoding"
+                | "host"
+                | "connection"
+                | "keep-alive"
+                | "te"
+                | "trailer"
+                | "upgrade"
+                | "proxy-connection"
+        )
     }
 
     /// Generate a value for a parameter
@@ -350,5 +380,67 @@ mod tests {
         assert_eq!(RequestGenerator::default_param_value("id"), "1");
         assert_eq!(RequestGenerator::default_param_value("limit"), "10");
         assert_eq!(RequestGenerator::default_param_value("unknown"), "test-value");
+    }
+
+    /// #79 (f): an integer `Content-Length` header param must not be
+    /// invented as `"42"`. k6 owns that header.
+    #[test]
+    fn spec_content_length_header_is_not_invented() {
+        use openapiv3::{HeaderStyle, IntegerType, ParameterData, Schema, SchemaData, SchemaKind};
+
+        let mut operation = Operation::default();
+        operation.parameters.push(ReferenceOr::Item(Parameter::Header {
+            parameter_data: ParameterData {
+                name: "Content-Length".to_string(),
+                description: None,
+                required: false,
+                deprecated: None,
+                format: ParameterSchemaOrContent::Schema(ReferenceOr::Item(Schema {
+                    schema_data: SchemaData::default(),
+                    schema_kind: SchemaKind::Type(Type::Integer(IntegerType::default())),
+                })),
+                example: None,
+                examples: Default::default(),
+                explode: None,
+                extensions: Default::default(),
+            },
+            style: HeaderStyle::Simple,
+        }));
+        // A normal header still comes through so we know the loop ran.
+        operation.parameters.push(ReferenceOr::Item(Parameter::Header {
+            parameter_data: ParameterData {
+                name: "x-amz-request-route".to_string(),
+                description: None,
+                required: false,
+                deprecated: None,
+                format: ParameterSchemaOrContent::Schema(ReferenceOr::Item(Schema {
+                    schema_data: SchemaData::default(),
+                    schema_kind: SchemaKind::Type(Type::String(openapiv3::StringType::default())),
+                })),
+                example: None,
+                examples: Default::default(),
+                explode: None,
+                extensions: Default::default(),
+            },
+            style: HeaderStyle::Simple,
+        }));
+
+        let api_op = ApiOperation {
+            method: "post".to_string(),
+            path: "/WriteGetObjectResponse".to_string(),
+            operation,
+            operation_id: Some("WriteGetObjectResponse".to_string()),
+        };
+        let template = RequestGenerator::generate_template(&api_op).expect("template");
+        let headers = template.get_headers();
+        assert!(
+            !headers.keys().any(|k| k.eq_ignore_ascii_case("content-length")),
+            "invented Content-Length={:?} would make k6 drop empty-body POSTs",
+            headers.get("Content-Length")
+        );
+        assert_eq!(headers.get("x-amz-request-route").map(String::as_str), Some("test-value"));
+        assert!(RequestGenerator::is_transport_owned_header("Content-Length"));
+        assert!(RequestGenerator::is_transport_owned_header("HOST"));
+        assert!(!RequestGenerator::is_transport_owned_header("x-amz-request-route"));
     }
 }


### PR DESCRIPTION
## Summary
- Stop inventing `Content-Length` / `Host` / `Transfer-Encoding` from OpenAPI header params so k6 computes length from the real body (Srikanth's S3 spec: `Content-Length: 42` on empty POSTs, 0 useful traffic).
- Deduplicate colliding JS identifiers and metric names when many WAFBench YAML files share titles (`normal request allowed`). That was k6 exit 107 (ScriptException) on the 32-target verbatim run.
- Reprint the per-file unique/total breakdown at end of run (`unique * RPS`) and write `bench-results/traffic-breakdown.json` for automation.

## Test plan
- [x] Unit: `spec_content_length_header_is_not_invented`
- [x] Unit: `colliding_operation_titles_get_unique_const_names`
- [x] Unit: `traffic_breakdown_json_multiplies_unique_by_rps`
- [x] Real CLI generate-only on `amazonaws_oas.yaml`: 0 `Content-Length` in k6 script
- [x] Real CLI `--wafbench-verbatim` with two files sharing titles: `normal_request_allowed_2_*` consts + `traffic-breakdown.json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SaaSy-Solutions/codesmith/mockforge/pr/1031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791136649&installation_model_id=435061&pr_number=1031&repository=SaaSy-Solutions%2Fmockforge&return_to=https%3A%2F%2Fgithub.com%2FSaaSy-Solutions%2Fmockforge%2Fpull%2F1031&signature=b7198da088a41cbac92d3ca097c433b89b9c19d78cfe32768c9088367d83d42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->