### PR TITLE
fix(bench): force HTTP/1.1 for WAF Connection headers (#79)

### DIFF
--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -1364,7 +1364,7 @@ impl BenchCommand {
     /// Round 63 (#79): generate-only still has to tell the user how to run
     /// the script. Connection-header cases need GODEBUG=http2client=0 or
     /// k6/Go ALPN-negotiates HTTP/2 and rejects the header.
-    fn print_k6_run_hint(script_path: &std::path::Path, force_http1: bool) {
+    fn print_k6_run_hint(script_path: &Path, force_http1: bool) {
         println!("\nScript generated successfully. Run it with:");
         if force_http1 {
             println!("  GODEBUG=http2client=0 k6 run {}", script_path.display());

--- a/crates/mockforge-bench/src/command.rs
+++ b/crates/mockforge-bench/src/command.rs
@@ -830,6 +830,14 @@ impl BenchCommand {
         // Parse headers
         let custom_headers = self.parse_headers()?;
 
+        // Round 63 (#79): WAF `Connection` headers are hop-by-hop. HTTP/2
+        // rejects them; keep the header and force HTTP/1.1 for k6.
+        let force_http1 = crate::request_gen::should_force_k6_http1(
+            self.wafbench_verbatim,
+            &templates,
+            &custom_headers,
+        );
+
         // Resolve base path (CLI option takes priority over spec's servers URL)
         let base_path = self.resolve_base_path(&parser);
         if let Some(ref bp) = base_path {
@@ -962,7 +970,8 @@ impl BenchCommand {
         };
 
         let generator = K6ScriptGenerator::new(k6_config, templates)
-            .with_abort_valve(self.abort_on_error, self.abort_on_error_rate);
+            .with_abort_valve(self.abort_on_error, self.abort_on_error_rate)
+            .with_force_http1(force_http1);
         let mut script = generator.generate()?;
         TerminalReporter::print_success("k6 script generated");
 
@@ -1026,20 +1035,25 @@ impl BenchCommand {
 
         // If generate-only mode, exit here
         if self.generate_only {
-            println!("\nScript generated successfully. Run it with:");
-            println!("  k6 run {}", script_path.display());
+            Self::print_k6_run_hint(&script_path, force_http1);
             return Ok(());
         }
 
         // Execute k6
         TerminalReporter::print_progress("Executing load test...");
+        if force_http1 {
+            TerminalReporter::print_progress(
+                "Forcing HTTP/1.1 (GODEBUG=http2client=0): Connection headers are hop-by-hop and HTTP/2 rejects them. The header stays on the wire.",
+            );
+        }
         // Round 57 (#79) — `--discard-response-bodies` opts a single-target
         // load run into K6_DISCARD_RESPONSE_BODIES. Safe here: this is the
         // plain load path (status/latency only), not conformance/extraction.
         let executor = K6Executor::new()?
             .with_local_ips(self.source_ips.join(","))
             .with_dns_policy(self.dns_policy.clone().unwrap_or_default())
-            .with_discard_response_bodies(self.discard_response_bodies);
+            .with_discard_response_bodies(self.discard_response_bodies)
+            .with_force_http1(force_http1);
 
         std::fs::create_dir_all(&self.output)?;
 
@@ -1347,6 +1361,21 @@ impl BenchCommand {
         }
     }
 
+    /// Round 63 (#79): generate-only still has to tell the user how to run
+    /// the script. Connection-header cases need GODEBUG=http2client=0 or
+    /// k6/Go ALPN-negotiates HTTP/2 and rejects the header.
+    fn print_k6_run_hint(script_path: &std::path::Path, force_http1: bool) {
+        println!("\nScript generated successfully. Run it with:");
+        if force_http1 {
+            println!("  GODEBUG=http2client=0 k6 run {}", script_path.display());
+            println!(
+                "  (HTTP/1.1: a Connection header is on the wire; HTTP/2 rejects it. mockforge bench sets this automatically when it invokes k6.)"
+            );
+        } else {
+            println!("  k6 run {}", script_path.display());
+        }
+    }
+
     /// Load traffic cases from `--wafbench-dir` and turn them into templates
     /// that are sent exactly as written (#994).
     ///
@@ -1607,10 +1636,12 @@ impl BenchCommand {
     fn format_unique_total(unique: usize, rps: Option<u32>) -> String {
         match rps {
             Some(r) if r > 0 => {
-                let total = unique.saturating_mul(r as usize);
-                format!("unique={unique} total={total} ({unique} * {r} RPS)")
+                let projected = unique.saturating_mul(r as usize);
+                format!(
+                    "unique_cases={unique} projected_per_second={projected} ({unique} * {r} RPS)"
+                )
             }
-            _ => format!("unique={unique}"),
+            _ => format!("unique_cases={unique}"),
         }
     }
 
@@ -1619,22 +1650,25 @@ impl BenchCommand {
         rps: Option<u32>,
         duration_secs: Option<u64>,
     ) -> serde_json::Value {
-        // `total` is unique * RPS when --rps is set (Srikanth's unique vs
-        // total ask). Do not invent rps=1 when --rps is absent: that made
-        // `expected_over_duration` look like a duration (5 unique * 1 * 60s
-        // = 300 on a 60s run). `expected_requests` is HTTP count over the
-        // whole run, not seconds, and is null without an explicit RPS.
+        // Round 63 (#79): these are the *plan*, not k6 counters. Srikanth
+        // read `expected_requests` as "actually sent on the wire". Honest
+        // names: unique_cases / projected_per_second / projected_over_run.
+        // unique / total / expected_requests stay as one-release aliases.
+        // Do not invent rps=1 when --rps is absent. Do not put "sent" in
+        // the new names. Drop expected_requests_unit (the only unit is HTTP).
         let per_second = rps.filter(|&r| r > 0).map(|r| (unique as u64).saturating_mul(r as u64));
         let total = per_second.unwrap_or(unique as u64);
-        let expected_requests = match (rps.filter(|&r| r > 0), duration_secs) {
+        let projected_over_run = match (rps.filter(|&r| r > 0), duration_secs) {
             (Some(r), Some(d)) => Some((unique as u64).saturating_mul(r as u64).saturating_mul(d)),
             _ => None,
         };
         serde_json::json!({
+            "unique_cases": unique,
             "unique": unique,
+            "projected_per_second": per_second,
             "total": total,
-            "expected_requests": expected_requests,
-            "expected_requests_unit": "http",
+            "projected_over_run": projected_over_run,
+            "expected_requests": projected_over_run,
         })
     }
 
@@ -1688,7 +1722,7 @@ impl BenchCommand {
         let payload = serde_json::json!({
             "rps": rps,
             "duration_secs": duration_secs,
-            "expected_requests_note": "HTTP requests over the run, not seconds. unique * rps * duration_secs, assuming each k6 iteration sends every unique case. null when --rps is unset.",
+            "note": "Plan, not k6 counters: unique_cases is YAML case count, projected_per_second is unique_cases * rps, projected_over_run is unique_cases * rps * duration_secs. Assumes each k6 iteration sends every unique case. projected_* are null when --rps is unset. unique/total/expected_requests are aliases for one release.",
             "files": files,
         });
         if let Some(parent) = self.output.parent() {
@@ -2394,6 +2428,12 @@ impl BenchCommand {
 
         let security_testing_enabled = self.security_testing_enabled();
 
+        let force_http1 = crate::request_gen::should_force_k6_http1(
+            self.wafbench_verbatim,
+            &templates,
+            &custom_headers,
+        );
+
         let k6_config = K6Config {
             target_url: self.target.clone(),
             base_path,
@@ -2425,7 +2465,8 @@ impl BenchCommand {
         };
 
         let generator = K6ScriptGenerator::new(k6_config, templates)
-            .with_abort_valve(self.abort_on_error, self.abort_on_error_rate);
+            .with_abort_valve(self.abort_on_error, self.abort_on_error_rate)
+            .with_force_http1(force_http1);
         let mut script = generator.generate()?;
 
         // Enhance script with advanced features (security testing, etc.)
@@ -2451,7 +2492,8 @@ impl BenchCommand {
             let executor = K6Executor::new()?
                 .with_local_ips(self.source_ips.join(","))
                 .with_dns_policy(self.dns_policy.clone().unwrap_or_default())
-                .with_discard_response_bodies(self.discard_response_bodies);
+                .with_discard_response_bodies(self.discard_response_bodies)
+                .with_force_http1(force_http1);
             let output_dir = self.output.join(format!("{}_results", spec_name.replace('.', "_")));
             std::fs::create_dir_all(&output_dir)?;
 
@@ -5038,6 +5080,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn single_target_k6_spawn_sets_force_http1() {
+        let src = include_str!("command.rs");
+        assert!(
+            src.contains("with_force_http1(force_http1)"),
+            "single-target k6 spawn must set GODEBUG=http2client=0 for Connection-header WAF cases"
+        );
+        assert!(
+            src.contains("print_k6_run_hint"),
+            "generate-only must print GODEBUG=http2client=0 when HTTP/1.1 is required"
+        );
+    }
+
     /// #79 (d)(e): unique vs total (unique * RPS) plus a JSON sidecar.
     #[test]
     fn traffic_breakdown_json_multiplies_unique_by_rps() {
@@ -5071,16 +5126,19 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert_eq!(v["rps"], 50);
         assert_eq!(v["duration_secs"], 1200);
+        assert_eq!(v["files"][0]["sent"]["unique_cases"], 5);
         assert_eq!(v["files"][0]["sent"]["unique"], 5);
+        assert_eq!(v["files"][0]["sent"]["projected_per_second"], 250);
         assert_eq!(v["files"][0]["sent"]["total"], 250);
+        assert_eq!(v["files"][0]["sent"]["projected_over_run"], 300000);
         assert_eq!(v["files"][0]["sent"]["expected_requests"], 300000);
-        assert_eq!(v["files"][0]["sent"]["expected_requests_unit"], "http");
+        assert!(v["files"][0]["sent"].get("expected_requests_unit").is_none());
         assert_eq!(v["files"][0]["attack"]["total"], 150);
         assert_eq!(v["files"][0]["normal"]["total"], 100);
-        assert!(v["expected_requests_note"].as_str().unwrap().contains("HTTP requests"));
+        assert!(v["note"].as_str().unwrap().contains("Plan, not k6 counters"));
         assert_eq!(
             BenchCommand::format_unique_total(5, Some(50)),
-            "unique=5 total=250 (5 * 50 RPS)"
+            "unique_cases=5 projected_per_second=250 (5 * 50 RPS)"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -5119,8 +5177,11 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert!(v["rps"].is_null());
         assert_eq!(v["duration_secs"], 60);
+        assert_eq!(v["files"][0]["sent"]["unique_cases"], 5);
         assert_eq!(v["files"][0]["sent"]["unique"], 5);
+        assert!(v["files"][0]["sent"]["projected_per_second"].is_null());
         assert_eq!(v["files"][0]["sent"]["total"], 5);
+        assert!(v["files"][0]["sent"]["projected_over_run"].is_null());
         assert!(v["files"][0]["sent"]["expected_requests"].is_null());
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/mockforge-bench/src/conformance/self_test.rs
+++ b/crates/mockforge-bench/src/conformance/self_test.rs
@@ -2190,7 +2190,7 @@ mod tests {
             header_params: headers.into_iter().map(|(a, b)| (a.into(), b.into())).collect(),
             path_params: path_params.into_iter().map(|(a, b)| (a.into(), b.into())).collect(),
             response_schema: None,
-            response_schemas: std::collections::BTreeMap::new(),
+            response_schemas: BTreeMap::new(),
             request_body_schema: None,
             security_schemes: Vec::new(),
         }

--- a/crates/mockforge-bench/src/executor.rs
+++ b/crates/mockforge-bench/src/executor.rs
@@ -115,6 +115,22 @@ fn extract_network_event_json(line: &str) -> Option<String> {
     extract_mockforge_marker_json(line, "MOCKFORGE_NETWORK_EVENT:")
 }
 
+/// Merge `http2client=0` into `GODEBUG` without clobbering other flags.
+///
+/// Round 63 (#79) / grafana/k6#2222: k6 has no per-request HTTP/1.1 API.
+/// An explicit `http2client=` already in the environment is left alone.
+pub(crate) fn merge_godebug_http2client_off(existing: Option<&str>) -> String {
+    const FLAG: &str = "http2client=0";
+    let existing = existing.unwrap_or("").trim();
+    if existing.is_empty() {
+        return FLAG.to_string();
+    }
+    if existing.split(',').any(|part| part.trim().starts_with("http2client=")) {
+        return existing.to_string();
+    }
+    format!("{existing},{FLAG}")
+}
+
 /// k6 executor
 pub struct K6Executor {
     k6_path: String,
@@ -139,6 +155,11 @@ pub struct K6Executor {
     /// `--local-ips` source ("no suitable address found"). `preferIPv6` /
     /// `onlyIPv6` fix that while keeping the hostname on the wire.
     dns_policy: String,
+    /// Round 63 (#79) — set `GODEBUG=http2client=0` so k6/Go does not
+    /// ALPN-negotiate HTTP/2. HTTP/2 forbids `Connection`; WAF hop-by-hop
+    /// cases must keep that header. grafana/k6#2222: no per-request HTTP/1.1
+    /// API, process-wide GODEBUG is the workaround.
+    force_http1: bool,
 }
 
 impl K6Executor {
@@ -154,6 +175,7 @@ impl K6Executor {
             local_ips: String::new(),
             discard_response_bodies: false,
             dns_policy: String::new(),
+            force_http1: false,
         })
     }
 
@@ -179,6 +201,24 @@ impl K6Executor {
     pub fn with_dns_policy(mut self, policy: impl Into<String>) -> Self {
         self.dns_policy = policy.into();
         self
+    }
+
+    /// Round 63 (#79) — force HTTP/1.1 for this k6 process via
+    /// `GODEBUG=http2client=0`. Use when the script sets a `Connection`
+    /// header or when `--wafbench-verbatim` is on.
+    pub fn with_force_http1(mut self, force: bool) -> Self {
+        self.force_http1 = force;
+        self
+    }
+
+    /// `GODEBUG` value this executor will set, or `None` when HTTP/2 is left
+    /// alone. Used by tests; `execute_with_port` applies the same string.
+    #[cfg(test)]
+    pub(crate) fn godebug_env_value(&self) -> Option<String> {
+        if !self.force_http1 {
+            return None;
+        }
+        Some(merge_godebug_http2client_off(std::env::var("GODEBUG").ok().as_deref()))
     }
 
     /// Check if k6 is installed
@@ -279,6 +319,14 @@ impl K6Executor {
         // high-concurrency runs (guards against the SIGKILL/OOM Srikanth hit).
         if self.discard_response_bodies {
             cmd.env("K6_DISCARD_RESPONSE_BODIES", "true");
+        }
+
+        // Round 63 (#79) — disable the Go HTTP/2 client so WAF `Connection`
+        // headers are not rejected as `http2: invalid Connection request
+        // header`. Merge with an existing GODEBUG rather than clobbering it.
+        if self.force_http1 {
+            let existing = std::env::var("GODEBUG").ok();
+            cmd.env("GODEBUG", merge_godebug_http2client_off(existing.as_deref()));
         }
 
         // Round 61 (#79) — force a DNS resolution policy so hostname targets can
@@ -686,6 +734,7 @@ mod tests {
             local_ips: String::new(),
             discard_response_bodies: false,
             dns_policy: String::new(),
+            force_http1: false,
         };
         assert!(!exec.discard_response_bodies);
         let exec = exec.with_discard_response_bodies(true);
@@ -702,6 +751,7 @@ mod tests {
             local_ips: String::new(),
             discard_response_bodies: false,
             dns_policy: String::new(),
+            force_http1: false,
         };
         assert!(exec.dns_policy.is_empty());
         let exec = exec.with_dns_policy("preferIPv6");
@@ -781,5 +831,49 @@ mod tests {
         let result = extract_exchange_json(line).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["k"], r#"a\"x""#);
+    }
+
+    #[test]
+    fn merge_godebug_appends_http2client_off_and_honors_existing() {
+        assert_eq!(merge_godebug_http2client_off(None), "http2client=0");
+        assert_eq!(merge_godebug_http2client_off(Some("")), "http2client=0");
+        assert_eq!(merge_godebug_http2client_off(Some("netdns=go")), "netdns=go,http2client=0");
+        assert_eq!(
+            merge_godebug_http2client_off(Some("http2client=1")),
+            "http2client=1",
+            "an explicit http2client= in the environment wins"
+        );
+        assert_eq!(merge_godebug_http2client_off(Some("http2client=0")), "http2client=0");
+    }
+
+    #[test]
+    fn force_http1_builder_sets_godebug_env_value() {
+        let exec = K6Executor {
+            k6_path: "k6".to_string(),
+            local_ips: String::new(),
+            discard_response_bodies: false,
+            dns_policy: String::new(),
+            force_http1: false,
+        };
+        assert!(exec.godebug_env_value().is_none());
+        let exec = exec.with_force_http1(true);
+        let value = exec.godebug_env_value().expect("force_http1 must set GODEBUG");
+        assert!(
+            value.split(',').any(|p| p.trim() == "http2client=0"),
+            "spawn env must contain http2client=0, got {value}"
+        );
+    }
+
+    #[test]
+    fn execute_with_port_applies_godebug_when_force_http1() {
+        let src = include_str!("executor.rs");
+        assert!(
+            src.contains("merge_godebug_http2client_off"),
+            "k6 spawn must merge GODEBUG=http2client=0 so Connection headers survive HTTPS ALPN"
+        );
+        assert!(
+            src.contains("if self.force_http1"),
+            "GODEBUG must be gated on force_http1, not applied to every k6 run"
+        );
     }
 }

--- a/crates/mockforge-bench/src/k6_gen.rs
+++ b/crates/mockforge-bench/src/k6_gen.rs
@@ -99,6 +99,11 @@ pub struct K6ScriptTemplateData {
     pub geo_source_ips_json: String,
     /// JSON-array string of `geo_source_headers` ready for embedding.
     pub geo_source_headers_json: String,
+    /// Round 63 (#79): when true, the rendered script documents
+    /// `GODEBUG=http2client=0`. HTTP/2 forbids `Connection`; WAF hop-by-hop
+    /// cases need HTTP/1.1. mockforge bench also sets the env when it
+    /// invokes k6. Must be present on every render path (#79).
+    pub force_http1: bool,
 }
 
 /// Typed template data for `k6_crud_flow.hbs`.
@@ -197,6 +202,10 @@ pub struct K6ScriptGenerator {
     /// Round 62 (#79) — failure-rate threshold for the abort valve. Default
     /// 0.95. Tunable via `--abort-on-error-rate`.
     abort_on_error_rate: f64,
+    /// Round 63 (#79) — force HTTP/1.1 even when this run's templates do
+    /// not currently set `Connection` (`--wafbench-verbatim` files routinely
+    /// do). Combined with auto-detect on template / custom headers.
+    force_http1: bool,
 }
 
 impl K6ScriptGenerator {
@@ -211,7 +220,17 @@ impl K6ScriptGenerator {
             templates,
             abort_on_error: true,
             abort_on_error_rate: 0.95,
+            force_http1: false,
         }
+    }
+
+    /// Round 63 (#79) — opt the generated script into the HTTP/1.1 comment
+    /// (`GODEBUG=http2client=0`). Also auto-detected when any template or
+    /// custom header is named `Connection`.
+    #[must_use]
+    pub fn with_force_http1(mut self, force_http1: bool) -> Self {
+        self.force_http1 = force_http1;
+        self
     }
 
     /// Configure the k6 abort-on-error memory safety valve (round 62 / #79).
@@ -226,6 +245,16 @@ impl K6ScriptGenerator {
         self.abort_on_error = abort_on_error;
         self.abort_on_error_rate = abort_on_error_rate;
         self
+    }
+
+    /// HTTP/2 forbids `Connection`. Keep the header (it IS the WAF case)
+    /// and force HTTP/1.1 instead.
+    pub fn should_force_http1(&self) -> bool {
+        crate::request_gen::should_force_k6_http1(
+            self.force_http1,
+            &self.templates,
+            &self.config.custom_headers,
+        )
     }
 
     /// Generate the k6 script
@@ -513,6 +542,7 @@ impl K6ScriptGenerator {
                 .unwrap_or_else(|_| "[]".to_string()),
             geo_source_headers_json: serde_json::to_string(&self.config.geo_source_headers)
                 .unwrap_or_else(|_| "[]".to_string()),
+            force_http1: self.should_force_http1(),
         })
     }
 
@@ -2710,5 +2740,95 @@ export default function() {{}}
             !script.contains("EMPTY_JAR"),
             "Script should NOT use shared EMPTY_JAR (accumulates Set-Cookie responses)"
         );
+    }
+
+    /// Round 63 (#79): a `Connection` header stays in the script (it is the
+    /// WAF case) and `force_http1` documents GODEBUG=http2client=0. Stripping
+    /// the header would skip the hop-by-hop test.
+    #[test]
+    fn connection_header_forces_http1_comment_and_stays_on_the_wire() {
+        use crate::spec_parser::ApiOperation;
+        use openapiv3::Operation;
+
+        let operation = ApiOperation {
+            method: "get".to_string(),
+            path: "/hop".to_string(),
+            operation: Operation::default(),
+            operation_id: Some("hop".to_string()),
+        };
+        let mut headers = HashMap::new();
+        headers.insert("Connection".to_string(), "Transfer-Encoding, keep-alive".to_string());
+        let template = RequestTemplate {
+            operation,
+            path_params: HashMap::new(),
+            query_params: HashMap::new(),
+            headers,
+            body: None,
+        };
+        let config = K6Config {
+            target_url: "https://waf.example.com".to_string(),
+            base_path: None,
+            scenario: LoadScenario::Constant,
+            duration_secs: 30,
+            max_vus: 1,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            auth_header: None,
+            custom_headers: HashMap::new(),
+            skip_tls_verify: true,
+            security_testing_enabled: false,
+            chunked_request_bodies: false,
+            target_rps: None,
+            no_keep_alive: false,
+            geo_source_ips: Vec::new(),
+            geo_source_headers: Vec::new(),
+        };
+        let generator = K6ScriptGenerator::new(config, vec![template]);
+        assert!(generator.should_force_http1());
+        let data = generator.build_template_data().expect("template data");
+        assert!(data.force_http1);
+        let script = generator.generate().expect("script generates");
+        assert!(
+            script.contains("GODEBUG=http2client=0"),
+            "script must tell a manual k6 run to disable HTTP/2"
+        );
+        assert!(
+            script.contains("Transfer-Encoding, keep-alive"),
+            "Connection value must stay in the script; stripping it skips the WAF case"
+        );
+        assert!(
+            script.contains("\"Connection\"") || script.contains("Connection"),
+            "Connection header key must stay on the wire"
+        );
+    }
+
+    /// `--wafbench-verbatim` forces the HTTP/1.1 comment even when this
+    /// particular file has no Connection header (the mix usually does).
+    #[test]
+    fn verbatim_flag_forces_http1_comment_without_connection_header() {
+        let config = K6Config {
+            target_url: "https://waf.example.com".to_string(),
+            base_path: None,
+            scenario: LoadScenario::Constant,
+            duration_secs: 30,
+            max_vus: 1,
+            threshold_percentile: "p(95)".to_string(),
+            threshold_ms: 500,
+            max_error_rate: 0.05,
+            auth_header: None,
+            custom_headers: HashMap::new(),
+            skip_tls_verify: true,
+            security_testing_enabled: false,
+            chunked_request_bodies: false,
+            target_rps: None,
+            no_keep_alive: false,
+            geo_source_ips: Vec::new(),
+            geo_source_headers: Vec::new(),
+        };
+        let generator = K6ScriptGenerator::new(config, vec![]).with_force_http1(true);
+        assert!(generator.should_force_http1());
+        let script = generator.generate().expect("script generates");
+        assert!(script.contains("GODEBUG=http2client=0"));
     }
 }

--- a/crates/mockforge-bench/src/parallel_executor.rs
+++ b/crates/mockforge-bench/src/parallel_executor.rs
@@ -188,6 +188,38 @@ impl ParallelExecutor {
         }
     }
 
+    /// Round 63 (#79): `--max-concurrency` is a semaphore, not a shared VU
+    /// pool. Each batch of up to `max_concurrency` targets runs the full
+    /// duration, then the next batch starts. Wall clock ≈
+    /// ceil(targets / concurrency) * duration.
+    pub(crate) fn estimated_wall_clock(
+        n_targets: usize,
+        max_concurrency: usize,
+        duration_secs: u64,
+    ) -> (usize, u64) {
+        let conc = max_concurrency.max(1);
+        let batches = if n_targets == 0 {
+            0
+        } else {
+            n_targets.div_ceil(conc)
+        };
+        (batches, (batches as u64).saturating_mul(duration_secs))
+    }
+
+    /// Human-readable duration for the wall-clock estimate (`35m00s`).
+    pub(crate) fn format_wall_clock(secs: u64) -> String {
+        let hours = secs / 3600;
+        let mins = (secs % 3600) / 60;
+        let rem = secs % 60;
+        if hours > 0 {
+            format!("{hours}h{mins:02}m{rem:02}s")
+        } else if mins > 0 {
+            format!("{mins}m{rem:02}s")
+        } else {
+            format!("{rem}s")
+        }
+    }
+
     /// Execute tests against all targets in parallel
     pub async fn execute_all(&self) -> Result<AggregatedResults> {
         let total_targets = self.targets.len();
@@ -364,7 +396,23 @@ impl ParallelExecutor {
 
         let duration_secs_val = BenchCommand::parse_duration(&self.base_command.duration)?;
 
+        // Round 63 (#79): batches of `--max-concurrency` each run the full
+        // `--duration`. Wall clock is ceil(targets / concurrency) * duration,
+        // not duration alone. --vus and --rps are per target, not shared.
+        let (batches, wall_secs) =
+            Self::estimated_wall_clock(total_targets, self.max_concurrency, duration_secs_val);
+        TerminalReporter::print_progress(&format!(
+            "Estimated wall clock: {batches} batch(es) × {duration_secs_val}s ≈ {} ({wall_secs}s). --vus and --rps are per target, not shared.",
+            Self::format_wall_clock(wall_secs),
+        ));
+
         let security_testing_enabled_val = self.base_command.security_testing_enabled();
+
+        if crate::request_gen::should_force_k6_http1(verbatim, &templates, &base_headers) {
+            TerminalReporter::print_progress(
+                "Forcing HTTP/1.1 (GODEBUG=http2client=0): Connection headers are hop-by-hop and HTTP/2 rejects them. The header stays on the wire.",
+            );
+        }
 
         // Pre-compute enhancement code once (same for all targets)
         let has_advanced_features = self.base_command.data_file.is_some()
@@ -504,6 +552,7 @@ impl ParallelExecutor {
                     &dns_policy,
                     &geo_source_ips,
                     &geo_source_headers,
+                    verbatim,
                 )
                 .await;
 
@@ -614,12 +663,20 @@ impl ParallelExecutor {
         dns_policy: &str,
         geo_source_ips: &[String],
         geo_source_headers: &[String],
+        wafbench_verbatim: bool,
     ) -> Result<TargetResult> {
         // Merge target-specific headers with base headers
         let mut custom_headers = base_headers.clone();
         if let Some(target_headers) = &target.headers {
             custom_headers.extend(target_headers.clone());
         }
+
+        // Round 63 (#79): keep Connection on the wire; force HTTP/1.1.
+        let force_http1 = crate::request_gen::should_force_k6_http1(
+            wafbench_verbatim,
+            templates,
+            &custom_headers,
+        );
 
         // Use target-specific auth if provided, otherwise use base auth
         let auth_header = target.auth.as_ref().or(auth.as_ref()).cloned();
@@ -647,7 +704,8 @@ impl ParallelExecutor {
 
         // Generate k6 script
         let generator = K6ScriptGenerator::new(k6_config, templates.to_vec())
-            .with_abort_valve(abort_on_error, abort_on_error_rate);
+            .with_abort_valve(abort_on_error, abort_on_error_rate)
+            .with_force_http1(force_http1);
         let mut script = generator.generate()?;
 
         // Apply pre-computed enhancement code (security definitions, etc.)
@@ -702,7 +760,8 @@ impl ParallelExecutor {
         let executor = K6Executor::new()?
             .with_local_ips(local_ips.to_string())
             .with_dns_policy(dns_policy.to_string())
-            .with_discard_response_bodies(true);
+            .with_discard_response_bodies(true)
+            .with_force_http1(force_http1);
         let results = executor
             .execute_with_port(&script_path, Some(&output_dir), verbose, Some(api_port))
             .await;
@@ -895,5 +954,31 @@ mod tests {
         // p99 should be the 99th percentile of [200, 300, 400] = index 2 = 400
         assert_eq!(metrics.p95_duration_ms, 350.0);
         assert_eq!(metrics.p99_duration_ms, 400.0);
+    }
+
+    #[test]
+    fn estimated_wall_clock_is_batches_times_duration() {
+        // Srikanth: 64 IPs, --max-concurrency 10, -d 300 → 7 batches × 300s.
+        let (batches, wall) = ParallelExecutor::estimated_wall_clock(64, 10, 300);
+        assert_eq!(batches, 7);
+        assert_eq!(wall, 2100);
+        assert_eq!(ParallelExecutor::format_wall_clock(2100), "35m00s");
+        assert_eq!(ParallelExecutor::estimated_wall_clock(10, 10, 300), (1, 300));
+        assert_eq!(ParallelExecutor::estimated_wall_clock(0, 10, 300), (0, 0));
+        assert_eq!(ParallelExecutor::format_wall_clock(45), "45s");
+        assert_eq!(ParallelExecutor::format_wall_clock(3661), "1h01m01s");
+    }
+
+    #[test]
+    fn parallel_k6_spawn_sets_force_http1() {
+        let src = include_str!("parallel_executor.rs");
+        assert!(
+            src.contains("with_force_http1(force_http1)"),
+            "multi-target k6 spawn must pass GODEBUG=http2client=0 when Connection headers are present"
+        );
+        assert!(
+            src.contains("Estimated wall clock"),
+            "multi-target start must print ceil(targets/concurrency)*duration"
+        );
     }
 }

--- a/crates/mockforge-bench/src/request_gen.rs
+++ b/crates/mockforge-bench/src/request_gen.rs
@@ -38,6 +38,15 @@ impl RequestTemplate {
         path
     }
 
+    /// True when this template sets a `Connection` header (any casing).
+    ///
+    /// Round 63 (#79): HTTP/2 forbids `Connection`. WAF hop-by-hop cases
+    /// must keep the header on the wire, so k6 is forced onto HTTP/1.1
+    /// instead of stripping it.
+    pub fn has_connection_header(&self) -> bool {
+        header_map_has_connection(&self.headers)
+    }
+
     /// Get all headers including content-type
     pub fn get_headers(&self) -> HashMap<String, String> {
         let mut headers = self.headers.clone();
@@ -50,6 +59,25 @@ impl RequestTemplate {
 
         headers
     }
+}
+
+/// Case-insensitive `Connection` lookup. HTTP/2 rejects this header;
+/// HTTP/1.1 is the only way to send the WAF smuggling cases as written.
+pub fn header_map_has_connection(headers: &HashMap<String, String>) -> bool {
+    headers.keys().any(|k| k.eq_ignore_ascii_case("connection"))
+}
+
+/// Round 63 (#79): force k6 onto HTTP/1.1 (`GODEBUG=http2client=0`) when
+/// `--wafbench-verbatim` is set (those files routinely set `Connection`)
+/// or when any request actually has a `Connection` header.
+pub fn should_force_k6_http1(
+    wafbench_verbatim: bool,
+    templates: &[RequestTemplate],
+    extra_headers: &HashMap<String, String>,
+) -> bool {
+    wafbench_verbatim
+        || header_map_has_connection(extra_headers)
+        || templates.iter().any(RequestTemplate::has_connection_header)
 }
 
 /// Request template generator
@@ -442,5 +470,17 @@ mod tests {
         assert!(RequestGenerator::is_transport_owned_header("Content-Length"));
         assert!(RequestGenerator::is_transport_owned_header("HOST"));
         assert!(!RequestGenerator::is_transport_owned_header("x-amz-request-route"));
+    }
+
+    #[test]
+    fn connection_header_detection_is_case_insensitive() {
+        let mut headers = HashMap::new();
+        headers.insert("connection".to_string(), "x-real-ip".to_string());
+        assert!(header_map_has_connection(&headers));
+        headers.clear();
+        headers.insert("X-Custom".to_string(), "1".to_string());
+        assert!(!header_map_has_connection(&headers));
+        assert!(should_force_k6_http1(true, &[], &HashMap::new()));
+        assert!(!should_force_k6_http1(false, &[], &HashMap::new()));
     }
 }

--- a/crates/mockforge-bench/src/templates/k6_script.hbs
+++ b/crates/mockforge-bench/src/templates/k6_script.hbs
@@ -1,3 +1,10 @@
+{{#if force_http1}}
+// HTTP/2 forbids Connection. k6/Go ALPN-negotiates HTTP/2 on HTTPS, then
+// rejects hop-by-hop WAF cases (`http2: invalid Connection request header`).
+// mockforge bench sets GODEBUG=http2client=0 when it invokes k6. For a
+// manual run:
+//   GODEBUG=http2client=0 k6 run this-script.js
+{{/if}}
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 import { Rate, Trend, Counter } from 'k6/metrics';


### PR DESCRIPTION
## Summary
- HTTPS + ALPN HTTP/2 was rejecting WAF `Connection` headers (`http2: invalid Connection request header`). The header stays on the wire (it is the test); k6 is forced onto HTTP/1.1 via `GODEBUG=http2client=0` when `--wafbench-verbatim` is set or any request has a `Connection` header. generate-only prints the same prefix for a manual `k6 run`.
- `traffic-breakdown.json` now uses plan names (`unique_cases`, `projected_per_second`, `projected_over_run`) instead of implying the values were observed on the wire. `unique` / `total` / `expected_requests` stay as aliases for one release. `expected_requests_unit` is dropped.
- Multi-target runs print estimated wall clock: `ceil(targets / max-concurrency) * duration`. `--vus` and `--rps` are per target, not shared.

## Test plan
- [x] `cargo test -p mockforge-bench --lib` (564 passed)
- [x] `cargo clippy -p mockforge-bench --all-targets -- -D warnings`
- [x] `cargo fmt -p mockforge-bench -- --check`
- [x] Real-binary generate-only on a 2-case YAML with `Connection: Transfer-Encoding, keep-alive` and `Connection: x-real-ip`: script keeps both headers, prints `GODEBUG=http2client=0 k6 run ...`, stub k6 spawn has `STUB_GODEBUG=http2client=0`
- [x] `--rps 1 -d 60s` JSON: `unique_cases=2`, `projected_per_second=2`, `projected_over_run=120`
- [x] 2-target `--max-concurrency 1 -d 300s` prints `2 batch(es) × 300s ≈ 10m00s (600s)`

Relates to #79

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SaaSy-Solutions/codesmith/mockforge/pr/1037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791647193&installation_model_id=435061&pr_number=1037&repository=SaaSy-Solutions%2Fmockforge&return_to=https%3A%2F%2Fgithub.com%2FSaaSy-Solutions%2Fmockforge%2Fpull%2F1037&signature=54a8b11785d64874201436cc0669df24d92dac058dcfd76476f0442710a6dd9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->