### PR TITLE
fix(bench): JSON-encode static k6 paths so WAF \x URIs parse (#79)

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -1619,14 +1619,22 @@ impl BenchCommand {
         rps: Option<u32>,
         duration_secs: Option<u64>,
     ) -> serde_json::Value {
-        let multiplier = rps.filter(|&r| r > 0).unwrap_or(1) as u64;
-        let total = (unique as u64).saturating_mul(multiplier);
-        let expected_over_duration =
-            duration_secs.map(|d| (unique as u64).saturating_mul(multiplier).saturating_mul(d));
+        // `total` is unique * RPS when --rps is set (Srikanth's unique vs
+        // total ask). Do not invent rps=1 when --rps is absent: that made
+        // `expected_over_duration` look like a duration (5 unique * 1 * 60s
+        // = 300 on a 60s run). `expected_requests` is HTTP count over the
+        // whole run, not seconds, and is null without an explicit RPS.
+        let per_second = rps.filter(|&r| r > 0).map(|r| (unique as u64).saturating_mul(r as u64));
+        let total = per_second.unwrap_or(unique as u64);
+        let expected_requests = match (rps.filter(|&r| r > 0), duration_secs) {
+            (Some(r), Some(d)) => Some((unique as u64).saturating_mul(r as u64).saturating_mul(d)),
+            _ => None,
+        };
         serde_json::json!({
             "unique": unique,
             "total": total,
-            "expected_over_duration": expected_over_duration,
+            "expected_requests": expected_requests,
+            "expected_requests_unit": "http",
         })
     }
 
@@ -1680,6 +1688,7 @@ impl BenchCommand {
         let payload = serde_json::json!({
             "rps": rps,
             "duration_secs": duration_secs,
+            "expected_requests_note": "HTTP requests over the run, not seconds. unique * rps * duration_secs, assuming each k6 iteration sends every unique case. null when --rps is unset.",
             "files": files,
         });
         if let Some(parent) = self.output.parent() {
@@ -5064,13 +5073,55 @@ mod tests {
         assert_eq!(v["duration_secs"], 1200);
         assert_eq!(v["files"][0]["sent"]["unique"], 5);
         assert_eq!(v["files"][0]["sent"]["total"], 250);
-        assert_eq!(v["files"][0]["sent"]["expected_over_duration"], 300000);
+        assert_eq!(v["files"][0]["sent"]["expected_requests"], 300000);
+        assert_eq!(v["files"][0]["sent"]["expected_requests_unit"], "http");
         assert_eq!(v["files"][0]["attack"]["total"], 150);
         assert_eq!(v["files"][0]["normal"]["total"], 100);
+        assert!(v["expected_requests_note"].as_str().unwrap().contains("HTTP requests"));
         assert_eq!(
             BenchCommand::format_unique_total(5, Some(50)),
             "unique=5 total=250 (5 * 50 RPS)"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #79 (e): without --rps, do not invent rps=1. unique*1*60 looked
+    /// like a duration (300) on a 60s run.
+    #[test]
+    fn traffic_breakdown_json_omits_expected_requests_without_rps() {
+        let dir = std::env::temp_dir().join(format!(
+            "mf-traffic-breakdown-norps-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let mut cmd = sample_bench_command();
+        cmd.output = dir.clone();
+        cmd.target_rps = None;
+        cmd.duration = "60s".to_string();
+        let stats = crate::wafbench::WafBenchStats {
+            per_file: vec![crate::wafbench::TrafficFileSummary {
+                file: "apisix_cve-2026-44087.yaml".into(),
+                sent: 5,
+                attack: 3,
+                normal: 2,
+                omitted: 1,
+                other: 0,
+            }],
+            ..Default::default()
+        };
+        cmd.emit_traffic_file_breakdown(&stats, "what to expect in proxy logs");
+        let raw = std::fs::read_to_string(dir.join("traffic-breakdown.json"))
+            .expect("traffic-breakdown.json");
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(v["rps"].is_null());
+        assert_eq!(v["duration_secs"], 60);
+        assert_eq!(v["files"][0]["sent"]["unique"], 5);
+        assert_eq!(v["files"][0]["sent"]["total"], 5);
+        assert!(v["files"][0]["sent"]["expected_requests"].is_null());
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/mockforge-bench/src/k6_gen.rs
+++ b/crates/mockforge-bench/src/k6_gen.rs
@@ -420,10 +420,19 @@ impl K6ScriptGenerator {
                 (None, false)
             };
 
+            // Issue #79 (g) round 2: Werkzeug UNC uri
+            // `/static/\\attacker.com\share\x` was interpolated into a JS
+            // template literal. `\x` is a hex escape that needs two digits;
+            // k6/goja then exits on `invalid escape: \x: len("") != 2` and
+            // sends 0 requests (Srikanth's 31-YAML verbatim run on 0.3.217).
+            // JSON-encode static paths *including the surrounding quotes*
+            // so the template can do `BASE_URL + {{{this.path}}}` and the
+            // runtime URI stays byte-identical. Dynamic paths are already
+            // JS expressions (backtick template literals) — leave them.
             let path_value = if processed_path.is_dynamic {
                 processed_path.value
             } else {
-                full_path
+                serde_json::to_string(&full_path).unwrap_or_else(|_| "\"/\"".to_string())
             };
 
             operations.push(K6OperationData {
@@ -610,6 +619,22 @@ impl K6ScriptGenerator {
                 }
             }
 
+            // Issue #79 (g): k6/goja rejects `\x` without two hex digits
+            // (`invalid escape: \x: len("") != 2`). Catch it here so a
+            // WAF URI with a trailing `\x` fails in-process instead of
+            // after a 32-target spawn with 0 requests. Skip `//` comments:
+            // they are not string literals, and a generated comment that
+            // mentions the escape must not trip this check.
+            if !trimmed.starts_with("//") {
+                if let Some(col) = Self::invalid_js_hex_escape_column(trimmed) {
+                    errors.push(format!(
+                        "Line {}:{}: invalid JS hex escape \\x (k6 requires two hex digits). Static paths must be JSON-encoded, not dumped into a template literal.",
+                        line_num + 1,
+                        col + 1
+                    ));
+                }
+            }
+
             // Check for invalid JavaScript variable names (containing dots)
             if trimmed.starts_with("const ") || trimmed.starts_with("let ") {
                 if let Some(equals_pos) = trimmed.find('=') {
@@ -632,6 +657,39 @@ impl K6ScriptGenerator {
         }
 
         errors
+    }
+
+    /// Column of an unescaped `\x` that is not followed by two hex digits.
+    ///
+    /// k6 (goja) treats `\x` as a 2-digit hex escape in string and template
+    /// literals. A WAF URI like `/static/\\attacker.com\share\x` dumped raw
+    /// into `` `${BASE_URL}...` `` trips `invalid escape: \x: len("") != 2`.
+    /// A doubled backslash (`\\x`) is a real backslash plus `x` and is fine.
+    fn invalid_js_hex_escape_column(line: &str) -> Option<usize> {
+        let bytes = line.as_bytes();
+        let mut i = 0;
+        while i + 1 < bytes.len() {
+            if bytes[i] == b'\\' && bytes[i + 1] == b'x' {
+                let mut preceding = 0usize;
+                let mut j = i;
+                while j > 0 && bytes[j - 1] == b'\\' {
+                    preceding += 1;
+                    j -= 1;
+                }
+                // The `\` at i is a real escape iff it is not itself escaped
+                // (even number of backslashes in front of it).
+                if preceding.is_multiple_of(2) {
+                    let hex_ok = i + 3 < bytes.len()
+                        && bytes[i + 2].is_ascii_hexdigit()
+                        && bytes[i + 3].is_ascii_hexdigit();
+                    if !hex_ok {
+                        return Some(i);
+                    }
+                }
+            }
+            i += 1;
+        }
+        None
     }
 
     /// Check if a string is a valid k6 metric name
@@ -823,6 +881,91 @@ mod tests {
         );
         let errors = K6ScriptGenerator::validate_script(&script);
         assert!(errors.is_empty(), "validate_script: {errors:#?}");
+    }
+
+    #[test]
+    fn werkzeug_unc_backslash_x_is_json_encoded_not_template_literal() {
+        // #79 (g) round 2: werkzeug_cve-2026-48818.yaml uri
+        // `/static/\\attacker.com\share\x` dumped into a template literal
+        // made k6/goja exit on `invalid escape: \x: len("") != 2`.
+        // Static paths are now JSON strings concatenated onto BASE_URL.
+        use crate::spec_parser::ApiOperation;
+        use openapiv3::Operation;
+
+        let path = "/static/\\\\attacker.com\\share\\x";
+        let template = RequestTemplate {
+            operation: ApiOperation {
+                method: "get".to_string(),
+                path: path.to_string(),
+                operation: Operation::default(),
+                operation_id: Some("literal UNC double-backslash path blocked".to_string()),
+            },
+            path_params: HashMap::new(),
+            query_params: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        let config = K6Config {
+            target_url: "https://example.test".to_string(),
+            base_path: None,
+            scenario: LoadScenario::Constant,
+            duration_secs: 5,
+            max_vus: 1,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            auth_header: None,
+            custom_headers: HashMap::new(),
+            skip_tls_verify: false,
+            security_testing_enabled: false,
+            chunked_request_bodies: false,
+            target_rps: None,
+            no_keep_alive: false,
+            geo_source_ips: Vec::new(),
+            geo_source_headers: Vec::new(),
+        };
+        let script = K6ScriptGenerator::new(config, vec![template])
+            .generate()
+            .expect("script generates");
+        let encoded = serde_json::to_string(path).expect("path JSON");
+        assert!(
+            script.contains(&format!("BASE_URL + {encoded}")),
+            "expected BASE_URL + {encoded} in script:\n{script}"
+        );
+        assert!(
+            !script.contains("${BASE_URL}/static/"),
+            "must not dump the raw path into a template literal:\n{script}"
+        );
+        let errors = K6ScriptGenerator::validate_script(&script);
+        assert!(errors.is_empty(), "validate_script: {errors:#?}\n{script}");
+    }
+
+    #[test]
+    fn validate_script_flags_bare_hex_escape_in_template_literal() {
+        // The 0.3.217 smoking gun, reduced: a template literal with a
+        // trailing `\x` must fail validation before k6 is spawned.
+        let bad = r#"
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+const t_latency = new Trend('t_latency');
+export default function() {
+    const res = http.get(`${BASE_URL}/static/\\attacker.com\share\x`);
+}
+"#;
+        let errors = K6ScriptGenerator::validate_script(bad);
+        assert!(
+            errors.iter().any(|e| e.contains("invalid JS hex escape")),
+            "expected hex-escape error, got {errors:#?}"
+        );
+        assert!(K6ScriptGenerator::invalid_js_hex_escape_column(
+            r#"http.get(`${BASE_URL}/static/\\attacker.com\share\x`)"#
+        )
+        .is_some());
+        assert!(K6ScriptGenerator::invalid_js_hex_escape_column(
+            r#"BASE_URL + "/static/\\\\attacker.com\\share\\x""#
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/mockforge-bench/src/templates/k6_script.hbs
+++ b/crates/mockforge-bench/src/templates/k6_script.hbs
@@ -171,7 +171,9 @@ export default function () {
     const __path = {{{this.path}}};
     let requestUrl = `${BASE_URL}${__path}`;
     {{else}}
-    let requestUrl = `${BASE_URL}{{{this.path}}}`;
+    // Issue #79 (g): JSON-encoded path (quotes included) so backslash-x
+    // in WAF URIs is a JS string, not a template-literal hex escape.
+    let requestUrl = BASE_URL + {{{this.path}}};
     {{/if}}
     let secBodyPayload = null;
     let hasSecCookie = false;
@@ -235,7 +237,7 @@ export default function () {
     const url = {{{this.path}}};
     const res = http.{{this.method}}(`${BASE_URL}${url}`, JSON.stringify(payload), { headers: requestHeaders, jar: new http.CookieJar() });
     {{else}}
-    const res = http.{{this.method}}(`${BASE_URL}{{{this.path}}}`, JSON.stringify(payload), { headers: requestHeaders, jar: new http.CookieJar() });
+    const res = http.{{this.method}}(BASE_URL + {{{this.path}}}, JSON.stringify(payload), { headers: requestHeaders, jar: new http.CookieJar() });
     {{/if}}
     {{/if}}
     {{else if this.is_get_or_head}}
@@ -247,7 +249,7 @@ export default function () {
     const url = {{{this.path}}};
     const res = http.{{this.method}}(`${BASE_URL}${url}`, { headers: requestHeaders, jar: new http.CookieJar() });
     {{else}}
-    const res = http.{{this.method}}(`${BASE_URL}{{{this.path}}}`, { headers: requestHeaders, jar: new http.CookieJar() });
+    const res = http.{{this.method}}(BASE_URL + {{{this.path}}}, { headers: requestHeaders, jar: new http.CookieJar() });
     {{/if}}
     {{/if}}
     {{else}}
@@ -265,7 +267,7 @@ export default function () {
     const url = {{{this.path}}};
     const res = http.{{this.method}}(`${BASE_URL}${url}`, null, { headers: requestHeaders, jar: new http.CookieJar() });
     {{else}}
-    const res = http.{{this.method}}(`${BASE_URL}{{{this.path}}}`, null, { headers: requestHeaders, jar: new http.CookieJar() });
+    const res = http.{{this.method}}(BASE_URL + {{{this.path}}}, null, { headers: requestHeaders, jar: new http.CookieJar() });
     {{/if}}
     {{/if}}
     {{/if}}


### PR DESCRIPTION
## Summary
- Static k6 paths are JSON-encoded and concatenated onto `BASE_URL`, so WAF URIs like `/static/\\attacker.com\share\x` no longer land in a JS template literal. k6/goja was exiting on `invalid escape: \x: len("") != 2` (Srikanth's 31-YAML verbatim run on 0.3.217, line 12946).
- `validate_script` now rejects a bare `\x` hex escape before k6 is spawned.
- `traffic-breakdown.json`: rename `expected_over_duration` to `expected_requests` (HTTP count, not seconds). Do not invent rps=1 when `--rps` is unset (`expected_requests: null`).

Fixes the 0.3.217 (g) blocker and the (e) JSON confusion in #79.

## Test plan
- [x] `cargo test -p mockforge-bench` (includes werkzeug UNC path test + traffic JSON tests)
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings`
- [x] Real binary `--generate-only --wafbench-verbatim` on the attached 31 YAML files: script validation passed, UNC line is `BASE_URL + "/static/\\\\attacker.com\\share\\x"` (192 concat sites, 0 invalid hex escapes)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SaaSy-Solutions/codesmith/mockforge/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791353628&installation_model_id=435061&pr_number=1034&repository=SaaSy-Solutions%2Fmockforge&return_to=https%3A%2F%2Fgithub.com%2FSaaSy-Solutions%2Fmockforge%2Fpull%2F1034&signature=39e0ffe6e481f53322fb67be2989da1dd08efe82793598f85386a4615d2e68db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->